### PR TITLE
platform portal release notes - fix title anchors

### DIFF
--- a/releasenotes/platform-portal/index.md
+++ b/releasenotes/platform-portal/index.md
@@ -3,11 +3,11 @@ title: "Platform Portal"
 space: "Release Notes"
 ---
 
-## <a name='release-2017-03-20'>Release date: March 20th, 2017</a>
+## <a name='release-2017-03-20'></a><a href='#release-2017-03-20'>March 20th, 2017</a>
 
 * The Deploy / Operate sections in the Platform Portal were broken on Internet Explorer 11 due to widget incompatability, introduced in the previous release. This was already hot-patched in production on March 16th.
 
-## <a name='release-2017-03-13'>Release date: March 13th, 2017</a>
+## <a name='release-2017-03-13'></a><a href='#release-2017-03-13'>March 13th, 2017</a>
 
 ### Bug fixes
 * The highlighted menu state was fixed, the wrong items were highlighted in some instances
@@ -16,11 +16,11 @@ space: "Release Notes"
 * Clicking **Operate -> Backups** resulted in errors for a Free App
 * Various fixes for internal beta program
 
-## <a name='release-2017-03-10'>Release date: March 10th, 2017</a>
+## <a name='release-2017-03-10'></a><a href='#release-2017-03-10'>March 10th, 2017</a>
 
 * We introduced a new setting in **Node Security**, you can now configure **Monitoring Permissions** separately from **Transport Permissions**. Immediately after this change, we granted all users that had **Transport Permissions** on an environment the **Monitoring Permissions** there as well. From now on, a **Technical Contact** can configure these settings for everyone in the team separately. While we introduced this setting, we revisited the layout of the **Node Security** screen, you now have a simpler interface to change the permissions en each environment.
 
-## <a name='release-2017-03-09'>Release date: March 9th, 2017</a>
+## <a name='release-2017-03-09'></a><a href='#release-2017-03-09'>March 9th, 2017</a>
 
 ### Improvements
 * We improved the performance of sprint completion. This should now take significantly less time.
@@ -31,7 +31,7 @@ space: "Release Notes"
 * We fixed the issue in which completing a sprint from the **Stories** page wouldn't properly update the UI.
 * The **getAccounts** call in the **UserManagementAPI** will now sort results consistently on **EmailAddress** when using limit/offset.
 
-## <a name='release-2017-02-21'>Release date: February 21st, 2017</a>
+## <a name='release-2017-02-21'></a><a href='#release-2017-02-21'>February 21st, 2017</a>
 
 ### New Features
 * We added the **View App** and **Edit App** buttons. The **View App** button brings you to the deployment URL of your Free App, or, if you have test, acceptance, and production environments, it lets you choose between these environments using a drop-down menu. The **Edit App** button will launch the Desktop Modeler if you have it installed; if you are part of the partner group testing the Web Modeler, then you'll have the choice to directly open your app in the WM.
@@ -45,44 +45,44 @@ space: "Release Notes"
 * We fixed the **Team** overview flickering every few seconds that occurred after you create a new app.
 * We fixed the screen jumping at every key-press that occurred while you were writing a large post on the Buzz.
 
-## <a name='release-2017-02-20'>Release date: February 20th, 2017</a>
+## <a name='release-2017-02-20'></a><a href='#release-2017-02-20'>February 20th, 2017</a>
 
 * We removed static information from the log lines in Mendix Cloud v3. Every line before contained `tr10000` and `127.0.0.1`. We removed these fields as they were useless.
 
-## <a name='release-2016-10-05'>Release date: October 5th, 2016</a>
+## <a name='release-2016-10-05'></a><a href='#release-2016-10-05'>October 5th, 2016</a>
 
 * On Webkit-based browsers such as Safari a "connection error" dialog would sometimes pop up while loading the Dev Portal, after which the page would continue to load normally. We now prevent this dialog from appearing so that people can open the Dev Portal uninterrupted.
 
-## <a name='release-2016-05-12'>Release date: May 12th, 2016</a>
+## <a name='release-2016-05-12'></a><a href='#release-2016-05-12'>May 12th, 2016</a>
 
 * The colors and styling of the Development Portal have been brought in line with the rest of the platform.
 
-## <a name='release-2016-03-24'>Release date: March 4th, 2016</a>
+## <a name='release-2016-03-24'></a><a href='#release-2016-03-24'>March 4th, 2016</a>
 
 * Fixed the Invite API - it is again possible to invite other users to your app using a custom invitation flow.
 
