### PR TITLE
added migration from 6 to 7 link

### DIFF
--- a/releasenotes/desktop-modeler/7.0.md
+++ b/releasenotes/desktop-modeler/7.0.md
@@ -10,6 +10,10 @@ parent: "7"
 
 {% modelerdownloadlink 7.0.2 %}
 
+### Migration from Mendix 6
+
+To make migration easier, see [Moving from 6 to 7] (https://docs.mendix.com/refguide7/moving-from-6-to-7).
+
 ### Stateless runtime
 
 An earlier version of Mendix enabled applications to move sessions to the database and files to an external file storage facility (for example, S3 or Azure Blob Storage). In Mendix 7, the server object state has been moved to the client, which means that the server is now completely stateless and can be scaled horizontally at will!

--- a/releasenotes/desktop-modeler/7.0.md
+++ b/releasenotes/desktop-modeler/7.0.md
@@ -12,7 +12,7 @@ parent: "7"
 
 ### Migration from Mendix 6
 
-To make migration easier, see [Moving from 6 to 7] (https://docs.mendix.com/refguide7/moving-from-6-to-7).
+To make migration easier, see [Moving From 6 to 7](/refguide7/moving-from-6-to-7).
 
 ### Stateless runtime
 


### PR DESCRIPTION
Added migration documentation link to the Release notes (like we did for Mendix 6.0)