### PR TITLE
Document navigation profiles in Mendix 7.2

### DIFF
--- a/refguide7/desktop-profile.md
+++ b/refguide7/desktop-profile.md
@@ -2,7 +2,7 @@
 title: "Desktop Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes the Desktop profile, which is the default profile used by a Mendix app."
+description: "Describes the Desktop profile, which is the default profile used by a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/desktop-profile.md
+++ b/refguide7/desktop-profile.md
@@ -7,7 +7,7 @@ description: "Describes the Desktop profile, which is the default profile used b
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/desktop-profile.md
+++ b/refguide7/desktop-profile.md
@@ -1,8 +1,15 @@
 ---
-title: "Desktop profile"
+title: "Desktop Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
+
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+
+{% endmarkdown %}</div>
+
 The Desktop profile is the default profile used by a Mendix application. It cannot be disabled and if all other profiles are disabled all device types will automatically redirect to Desktop. 
 
 {% snippet Profile+properties.md %}

--- a/refguide7/desktop-profile.md
+++ b/refguide7/desktop-profile.md
@@ -2,11 +2,12 @@
 title: "Desktop Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+description: "Describes the Desktop profile, which is the default profile used by a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/hybrid-phone-profile.md
+++ b/refguide7/hybrid-phone-profile.md
@@ -7,7 +7,7 @@ description: "Describes usage of the Hybrid Phone profile in a Mendix app."
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/hybrid-phone-profile.md
+++ b/refguide7/hybrid-phone-profile.md
@@ -2,11 +2,12 @@
 title: "Hybrid Phone Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+description: "Describes usage of the Hybrid Phone profile in a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/hybrid-phone-profile.md
+++ b/refguide7/hybrid-phone-profile.md
@@ -1,9 +1,14 @@
 ---
 title: "Hybrid Phone Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
 
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+
+{% endmarkdown %}</div>
 
 When the Hybrid Phone profile is enabled, users who accesses the Mendix application from a PhoneGap hybrid application running on a phone device will automatically be redirected to this profile. If the Hybrid Phone profile is disabled, phone users will be redirected to the [Hybrid Tablet Profile](hybrid-tablet-profile). If there is no Hybrid Tablet profile, users will be redirected to the [Desktop Profile](desktop-profile).
 

--- a/refguide7/hybrid-phone-profile.md
+++ b/refguide7/hybrid-phone-profile.md
@@ -2,7 +2,7 @@
 title: "Hybrid Phone Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes usage of the Hybrid Phone profile in a Mendix app."
+description: "Describes usage of the Hybrid Phone profile in a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/hybrid-tablet-profile.md
+++ b/refguide7/hybrid-tablet-profile.md
@@ -2,7 +2,7 @@
 title: "Hybrid Tablet Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes usage of the Hybrid Tablet profile in a Mendix app."
+description: "Describes usage of the Hybrid Tablet profile in a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/hybrid-tablet-profile.md
+++ b/refguide7/hybrid-tablet-profile.md
@@ -7,7 +7,7 @@ description: "Describes usage of the Hybrid Tablet profile in a Mendix app."
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/hybrid-tablet-profile.md
+++ b/refguide7/hybrid-tablet-profile.md
@@ -1,9 +1,14 @@
 ---
 title: "Hybrid Tablet Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
 
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+
+{% endmarkdown %}</div>
 
 When the Hybrid Tablet profile is enabled, every user that accesses the Mendix application from a PhoneGap hybrid application running on a tablet device will automatically be redirected to this profile. If the Hybrid Tablet profile is disabled, tablet users will be redirected to the [Hybrid Phone Profile](hybrid-phone-profile). If the Hybrid Phone profile is disabled, users will be redirected to the [Desktop Profile](desktop-profile).
 

--- a/refguide7/hybrid-tablet-profile.md
+++ b/refguide7/hybrid-tablet-profile.md
@@ -2,11 +2,12 @@
 title: "Hybrid Tablet Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+description: "Describes usage of the Hybrid Tablet profile in a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+For Mendix 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -37,8 +37,8 @@ Mendix Runtime automatically redirects users to the home page of the appropriate
 
 | User-Agent String Regular Expression | Device Type |
 | --- | --- |
-| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
-| Android|iPad | Tablet |
+| Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry | Phone |
+| Android&#124;iPad | Tablet |
 | _(other)_ | Desktop |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -1,0 +1,58 @@
