### PR TITLE
Restructured the Add Document menu in 7.9

### DIFF
--- a/content/refguide/mapping-documents.md
+++ b/content/refguide/mapping-documents.md
@@ -3,10 +3,11 @@ title: "Mapping Documents"
 parent: "integration"
 ---
 
+## 1 Introduction
 
-Mapping Documents are used to define how Mendix objects can be converted to and from XML or JSON, according to a specific XML schema or JSON structure. There are two types of mappings: [Import Mappings](import-mappings) and [Export Mappings](export-mappings).
+Mapping documents are used to define how Mendix objects can be converted to and from XML or JSON, according to a specific XML schema or JSON structure. There are two types of mappings: [Import Mappings](import-mappings) and [Export Mappings](export-mappings).
 
-## Import Mappings
+## 2 Import Mappings
 
 Import mappings are used to define how incoming XML or JSON is converted into Mendix objects, according to a specific XML schema or JSON structure. This is needed to be able to interpret data received from other systems. In Mendix there are three basic scenarios for converting Mendix objects to XML or JSON:
 
@@ -14,63 +15,61 @@ Import mappings are used to define how incoming XML or JSON is converted into Me
 *   Receiving XML or JSON from a call action [Call Rest Action](call-rest-action).
 *   Importing XML or JSON directly in an [Import from Mapping](import-mapping-action) action. 
 
-An example of an import mapping document is depicted in figure 1\. More details on import mapping specifics can be found at the [Import Mappings](import-mappings) page.
+An example of an import mapping document is depicted in **Figure 1**. More details on import mapping specifics can be found at the [Import Mappings](import-mappings) page.
 
-![Figure 2](attachments/16713725/16843933.png)
+![](attachments/16713725/16843933.png)
 
 **Figure 1**
 
-## Export Mappings
+## 3 Export Mappings
 
 Export mappings are used to define how Mendix objects can be converted to XML according to a specific XML schema. This is needed to be able to send data to other systems in a format the other system can process. In Mendix there are two basic scenarios for converting Mendix objects to XML:
 
 *   Sending XML to a web service (defined in an [imported web service](consumed-web-service)) in a [Call Web Service Action](call-web-service-action) activity.
 *   Exporting XML directly in an [Export with Mapping](export-mapping-action) action. 
 
-An example of an export mapping document is depicted in figure 2. In that example a Cheesecake entity will be passed when the export mapping is called. Subsequently the Topping entities will be fetched by following the "Topping_Cheesecake" association from the passed Cheesecake Mendix object. The result is passed to an XML document, or sent to a webservice. More details on export mapping specifics can be found at the [Export Mappings](export-mappings) page.
+An example of an export mapping document is depicted in **Figure 2**. In that example a Cheesecake entity will be passed when the export mapping is called. Subsequently the Topping entities will be fetched by following the "Topping_Cheesecake" association from the passed Cheesecake Mendix object. The result is passed to an XML document, or sent to a webservice. More details on export mapping specifics can be found at the [Export Mappings](export-mappings) page.
 
 ![](attachments/16713726/16843940.png)
 
 **Figure 2**
 
-## Creating a new Mapping document
+## 4 Creating a New Mapping Document
 
 To specify an import or export mapping, the user needs to do a number of things:
 
 1.  Create a new **Import Mapping** or **Export Mapping** document.
 
-2.  Click **Select elements...** to select an XML schema, imported web service document, or JSON structure document as the source schema for this mapping. See figure 1.
-
-
+2.  Click **Select elements...** to select an XML schema, imported web service document, or JSON structure document as the source schema for this mapping. See **Figure 1**. 
 
     If the schema is large, a subset of elements can be selected so you don't have to map all of them. This is explained in more detail in the [Select Elements](select--elements) section.
