### PR TITLE
Reference the Mendix BuildPack (cf-mendix-buildpack) Documentation

### DIFF
--- a/howto50/deploying-a-mendix-app-to-cloud-foundry.md
+++ b/howto50/deploying-a-mendix-app-to-cloud-foundry.md
@@ -22,7 +22,7 @@ Cloud Foundry is an Open Source Platform-as-a-Service that can run all kinds of 
 
 ![](attachments/18448647/18580558.png)Extending to more software architectures via custom buildpacks
 
-![](attachments/18448647/18580560.png) Automatic health monitoring and recovery
+![](attachments/18448647/18580560.png)Automatic health monitoring and recovery
 
 
 

--- a/howto50/deploying-a-mendix-app-to-hp-helion.md
+++ b/howto50/deploying-a-mendix-app-to-hp-helion.md
@@ -145,6 +145,7 @@ If you encounter any problems you should consult the application logs.
 
 ## 8\. Read More
 
+*   [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 *   [Deploying a Mendix App to Pivotal](deploying-a-mendix-app-to-pivotal)
 *   [Deploying a Mendix App to HP Helion](deploying-a-mendix-app-to-hp-helion)
 *   [Deploying a Mendix App to Cloud Foundry](deploying-a-mendix-app-to-cloud-foundry)

--- a/howto50/deploying-a-mendix-app-to-pivotal.md
+++ b/howto50/deploying-a-mendix-app-to-pivotal.md
@@ -137,6 +137,7 @@ If you encounter any problems you should consult the application logs.
 
 ## 8\. Related content
 
+*   [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 *   [Deploying a Mendix App to Pivotal](deploying-a-mendix-app-to-pivotal)
 *   [Deploying a Mendix App to HP Helion](deploying-a-mendix-app-to-hp-helion)
 *   [Deploying a Mendix App to Cloud Foundry](deploying-a-mendix-app-to-cloud-foundry)

--- a/howto6/deploy-a-mendix-app-to-hp-helion.md
+++ b/howto6/deploy-a-mendix-app-to-hp-helion.md
@@ -184,6 +184,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to Cloud Foundry](deploying-a-mendix-app-to-cloud-foundry)

--- a/howto6/deploy-a-mendix-app-to-ibm-bluemix.md
+++ b/howto6/deploy-a-mendix-app-to-ibm-bluemix.md
@@ -151,6 +151,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)

--- a/howto6/deploy-a-mendix-app-to-pivotal.md
+++ b/howto6/deploy-a-mendix-app-to-pivotal.md
@@ -189,6 +189,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)

--- a/howto7/deploy-a-mendix-app-to-hp-helion.md
+++ b/howto7/deploy-a-mendix-app-to-hp-helion.md
@@ -189,5 +189,5 @@ If you encounter any problems, you should consult the application logs:
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)
 * [How to Deploy a Mendix App to Cloud Foundry](deploy-a-mendix-app-to-cloud-foundry)
-* [HP Helion Development Platform ALS documentation](http://docs.hpcloud.com/als/v1/)
+* [HP Helion Development Platform ALS Documentation](http://docs.hpcloud.com/als/v1/)
 * [HP Helion Development Platform Documentation](http://docs.hpcloud.com/helion/devplatform/1.1/)

--- a/howto7/deploy-a-mendix-app-to-hp-helion.md
+++ b/howto7/deploy-a-mendix-app-to-hp-helion.md
@@ -190,4 +190,4 @@ If you encounter any problems, you should consult the application logs:
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)
 * [How to Deploy a Mendix App to Cloud Foundry](deploy-a-mendix-app-to-cloud-foundry)
 * [HP Helion Development Platform ALS documentation](http://docs.hpcloud.com/als/v1/)
-* [HP Helion Development Platform documentation](http://docs.hpcloud.com/helion/devplatform/1.1/)
+* [HP Helion Development Platform Documentation](http://docs.hpcloud.com/helion/devplatform/1.1/)

--- a/howto7/deploy-a-mendix-app-to-hp-helion.md
+++ b/howto7/deploy-a-mendix-app-to-hp-helion.md
@@ -184,6 +184,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)

--- a/howto7/deploy-a-mendix-app-to-ibm-bluemix.md
+++ b/howto7/deploy-a-mendix-app-to-ibm-bluemix.md
@@ -164,6 +164,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)

--- a/howto7/deploy-a-mendix-app-to-ibm-bluemix.md
+++ b/howto7/deploy-a-mendix-app-to-ibm-bluemix.md
@@ -169,4 +169,4 @@ If you encounter any problems, you should consult the application logs:
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)
 * [How to Deploy a Mendix App to Cloud Foundry](deploy-a-mendix-app-to-cloud-foundry)
-* [IBM Bluemix documentation](https://www.eu-gb.bluemix.net/docs)
+* [IBM Bluemix Documentation](https://www.eu-gb.bluemix.net/docs)

--- a/howto7/deploy-a-mendix-app-to-pivotal.md
+++ b/howto7/deploy-a-mendix-app-to-pivotal.md
@@ -194,5 +194,5 @@ If you encounter any problems, you should consult the application logs:
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)
 * [How to Deploy a Mendix App to Cloud Foundry](deploy-a-mendix-app-to-cloud-foundry)
-* [Pivotal Web Services documentation](http://docs.run.pivotal.io/)
-* [Pivotal Cloud Foundry blog](http://blog.pivotal.io/cloud-foundry-pivotal)
+* [Pivotal Web Services Documentation](http://docs.run.pivotal.io/)
+* [Pivotal Cloud Foundry Blog](http://blog.pivotal.io/cloud-foundry-pivotal)

--- a/howto7/deploy-a-mendix-app-to-pivotal.md
+++ b/howto7/deploy-a-mendix-app-to-pivotal.md
@@ -189,6 +189,7 @@ If you encounter any problems, you should consult the application logs:
 
 ## 9 Related Content
 
+* [Mendix BuildPack Documentation](https://github.com/mendix/cf-mendix-buildpack)
 * [How to Deploy a Mendix App to IBM Bluemix](deploy-a-mendix-app-to-ibm-bluemix)
 * [How to Deploy a Mendix App to Pivotal](deploy-a-mendix-app-to-pivotal)
 * [How to Deploy a Mendix App to HP Helion](deploy-a-mendix-app-to-hp-helion)


### PR DESCRIPTION
It seems that some customers were unable to find their way to our cf-mendix-buildpack, so let's help them out a bit more. This is mostly useful for advanced users of our platform, and people that host on-premise on Cloud Foundry, but it might be good for our users in general to be able to find the inner workings of our BuildPack.