+---
+title: "Navigation before 7.2"
+space: "Mendix 7 Reference Guide"
+parent: "project"
+---
+
+
+<div class="alert alert-info">{% markdown %}
+
+This document describes the concept of navigation in Mendix applications and the properties of a profile. For Mendix 7.2 or higher,
+see [Navigation](navigation).
+
+{% endmarkdown %}</div>
+
+The Navigation document defines the navigation structure of the application for users. It allows you to set the home page of your application as well as define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
+
+## Profiles
+
+At the heart of the navigation model in Mendix are four navigation profiles: Desktop, Tablet, Phone and Offline device. You can define separate home pages and menus for each of these profiles. The Desktop profile is always enabled, while Tablet, Phone, and Offline device can be disabled if you do not want to use them. Users that access the application via a particular device type are automatically redirected to the home page of the appropriate profile (see Redirection to profiles below).
+
+<div class="alert alert-info">{% markdown %}
+
+In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, called the [Hybrid Tablet profile](hybrid-tablet-profile). All settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
+
+{% endmarkdown %}</div>
+
+The device type of the currently logged-in user is available in [microflows](microflows) as the variable `$currentDeviceType`. The type of this variable is [enumeration](enumerations) 'System.DeviceType', which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
+
+## Hybrid Profiles
+
+The Hybrid Tablet and Hybrid Phone profiles are different from the other profiles in that they do more than simply redirect users based on the their device type. These profiles are designed to allow users to continue using their Mendix application even when they have no Internet connection, though certain restrictions apply. An overview of the ramifications of running an offline device profile can be found on the [Offline](offline) page. 
+
+## Redirection to Profiles
+
+The Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
+
+| User-Agent String Regular Expression | Device Type |
+| --- | --- |
+| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
+| Android|iPad | Tablet |
+| _(other)_ | Desktop |
+
+To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
+
+If a profile is not enabled, it falls back to another device type as shown in the following table:
+
+| Device Type | Fallback |
+| --- | --- |
+| Phone | Tablet, Desktop |
+| Tablet | Phone, Desktop |
+| Desktop | None, Desktop is always enabled |
+
+It is also possible to force the client to use a specific profile by adding a *profile* query string parameter to the URL when visiting a Mendix application. The possible values are Desktop, Tablet, and Phone. For example:
+
+```html
+https://myapp.mendixcloud.com/index.html?profile=Phone
+
+```

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -1,48 +1,49 @@
 ---
-title: "Navigation before 7.2"
+title: "Navigation Before Mendix Version 7.2"
 space: "Mendix 7 Reference Guide"
 parent: "project"
+description: "Describes the concept of navigation in apps and the properties of a profile for Mendix versions up to and including 7.1."
 ---
 
+## 1 Introduction
 
 <div class="alert alert-info">{% markdown %}
 
-This document describes the concept of navigation in Mendix applications and the properties of a profile. For Mendix 7.2 or higher,
-see [Navigation](navigation).
+This document describes the concept of navigation in Mendix applications and the properties of a profile. For details on how this works in Mendix version 7.2 and higher, see [Navigation](navigation).
 
 {% endmarkdown %}</div>
 
-The Navigation document defines the navigation structure of the application for users. It allows you to set the home page of your application as well as define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
+The Navigation document defines the navigation structure of the application for users. It allows you to set the home page of your application as well as to define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
 
-## Profiles
+## 2 Profiles
 
