### PR TITLE
Export swagger button was moved to Published REST service context menu

### DIFF
--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -35,7 +35,7 @@ The public documentation is used in the service's [OpenAPI (Swagger) documentati
 
 ### <a name="export-swagger-json"></a>2.5 Export swagger.json
 
-When you right click on your service in the project explorer you can select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
+When you right-click your service in the Project Explorer, select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
 
 When the app is running, this file is available under `/rest-doc/servicename/swagger.json`.
 

--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -35,7 +35,7 @@ The public documentation is used in the service's [OpenAPI (Swagger) documentati
 
 ### <a name="export-swagger-json"></a>2.5 Export swagger.json
 
-Click **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
+When you right click on your service you can select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
 
 When the app is running, this file is available under `/rest-doc/servicename/swagger.json`.
 

--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -35,7 +35,7 @@ The public documentation is used in the service's [OpenAPI (Swagger) documentati
 
 ### <a name="export-swagger-json"></a>2.5 Export swagger.json
 
-When you right-click your service in the Project Explorer, select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
+To save a service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine, simply right-click the service in the **Project Explorer** and select **Export swagger.json** (or just click the **Export swagger.json** button, depending on your Modeler version). This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
 
 When the app is running, this file is available under `/rest-doc/servicename/swagger.json`.
 

--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -35,7 +35,7 @@ The public documentation is used in the service's [OpenAPI (Swagger) documentati
 
 ### <a name="export-swagger-json"></a>2.5 Export swagger.json
 
-When you right click on your service you can select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
+When you right click on your service in the project explorer you can select **Export swagger.json** to save the service's [OpenAPI (Swagger) documentation](open-api) somewhere on your machine. This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
 
 When the app is running, this file is available under `/rest-doc/servicename/swagger.json`.
 


### PR DESCRIPTION
We have moved "Export swagger.json" button to "Published REST service" context menu. This will be in with version 7.12.