-
 
 3.  Click **OK**. A structure is created with placeholders for entities on the left-hand side, and the selected XSD elements on the right-hand side.
 
     It is possible to include a parameter entity in mapping documents. Mapping documents with a parameter entity need to be invoked (in a [Call Web Service Action](call-web-service-action) or [Export with Mapping](export-mapping-action) action) by passing a parameter of the configured type. Mapping documents without a parameter entity can be invoked without passing a parameter. For import mappings, a parameter entity can be included by dragging one onto the placeholder in the created structure using the Connector tool. Export mappings always need to have a parameter entity (the object that is being exported) and the mapped root element is used for this. In both cases, the parameter entity is depicted as a yellow arrow parameter symbol.
 
 4.  Map the child elements of the schema. Entities can be obtained in four ways:
-*   From a mapping parameter
-*   By associations
-*   From a custom microflow
-*   By entity specializations in the case of choice or inheritance XML elements
+    
+    * From a mapping parameter
+    * By associations
+    * From a custom microflow
+    * By entity specializations in the case of choice or inheritance XML elements
 
-5.  Finally the user needs to configure how entity attributes should be transformed into the XML or JSON structure. This is explained in more detail in the sections and .
+5.  Finally the user needs to configure how entity attributes should be transformed into the XML or JSON structure.
 
-## Convenience functions
+## 5 Convenience Functions
 
 *   Map automatically: Automatically look for entities and associations in the domain model that can be used in the mapping. If a matching entity or association is not found, it is created in the domain model. This function is explained in more detail in the [Map Automatically](map-automatically) section.
 *   Clear mappings: Disconnects all mapping elements in the document from entities and associations. They are not deleted in the domain model.
 
-## Tip: Important Windows
+## 6 Tip: Important Windows
 
 Mapping documents rely heavily on two windows. If they are not visible in the Modeler, they can be enabled from the **View menu**.
 
 *   **Properties window**. Details of individual mapping elements are shown here.
 *   **Connector window**. Entities from the connector window are dragged into the mapping document.
 
-## User Interactions
+## 7 User Interactions
 
 *   Dragging entities. Drag an entity from the Connector Window and drop it on an entity placeholder (dashed box) to relate it to an XML element. 
 *   Double clicking on a mapping element (on either the entity side or the XML side). Opens a dialog that allows you to specify details for the individual mapping. If the element is not yet related to an entity, a dialog appears that lets you select the entity first.
@@ -81,9 +80,9 @@ Mapping documents rely heavily on two windows. If they are not visible in the Mo
 *   Left mouse click on "-" icon (below mapping element). Makes underlying elements invisible.
 *   Left mouse, click on "+" icon (below mapping element). Makes underlying elements visible again.
 
-## Properties
+## 8 Properties
 
-### Common Properties
+### 8.1 Common Properties
 
 | Property | Description |
 | --- | --- |
@@ -99,7 +98,7 @@ Mapping documents rely heavily on two windows. If they are not visible in the Mo
 | Start at | Determines which part of the XML structure this mapping defines. |
 | Send empty values | Only applicable for export mappings. If a mapping element is optional and nillable, you need to select whether or not to send the empty values. The default is do not send the empty values. |
 
-## Read more
+## 8.2 Read More
 
 **Content by label**
 

--- a/content/refguide/mapping-documents.md
+++ b/content/refguide/mapping-documents.md
@@ -51,10 +51,10 @@ To specify an import or export mapping, the user needs to do a number of things:
     It is possible to include a parameter entity in mapping documents. Mapping documents with a parameter entity need to be invoked (in a [Call Web Service Action](call-web-service-action) or [Export with Mapping](export-mapping-action) action) by passing a parameter of the configured type. Mapping documents without a parameter entity can be invoked without passing a parameter. For import mappings, a parameter entity can be included by dragging one onto the placeholder in the created structure using the Connector tool. Export mappings always need to have a parameter entity (the object that is being exported) and the mapped root element is used for this. In both cases, the parameter entity is depicted as a yellow arrow parameter symbol.
 
 4.  Map the child elements of the schema. Entities can be obtained in four ways:
-        * From a mapping parameter
-        * By associations
-        * From a custom microflow
-        * By entity specializations in the case of choice or inheritance XML elements
+*   From a mapping parameter
+*   By associations
+*   From a custom microflow
+*   By entity specializations in the case of choice or inheritance XML elements
 
 5.  Finally the user needs to configure how entity attributes should be transformed into the XML or JSON structure. This is explained in more detail in the sections and .
 

