### PR TITLE
Add missing release note

### DIFF
--- a/releasenotes/desktop-modeler/7.0.md
+++ b/releasenotes/desktop-modeler/7.0.md
@@ -127,7 +127,7 @@ In addition, it is now possible to select **HTTP response** as the return type o
 * We fixed the importing of XML. When you find values by keys that contain special characters (like a quote), the system now updates the object instead of creating a new object. (Ticket 47441)
 * We fixed the unknown primitive types that should not be allowed for selection in the mapping. (Ticket 48903)
 * We fixed the issue in which enumerations without translations throw an error when importing an app service. (Ticket 48806)
-* Building a deployment package of your project in the Mendix Cloud could result in an error, whereas building the package locally and then uploading it manually would work correctly. This issue is fixed. (Tickets 38372, 38506, 38256, 39943, 40344, 39989, 43819, 46883, 48796, 43854)
+* We fixed the issue in which building a deployment package of your project in the Mendix Cloud resulted in an error but building the package locally and then uploading it manually worked correctly. (Tickets 38372, 38506, 38256, 39943, 40344, 39989, 43819, 46883, 48796, 43854)
 
 ### Deprecations
 

--- a/releasenotes/desktop-modeler/7.0.md
+++ b/releasenotes/desktop-modeler/7.0.md
@@ -127,7 +127,7 @@ In addition, it is now possible to select **HTTP response** as the return type o
 * We fixed the importing of XML. When you find values by keys that contain special characters (like a quote), the system now updates the object instead of creating a new object. (Ticket 47441)
 * We fixed the unknown primitive types that should not be allowed for selection in the mapping. (Ticket 48903)
 * We fixed the issue in which enumerations without translations throw an error when importing an app service. (Ticket 48806)
-* We fixed the issue in which building a deployment package of your project in the Mendix Cloud resulted in an error but building the package locally and then uploading it manually worked correctly. (Tickets 38372, 38506, 38256, 39943, 40344, 39989, 43819, 46883, 48796, 43854)
+* We fixed the issue in which building a deployment package of your project in the Mendix Cloud resulted in an error (whereas building the package locally and then uploading it manually worked correctly). (Tickets 38372, 38506, 38256, 39943, 40344, 39989, 43819, 46883, 48796, 43854)
 
 ### Deprecations
 

--- a/releasenotes/desktop-modeler/7.0.md
+++ b/releasenotes/desktop-modeler/7.0.md
@@ -127,6 +127,7 @@ In addition, it is now possible to select **HTTP response** as the return type o
 * We fixed the importing of XML. When you find values by keys that contain special characters (like a quote), the system now updates the object instead of creating a new object. (Ticket 47441)
 * We fixed the unknown primitive types that should not be allowed for selection in the mapping. (Ticket 48903)
 * We fixed the issue in which enumerations without translations throw an error when importing an app service. (Ticket 48806)
+* Building a deployment package of your project in the Mendix Cloud could result in an error, whereas building the package locally and then uploading it manually would work correctly. This issue is fixed. (Tickets 38372, 38506, 38256, 39943, 40344, 39989, 43819, 46883, 48796, 43854)
 
 ### Deprecations
 


### PR DESCRIPTION
We forgot to mention that we fixed the issue with building deployment packages
in the cloud because of the old Mono version we used for this.