### PR TITLE
Update query-tool.md

### DIFF
--- a/addons/APM/query-tool.md
+++ b/addons/APM/query-tool.md
@@ -5,13 +5,11 @@ parent: "user-manual"
 ---
 To collect database or application information the Query Tool has been introduced.
 
-The Query Tool allows you to perform OQL, XPath and JDBC queries. Opening the Query Tool shows an overview
- of all configured queries and allows for adding, modifying and deleting queries.
+The Query Tool allows you to perform OQL, XPath and JDBC queries. Opening the Query Tool shows an overview of all configured queries and allows for adding, modifying and deleting queries.
 
 ![](attachments/Query_Tool/List.png)
 
-If you open a query to edit you get a dialog where you can select give a description, select a type,
- enter a query and set the maximum number of rows to retrieve.
+If you open a query to edit you get a dialog where you can select give a description, select a type, enter a query and set the maximum number of rows to retrieve.
 
 When you use the execute button you will see the results.
 
@@ -27,8 +25,6 @@ Additionally the ID query can specify columns specific to the entity related to 
 
 Additionally its possible to perform JDBC(pure SQL) queries to get information from the database.
 
-To use a query for measurements the query should either return 1 result or if a query results in multiple rows
-the first column is used as a unique identifier:
+To use a query for measurements the query should either return 1 result or if a query results in multiple rows the first column is used as a unique identifier:
 
-Under search ment option Search Query History you see all statements executed from the GUI. Collect
- measurement queries are not added to the history as they result into measurements.
+Under search ment option Search Query History you see all statements executed from the GUI. Collect measurement queries are not added to the history as they result into measurements.


### PR DESCRIPTION
In this change, line connections for one sentence is important for translating English to Japanese.  Otherwise, it causes too many errors.