### PR TITLE
Rename Extendability to Extensibility in HowTo6

### DIFF
--- a/data/spaces.yml
+++ b/data/spaces.yml
@@ -82,7 +82,7 @@ howto6:
     - "Mobile"
     - "Security"
     - "Integration"
-    - "Extendability"
+    - "Extensibility"
     - "Custom Widget Development"
     - "Testing"
     - "Monitoring & Troubleshooting"


### PR DESCRIPTION
Travis had a warning:

[09:20:03] [MENU_CHECK] MISSING   page: /howto6/extendability has no category/parent, but is also not a category. Please check the page!

Hope this will solve it.