### PR TITLE
Update deploy-api.md

### DIFF
--- a/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/apidocs-mxsdk/apidocs/deploy-api.md
@@ -24,8 +24,7 @@ Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supporte
 
 ### <a name="DeployAPI-Description" rel="nofollow"></a>Description
 
-Retrieves all apps which the authenticated user has access to as a regular user. These apps can be found via
-the "Nodes overview" screen in the Mendix Platform. 
+Retrieves all apps which the authenticated user has access to as a regular user. These apps can be found via the "Nodes overview" screen in the Mendix Platform. 
 
 ```bash
 HTTP Method: GET
@@ -133,8 +132,7 @@ Response object with the following fields:
 
 ### <a rel="nofollow"></a>Description
 
-Retrieves a specific app which the authenticated user has access to as a regular user. These app can be found via
-the "Nodes overview" screen in the Mendix Platform. 
+Retrieves a specific app which the authenticated user has access to as a regular user. These app can be found via the "Nodes overview" screen in the Mendix Platform. 
 
 ```bash
 HTTP Method: GET


### PR DESCRIPTION
In this change, line connections for one sentence is important for translating English to Japanese.  Otherwise, it causes too many errors.