### PR TITLE
unlink sandbox -> download a backup, not create

### DIFF
--- a/howtogeneral/mendixcloud/how-to-unlink-sandbox.md
+++ b/howtogeneral/mendixcloud/how-to-unlink-sandbox.md
@@ -23,7 +23,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 <div class="alert alert-warning">{% markdown %}
 
-Please note that because you are going to unlink the Sandbox from your Free App, the Sandbox environment will be permanently deleted. This means that all data will be lost from the Sandbox/Free App. To keep your data, you need to create a backup.
+Please note that because you are going to unlink the Sandbox from your Free App, the Sandbox environment will be permanently deleted. This means that all data will be lost from the Sandbox/Free App. To keep your data, you need to download a backup.
 
 {% endmarkdown %}</div>
 


### PR DESCRIPTION
Currently the text says to create a backup, but that's not possible for Free Apps. Also, the most important issue is that the backup is downloaded locally, because once you permanently delete the Free App, the backups will be gone too..