### PR TITLE
CLD-2336: deploy api requires application/json as Content-Type

### DIFF
--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -19,7 +19,7 @@ As APIs are designed for automated systems, the Deploy API does not require two-
 
 # 3 <a name="DeployAPI-APIcalls" rel="nofollow"></a> API Calls
 
-Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supported for sandbox applications. Please note that most api calls with the exception of _Upload Package_ requires the _Content-Type_ header to be set to _application/json_.
+Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supported for sandbox applications. Please note that most API calls—with the exception of _Upload Package_—require that the _Content-Type_ header be set to _application/json_.
 
 ## 3.1 <a name="DeployAPI-Retrieveapps" rel="nofollow"></a>Retrieve Apps
 

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -34,7 +34,7 @@ URL: https://deploy.mendix.com/api/1/apps/
 
 ### 3.1.2 <a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### 3.1.2.1 <a name="DeployAPI-Example" rel="nofollow"></a>Example
+#### 3.1.2.1 <a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/ HTTP/1.1
@@ -53,7 +53,7 @@ List of objects with the following key-value pairs:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.1.3.1 <a rel="nofollow"></a>Example
+#### 3.1.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [{
@@ -82,13 +82,13 @@ URL: https://deploy.mendix.com/api/1/apps/
 
 ### 3.2.2 <a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### 3.2.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+#### 3.2.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 An object with the following key-value pair:
 
 *   _ProjectId_ (String) : The Developer Portal project identifier that should be linked to the new sandbox application. This value can be found under Settings > General, and it is represented as App ID.
 
-##### 3.2.2.2 <a name="DeployAPI-Example" rel="nofollow"></a>Example
+#### 3.2.2.2 <a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 POST /api/1/apps/ HTTP/1.1
@@ -111,14 +111,14 @@ Response object with the following fields:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.2.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
+#### 3.2.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_PROJECTID | Invalid ProjectId |
 | 400 | APPLICATION_ALREADY_EXISTS | Application already exists |
 
-##### 3.2.3.2 <a rel="nofollow"></a>Example
+#### 3.2.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -142,11 +142,11 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>
 
 ### 3.3.2 <a rel="nofollow"></a>Request
 
-##### 3.3.2.1 <a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
+#### 3.3.2.1 <a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Sub-domain name of an app.
 
-##### 3.3.2.2 <a rel="nofollow"></a>Example
+#### 3.3.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/ HTTP/1.1
@@ -164,14 +164,14 @@ Object with the following key-value pairs:
 *   _Name_ (String): Name of the app.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.3.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
+#### 3.3.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_APPID | Invalid AppId |
 | 404 | APP_NOT_FOUND | App not found |
 
-##### 3.3.3.2 <a rel="nofollow"></a>Example
+#### 3.3.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -195,11 +195,11 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/
 
 ### 3.4.2 <a rel="nofollow"></a>Request
 
-##### 3.4.2.1 <a rel="nofollow"></a>Parameter
+#### 3.4.2.1 <a rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Subdomain name of an app.
 
