### PR TITLE
Add release notes about document generation and string columns in databases.

### DIFF
--- a/releasenotes/desktop-modeler/4.8.md
+++ b/releasenotes/desktop-modeler/4.8.md
@@ -13,8 +13,9 @@ parent: "4"
 ### Fixes
 
 * The mobile client now runs on iOS 10. (Ticket 45041)
-* Fix XHTML rendering error on templates for document generator. (Ticket 253401)
-* Prevent data truncation when changing existing string attributes with a fixed length to unlimited. (Ticket 257984)  
+* Fixed XHTML rendering error on templates for document generator. (Ticket 253401)
+* Preventing data truncation when changing existing string attributes with a fixed length to unlimited. (Ticket 257984)
+
 There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data. This problem is fixed in Oracle 11.2.0.4. See https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8 and http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2.
 
 ## 4.8.10

--- a/releasenotes/desktop-modeler/4.8.md
+++ b/releasenotes/desktop-modeler/4.8.md
@@ -13,6 +13,9 @@ parent: "4"
 ### Fixes
 
 * The mobile client now runs on iOS 10. (Ticket 45041)
+* Fix XHTML rendering error on templates for document generator. (Ticket 253401)
+* Prevent data truncation when changing existing string attributes with a fixed length to unlimited. (Ticket 257984)  
+There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data. This problem is fixed in Oracle 11.2.0.4. See https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8 and http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2.
 
 ## 4.8.10
 


### PR DESCRIPTION
The document generator error was fixed in Mendix 5 since 5.21.
The 'data truncation bug' was fixed in Mendix 5 since 5.16.