### PR TITLE
Update measurements-tool.md

### DIFF
--- a/addons/APM/measurements-tool.md
+++ b/addons/APM/measurements-tool.md
@@ -3,8 +3,7 @@ title: "Measurements Tool"
 space: "Other Add-Ons"
 parent: "user-manual"
 ---
-The measurements tool is meant to measure system resources and to trigger actions on thresholds. This allows 
-you to monitor memory and save statistics or perform a trap when memory usage reaches, for example, 80%. 
+The measurements tool is meant to measure system resources and to trigger actions on thresholds. This allows you to monitor memory and save statistics or perform a trap when memory usage reaches, for example, 80%. 
 
 Measurements are created via the **Collect in Measurements Tool** button in the JVM browser or in the query tool. The collected measurements can be stored in the database and used for generating graphs or for triggering events.
 
@@ -18,13 +17,11 @@ Double-clicking the measurement will open a read-only view of the measurement co
 
 ## Measurement Configuration
 
-Measurements can be configured on the **Measurement configuration** tab. If the measurement is running, you can only
-view the measurement configuration. 
+Measurements can be configured on the **Measurement configuration** tab. If the measurement is running, you can only view the measurement configuration. 
 
   ![](attachments/Measurements_Tool/Measurement_Configuration_Tab.png)                     
 
-Measurements can be started and stopped here. In the dialog behind the play-button, you can start or stop all 
-measurements at once.
+Measurements can be started and stopped here. In the dialog behind the play-button, you can start or stop all measurements at once.
 
 ### Measurement Configuration Tab
 
@@ -47,11 +44,8 @@ The **Measurment configuration** tab allows you to do the folllowing:
  * You can only measure for triggers; for charts you need the database to be stored in the database
 *   The **Remove data after (days)** configures the automatic cleanup (purge) of the data
  * Measurements will automatically be removed after a certain amount of days
-*   For a query measurement, the **Expose query results to JMX** makes the query results visible in other Java management
- consoles – this is only useful for query measurements, since JVM Browser measurements are already available
-  there
-*   If a query has multiple results, you can configure using the first column a part of the name via **Use first 
-result column in name**
+*   For a query measurement, the **Expose query results to JMX** makes the query results visible in other Java management consoles – this is only useful for query measurements, since JVM Browser measurements are already available  there
+*   If a query has multiple results, you can configure using the first column a part of the name via **Use first result column in name**
 
 ### Triggers Tab
 Here you can define triggers on high memory usage for example.
@@ -74,13 +68,11 @@ The `$Measurement` variables is available with columns:
 * `ValueBoolean`
 * `TimeStamp`
 
-Also, the last **N** measurements are available as $Measurement_1 (the previous one) up to $Measurement_**N**. The 
-amount of previous measurements (**N**) is configured in the app. The default is 5, but an admin can changed this. 
+Also, the last **N** measurements are available as $Measurement_1 (the previous one) up to $Measurement_**N**. The amount of previous measurements (**N**) is configured in the app. The default is 5, but an admin can changed this. 
 
 At startup, the last **N** measurements are empty, so handle the empty case!
 
-When the measurement is run only once, the previous measurements are retrieved from the database and can be
- used as `$MeasurementDB_1` to `$MeasurementDB_N`. 
+When the measurement is run only once, the previous measurements are retrieved from the database and can be used as `$MeasurementDB_1` to `$MeasurementDB_N`. 
 
 This is an example to calculate the difference between the current and the previous measurement:
 
@@ -100,22 +92,18 @@ In the tester, you can clear the cache and also remove all records from the data
 
 If a trigger fires, a record is created in the triggered events. 
 
-The events are automatically deleted after a certain amount of days as 
-configured in the global setting [More tab](configuration#more). 
+The events are automatically deleted after a certain amount of days as configured in the global setting [More tab](configuration#more). 
 **Remove triggered events after (days)**. 
 
-If you want to keep an event for future reference you can use the **Keep**-button
- above the triggered event grid.
+If you want to keep an event for future reference you can use the **Keep**-button above the triggered event grid.
 
 ![](attachments/Triggers/Triggered_Events.png)
 
 If a trap is created with the trigger actions, you can open the trap.
 
-If a statistics snapshot is created with the trigger actions you can open the 
-statistics snapshot.
+If a statistics snapshot is created with the trigger actions you can open the statistics snapshot.
 
 If a heap dump is created with the trigger actions you can download the heap dump. 
 You only get this option if you have special permissions.
 
-You can open the measurement configuration that contains the trigger with the 
-**Show trigger** button.
+You can open the measurement configuration that contains the trigger with the **Show trigger** button.


### PR DESCRIPTION
In this change, line connections for one sentence is important for translating English to Japanese.  Otherwise, it causes too many errors.