### PR TITLE
releasenotes/platform-portal: remove "X-" from X-SSL-Version, X-SSL-Cipher

### DIFF
--- a/releasenotes/platform-portal/index.md
+++ b/releasenotes/platform-portal/index.md
@@ -8,7 +8,7 @@ toc-level: "1"
 
 ### Improvements
 
-* For all apps running on the Mendix Cloud, the following HTTP headers are now available: `X-SSL-Version` (possible values: `TLSv1`, `TLSv1.1`, `TLSv1.2`) and `X-SSL-Cipher` (for example, `ECDHE-RSA-AES256-GCM-SHA384`). These can be used to block login attempts (for example, `TLSv1.0` connections).
+* For all apps running on the Mendix Cloud, the following HTTP headers are now available: `SSL-Version` (possible values: `TLSv1`, `TLSv1.1`, `TLSv1.2`) and `SSL-Cipher` (for example, `ECDHE-RSA-AES256-GCM-SHA384`). These can be used to block login attempts (for example, `TLSv1.0` connections).
 * Modern browsers are aggressively caching static HTML resources, which can lead to user problems after deploying new versions of applications. Clearing the cache can solve this, but that is a bad user experience. So, for all apps running on Mendix Cloud v3, we have added an explicit `no-cache` header to the resources `/` and `/index.html`, `/login.html`, and `/index[0-9].html`. For Mendix Cloud v4, an `expires` with a negative value was already used, so no changes are required there. We believe this change eliminates most of the browser caching issues we have seen so far.
 * You can now restrict access to your Mendix Cloud v4 applications based on IP ranges. This is available for all Mendix Cloud v4 regions and can be configured from the **Network** tab of your cloud environment.
 


### PR DESCRIPTION
Otherwise we look like n00bs, see RFC6648.