### PR TITLE
Edit Mendix API key description

### DIFF
--- a/ATS/Projects.md
+++ b/ATS/Projects.md
@@ -30,7 +30,7 @@ The project ID of the Mendix sprintr project that you want to get your stories f
 
 **Mendix API Key**
 
-The API key that you created in your sprintr project for ATS.
+The API key that you created in your sprintr project for ATS. (Be aware of the fact that this is not the User API key, but the Project API key which can be found in the project settings in sprintr)
 
 **Project Users**
 


### PR DESCRIPTION
Edit the description to ensure users go for the Project API key and not the User API key. Something I did wrong myself, since the Project API key is something that is rarely used. People do not know it exists. 