### PR TITLE
Update index.md

### DIFF
--- a/addons/AQM/index.md
+++ b/addons/AQM/index.md
@@ -7,8 +7,7 @@ space: "Other Add-Ons"
 
 Mendix Application Quality Monitor (AQM) is a cloud service developed by Mendix and the Software Improvement Group (SIG). 
 Mendix AQM performs a static analysis of Mendix application models according the ISO 25010 standard for maintainability. 
-Dashboards provide instant insight into the quality of the application models as they're built, 
-including quality ratings based on benchmarks of thousands of projects. 
+Dashboards provide instant insight into the quality of the application models as they're built, including quality ratings based on benchmarks of thousands of projects. 
 
 By proactively monitoring quality on a daily basis customers can improve maintainability and reduce lifecycle costs.
 


### PR DESCRIPTION
In this change, line connections for one sentence is important for translating English to Japanese.  Otherwise, it causes too many errors.