--- a/content/refguide/message-definitions.md
+++ b/content/refguide/message-definitions.md
@@ -19,4 +19,4 @@ In the list of message definitions, you can add, edit, or delete a [message defi
 
 ## 3 Documentation
 
-Use the **Documentation to describe what the message definitions are used for.
+Use the documentation to describe what the message definitions are used for.

--- a/content/refguide/published-app-services.md
+++ b/content/refguide/published-app-services.md
@@ -4,7 +4,7 @@ parent: "integration"
 ---
 
 
-An App Service can be created by selecting 'Published App Service' in the 'Add' context menu of a module.
+An App Service can be created via **File** > **New Document**.
 
 Names of Published App Service documents must be unique, also with regard to Published Web Services.
 
@@ -12,8 +12,7 @@ Names of Published App Service documents must be unique, also with regard to Pub
 
 ### Create version
 
-The button 'Create version' instantiates a new app service version.
-For more information, see [Published App Service](published-app-service).
+The button **Create version** instantiates a new app service version. For more information, see [Published App Service](published-app-service).
 
 ### Edit
 

--- a/content/refguide/published-app-services.md
+++ b/content/refguide/published-app-services.md
@@ -3,21 +3,22 @@ title: "Published App Services"
 parent: "integration"
 ---
 
+## 1 Introduction
 
-An App Service can be created via **File** > **New Document**.
+An app service can be created via **File** > **New Document**.
 
-Names of Published App Service documents must be unique, also with regard to Published Web Services.
+Names of published app service documents must be unique (also with regard to published web service).
 
 ![](attachments/16713717/16843911.png)
 
-### Create version
+## 2 Create Version
 
-The button **Create version** instantiates a new app service version. For more information, see [Published App Service](published-app-service).
+The **Create version** button instantiates a new app service version. For more information, see [Published App Service](published-app-service).
 
-### Edit
+## 3 Edit
 
-Opens the selected app service version dialog. Only **Draft** versions are editable. The settings of **Consumable** versions can only be viewed.
+This button opens the selected app service version dialog box. Only **Draft** versions are editable. The settings of **Consumable** versions can only be viewed.
 
-### Delete
+## 4 Delete
 
-Deletes the selected app service version.
+This button deletes the selected app service version.

--- a/content/refguide/xml-schemas.md
+++ b/content/refguide/xml-schemas.md
@@ -8,7 +8,7 @@ An XML schema is defined in an XML Schema Definition (XSD) file and can be impor
 
 ![Figure 1](attachments/16713706/18582294.png)
 
-**Figure 1. **
+**Figure 1: An example of an XML schema**
 
 ## General
 

--- a/content/refguide/xml-schemas.md
+++ b/content/refguide/xml-schemas.md
@@ -3,23 +3,24 @@ title: "XML Schemas"
 parent: "integration"
 ---
 
+## 1 Introduction
 
-An XML schema is defined in an XML Schema Definition (XSD) file and can be imported in your model. It describes what a certain XML document should look like. An example is shown in figure 1\. The schema can then be used in [Import Mappings](import-mappings) or [Export Mappings](export-mappings).
+An XML schema is defined in an XML Schema Definition (XSD) file and can be imported in your model. It describes what a certain XML document should look like. An example is shown in **Figure 1**. The schema can then be used in [Import Mappings](import-mappings) or [Export Mappings](export-mappings).
 
 ![Figure 1](attachments/16713706/18582294.png)
 
-**Figure 1: An example of an XML schema**
+**Figure 1: example of an XML schema**
 
-## General
+## 2 General
 
-### XML Schema
+### 2.1 XML Schema
 
 The file path to the XSD file.
 
-### Preview
+### 2.2 Preview
 
 The elements of which the XML file is comprised.
 
-## Documentation
+## 3 Documentation
 
 Documentation that describes the schema.


### PR DESCRIPTION
The context menu item for 'Consumed app service' has moved.
Rewrote it in such a way that the documentation is valid for all 7 releases.
Also includes some layout fixes for other pages.