-##### 3.4.2.2 <a rel="nofollow"></a>Example
+#### 3.4.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/ HTTP/ 1.1
@@ -218,7 +218,7 @@ List of objects with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   Mode (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.4.3.1 <a rel="nofollow"></a>Example
+#### 3.4.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -248,12 +248,12 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>
 
 ### 3.5.2 <a rel="nofollow"></a>Request
 
-##### 3.5.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+#### 3.5.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): The mode of the environment of the app. An environment with this mode should exist.
 
-##### 3.5.2.2 <a rel="nofollow"></a>Example
+#### 3.5.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/Acceptance HTTP/1.1
@@ -271,7 +271,7 @@ An object with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.5.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.5.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -279,7 +279,7 @@ An object with the following key-value pairs:
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 
-##### 3.5.3.2 <a rel="nofollow"></a>Example
+#### 3.5.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -302,13 +302,13 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/start
 
 ### 3.6.2 Request
 
-##### 3.6.2.1 <a name="DeployAPI-Payload" rel="nofollow"></a>Payload
+#### 3.6.2.1 <a name="DeployAPI-Payload" rel="nofollow"></a>Payload
 
 An object with the following key-value pair:
 
 *   _AutoSyncDb_ (Boolean) : Define whether the database should be synchronized automatically with the model during the start phase of the app. This is only applicable if your Mendix Cloud version is older than v4.
 
-##### 3.6.2.2 <a rel="nofollow"></a>Example
+#### 3.6.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/Acceptance/start HTTP/ 1.1
@@ -329,7 +329,7 @@ An object with the following key-value pairs:
 
 *   _JobId_ (String): The identifier which can be used to track the progress of the start action
 
-##### 3.6.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.6.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -339,7 +339,7 @@ An object with the following key-value pairs:
 | 500 | APP_ALREADY_HAS_A_STARTING_JOB | Cannot start app. There is already a starting job id found. |
 | 500 | ALREADY_STARTED | Cannot start app. App is already running. |
 
-##### 3.6.3.2 <a rel="nofollow"></a>Example
+#### 3.6.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -360,7 +360,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/start/<Job
 
 ### 3.7.2 Request
 
-##### 3.7.2.1 <a rel="nofollow"></a>Example
+#### 3.7.2.1 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/Acceptance/start/02df2e50-0e79-11e4- 9191 -0800200c9a66 HTTP/ 1.1
@@ -377,7 +377,7 @@ An object with the following key-value pair:
 
 *   _Status_ (String): Possible values are Starting and Started
 
-##### 3.7.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.7.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -395,7 +395,7 @@ An object with the following key-value pair:
 | 500 | STARTUP_ACTION_FAILED | Cannot start app. Startup action failed. |
 | 500 | START_FAILED | Cannot start app: result (detail status) |
 
-##### 3.7.3.2 <a rel="nofollow"></a>Example
+#### 3.7.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -416,7 +416,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/stop
 
 ### 3.8.2 Request
 
-##### 3.8.2.1 <a rel="nofollow"></a>Example
+#### 3.8.2.1 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/Acceptance/stop HTTP/ 1.1
@@ -429,7 +429,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.8.3 <a rel="nofollow"></a>Output
 
-##### 3.8.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.8.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -451,12 +451,12 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/package
 
 ### 3.9.2 Request
 
-##### 3.9.2.1 <a rel="nofollow"></a>Parameters
+#### 3.9.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): The mode of the environment of the app. An environment with this mode should exist.
 
-##### 3.9.2.2 <a rel="nofollow"></a>Example
+#### 3.9.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/Acceptance/ package HTTP/ 1.1
@@ -482,7 +482,7 @@ An object with the following key-value pairs:
     Possible values: Succeeded, Queued, Building, Uploading and Failed.
 *   _Size_ (Long): Size of the package in bytes.
 
-##### 3.9.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.9.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -490,7 +490,7 @@ An object with the following key-value pairs:
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | PACKAGE_NOT_FOUND | No package found for this environment |
 
-##### 3.9.3.2 <a rel="nofollow"></a>Example
+#### 3.9.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -519,13 +519,13 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/packages/upload
 
 ### 3.9.5 Request
 
-##### 3.9.5.1 <a rel="nofollow"></a>Parameters
+#### 3.9.5.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Name_ (String): Name of the deployment package as query parameter
 *   _file_ (File): Deployment package as multipart/form-data
 
-##### 3.9.5.2 <a rel="nofollow"></a>Example
+#### 3.9.5.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/packages/upload HTTP/ 1.1
@@ -542,7 +542,7 @@ curl -v -F "file=@/tmp/some.mda" -X POST -H "Mendix-Username: richard.ford51@exa
 
 ### 3.9.6 <a name="DeployAPI-Ouput" rel="nofollow"></a>Ouput
 
-##### 3.9.6.1 <a rel="nofollow"></a>Error Codes
+#### 3.9.6.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -564,13 +564,13 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/transport
 
 ### 3.10.2 <a rel="nofollow"></a>Request
 
-##### 3.10.2.1 <a rel="nofollow"></a>Parameters
+#### 3.10.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _PackageId_ (String): ID of the deployment package
 
-##### 3.10.2.2 <a rel="nofollow"></a>Example
+#### 3.10.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/acceptance/transport HTTP/ 1.1
@@ -587,7 +587,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.10.3 <a rel="nofollow"></a>Output
 
-##### 3.10.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.10.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -19,7 +19,7 @@ As APIs are designed for automated systems, the Deploy API does not require two-
 
 # <a name="DeployAPI-APIcalls" rel="nofollow"></a>API Calls
 
-Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supported for sandbox applications.
+Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supported for sandbox applications. Please note that most api calls with the exception of _Upload Package_ requires the _Content-Type_ header to be set to _application/json_.
 
 ## <a name="DeployAPI-Retrieveapps" rel="nofollow"></a>Retrieve Apps
 
@@ -39,7 +39,7 @@ URL: https://deploy.mendix.com/api/1/apps/
 ```bash
 GET /api/1/apps/ HTTP/1.1
 Host: deploy.mendix.com
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -93,7 +93,7 @@ An object with the following key-value pair:
 ```bash
 POST /api/1/apps/ HTTP/1.1
 Host: deploy.mendix.com
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 
@@ -151,7 +151,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>
 ```bash
 GET /api/1/apps/calc/ HTTP/1.1
 Host: deploy.mendix.com
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -205,7 +205,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/
 GET /api/ 1 /apps/calc/environments/ HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -258,7 +258,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>
 ```bash
 GET /api/1/apps/calc/environments/Acceptance HTTP/1.1
 Host: deploy.mendix.com
-Accept: /
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -314,7 +314,7 @@ An object with the following key-value pair:
 POST /api/ 1 /apps/calc/environments/Acceptance/start HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
@@ -366,7 +366,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/start/<Job
 GET /api/ 1 /apps/calc/environments/Acceptance/start/02df2e50-0e79-11e4- 9191 -0800200c9a66 HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -422,7 +422,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/stop
 POST /api/ 1 /apps/calc/environments/Acceptance/stop HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -462,7 +462,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/package
 GET /api/ 1 /apps/calc/environments/Acceptance/ package HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -531,7 +531,6 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/packages/upload
 POST /api/ 1 /apps/calc/packages/upload HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -577,7 +576,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/transport
 POST /api/ 1 /apps/calc/environments/acceptance/transport HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
@@ -626,7 +625,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/clean
 POST /api/ 1 /apps/calc/environments/acceptance/clean HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -679,7 +678,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
@@ -743,7 +742,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings/
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
@@ -831,7 +830,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots
 GET /api/1/apps/calc/environments/acceptance/snapshots HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
@@ -897,7 +896,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots/
 GET /api/1/apps/calc/environments/acceptance/snapshots/201703221355 HTTP/ 1.1
 Host: deploy.mendix.com
 
-Accept: */*
+Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -11,7 +11,7 @@ This image provides a domain model representation of the concepts discussed belo
 
 ![](attachments/deploy-api/api-model.png)
 
-# <a name="DeployAPI-Authentication" rel="nofollow"></a>2 Authentication
+# 2 <a name="DeployAPI-Authentication" rel="nofollow"></a> Authentication
 
 The Deploy API requires authentication via API keys that are bound to your Mendix account (for more information, see [Authentication](authentication).
 
@@ -32,9 +32,9 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/
 ```
 
-### 3.1.2<a name="DeployAPI-Request" rel="nofollow"></a>Request
+### 3.1.2 <a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### 3.1.2.1<a name="DeployAPI-Example" rel="nofollow"></a>Example
+##### 3.1.2.1 <a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/ HTTP/1.1
@@ -44,7 +44,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### 3.1.3<a rel="nofollow"></a>Output
+### 3.1.3 <a rel="nofollow"></a>Output
 
 List of objects with the following key-value pairs:
 
@@ -53,7 +53,7 @@ List of objects with the following key-value pairs:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.1.3.1<a rel="nofollow"></a>Example
+##### 3.1.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [{
@@ -69,9 +69,9 @@ List of objects with the following key-value pairs:
 }]
 ```
 
-## 3.2<a name="DeployAPI-CreateSandbox" rel="nofollow"></a>Create Sandbox
+## 3.2 <a name="DeployAPI-CreateSandbox" rel="nofollow"></a>Create Sandbox
 
-### 3.2.1<a name="DeployAPI-Description" rel="nofollow"></a>Description
+### 3.2.1 <a name="DeployAPI-Description" rel="nofollow"></a>Description
 
 Creates a sandbox application for a requested project id.
 
@@ -80,15 +80,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/
 ```
 
-### 3.2.2<a name="DeployAPI-Request" rel="nofollow"></a>Request
+### 3.2.2 <a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### 3.2.2.1<a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+##### 3.2.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 An object with the following key-value pair:
 
 *   _ProjectId_ (String) : The Developer Portal project identifier that should be linked to the new sandbox application. This value can be found under Settings > General, and it is represented as App ID.
 
-##### 3.2.2.2<a name="DeployAPI-Example" rel="nofollow"></a>Example
+##### 3.2.2.2 <a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 POST /api/1/apps/ HTTP/1.1
@@ -102,7 +102,7 @@ Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### 3.2.3<a rel="nofollow"></a>Output
+### 3.2.3 <a rel="nofollow"></a>Output
 
 Response object with the following fields:
 
@@ -111,14 +111,14 @@ Response object with the following fields:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.2.3.1<a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
+##### 3.2.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_PROJECTID | Invalid ProjectId |
 | 400 | APPLICATION_ALREADY_EXISTS | Application already exists |
 
-##### 3.2.3.2<a rel="nofollow"></a>Example
+##### 3.2.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -129,9 +129,9 @@ Response object with the following fields:
 }
 ```
 
-## 3.3<a name="DeployAPI-Retrieveapp" rel="nofollow"></a>Retrieve App
+## 3.3 <a name="DeployAPI-Retrieveapp" rel="nofollow"></a>Retrieve App
 
-### 3.3.1<a rel="nofollow"></a>Description
+### 3.3.1 <a rel="nofollow"></a>Description
 
 Retrieves a specific app which the authenticated user has access to as a regular user. These app can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -140,9 +140,9 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>
 ```
 
-### 3.3.2<a rel="nofollow"></a>Request
+### 3.3.2 <a rel="nofollow"></a>Request
 
-##### 3.3.2.1<a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
+##### 3.3.2.1 <a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Sub-domain name of an app.
 
@@ -156,7 +156,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### 3.3.3<a name="DeployAPI-Output" rel="nofollow"></a>Output
+### 3.3.3 <a name="DeployAPI-Output" rel="nofollow"></a>Output
 
 Object with the following key-value pairs:
 
@@ -164,14 +164,14 @@ Object with the following key-value pairs:
 *   _Name_ (String): Name of the app.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### 3.3.3.1<a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
+##### 3.3.3.1 <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_APPID | Invalid AppId |
 | 404 | APP_NOT_FOUND | App not found |
 
-##### 3.3.3.2<a rel="nofollow"></a>Example
+##### 3.3.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -182,9 +182,9 @@ Object with the following key-value pairs:
 }
 ```
 
-## 3.4<a name="DeployAPI-Retrieveenvironments" rel="nofollow"></a>Retrieve Environments
+## 3.4 <a name="DeployAPI-Retrieveenvironments" rel="nofollow"></a>Retrieve Environments
 
-### 3.4.1<a rel="nofollow"></a>Description
+### 3.4.1 <a rel="nofollow"></a>Description
 
 Retrieves all environments that are connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -193,13 +193,13 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/
 ```
 
-### 3.4.2<a rel="nofollow"></a>Request
+### 3.4.2 <a rel="nofollow"></a>Request
 
-##### 3.4.2.1<a rel="nofollow"></a>Parameter
+##### 3.4.2.1 <a rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Subdomain name of an app.
 
-##### 3.4.2.2<a rel="nofollow"></a>Example
+##### 3.4.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/ HTTP/ 1.1
@@ -210,7 +210,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### 3.4.3<a rel="nofollow"></a>Output
+### 3.4.3 <a rel="nofollow"></a>Output
 
 List of objects with the following key-value pairs:
 
@@ -218,7 +218,7 @@ List of objects with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   Mode (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.4.3.1<a rel="nofollow"></a>Example
+##### 3.4.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -235,9 +235,9 @@ List of objects with the following key-value pairs:
 ]
 ```
 
-## 3.5<a name="DeployAPI-Retrieveenvironment" rel="nofollow"></a>Retrieve Environment
+## 3.5 <a name="DeployAPI-Retrieveenvironment" rel="nofollow"></a>Retrieve Environment
 
-### 3.5.1<a rel="nofollow"></a>Description
+### 3.5.1 <a rel="nofollow"></a>Description
 
 Retrieves a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -246,14 +246,14 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>
 ```
 
-### 3.5.2<a rel="nofollow"></a>Request
+### 3.5.2 <a rel="nofollow"></a>Request
 
-##### 3.5.2.1<a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+##### 3.5.2.1 <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): The mode of the environment of the app. An environment with this mode should exist.
 
-##### 3.5.2.2<a rel="nofollow"></a>Example
+##### 3.5.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/Acceptance HTTP/1.1
@@ -271,7 +271,7 @@ An object with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.5.3.1<a rel="nofollow"></a>Error Codes
+##### 3.5.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -279,7 +279,7 @@ An object with the following key-value pairs:
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 
-##### 3.5.3.2<a rel="nofollow"></a>Example
+##### 3.5.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -289,9 +289,9 @@ An object with the following key-value pairs:
 }
 ```
 
-## 3.6<a name="DeployAPI-Startenvironment" rel="nofollow"></a>Start Environment
+## 3.6 <a name="DeployAPI-Startenvironment" rel="nofollow"></a>Start Environment
 
-### 3.6.1<a rel="nofollow"></a>Description
+### 3.6.1 <a rel="nofollow"></a>Description
 
 Starts a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -308,7 +308,7 @@ An object with the following key-value pair:
 
 *   _AutoSyncDb_ (Boolean) : Define whether the database should be synchronized automatically with the model during the start phase of the app. This is only applicable if your Mendix Cloud version is older than v4.
 
-##### 3.6.2.2<a rel="nofollow"></a>Example
+##### 3.6.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/Acceptance/start HTTP/ 1.1
@@ -323,13 +323,13 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### 3.6.3<a rel="nofollow"></a>Output
+### 3.6.3 <a rel="nofollow"></a>Output
 
 An object with the following key-value pairs:
 
 *   _JobId_ (String): The identifier which can be used to track the progress of the start action
 
-##### 3.6.3.1<a rel="nofollow"></a>Error Codes
+##### 3.6.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -339,7 +339,7 @@ An object with the following key-value pairs:
 | 500 | APP_ALREADY_HAS_A_STARTING_JOB | Cannot start app. There is already a starting job id found. |
 | 500 | ALREADY_STARTED | Cannot start app. App is already running. |
 
-##### 3.6.3.2<a rel="nofollow"></a>Example
+##### 3.6.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -347,9 +347,9 @@ An object with the following key-value pairs:
 }
 ```
 
-## 3.7<a name="DeployAPI-Getstartenvironmentstatus" rel="nofollow"></a>Get Start Environment Status
+## 3.7 <a name="DeployAPI-Getstartenvironmentstatus" rel="nofollow"></a>Get Start Environment Status
 
-### 3.7.1<a rel="nofollow"></a>Description
+### 3.7.1 <a rel="nofollow"></a>Description
 
 Retrieve the status of the start environment action.
 

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -3,7 +3,7 @@ title: "Deploy API"
 category: "API Documentation"
 ---
 
-# Introduction
+# 1 Introduction
 
 The Deploy API allows you to manage application environments in the Mendix Cloud. You can retrieve the status and start and stop applications, and you can also deploy and configure new model versions to application environments. You will also need the Build API to create and manage deployment packages.
 
@@ -11,19 +11,19 @@ This image provides a domain model representation of the concepts discussed belo
 
 ![](attachments/deploy-api/api-model.png)
 
-# <a name="DeployAPI-Authentication" rel="nofollow"></a>Authentication
+# <a name="DeployAPI-Authentication" rel="nofollow"></a>2 Authentication
 
 The Deploy API requires authentication via API keys that are bound to your Mendix account (for more information, see [Authentication](authentication).
 
 As APIs are designed for automated systems, the Deploy API does not require two-factor authentication, which is normally required to make changes to production environments. This is a potential security risk. Therefore, the Technical Contact of an application needs to explicitly allow API access for team members that want to use the Deploy API. This can be configured from the **Node Security** screen under **Project Settings**. By default, API access is already enabled for test and acceptance environments for all team members. To perform an action via the Deploy API, such as transporting a new deployment package, both the **Transport** and **API Access** permissions need to be enabled.
 
-# <a name="DeployAPI-APIcalls" rel="nofollow"></a>API Calls
+# 3 <a name="DeployAPI-APIcalls" rel="nofollow"></a> API Calls
 
 Only _Retrieve apps_, _Create Sandbox_ and _Retrieve app_ API calls are supported for sandbox applications. Please note that most api calls with the exception of _Upload Package_ requires the _Content-Type_ header to be set to _application/json_.
 
-## <a name="DeployAPI-Retrieveapps" rel="nofollow"></a>Retrieve Apps
+## 3.1 <a name="DeployAPI-Retrieveapps" rel="nofollow"></a>Retrieve Apps
 
-### <a name="DeployAPI-Description" rel="nofollow"></a>Description
+### 3.1.1 <a name="DeployAPI-Description" rel="nofollow"></a>Description
 
 Retrieves all apps which the authenticated user has access to as a regular user. These apps can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -32,9 +32,9 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/
 ```
 
-### <a name="DeployAPI-Request" rel="nofollow"></a>Request
+### 3.1.2<a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### <a name="DeployAPI-Example" rel="nofollow"></a>Example
+##### 3.1.2.1<a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/ HTTP/1.1
@@ -44,7 +44,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.1.3<a rel="nofollow"></a>Output
 
 List of objects with the following key-value pairs:
 
@@ -53,7 +53,7 @@ List of objects with the following key-value pairs:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### <a rel="nofollow"></a>Example
+##### 3.1.3.1<a rel="nofollow"></a>Example
 
 ```bash
 [{
@@ -69,9 +69,9 @@ List of objects with the following key-value pairs:
 }]
 ```
 
-## <a name="DeployAPI-CreateSandbox" rel="nofollow"></a>Create Sandbox
+## 3.2<a name="DeployAPI-CreateSandbox" rel="nofollow"></a>Create Sandbox
 
-### <a name="DeployAPI-Description" rel="nofollow"></a>Description
+### 3.2.1<a name="DeployAPI-Description" rel="nofollow"></a>Description
 
 Creates a sandbox application for a requested project id.
 
@@ -80,15 +80,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/
 ```
 
-### <a name="DeployAPI-Request" rel="nofollow"></a>Request
+### 3.2.2<a name="DeployAPI-Request" rel="nofollow"></a>Request
 
-##### <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+##### 3.2.2.1<a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 An object with the following key-value pair:
 
 *   _ProjectId_ (String) : The Developer Portal project identifier that should be linked to the new sandbox application. This value can be found under Settings > General, and it is represented as App ID.
 
-##### <a name="DeployAPI-Example" rel="nofollow"></a>Example
+##### 3.2.2.2<a name="DeployAPI-Example" rel="nofollow"></a>Example
 
 ```bash
 POST /api/1/apps/ HTTP/1.1
@@ -102,7 +102,7 @@ Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.2.3<a rel="nofollow"></a>Output
 
 Response object with the following fields:
 
@@ -111,14 +111,14 @@ Response object with the following fields:
 *   _ProjectId_ (String): Developer Portal Project identifier.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
+##### 3.2.3.1<a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_PROJECTID | Invalid ProjectId |
 | 400 | APPLICATION_ALREADY_EXISTS | Application already exists |
 
-##### <a rel="nofollow"></a>Example
+##### 3.2.3.2<a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -129,9 +129,9 @@ Response object with the following fields:
 }
 ```
 
-## <a name="DeployAPI-Retrieveapp" rel="nofollow"></a>Retrieve App
+## 3.3<a name="DeployAPI-Retrieveapp" rel="nofollow"></a>Retrieve App
 
-### <a rel="nofollow"></a>Description
+### 3.3.1<a rel="nofollow"></a>Description
 
 Retrieves a specific app which the authenticated user has access to as a regular user. These app can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -140,13 +140,13 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.3.2<a rel="nofollow"></a>Request
 
-##### <a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
+##### 3.3.2.1<a name="DeployAPI-Parameter" rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Sub-domain name of an app.
 
-##### <a rel="nofollow"></a>Example
+##### 3.3.2.2<a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/ HTTP/1.1
@@ -156,7 +156,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a name="DeployAPI-Output" rel="nofollow"></a>Output
+### 3.3.3<a name="DeployAPI-Output" rel="nofollow"></a>Output
 
 Object with the following key-value pairs:
 
@@ -164,14 +164,14 @@ Object with the following key-value pairs:
 *   _Name_ (String): Name of the app.
 *   _Url_ (String): Production or sandbox URL to access your app.
 
-##### <a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
+##### 3.3.3.1<a name="DeployAPI-Errorcodes" rel="nofollow"></a>Error codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
 | 400 | INVALID_APPID | Invalid AppId |
 | 404 | APP_NOT_FOUND | App not found |
 
-##### <a rel="nofollow"></a>Example
+##### 3.3.3.2<a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -182,9 +182,9 @@ Object with the following key-value pairs:
 }
 ```
 
-## <a name="DeployAPI-Retrieveenvironments" rel="nofollow"></a>Retrieve Environments
+## 3.4<a name="DeployAPI-Retrieveenvironments" rel="nofollow"></a>Retrieve Environments
 
-### <a rel="nofollow"></a>Description
+### 3.4.1<a rel="nofollow"></a>Description
 
 Retrieves all environments that are connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -193,13 +193,13 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.4.2<a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameter
+##### 3.4.2.1<a rel="nofollow"></a>Parameter
 
 *   _AppId_ (String): Subdomain name of an app.
 
-##### <a rel="nofollow"></a>Example
+##### 3.4.2.2<a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/ HTTP/ 1.1
@@ -210,7 +210,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.4.3<a rel="nofollow"></a>Output
 
 List of objects with the following key-value pairs:
 
@@ -218,7 +218,7 @@ List of objects with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   Mode (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### <a rel="nofollow"></a>Example
+##### 3.4.3.1<a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -235,9 +235,9 @@ List of objects with the following key-value pairs:
 ]
 ```
 
-## <a name="DeployAPI-Retrieveenvironment" rel="nofollow"></a>Retrieve Environment
+## 3.5<a name="DeployAPI-Retrieveenvironment" rel="nofollow"></a>Retrieve Environment
 
-### <a rel="nofollow"></a>Description
+### 3.5.1<a rel="nofollow"></a>Description
 
 Retrieves a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -246,14 +246,14 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.5.2<a rel="nofollow"></a>Request
 
-##### <a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
+##### 3.5.2.1<a name="DeployAPI-Parameters" rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): The mode of the environment of the app. An environment with this mode should exist.
 
-##### <a rel="nofollow"></a>Example
+##### 3.5.2.2<a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/Acceptance HTTP/1.1
@@ -263,7 +263,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### Output
+### 3.5.3 Output
 
 An object with the following key-value pairs:
 
@@ -271,7 +271,7 @@ An object with the following key-value pairs:
 *   _Url_ (String): URL to access your application.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.5.3.1<a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -279,7 +279,7 @@ An object with the following key-value pairs:
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.5.3.2<a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -289,9 +289,9 @@ An object with the following key-value pairs:
 }
 ```
 
-## <a name="DeployAPI-Startenvironment" rel="nofollow"></a>Start Environment
+## 3.6<a name="DeployAPI-Startenvironment" rel="nofollow"></a>Start Environment
 
-### <a rel="nofollow"></a>Description
+### 3.6.1<a rel="nofollow"></a>Description
 
 Starts a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -300,15 +300,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/start
 ```
 
-### Request
+### 3.6.2 Request
 
-##### <a name="DeployAPI-Payload" rel="nofollow"></a>Payload
+##### 3.6.2.1 <a name="DeployAPI-Payload" rel="nofollow"></a>Payload
 
 An object with the following key-value pair:
 
 *   _AutoSyncDb_ (Boolean) : Define whether the database should be synchronized automatically with the model during the start phase of the app. This is only applicable if your Mendix Cloud version is older than v4.
 
-##### <a rel="nofollow"></a>Example
+##### 3.6.2.2<a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/Acceptance/start HTTP/ 1.1
@@ -323,13 +323,13 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.6.3<a rel="nofollow"></a>Output
 
 An object with the following key-value pairs:
 
 *   _JobId_ (String): The identifier which can be used to track the progress of the start action
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.6.3.1<a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -339,7 +339,7 @@ An object with the following key-value pairs:
 | 500 | APP_ALREADY_HAS_A_STARTING_JOB | Cannot start app. There is already a starting job id found. |
 | 500 | ALREADY_STARTED | Cannot start app. App is already running. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.6.3.2<a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -347,9 +347,9 @@ An object with the following key-value pairs:
 }
 ```
 
-## <a name="DeployAPI-Getstartenvironmentstatus" rel="nofollow"></a>Get Start Environment Status
+## 3.7<a name="DeployAPI-Getstartenvironmentstatus" rel="nofollow"></a>Get Start Environment Status
 
-### <a rel="nofollow"></a>Description
+### 3.7.1<a rel="nofollow"></a>Description
 
 Retrieve the status of the start environment action.
 
@@ -358,9 +358,9 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/start/<JobId>
 ```
 
-### Request
+### 3.7.2 Request
 
-##### <a rel="nofollow"></a>Example
+##### 3.7.2.1 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/Acceptance/start/02df2e50-0e79-11e4- 9191 -0800200c9a66 HTTP/ 1.1
@@ -371,13 +371,13 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.7.3 <a rel="nofollow"></a>Output
 
 An object with the following key-value pair:
 
 *   _Status_ (String): Possible values are Starting and Started
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.7.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -395,7 +395,7 @@ An object with the following key-value pair:
 | 500 | STARTUP_ACTION_FAILED | Cannot start app. Startup action failed. |
 | 500 | START_FAILED | Cannot start app: result (detail status) |
 
-##### <a rel="nofollow"></a>Example
+##### 3.7.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -403,9 +403,9 @@ An object with the following key-value pair:
 }
 ```
 
-## <a name="DeployAPI-Stopenvironment" rel="nofollow"></a>Stop Environment
+## 3.8 <a name="DeployAPI-Stopenvironment" rel="nofollow"></a>Stop Environment
 
-### <a rel="nofollow"></a>Description
+### 3.8.1 <a rel="nofollow"></a>Description
 
 Stops a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -414,9 +414,9 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/stop
 ```
 
-### Request
+### 3.8.2 Request
 
-##### <a rel="nofollow"></a>Example
+##### 3.8.2.1 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/Acceptance/stop HTTP/ 1.1
@@ -427,9 +427,9 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.8.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.8.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -438,9 +438,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found |
 | 500 | STOP_FAILED | Cannot stop app: reason |
 
-## <a name="DeployAPI-Retrieveenvironmentpackage" rel="nofollow"></a>Retrieve Environment Package
+## 3.9 <a name="DeployAPI-Retrieveenvironmentpackage" rel="nofollow"></a>Retrieve Environment Package
 
-### <a rel="nofollow"></a>Description
+### 3.9.1 <a rel="nofollow"></a>Description
 
 Retrieves the deployed package of a specific environment that is connected to a specific app which the authenticated user has access to as a regular user. These environments can be found via the "Nodes overview" screen in the Mendix Platform.
 
@@ -449,14 +449,14 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/package
 ```
 
-### Request
+### 3.9.2 Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.9.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): The mode of the environment of the app. An environment with this mode should exist.
 
-##### <a rel="nofollow"></a>Example
+##### 3.9.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/Acceptance/ package HTTP/ 1.1
@@ -467,7 +467,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.9.3 <a rel="nofollow"></a>Output
 
 An object with the following key-value pairs:
 
@@ -482,7 +482,7 @@ An object with the following key-value pairs:
     Possible values: Succeeded, Queued, Building, Uploading and Failed.
 *   _Size_ (Long): Size of the package in bytes.
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.9.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -490,7 +490,7 @@ An object with the following key-value pairs:
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | PACKAGE_NOT_FOUND | No package found for this environment |
 
-##### <a rel="nofollow"></a>Example
+##### 3.9.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -506,9 +506,9 @@ An object with the following key-value pairs:
 }
 ```
 
-## <a name="DeployAPI-Uploadpackage" rel="nofollow"></a>Upload Package
+## 3.9.4 <a name="DeployAPI-Uploadpackage" rel="nofollow"></a>Upload Package
 
-### <a rel="nofollow"></a>Description
+### 3.9.4.1 <a rel="nofollow"></a>Description
 
 Uploads a deployment package from the local system to a specific app. This package can then be transported to a specific environment for deployment.
 
@@ -517,15 +517,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/packages/upload
 ```
 
-### Request
+### 3.9.5 Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.9.5.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Name_ (String): Name of the deployment package as query parameter
 *   _file_ (File): Deployment package as multipart/form-data
 
-##### <a rel="nofollow"></a>Example
+##### 3.9.5.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/packages/upload HTTP/ 1.1
@@ -540,9 +540,9 @@ Curl example:
 curl -v -F "file=@/tmp/some.mda" -X POST -H "Mendix-Username: richard.ford51@example.com" -H "Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6" "https://deploy.mendix.com/api/1/apps/calc/packages/upload" -F 'Name=some.mda'
 ```
 
-### <a name="DeployAPI-Ouput" rel="nofollow"></a>Ouput
+### 3.9.6 <a name="DeployAPI-Ouput" rel="nofollow"></a>Ouput
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.9.6.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -551,9 +551,9 @@ curl -v -F "file=@/tmp/some.mda" -X POST -H "Mendix-Username: richard.ford51@exa
 | 500 | UPLOAD_COPY_FAILED | Failed to store the deployment package. |
 | 500 | INVALID_PACKAGE | Failed to process the deployment package. |
 
-## <a name="DeployAPI-Transportadeploymentpackagetoanenvironment" rel="nofollow"></a>Transporting a Deployment Package to an Environment
+## 3.10 <a name="DeployAPI-Transportadeploymentpackagetoanenvironment" rel="nofollow"></a>Transporting a Deployment Package to an Environment
 
-### <a rel="nofollow"></a>Description
+### 3.10.1 <a rel="nofollow"></a>Description
 
 Transports a specific deployment package to a specific environment. This action requires the environment to be in the "NotRunning" status. This call is not available for Sandboxes, in which case the Build API can be used to trigger a deployment.
 
@@ -562,15 +562,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/transport
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.10.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.10.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _PackageId_ (String): ID of the deployment package
 
-##### <a rel="nofollow"></a>Example
+##### 3.10.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/acceptance/transport HTTP/ 1.1
@@ -585,9 +585,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.10.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.10.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -601,9 +601,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | PACKAGE_NOT_FOUND | Package not found. |
 | 500 | PACKAGE_PARSE_FAILED | Failed to parse deployment package file. |
 
-## <a name="DeployAPI-Cleanenvironment" rel="nofollow"></a>Clean environment
+## 3.11 <a name="DeployAPI-Cleanenvironment" rel="nofollow"></a>Clean environment
 
-### <a rel="nofollow"></a>Description
+### 3.11.1 <a rel="nofollow"></a>Description
 
 Removes all data from a specific environment including files and database records. This action requires the environment to be in "NotRunning" status.
 
@@ -612,14 +612,14 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/clean
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.11.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.11.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### <a rel="nofollow"></a>Example
+##### 3.11.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/acceptance/clean HTTP/ 1.1
@@ -630,9 +630,9 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.11.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Example
+##### 3.11.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -644,7 +644,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ]
 ```
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.11.3.2 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -654,9 +654,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 500 | ENVIRONMENT_CLEAN_FAILED | Unable to clean the environment. Please contact support. |
 
-## <a name="DeployAPI-Retrieveenvironmentsettings" rel="nofollow"></a>Retrieve Environment Settings
+## 3.12 <a name="DeployAPI-Retrieveenvironmentsettings" rel="nofollow"></a>Retrieve Environment Settings
 
-### <a rel="nofollow"></a>Description
+### 3.12.1 <a rel="nofollow"></a>Description
 
 Gets current values of custom settings, constants and scheduled events used by the target environment.
 
@@ -665,14 +665,14 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.12.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.12.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### <a rel="nofollow"></a>Example
+##### 3.12.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
@@ -683,9 +683,9 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.12.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.12.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -693,7 +693,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.12.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -717,9 +717,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-## <a name="DeployAPI-Setenvironmentsettings" rel="nofollow"></a>Set Environment Settings
+## 3.13 <a name="DeployAPI-Setenvironmentsettings" rel="nofollow"></a>Set Environment Settings
 
-### <a rel="nofollow"></a>Description
+### 3.13.1 <a rel="nofollow"></a>Description
 
 Changes value of existing environment settings like custom settings, constants and scheduled events. These changes are applied after restarting the environment.
 
@@ -728,15 +728,15 @@ HTTP Method: POST
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings/
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.13.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.13.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _Body_: JSON collection retrieved with GET method at the same URI
 
-##### <a rel="nofollow"></a>Example
+##### 3.13.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
@@ -767,9 +767,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.13.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.13.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -781,7 +781,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 500 | INVALID_SCHEDULED_EVENT_PARAMETER | Scheduled Event parameter should be Enabled or Disabled. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.13.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -805,9 +805,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 }
 ```
 
-## <a name="DeployAPI-ListBackups" rel="nofollow"></a>List Environment Backups
+## 3.14 <a name="DeployAPI-ListBackups" rel="nofollow"></a>List Environment Backups
 
-### <a rel="nofollow"></a>Description
+### 3.14.1 <a rel="nofollow"></a>Description
 
 Lists the backups of an environment.
 
@@ -817,14 +817,14 @@ curl -H "Mendix-Username: $username" -H "Mendix-ApiKey: $apikey" $baseurl/apps/r
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.14.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.14.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### <a rel="nofollow"></a>Example
+##### 3.14.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/acceptance/snapshots HTTP/ 1.1
@@ -836,9 +836,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.14.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.14.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -848,7 +848,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 500 | SNAPSHOT_LISTING_FAILED | An error occurred while listing the backups. Please contact support. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.14.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -871,9 +871,9 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ]
 ```
 
-## <a name="DeployAPI-DownloadBackup" rel="nofollow"></a>Download a Backup for an Environment
+## 3.15 <a name="DeployAPI-DownloadBackup" rel="nofollow"></a>Download a Backup for an Environment
 
-### <a rel="nofollow"></a>Description
+### 3.15.1 <a rel="nofollow"></a>Description
 
 Download the backup for an environment. The response contains direct links to the external backup system, you can use these links to download three types of backups.
 
@@ -882,15 +882,15 @@ HTTP Method: GET
 URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots/<SnapshotId>
 ```
 
-### <a rel="nofollow"></a>Request
+### 3.15.2 <a rel="nofollow"></a>Request
 
-##### <a rel="nofollow"></a>Parameters
+##### 3.15.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _SnapshotId_ (String): Identifier of the backup
 
-##### <a rel="nofollow"></a>Example
+##### 3.15.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/acceptance/snapshots/201703221355 HTTP/ 1.1
@@ -901,9 +901,9 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-### <a rel="nofollow"></a>Output
+### 3.15.3 <a rel="nofollow"></a>Output
 
-##### <a rel="nofollow"></a>Error Codes
+##### 3.15.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -913,7 +913,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 404 | SNAPSHOT_NOT_FOUND | Snapshot not found. |
 
-##### <a rel="nofollow"></a>Example
+##### 3.15.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -146,7 +146,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>
 
 *   _AppId_ (String): Sub-domain name of an app.
 
-##### 3.3.2.2<a rel="nofollow"></a>Example
+##### 3.3.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/ HTTP/1.1
@@ -614,12 +614,12 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/clean
 
 ### 3.11.2 <a rel="nofollow"></a>Request
 
-##### 3.11.2.1 <a rel="nofollow"></a>Parameters
+#### 3.11.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.11.2.2 <a rel="nofollow"></a>Example
+#### 3.11.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 POST /api/ 1 /apps/calc/environments/acceptance/clean HTTP/ 1.1
@@ -632,7 +632,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.11.3 <a rel="nofollow"></a>Output
 
-##### 3.11.3.1 <a rel="nofollow"></a>Example
+#### 3.11.3.1 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -644,7 +644,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ]
 ```
 
-##### 3.11.3.2 <a rel="nofollow"></a>Error Codes
+#### 3.11.3.2 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -667,12 +667,12 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings
 
 ### 3.12.2 <a rel="nofollow"></a>Request
 
-##### 3.12.2.1 <a rel="nofollow"></a>Parameters
+#### 3.12.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.12.2.2 <a rel="nofollow"></a>Example
+#### 3.12.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
@@ -685,7 +685,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.12.3 <a rel="nofollow"></a>Output
 
-##### 3.12.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.12.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -693,7 +693,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 400 | INVALID_ENVIRONMENT | Could not parse environment mode 'mode'. Valid options are 'Test', 'Acceptance' and 'Production'. |
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 
-##### 3.12.3.2 <a rel="nofollow"></a>Example
+#### 3.12.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -730,13 +730,13 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings/
 
 ### 3.13.2 <a rel="nofollow"></a>Request
 
-##### 3.13.2.1 <a rel="nofollow"></a>Parameters
+#### 3.13.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _Body_: JSON collection retrieved with GET method at the same URI
 
-##### 3.13.2.2 <a rel="nofollow"></a>Example
+#### 3.13.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/ 1 /apps/calc/environments/acceptance/settings/ HTTP/ 1.1
@@ -769,7 +769,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.13.3 <a rel="nofollow"></a>Output
 
-##### 3.13.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.13.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -781,7 +781,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 500 | INVALID_SCHEDULED_EVENT_PARAMETER | Scheduled Event parameter should be Enabled or Disabled. |
 
-##### 3.13.3.2 <a rel="nofollow"></a>Example
+#### 3.13.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {
@@ -819,12 +819,12 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots
 
 ### 3.14.2 <a rel="nofollow"></a>Request
 
-##### 3.14.2.1 <a rel="nofollow"></a>Parameters
+#### 3.14.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Sub-domain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 
-##### 3.14.2.2 <a rel="nofollow"></a>Example
+#### 3.14.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/acceptance/snapshots HTTP/ 1.1
@@ -838,7 +838,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.14.3 <a rel="nofollow"></a>Output
 
-##### 3.14.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.14.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -848,7 +848,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 500 | SNAPSHOT_LISTING_FAILED | An error occurred while listing the backups. Please contact support. |
 
-##### 3.14.3.2 <a rel="nofollow"></a>Example
+#### 3.14.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 [
@@ -884,13 +884,13 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/snapshots/
 
 ### 3.15.2 <a rel="nofollow"></a>Request
 
-##### 3.15.2.1 <a rel="nofollow"></a>Parameters
+#### 3.15.2.1 <a rel="nofollow"></a>Parameters
 
 *   _AppId_ (String): Subdomain name of an app.
 *   _Mode_ (String): Mode of the environment. Possible values: Test, Acceptance, Production.
 *   _SnapshotId_ (String): Identifier of the backup
 
-##### 3.15.2.2 <a rel="nofollow"></a>Example
+#### 3.15.2.2 <a rel="nofollow"></a>Example
 
 ```bash
 GET /api/1/apps/calc/environments/acceptance/snapshots/201703221355 HTTP/ 1.1
@@ -903,7 +903,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
 ### 3.15.3 <a rel="nofollow"></a>Output
 
-##### 3.15.3.1 <a rel="nofollow"></a>Error Codes
+#### 3.15.3.1 <a rel="nofollow"></a>Error Codes
 
 | HTTP Status | Error code | Description |
 | --- | --- | --- |
@@ -913,7 +913,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 | 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
 | 404 | SNAPSHOT_NOT_FOUND | Snapshot not found. |
 
-##### 3.15.3.2 <a rel="nofollow"></a>Example
+#### 3.15.3.2 <a rel="nofollow"></a>Example
 
 ```bash
 {


### PR DESCRIPTION
This makes it more explicit for users to use proper content-type when consuming the deploy API. 