### PR TITLE
Update deploy-mendix-on-microsoft-windows.md

### DIFF
--- a/content/deployment/on-premises/deploy-mendix-on-microsoft-windows.md
+++ b/content/deployment/on-premises/deploy-mendix-on-microsoft-windows.md
@@ -215,8 +215,8 @@ If you need to add additional request handlers, use this example:
 
 Replace **requesthandler** with your own request handler needed for the application.
 
+### 5.6 Adding the `Cache control: no-cache` Header
 
-### 5.6 Add "Cache control: no-cache" header
 In the application directory under **Project/Web**, you will find the `web.config` file that contains the Microsoft IIS configuration for the application. Here you should add the following code:
 
 ```xml
@@ -229,7 +229,7 @@ In the application directory under **Project/Web**, you will find the `web.confi
 </configuration>
 ```
 
-Afterwards the contents of this file must be similar to the following example:
+Afterwards, the contents of this file must be similar to the following example:
 
 **web.config**
 

--- a/content/deployment/on-premises/deploy-mendix-on-microsoft-windows.md
+++ b/content/deployment/on-premises/deploy-mendix-on-microsoft-windows.md
@@ -215,7 +215,21 @@ If you need to add additional request handlers, use this example:
 
 Replace **requesthandler** with your own request handler needed for the application.
 
-In the application directory under **Project/Web**, you will find the `web.config` file that contains the Microsoft IIS configuration for the application. The contents of this file must be similar to the following example:
+
+### 5.6 Add "Cache control: no-cache" header
+In the application directory under **Project/Web**, you will find the `web.config` file that contains the Microsoft IIS configuration for the application. Here you should add the following code:
+
+```xml
+<configuration>
+   <system.webServer>
+      <staticContent>
+         **<clientCache cacheControlMode="DisableCache" />**
+      </staticContent>
+   </system.webServer>
+</configuration>
+```
+
+Afterwards the contents of this file must be similar to the following example:
 
 **web.config**
 
@@ -249,6 +263,7 @@ In the application directory under **Project/Web**, you will find the `web.confi
         </rewrite>
         <staticContent>
             <mimeMap fileExtension=".mxf" mimeType="text/xml" />
+            <clientCache cacheControlMode="DisableCache" />
         </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Based on ticket: https://mendixsupport.zendesk.com/agent/tickets/53238 and Mitya's comment (see last line):

Proper fix

If the cause is indeed such as I've guessed, then the fix would be to add cache-control header to the ngnix config for resources that are cached by the etag/date (i.e. resources without a cacheburst). Probably, example config that we give for on-premise deployments should also be corrected.