### PR TITLE
Correct Travis Warning Extendability in HowTo6

### DIFF
--- a/content/howto6/extendability.md
+++ b/content/howto6/extendability.md
@@ -1,5 +1,5 @@
 ---
-title: "Extensibility"
+title: "Extendability"
 ---
 
 One of the strengths of Mendix is that it’s easy to connect your Mendix application with other systems. The Mendix App Store is stocked with all kinds of connectors and adapters. You're also able to extend your app by using and creating widgets.


### PR DESCRIPTION
Travis warned that the title did not match the category.
Have changed the title back to Extendability to try to solve the problem.