### PR TITLE
removed 'deploying to a free app'

### DIFF
--- a/howtogeneral/mendixcloud/how-to-deploy-a-mendix-app-on-amazon-web-services.md
+++ b/howtogeneral/mendixcloud/how-to-deploy-a-mendix-app-on-amazon-web-services.md
@@ -182,9 +182,8 @@ The Mendix instance on AWS is now fully configured and ready for use. Let's try 
 ## 6\. Read more
 
 *   [Trends](trends)
-*   [Deploying to the cloud](deploying-to-the-cloud)
+*   [How to Deploy to the Mendix Cloud](deploying-to-the-cloud)
 *   [How to deploy a Mendix app on Azure](how-to-deploy-a-mendix-app-on-azure)
 *   [Sending Email](sending-email)
 *   [Different user logins when integrated with Mendix SSO](different-user-logins-when-integrated-with-mendix-sso)
 *   [Integrate your app with Mendix SSO](integrate-your-app-with-mendix-sso)
-*   [Deploying to a Free App](deploying-to-a-free-app)


### PR DESCRIPTION
removed 'deploying to a free app' from How to deploy a Mendix app on Amazon Web Services