### PR TITLE
Update Runtime+API+changes.md

### DIFF
--- a/apidocs/Runtime+API+changes.md
+++ b/apidocs/Runtime+API+changes.md
@@ -54,5 +54,5 @@ Deprecated classes/methods will be removed in Mendix 7.
 | com.mendix.systemwideinterfaces.core.meta.IMetaObject.getComponent() | - |
 | com.mendix.systemwideinterfaces.core.ISession.getComponent() | - |
 | com.mendix.modules.exportmanager.excel.ExcelExporter., generateWorkbook(LocalComponent component, IContext context, List<IExcelGrid> grids) | - |
-| com.mendix.core.callWebservice() | Use the microflow action *Call REST Action* to do the HTTP post |
+| com.mendix.core.callWebservice() | Use the microflow action *Call REST Action* to do the HTTP POST |
 | com.mendix.core.importxmlStream() | Use *com.mendix.core.importStream()* instead |

--- a/apidocs/Runtime+API+changes.md
+++ b/apidocs/Runtime+API+changes.md
@@ -55,3 +55,6 @@ Deprecated classes/methods will be removed in Mendix 7.
 | com.mendix.systemwideinterfaces.core.ISession.getComponent() | - |
 | com.mendix.modules.exportmanager.excel.ExcelExporter., generateWorkbook(LocalComponent component, IContext context, List<IExcelGrid> grids) | - |
 | com.mendix.core.callWebservice() | use microflow action `Call REST Action` to do HTTP Post |
+| com.mendix.core.importxmlStream() | use com.mendix.core.importStream() instead |
+
+

--- a/apidocs/Runtime+API+changes.md
+++ b/apidocs/Runtime+API+changes.md
@@ -54,3 +54,4 @@ Deprecated classes/methods will be removed in Mendix 7.
 | com.mendix.systemwideinterfaces.core.meta.IMetaObject.getComponent() | - |
 | com.mendix.systemwideinterfaces.core.ISession.getComponent() | - |
 | com.mendix.modules.exportmanager.excel.ExcelExporter., generateWorkbook(LocalComponent component, IContext context, List<IExcelGrid> grids) | - |
+| com.mendix.core.callWebservice() | use microflow action `Call REST Action` to do HTTP Post |

--- a/apidocs/Runtime+API+changes.md
+++ b/apidocs/Runtime+API+changes.md
@@ -54,5 +54,5 @@ Deprecated classes/methods will be removed in Mendix 7.
 | com.mendix.systemwideinterfaces.core.meta.IMetaObject.getComponent() | - |
 | com.mendix.systemwideinterfaces.core.ISession.getComponent() | - |
 | com.mendix.modules.exportmanager.excel.ExcelExporter., generateWorkbook(LocalComponent component, IContext context, List<IExcelGrid> grids) | - |
-| com.mendix.core.callWebservice() | use microflow action `Call REST Action` to do HTTP Post |
-| com.mendix.core.importxmlStream() | use com.mendix.core.importStream() instead |
+| com.mendix.core.callWebservice() | Use the microflow action *Call REST Action* to do the HTTP post |
+| com.mendix.core.importxmlStream() | Use *com.mendix.core.importStream()* instead |

--- a/apidocs/Runtime+API+changes.md
+++ b/apidocs/Runtime+API+changes.md
@@ -56,5 +56,3 @@ Deprecated classes/methods will be removed in Mendix 7.
 | com.mendix.modules.exportmanager.excel.ExcelExporter., generateWorkbook(LocalComponent component, IContext context, List<IExcelGrid> grids) | - |
 | com.mendix.core.callWebservice() | use microflow action `Call REST Action` to do HTTP Post |
 | com.mendix.core.importxmlStream() | use com.mendix.core.importStream() instead |
-
-


### PR DESCRIPTION
com.mendix.core.callWebservice() has been deprecated since Mendix 5. Now there is an alternative to invoke HTTP Post. This method will be gone when Mendix 7 is released.