### PR TITLE
Update statistics-tool.md

### DIFF
--- a/addons/APM/statistics-tool.md
+++ b/addons/APM/statistics-tool.md
@@ -3,8 +3,7 @@ title: "Statistics Tool"
 space: "Other Add-Ons"
 parent: "user-manual"
 ---
-This chapter gives an overview of the statistics tool, which measures the durations of microflows and browser-client requests and gathers statistics like number of executions as well as the, minimum, maximum and average durations. The statistics tool is used as 
-the first step in gaining insight into what a system is doing when it doesn’t perform  optimally. The tool is also used to determine potential performance issues by looking at the trends.
+This chapter gives an overview of the statistics tool, which measures the durations of microflows and browser-client requests and gathers statistics like number of executions as well as the, minimum, maximum and average durations. The statistics tool is used as the first step in gaining insight into what a system is doing when it doesn’t perform  optimally. The tool is also used to determine potential performance issues by looking at the trends.
 
 ## Statistics
 
@@ -12,8 +11,7 @@ The statistics tool screen is split into several sections:
 
  ![](attachments/Statistics_Tool/Overview.png)
 
-Statistics are stored periodically to be able to determine potential trends. The 
-**Periodic store frequency** can be changed in the [Options](#Options).   
+Statistics are stored periodically to be able to determine potential trends. The **Periodic store frequency** can be changed in the [Options](#Options).   
 
 ## History chart
 It is possible to select a microflow and press the **History chart** button to see a graph with history statistics:  
@@ -28,9 +26,7 @@ The statistics can be started or stopped using the start/stop buttons in the **S
 
 In the manual statistics section it is possible to create a snapshot of statistics. This snapshot can be used to compare with other snapshots or to gain insight in statistics for a certain duration. By using the **Reset snapshot** button, the statistics will be reset. With the **Store snapshot** button, the statistics will be saved to a stored snapshot in the database.
 
-**Note**: By default, the result is sorted by **Total (ms)**. This will give a overview of the actions and microflows on which the
-application spent the most time. The average (**Avg**) is **Total (ms)** divided by **Count**. Sorted on **Avg**, the actions and
-microflows with the longest average duration can be found. Sorted on **Count** the actions and microflows that were executed the most can be found. The results can also be sorted on **Last run** to see what microflows have been executed recently.
+**Note**: By default, the result is sorted by **Total (ms)**. This will give a overview of the actions and microflows on which the application spent the most time. The average (**Avg**) is **Total (ms)** divided by **Count**. Sorted on **Avg**, the actions and microflows with the longest average duration can be found. Sorted on **Count** the actions and microflows that were executed the most can be found. The results can also be sorted on **Last run** to see what microflows have been executed recently.
 
 ## Running Actions
 
@@ -38,9 +34,7 @@ This section will give a real-time overview of running actions and microflows. T
 
 ![](attachments/Statistics_Tool/Now_Running.png)
 
-**Note**: When the server generates a lot of log messages, the server is running at a high CPU, and all the tools are running, a queue can build up in the Mendix thread that sends the log messages to the subscribers. As a consequence, it can look like running 
-microflows takes 10 seconds while the maximum in the statistics is 1 second. This is caused by the fact that the running time is calculated on the refresh date, and the duration of a microflow is calculated by the message date. When this happens, the debug running 
-counter for the message delay shows a high number (for example, 10000 milliseconds). The statistics tool pauses collecting and handling messages if the processing delay is above the configured **Max Processing Delay (ms)**.*
+**Note**: When the server generates a lot of log messages, the server is running at a high CPU, and all the tools are running, a queue can build up in the Mendix thread that sends the log messages to the subscribers. As a consequence, it can look like running microflows takes 10 seconds while the maximum in the statistics is 1 second. This is caused by the fact that the running time is calculated on the refresh date, and the duration of a microflow is calculated by the message date. When this happens, the debug running counter for the message delay shows a high number (for example, 10000 milliseconds). The statistics tool pauses collecting and handling messages if the processing delay is above the configured **Max Processing Delay (ms)**.*
 
 ## Stored Snapshot
 
@@ -70,21 +64,13 @@ This screenshot shows the options of the statistics tool:
 
  ![](attachments/Statistics_Tool/Options.png)
 
-The statistics tool will measure all microflow statistics all the time. The statistics 
-tool can exclude certain microflows while presenting from memory or storing to the 
-database.
+The statistics tool will measure all microflow statistics all the time. The statistics tool can exclude certain microflows while presenting from memory or storing to the database.
 
-You can configure the frequency of the statistics tool snapshots that are stored, for 
-example, daily or hourly. You also configure the top **N** statistics to be stored and an 
-exclude pattern. The APM tools itself are excluded via a constant as configured by an 
-administrator.
+You can configure the frequency of the statistics tool snapshots that are stored, for example, daily or hourly. You also configure the top **N** statistics to be stored and an exclude pattern. The APM tools itself are excluded via a constant as configured by an administrator.
 
-The top **N** is both for maximum duration and total duration, so between *N* and *2 times N*, 
-records are presented or stored in the database. When the top **N** value is empty or 0, all 
-microflows are retrieved.
+The top **N** is both for maximum duration and total duration, so between *N* and *2 times N*, records are presented or stored in the database. When the top **N** value is empty or 0, all microflows are retrieved.
 
-The dashboard options include also a top **N** and an exclude pattern to interactively filter 
-with these options.
+The dashboard options include also a top **N** and an exclude pattern to interactively filter with these options.
 
 ### Protections Tab
 


### PR DESCRIPTION
In this change, line connections for one sentence is important for translating English to Japanese.  Otherwise, it causes too many errors.