-At the heart of the navigation model in Mendix are four navigation profiles: Desktop, Tablet, Phone and Offline device. You can define separate home pages and menus for each of these profiles. The Desktop profile is always enabled, while Tablet, Phone, and Offline device can be disabled if you do not want to use them. Users that access the application via a particular device type are automatically redirected to the home page of the appropriate profile (see Redirection to profiles below).
+At the heart of the navigation model in Mendix are four navigation profiles: Desktop, Tablet, Phone, and Offline device. You can define separate home pages and menus for each of these profiles. The Desktop profile is always enabled, while Tablet, Phone, and Offline device can be disabled if you do not want to use them. Users that access the application via a particular device type are automatically redirected to the home page of the appropriate profile (for details, see [4 Redirection to Profiles](#Redirection)).
 
 <div class="alert alert-info">{% markdown %}
 
-In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, called the [Hybrid Tablet profile](hybrid-tablet-profile). All settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
+In Mendix 7.0.2, the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, called the [Hybrid Tablet profile](hybrid-tablet-profile). All settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
 
 {% endmarkdown %}</div>
 
-The device type of the currently logged-in user is available in [microflows](microflows) as the variable `$currentDeviceType`. The type of this variable is [enumeration](enumerations) 'System.DeviceType', which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
+The device type of a currently logged-in user is available in [microflows](microflows) as the `$currentDeviceType` variable. The type of this variable is the [enumeration](enumerations) `System.DeviceType`, which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
 
-## Hybrid Profiles
+## 3 Hybrid Profiles
 
-The Hybrid Tablet and Hybrid Phone profiles are different from the other profiles in that they do more than simply redirect users based on the their device type. These profiles are designed to allow users to continue using their Mendix application even when they have no Internet connection, though certain restrictions apply. An overview of the ramifications of running an offline device profile can be found on the [Offline](offline) page. 
+The Hybrid Tablet and Hybrid Phone profiles are different from the other profiles in that they do more than simply redirect users based on their device type. These profiles are designed to allow users to continue using their Mendix application even when they have no Internet connection, though certain restrictions apply. For an overview of the ramifications of running an offline device profile, see [Offline](offline).
 
-## Redirection to Profiles
+## 4 Redirection to Profiles<a name="Redirection"></a>
 
-The Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
+Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
 
 | User-Agent String Regular Expression | Device Type |
 | --- | --- |
-| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
-| Android|iPad | Tablet |
+| `Android.*Mobile`|iPhone, iPod, BlackBerry Phone |
+| `Android` |iPad Tablet |
 | _(other)_ | Desktop |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
 
-If a profile is not enabled, it falls back to another device type as shown in the following table:
+If a profile is not enabled, it falls back to another device type as shown in this table:
 
 | Device Type | Fallback |
 | --- | --- |
@@ -50,7 +51,7 @@ If a profile is not enabled, it falls back to another device type as shown in th
 | Tablet | Phone, Desktop |
 | Desktop | None, Desktop is always enabled |
 
-It is also possible to force the client to use a specific profile by adding a *profile* query string parameter to the URL when visiting a Mendix application. The possible values are Desktop, Tablet, and Phone. For example:
+It is also possible to force the client to use a specific profile by adding a `profile` query string parameter to the URL when visiting a Mendix application. The possible values are `Desktop`, `Tablet`, and `Phone`. For example:
 
 ```html
 https://myapp.mendixcloud.com/index.html?profile=Phone

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -35,11 +35,11 @@ The Hybrid Tablet and Hybrid Phone profiles are different from the other profile
 
 Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
 
-| User-Agent String Regular Expression | Device Type |
-| --- | --- |
-| `Android.*Mobile`|iPhone, iPod, BlackBerry Phone |
-| `Android` |iPad Tablet |
-| _(other)_ | Desktop |
++| User-Agent String Regular Expression | Device Type |
++| --- | --- |
++| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
++| Android|iPad | Tablet |
++| _(other)_ | Desktop |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
 

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -25,7 +25,7 @@ In Mendix 7.0.2, the Offline device profile is replaced by the [Hybrid Phone pro
 
 {% endmarkdown %}</div>
 
-The device type of a currently logged-in user is available in [microflows](microflows) as the `$currentDeviceType` variable. The type of this variable is the [enumeration](enumerations) `System.DeviceType`, which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
+The device type of a currently logged-in user is available in [microflows](microflows) as the `$currentDeviceType` variable. The type of this variable is the [enumeration](enumerations) `System.DeviceType`, which has the values `Phone`, `Tablet`, and `Desktop`. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
 
 ## 3 Hybrid Profiles
 

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -2,7 +2,7 @@
 title: "Navigation Before Mendix Version 7.2"
 space: "Mendix 7 Reference Guide"
 parent: "project"
-description: "Describes the concept of navigation in apps and the properties of a profile for Mendix versions up to and including 7.1."
+description: "Describes the concept of navigation in apps and the properties of a profile for Mendix versions 7.0 and 7.1."
 ---
 
 ## 1 Introduction

--- a/refguide7/navigation-before-72.md
+++ b/refguide7/navigation-before-72.md
@@ -35,11 +35,11 @@ The Hybrid Tablet and Hybrid Phone profiles are different from the other profile
 
 Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
 
-+| User-Agent String Regular Expression | Device Type |
-+| --- | --- |
-+| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
-+| Android|iPad | Tablet |
-+| _(other)_ | Desktop |
+| User-Agent String Regular Expression | Device Type |
+| --- | --- |
+| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
+| Android|iPad | Tablet |
+| _(other)_ | Desktop |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
 

--- a/refguide7/navigation-profile.md
+++ b/refguide7/navigation-profile.md
@@ -1,0 +1,69 @@
+---
+title: "Navigation Profile"
+space: "Mendix 7 Reference Guide"
+parent: "navigation"
+---
+
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.0 and 7.1 see [Navigation](navigation-before-72).
+
+{% endmarkdown %}</div>
+
+## Profile Properties
+
+### General
+
+**Profile name**
+
+Name to uniquely identify a profile. [Menu widgets](menu-widgets) using the menu of a profile refer to this name.
+
+**Application Title**
+
+Specify the application title. This title is shown in the title bar of the browser.
+
+### Home Pages
+
+**Default Home Page**
+
+The default home page indicates which [page](page) or [microflow](microflow) is opened after a user has signs in. If role-based home pages (see below) are specified for one of the [user roles](user-roles) of the user, then that home page will be used instead.
+
+**Role-based Home Pages**
+
+By using role-based home pages you can show different home pages for different users. If a user logs in, the first role-based home page of which the user role matches a user role of the user is displayed. If no match is found, the default home page is used.
+
+Per role-based home page you can specify the user role it applies to and the target (page or microflow) that will be opened.
+
+### Authentication
+
+If an [anonymous user](anonymous-users) tries to access a resource to which the user has no access, the configured [sign-in page](authentication-widgets) will be displayed, prompting the user to sign in.
+
+If the sign-in page is set to none, a built-in pop-up window will appear instead. The page title may be overridden and is translatable.
+
+### Menu
+
+Each device type contains a default menu. You can use these menus in [menu widgets](menu-widgets). Defining the menu for a device type works in the same way as when editing a menu document.
+
+See [Menu](menu).
+
+<div class="alert alert-warning">{% markdown %}
+
+If [security](project-security) is enabled, the menu will only show items that the user has access to.
+
+{% endmarkdown %}</div>
+
+## Profile Buttons
+
+### Add
+
+Allows adding new profiles. The profile name and profile kind can be provided. 
+
+The checkbox "Copy settings from profile 'Profile'" allows creating a duplicate of the current profile. It copies over all settings except the profile name and profile kind.
+
+### Change kind
+
+Allows changing the [profile kind](navigation).
+
+### Delete
+
+Deletes the profile. If [menu widgets](menu-widgets) are still referring to the profile errors will appear. It is possible to undo the deletion of a profile.

--- a/refguide7/navigation-profile.md
+++ b/refguide7/navigation-profile.md
@@ -2,68 +2,67 @@
 title: "Navigation Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation"
+description: "Describes the profile properties and profile buttons for Mendix version 7.2 and higher."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.0 and 7.1 see [Navigation](navigation-before-72).
+For details on how this works in Mendix versions 7.0 and 7.1, see [Navigation Before Mendix Version 7.2](navigation-before-72).
 
 {% endmarkdown %}</div>
 
-## Profile Properties
+## 1 Profile Properties
 
-### General
+### 1.1 General
 
 **Profile name**
 
-Name to uniquely identify a profile. [Menu widgets](menu-widgets) using the menu of a profile refer to this name.
+The name to uniquely identify a profile. [Menu widgets](menu-widgets) using the menu of a profile refer to this name.
 
 **Application Title**
 
-Specify the application title. This title is shown in the title bar of the browser.
+Specifies the application title. This title is shown in the title bar of the browser.
 
-### Home Pages
+### 1.2 Home Pages
 
 **Default Home Page**
 
-The default home page indicates which [page](page) or [microflow](microflow) is opened after a user has signs in. If role-based home pages (see below) are specified for one of the [user roles](user-roles) of the user, then that home page will be used instead.
+The default home page indicates which [page](page) or [microflow](microflow) is opened after a user signs in. If role-based home pages (see below) are specified for one of the [user roles](user-roles) of the user, then that home page will be used instead.
 
-**Role-based Home Pages**
+**Role-Based Home Pages**
 
-By using role-based home pages you can show different home pages for different users. If a user logs in, the first role-based home page of which the user role matches a user role of the user is displayed. If no match is found, the default home page is used.
+By using role-based home pages, you can show different home pages for different users. If a user logs in, the first role-based home page of which the user role matches the user role of the user is displayed. If no match is found, the default home page is used.
 
-Per role-based home page you can specify the user role it applies to and the target (page or microflow) that will be opened.
+For each role-based home page, you can specify the user role it applies to and the target (page or microflow) that will be opened.
 
-### Authentication
+### 1.3 Authentication
 
 If an [anonymous user](anonymous-users) tries to access a resource to which the user has no access, the configured [sign-in page](authentication-widgets) will be displayed, prompting the user to sign in.
 
-If the sign-in page is set to none, a built-in pop-up window will appear instead. The page title may be overridden and is translatable.
+If the sign-in page is set to none, a built-in pop-up window will appear instead. The page title is translatable and may be overridden.
 
-### Menu
+### 1.4 Menu
 
-Each device type contains a default menu. You can use these menus in [menu widgets](menu-widgets). Defining the menu for a device type works in the same way as when editing a menu document.
-
-See [Menu](menu).
+Each device type contains a default menu. You can use these menus in [menu widgets](menu-widgets). Defining the menu for a device type works the same as when editing a menu document. For more details, see [Menu](menu).
 
 <div class="alert alert-warning">{% markdown %}
 
-If [security](project-security) is enabled, the menu will only show items that the user has access to.
+If [security](project-security) is enabled, the menu will only show the items to which the user has access.
 
 {% endmarkdown %}</div>
 
-## Profile Buttons
+## 2 Profile Buttons
 
-### Add
+### 2.1 Add
 
-Allows adding new profiles. The profile name and profile kind can be provided. 
+Allows for adding new profiles. The profile name and profile kind can be provided. 
 
-The checkbox "Copy settings from profile 'Profile'" allows creating a duplicate of the current profile. It copies over all settings except the profile name and profile kind.
+The **Copy settings from profile 'Profile'** check box enables creating a duplicate of the current profile. It copies over all the settings except the profile name and profile kind.
 
-### Change kind
+### 2.2 Change Kind
 
-Allows changing the [profile kind](navigation).
+Allows for changing the [profile kind](navigation).
 
-### Delete
+### 2.3 Delete
 
-Deletes the profile. If [menu widgets](menu-widgets) are still referring to the profile errors will appear. It is possible to undo the deletion of a profile.
+Deletes the profile. If [menu widgets](menu-widgets) are still referring to the profile, errors will appear. It is possible to undo the deletion of a profile.

--- a/refguide7/navigation.md
+++ b/refguide7/navigation.md
@@ -2,7 +2,7 @@
 title: "Navigation"
 space: "Mendix 7 Reference Guide"
 parent: "project"
-description: "
+description: "Describes the concept of navigation in apps and the properties of a profile for Mendix version 7.2 and higher."
 ---
 
 ## 1 Introduction

--- a/refguide7/navigation.md
+++ b/refguide7/navigation.md
@@ -2,68 +2,68 @@
 title: "Navigation"
 space: "Mendix 7 Reference Guide"
 parent: "project"
+description: "
 ---
 
+## 1 Introduction
 
 <div class="alert alert-info">{% markdown %}
 
-This document describes the concept of navigation in Mendix applications and the properties of a profile.
-
-In Mendix 7.2.0 the profiles have received an update. Documentation for Mendix 7.0 and 7.1 is [here](navigation-before-72).
+This document describes the concept of navigation in Mendix applications and the properties of a profile. In Mendix 7.2.0, the profiles have received an update. For details on how this works in Mendix versions 7.0 and 7.1, see [Navigation Before Mendix Version 7.2](navigation-before-72).
 
 {% endmarkdown %}</div>
 
-The Navigation document can be found by expanding the Project node in the Project Explorer. It defines the navigation structure of the application for users. It allows you to set the home page of your application as well as define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
+The Navigation document can be found by expanding the Project node in the Project Explorer. It defines the navigation structure of the application for users. It allows you to set the home page of your application and to define the menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [user roles](user-roles).
 
-## Profiles
+## 2 Profiles
 
-At the heart of the navigation model in Mendix there are five different kinds of profiles: Responsive, Tablet (browser), Phone (browser), Hybrid app and Hybrid offline app. Users that access the app via a particular device type are automatically redirected to the homepage of the appropriate profile based on the profile kind (see Redirection to profiles below).
+At the heart of the navigation model in Mendix, there are five kinds of profiles: Responsive, Tablet (browser), Phone (browser), Hybrid app, and Hybrid offline app. Users that access the app via a particular device type are automatically redirected to the homepage of the appropriate profile based on the profile kind (for details, see [3 Redirection to Profiles](#Redirection)).
 
 <div class="alert alert-info">{% markdown %}
 
-In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, called the [Hybrid Tablet profile](hybrid-tablet-profile). All settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
+As of Mendix 7.0.2, the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, which is called the [Hybrid Tablet profile](hybrid-tablet-profile). All the settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
 
-In Mendix 7.2.0 the Hybrid Tablet and Hybrid Phone profiles are converted to profiles of kind Hybrid app or Hybrid offline app, based on the offline enabled option.
+In Mendix 7.2.0, the Hybrid Tablet and Hybrid Phone profiles are converted to profiles of the Hybrid app or Hybrid offline app type, based on the offline enabled option.
 
 {% endmarkdown %}</div>
 
-The device type of the currently logged-in user is available in [microflows](microflows) as the variable `$currentDeviceType`. The type of this variable is [enumeration](enumerations) 'System.DeviceType', which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
+The device type of the currently logged-in user is available in [microflows](microflows) as the `$currentDeviceType` variable. The type of this variable is the [enumeration](enumerations) `System.DeviceType`, which has the values `Phone`, `Tablet`, and `Desktop`. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
 
-### Responsive
+### 2.1 Responsive
 
-Every app always has one profile of kind Responsive which cannot be deleted. It is the default profile used by a Mendix app.
+Every app always has one profile of a Responsive type which cannot be deleted. This is the default profile used by a Mendix app.
 
-### Tablet (browser)
+### 2.2 Tablet (Browser)
 
-All users accessing the Mendix app from a browser on a tablet will automatically be redirected to a profile of kind Tablet. If no profile exists of that kind, the user will be redirected to the Responsive profile. Only one profile of kind Tablet (browser) may exist.
+All the users accessing the Mendix app from a browser on a tablet will automatically be redirected to a profile of the Tablet type. If no profile exists of that type, the user will be redirected to the Responsive profile. Only one profile of the Tablet (browser) type may exist.
 
-### Phone (browser)
+### 2.3 Phone (Browser)
 
-All users accessing the Mendix app from a browser on a phone will automatically be redirected to a profile of kind Tablet. If no profile exists of that kind, the user will be redirected to the Responsive profile. Only one profile of kind Phone (browser) may exist.
+All the users accessing the Mendix app from a browser on a phone will automatically be redirected to a profile of the Phone type. If no profile exists of that type, the user will be redirected to the Responsive profile. Only one profile of the Phone (browser) type may exist.
 
-### Hybrid app
+### 2.4 Hybrid App
 
-The Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the kind Hybrid app can be accessed from such a PhoneGap app. Hybrid app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
+A Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the Hybrid app type can be accessed from such a PhoneGap app. Hybrid app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
 
-### Hybrid offline app
+### 2.5 Hybrid Offline App
 
-The Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the kind Hybrid offline app can be accessed from such a PhoneGap app. Hybrid offline app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
+The Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the Hybrid offline app type can be accessed from such a PhoneGap app. Hybrid offline app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
 
-Hybrid offline apps are designed to allow users to continue using their Mendix app even when they have no internet connection, though certain restrictions apply. An overview of the ramifications of running an offline device profile can be found on the [Offline](offline) page.
+Hybrid offline apps are designed to allow users to continue using their Mendix app even when they have no internet connection. However, certain restrictions apply. For an overview of the ramifications of running an offline device profile, see [Offline](offline).
 
-## Redirection to Profiles
+## 3 Redirection to Profiles<a name="Redirection"></a>
 
-The Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. Hybrid apps do not use this mechanism, but are referred to by name. The default configuration for this redirection is as follows:
+Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the `User-Agent` string that is sent by the device's browser. Hybrid apps do not use this mechanism, as they are referred to by name. The default configuration for this redirection is as follows:
 
 | User-Agent String Regular Expression | Device Type |
 | --- | --- |
-| Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry | Phone |
-| Android&#124;iPad | Tablet |
+| `Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry` | Phone |
+| `Android&#124;iPad` | Tablet |
 | _(other)_ | Responsive |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
 
-It is also possible to force the client to use a specific profile by adding a *profile* query string parameter to the URL when visiting a Mendix application. The possible values are the names of the profiles. For example:
+It is also possible to force the client to use a specific profile by adding a `profile` query string parameter to the URL when visiting a Mendix application. The possible values are the names of the profiles. For example:
 
 ```html
 https://myapp.mendixcloud.com/index.html?profile=Responsive

--- a/refguide7/navigation.md
+++ b/refguide7/navigation.md
@@ -9,49 +9,63 @@ parent: "project"
 
 This document describes the concept of navigation in Mendix applications and the properties of a profile.
 
+In Mendix 7.2.0 the profiles have received an update. Documentation for Mendix 7.0 and 7.1 is [here](navigation-before-72).
+
 {% endmarkdown %}</div>
 
-The Navigation document defines the navigation structure of the application for users. It allows you to set the home page of your application as well as define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
+The Navigation document can be found by expanding the Project node in the Project Explorer. It defines the navigation structure of the application for users. It allows you to set the home page of your application as well as define menu structures that can be used in [menu widgets](menu-widgets). A user's home page can vary based on their [roles](user-roles).
 
 ## Profiles
 
-At the heart of the navigation model in Mendix are four navigation profiles: Desktop, Tablet, Phone and Offline device. You can define separate home pages and menus for each of these profiles. The Desktop profile is always enabled, while Tablet, Phone, and Offline device can be disabled if you do not want to use them. Users that access the application via a particular device type are automatically redirected to the home page of the appropriate profile (see Redirection to profiles below).
+At the heart of the navigation model in Mendix there are five different kinds of profiles: Responsive, Tablet (browser), Phone (browser), Hybrid app and Hybrid offline app. Users that access the app via a particular device type are automatically redirected to the homepage of the appropriate profile based on the profile kind (see Redirection to profiles below).
 
 <div class="alert alert-info">{% markdown %}
 
 In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone profile](hybrid-phone-profile). In addition to this, a new device profile is now available, called the [Hybrid Tablet profile](hybrid-tablet-profile). All settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
 
+In Mendix 7.2.0 the Hybrid Tablet and Hybrid Phone profiles are converted to profiles of kind Hybrid app or Hybrid offline app, based on the offline enabled option.
+
 {% endmarkdown %}</div>
 
 The device type of the currently logged-in user is available in [microflows](microflows) as the variable `$currentDeviceType`. The type of this variable is [enumeration](enumerations) 'System.DeviceType', which has the values Phone, Tablet, and Desktop. You can use the `$currentDeviceType` variable to perform different actions based on the device type. A typical example is to show different pages based on the device type.
 
-## Hybrid Profiles
+### Responsive
 
-The Hybrid Tablet and Hybrid Phone profiles are different from the other profiles in that they do more than simply redirect users based on the their device type. These profiles are designed to allow users to continue using their Mendix application even when they have no Internet connection, though certain restrictions apply. An overview of the ramifications of running an offline device profile can be found on the [Offline](offline) page. 
+Every app always has one profile of kind Responsive which cannot be deleted. It is the default profile used by a Mendix app.
+
+### Tablet (browser)
+
+All users accessing the Mendix app from a browser on a tablet will automatically be redirected to a profile of kind Tablet. If no profile exists of that kind, the user will be redirected to the Responsive profile. Only one profile of kind Tablet (browser) may exist.
+
+### Phone (browser)
+
+All users accessing the Mendix app from a browser on a phone will automatically be redirected to a profile of kind Tablet. If no profile exists of that kind, the user will be redirected to the Responsive profile. Only one profile of kind Phone (browser) may exist.
+
+### Hybrid app
+
+The Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the kind Hybrid app can be accessed from such a PhoneGap app. Hybrid app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
+
+### Hybrid offline app
+
+The Mendix app can be installed on a tablet or phone as an app by creating a PhoneGap hybrid package. Profiles of the kind Hybrid offline app can be accessed from such a PhoneGap app. Hybrid offline app profiles are requested by profile name. If no profile exists with the requested name, an error will be displayed in the app.
+
+Hybrid offline apps are designed to allow users to continue using their Mendix app even when they have no internet connection, though certain restrictions apply. An overview of the ramifications of running an offline device profile can be found on the [Offline](offline) page.
 
 ## Redirection to Profiles
 
-The Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. The default configuration for this redirection is as follows:
+The Mendix Runtime automatically redirects users to the home page of the appropriate device type based on the device they are using. This happens by examining the User-Agent string that is sent by the device's browser. Hybrid apps do not use this mechanism, but are referred to by name. The default configuration for this redirection is as follows:
 
 | User-Agent String Regular Expression | Device Type |
 | --- | --- |
-| Android.*Mobile|iPhone|iPod|BlackBerry | Phone |
-| Android|iPad | Tablet |
-| _(other)_ | Desktop |
+| Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry | Phone |
+| Android&#124;iPad | Tablet |
+| _(other)_ | Responsive |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).
 
-If a profile is not enabled, it falls back to another device type as shown in the following table:
-
-| Device Type | Fallback |
-| --- | --- |
-| Phone | Tablet, Desktop |
-| Tablet | Phone, Desktop |
-| Desktop | None, Desktop is always enabled |
-
-It is also possible to force the client to use a specific profile by adding a *profile* query string parameter to the URL when visiting a Mendix application. The possible values are Desktop, Tablet, and Phone. For example:
+It is also possible to force the client to use a specific profile by adding a *profile* query string parameter to the URL when visiting a Mendix application. The possible values are the names of the profiles. For example:
 
 ```html
-https://myapp.mendixcloud.com/index.html?profile=Phone
+https://myapp.mendixcloud.com/index.html?profile=Responsive
 
 ```

--- a/refguide7/navigation.md
+++ b/refguide7/navigation.md
@@ -57,8 +57,8 @@ Mendix Runtime automatically redirects users to the home page of the appropriate
 
 | User-Agent String Regular Expression | Device Type |
 | --- | --- |
-| `Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry` | Phone |
-| `Android&#124;iPad` | Tablet |
+| Android.*Mobile&#124;iPhone&#124;iPod&#124;BlackBerry | Phone |
+| Android&#124;iPad | Tablet |
 | _(other)_ | Responsive |
 
 To configure the regular expressions used to match phone or tablet users, see [Custom Settings](custom-settings).

--- a/refguide7/offline-device-profile.md
+++ b/refguide7/offline-device-profile.md
@@ -2,7 +2,7 @@
 title: "Offline Device Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes usage of the Offline Device profile in a Mendix app."
+description: "Describes usage of the Offline Device profile in a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/offline-device-profile.md
+++ b/refguide7/offline-device-profile.md
@@ -2,14 +2,14 @@
 title: "Offline Device Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+description: "Describes usage of the Offline Device profile in a Mendix app."
 ---
-
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
-
-In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone Profile.](hybrid-phone-profile) All settings from the Offline device profile are automatically
-copied to the Hybrid Phone profile.
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
+
+As of Mendix 7.0.2, the Offline device profile is replaced by the [Hybrid Phone profile.](hybrid-phone-profile) All the settings from the Offline device profile are automatically copied to the Hybrid Phone profile.
+

--- a/refguide7/offline-device-profile.md
+++ b/refguide7/offline-device-profile.md
@@ -1,11 +1,13 @@
 ---
 title: "Offline Device Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
 
 
 <div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
 
 In Mendix 7.0.2 the Offline device profile is replaced by the [Hybrid Phone Profile.](hybrid-phone-profile) All settings from the Offline device profile are automatically
 copied to the Hybrid Phone profile.

--- a/refguide7/phone-profile.md
+++ b/refguide7/phone-profile.md
@@ -2,7 +2,7 @@
 title: "Phone Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes usage of the Phone profile in a Mendix app."
+description: "Describes usage of the Phone profile in a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/phone-profile.md
+++ b/refguide7/phone-profile.md
@@ -1,8 +1,15 @@
 ---
-title: "Phone profile"
+title: "Phone Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
+
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+
+{% endmarkdown %}</div>
+
 When enabled, all users accessing the Mendix application from a smart phone will automatically be redirected to this profile. If disabled, smart phone users will be redirected to the [Tablet profile.](tablet-profile) Lacking that, the user will be redirected to the [Desktop profile.](desktop-profile) 
 
 {% snippet Profile+properties.md %}

--- a/refguide7/phone-profile.md
+++ b/refguide7/phone-profile.md
@@ -2,11 +2,12 @@
 title: "Phone Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+"Describes usage of the Phone profile in a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/phone-profile.md
+++ b/refguide7/phone-profile.md
@@ -2,7 +2,7 @@
 title: "Phone Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-"Describes usage of the Phone profile in a Mendix app."
+description: "Describes usage of the Phone profile in a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/tablet-profile.md
+++ b/refguide7/tablet-profile.md
@@ -2,7 +2,7 @@
 title: "Tablet Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
-description: "Describes usage of the Tablet profile in a Mendix app."
+description: "Describes usage of the Tablet profile in a Mendix app for Mendix versions 7.0 and 7.1."
 ---
 
 <div class="alert alert-info">{% markdown %}

--- a/refguide7/tablet-profile.md
+++ b/refguide7/tablet-profile.md
@@ -2,11 +2,12 @@
 title: "Tablet Profile"
 space: "Mendix 7 Reference Guide"
 parent: "navigation-before-72"
+description: "Describes usage of the Tablet profile in a Mendix app."
 ---
 
 <div class="alert alert-info">{% markdown %}
 
-For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+For details on how this works in Mendix version 7.2 and higher, see [Navigation Profile](navigation-profile).
 
 {% endmarkdown %}</div>
 

--- a/refguide7/tablet-profile.md
+++ b/refguide7/tablet-profile.md
@@ -1,8 +1,15 @@
 ---
-title: "Tablet profile"
+title: "Tablet Profile"
 space: "Mendix 7 Reference Guide"
-parent: "navigation"
+parent: "navigation-before-72"
 ---
+
+<div class="alert alert-info">{% markdown %}
+
+For Mendix 7.2 and higher see [navigation profile](navigation-profile).
+
+{% endmarkdown %}</div>
+
 When enabled, all users accessing the Mendix application from a tablet device will automatically be redirected to this profile. If disabled, tablet users will be redirected to the [Phone profile.](phone-profile) Lacking that, the user will be redirected to the [Desktop profile.](desktop-profile) 
 
 {% snippet Profile+properties.md %}


### PR DESCRIPTION
Due to the differences between profiles in 7.1 and 7.2 the old navigation page is renamed and links to the newly written navigation page. The old, hard coded profile pages stay underneath the old navigation page and a new navigation profile page is written to document all fields and options. I've made a copy of all the fields and options to avoid that new features pop-up in the old documentation as those pages use snippets.