### PR TITLE
Add release notes for desktop modeler 6.10.11

### DIFF
--- a/content/releasenotes/desktop-modeler/6.10.md
+++ b/content/releasenotes/desktop-modeler/6.10.md
@@ -6,7 +6,7 @@ description: "The release notes for Mendix Modeler version 6.10 (including all p
 
 ## 6.10.11
 
-**Release date: November 29, 2017**
+**Release date: December 1, 2017**
 
 {{% modelerdownloadlink "6.10.11" %}}
 

--- a/content/releasenotes/desktop-modeler/6.10.md
+++ b/content/releasenotes/desktop-modeler/6.10.md
@@ -4,6 +4,17 @@ parent: "6"
 description: "The release notes for Mendix Modeler version 6.10 (including all patches) with details on new features, bug fixes, and known issues."
 ---
 
+## 6.10.11
+
+**Release date: November 29, 2017**
+
+{{% modelerdownloadlink "6.10.11" %}}
+
+### Improvements
+
+* We upgraded our internal web server Jetty to version 9.4.7. When retrieving [server statistics](https://docs.mendix.com/refguide6/monitoring-mendix-runtime#server-statistics), the `max_idle_time_s_low_resources` information is not returned anymore because Jetty does not provide this information anymore. Also the shutdown procedure of Mendix apps has been improved in the process of upgrade.
+* We upgraded the Akka dependency to version 2.4.20 because of a vulnerability. For more information, see https://nvd.nist.gov/vuln/detail/CVE-2017-1000034.
+
 ## 6.10.10
 
 **Release date: September 8th, 2017**

--- a/content/releasenotes/desktop-modeler/6.10.md
+++ b/content/releasenotes/desktop-modeler/6.10.md
@@ -12,8 +12,8 @@ description: "The release notes for Mendix Modeler version 6.10 (including all p
 
 ### Improvements
 
-* We upgraded our internal web server Jetty to version 9.4.7. When retrieving [server statistics](https://docs.mendix.com/refguide6/monitoring-mendix-runtime#server-statistics), the `max_idle_time_s_low_resources` information is not returned anymore because Jetty does not provide this information anymore. Also the shutdown procedure of Mendix apps has been improved in the process of upgrade.
-* We upgraded the Akka dependency to version 2.4.20 because of a vulnerability. For more information, see https://nvd.nist.gov/vuln/detail/CVE-2017-1000034.
+* We upgraded our internal web server Jetty to version 9.4.7. When retrieving [server statistics](/refguide6/monitoring-mendix-runtime#server-statistics), the `max_idle_time_s_low_resources` information is not returned anymore, because Jetty does not provide this information anymore. Also, the shutdown procedure of Mendix apps has been improved in the process of upgrade.
+* We upgraded the Akka dependency to version 2.4.20 because of a vulnerability. For more information, see [CVE-2017-1000034 Detail](https://nvd.nist.gov/vuln/detail/CVE-2017-1000034).
 
 ## 6.10.10
 


### PR DESCRIPTION
6.10.11 is scheduled to release on November 29, 2017.