-## <a name='release-2016-02-18'>Release date: February 8th, 2016</a>
+## <a name='release-2016-02-18'></a><a href='#release-2016-02-18'>February 8th, 2016</a>
 
 * Advanced Runtime Settings can now be configured for the paid tiers in Mendix Cloud applications. You can find a list of all custom settings here: [Custom Settings](/refguide6/custom-settings)
 * The advanced settings LogMinDurationQuery and ClientQueryTimeout have been enabled by default. LogMinDurationQuery will print all database queries that take longer than 10 seconds to the application log and ClientQueryTimeout will cancel database select queries triggered from the Client that take longer than 15 minutes, which is when the http timeout has kicked in so the results can not be delivered and the query can safely be killed. A restart of the application is required for these changes to take effect.
 
-## <a name='release-2016-01-13'>Release date: January 13th, 2016</a>
+## <a name='release-2016-01-13'></a><a href='#release-2016-01-13'>January 13th, 2016</a>
 
 * The Technical Contact of an application can now assign other people as the Technical Contact using the Node Security tab in the Project Settings on [https://home.mendix.com/](https://home.mendix.com/).
 
-## <a name='release-2015-12-01'>Release date: December 1st, 2015</a>
+## <a name='release-2015-12-01'></a><a href='#release-2015-12-01'>December 1st, 2015</a>
 
 ### Bug fixes
 * The Mendix Cloud switched from the Jetty blocking I/O connector to a selector based non-blocking I/O connector for all applications. Due to a bug in the blocking I/O connector HTTP requests could be fired multiple times for long-running (> 2 minutes) requests, which would result in strange results in the Mendix Debugger (ticket 462699). If you want to apply this fix you can simply restart your application.
 * Fixed bug that occurs when a which contains a large SVN directory is exposed into an Online Working Copy using Mendix Platform SDK.
 
-## <a name='release-2015-11-30'>Release date: November 30th, 2015</a>
+## <a name='release-2015-11-30'></a><a href='#release-2015-11-30'>November 30th, 2015</a>
 
 ### Improvements
 * The story details page now provides more context, by showing comments, tasks and feedback when applicable.
 * It is now easier to swap the priority of stories, using the arrow buttons at the left of each story and task.
 
-## <a name='release-2015-10-16'>Release date: October 16th, 2015</a>
+## <a name='release-2015-10-16'></a><a href='#release-2015-10-16'>October 16th, 2015</a>
 
 ### Improvements
 * Document links in comments will now open in a new tab, preventing loss of context. 
@@ -92,12 +92,12 @@ space: "Release Notes"
 * Fixed issue which hid the tooltip explaining password requirements in the password reset screen.
 * Fixed issue causing some messages on the Buzz to be rendered twice when clicking 'Show more'.
 
-## <a name='release-2015-09-17'>Release date: September 17th, 2015</a>
+## <a name='release-2015-09-17'></a><a href='#release-2015-09-17'>September 17th, 2015</a>
 
 ### Bug fixes
 * Fixed issue which caused collapsed/expanded state of sprints and stories to be forgotten when switching between the stories overview of a project and a story's details page.
 
-## <a name='release-2015-09-03'>Release date: September 3rd, 2015</a>
+## <a name='release-2015-09-03'></a><a href='#release-2015-09-03'>September 3rd, 2015</a>
 
 ### New features
 * All expanded items in the backlog can be collapsed at once, by using either the new 'Collapse All' button in the toolbar or the keyboard shortcut <ctrl+space>.
@@ -110,12 +110,12 @@ space: "Release Notes"
 ### Bug fix
 * Removed the unnecessary confirmation popup at the end of the sign up process.
 
-## <a name='release-2015-08-06'>Release date: August 6th, 2015</a>
+## <a name='release-2015-08-06'></a><a href='#release-2015-08-06'>August 6th, 2015</a>
 
 ### New feature
 * We have rolled out our new project creation flow to all users. When creating a new project from the Portal, you are presented with a set of themes and sample apps that you can use as a basis for your new application.
 
-## <a name='release-2015-07-31'>Release date: July 31st, 2015</a>
+## <a name='release-2015-07-31'></a><a href='#release-2015-07-31'>July 31st, 2015</a>
 
 ### Improvement
 * Improved project creation performance. Users will now quickly navigate to the project homepage, with the project's Team Server repository being set up in the background.
@@ -123,7 +123,7 @@ space: "Release Notes"
 ### Bug fix
 * Added limits to search input fields in a number of pages.
 
-## <a name='release-2015-07-24'>Release date: July 24th, 2015</a>
+## <a name='release-2015-07-24'></a><a href='#release-2015-07-24'>July 24th, 2015</a>
 
 ### New functionality
 * The status of stories and tasks can now be changed from the story details page
@@ -131,33 +131,33 @@ space: "Release Notes"
 ### Bug fix
 * Clicking on feedback items on your profile brings you to the proper details page
 
-## <a name='release-2015-07-16'>Release date: July 16th, 2015</a>
+## <a name='release-2015-07-16'></a><a href='#release-2015-07-16'>July 16th, 2015</a>
 
 * Various small fixes
 
-## <a name='release-2015-07-03'>Release date: July 3rd, 2015</a>
+## <a name='release-2015-07-03'></a><a href='#release-2015-07-03'>July 3rd, 2015</a>
 
 * Improved project creation performance. Creating a new project will now take several seconds less than before.
 
-## <a name='release-2015-06-16'>Release date: June 16th, 2015</a>
+## <a name='release-2015-06-16'></a><a href='#release-2015-06-16'>June 16th, 2015</a>
 
 * Fixed an issue where in certain cases the input element was not focusable in Internet Explorer, after submitting feedback with the feedback widget  (Ticket #278349)
 
-## <a name='release-2015-06-02'>Release date: June 2nd, 2015</a>
+## <a name='release-2015-06-02'></a><a href='#release-2015-06-02'>June 2nd, 2015</a>
 
 * Various small improvements
 
-## <a name='release-2015-05-29'>Release date: May 29th, 2015</a>
+## <a name='release-2015-05-29'></a><a href='#release-2015-05-29'>May 29th, 2015</a>
 
 ### Fixes
 * Some users experienced stability issues when filtering projects on the Buzz. These issues has now been resolved.
 * Several small fixes related to the UI and stability of Sprintr
 
-## <a name='release-2015-04-21'>Release date: April 21st, 2015</a>
+## <a name='release-2015-04-21'></a><a href='#release-2015-04-21'>April 21st, 2015</a>
 
 * Fixed [home.mendix.com](https://home.mendix.com/) stability issue.
 
-## <a name='release-2015-04-16'>Release date: April 16th, 2015</a>
+## <a name='release-2015-04-16'></a><a href='#release-2015-04-16'>April 16th, 2015</a>
 
 ### Improvement
 * Added guidance to the Develop page
@@ -168,7 +168,7 @@ space: "Release Notes"
 * Various performance fixes
 * Various styling fixes
 
-## <a name='release-2015-03-31'>Release date: March 31st, 2015</a>
+## <a name='release-2015-03-31'></a><a href='#release-2015-03-31'>March 31st, 2015</a>
 
 ### New features
 * The blue toolbar now contains a button for quickly creating new apps, and a shortcut that leads to the Mendix Developer Portal ([https://developers.mendix.com/](https://developers.mendix.com/)).
@@ -181,21 +181,21 @@ space: "Release Notes"
 * Several UI improvements, including a new navigation sidebar and a revised Projects page.
 * Story / task detail pages contain buttons to quickly navigate back and forth between all stories / tasks within the same context.
 
-## <a name='release-2015-02-26'>Release date: February 26th, 2015</a>
+## <a name='release-2015-02-26'></a><a href='#release-2015-02-26'>February 26th, 2015</a>
 
 ### Improvements
 * Searching for a term on the Capture page no longer causes spaces to be added within the results list.
 * Various small UX fixes.
 
-## <a name='release-2015-02-19'>Release date: February 19th, 2015</a>
+## <a name='release-2015-02-19'></a><a href='#release-2015-02-19'>February 19th, 2015</a>
 
 * Various small improvements
 
-## <a name='release-2015-02-05'>Release date: February 5th, 2015</a>
+## <a name='release-2015-02-05'></a><a href='#release-2015-02-05'>February 5th, 2015</a>
 
 * Various small user interface improvements
 
-## <a name='release-2015-01-22'>Release date: January 22nd, 2015</a>
+## <a name='release-2015-01-22'></a><a href='#release-2015-01-22'>January 22nd, 2015</a>
 
 ### Improvement
 * Numerous small user interface improvements
@@ -203,13 +203,13 @@ space: "Release Notes"
 ### New feature
 * For deployment, a new graph was introduced: JVM Process memory usage (read more about this here: [https://tech.mendix.com/linux/2015/01/14/whats-in-my-jvm-memory/](https://tech.mendix.com/linux/2015/01/14/whats-in-my-jvm-memory/))
 
-## <a name='release-2014-12-30'>Release date: December 30th, 2014</a>
+## <a name='release-2014-12-30'></a><a href='#release-2014-12-30'>December 30th, 2014</a>
 
 ### Improvements
 * The loading time of the Deploy tab of a project has been decreased dramatically.
 * The "Create package from teamserver" button is now always visible. Previously it was only visible for projects that are on Mendix 5, but as most users are on Mendix 5 we dropped this restriction. Users that are not on Mendix 5 or do not have data in their Teamserver repository will be shown a pop up message stating that the feature is only available after an upgrade.
 
-## <a name='release-2014-12-23'>Release date: December 23rd, 2014</a>
+## <a name='release-2014-12-23'></a><a href='#release-2014-12-23'>December 23rd, 2014</a>
 
 ### New features
 * It's now possible to move a user story to a different project from the Story details page. 


### PR DESCRIPTION
The anchors now have two <a> tags, one for the anchor itself,
and the other so that you have a clickable link which you can
copy and share.

Also removed the duplicate "Release date:" in every title because that is a given here.