### PR TITLE
Sprintr renamed to Development Portal

### DIFF
--- a/content/ats/howtos/ht-version-1/getting-started.md
+++ b/content/ats/howtos/ht-version-1/getting-started.md
@@ -46,8 +46,8 @@ To create a new project, follow these steps:
       --- | ---
       **Project type** | Select **Project**.
       **Name** | Enter a name for your project. You can enter any name, but using the actual name of your application here is advised.
-      **Mendix Project/App ID** | Enter the Mendix project/app ID of the app you want to test, NOT the project ID of ATS! This will give ATS access to your Sprintr and user stories. A project can be created without a Mendix project/app ID, but than you have no access to the Sprintr and user stories.
-      **Mendix API Key** | This is the API key you created in your Sprintr project for ATS.
+      **Mendix Project/App ID** | Enter the Mendix project/app ID of the app you want to test, NOT the project ID of ATS! This will give ATS access to your Developer Portal and user stories. A project can be created without a Mendix project/app ID, but than you have no access to the Developer Portal and user stories.
+      **Mendix API Key** | This is the API key you created in your Developer Portal project for ATS.
       **Project Users** | Enter the people that need access to this project. This project will then appear in their **My Projects** menu. You can always edit this later. There are two different roles for a project user: a **Tester** can only test, create tests, and monitor results; a **Project Administrator** has the same rights as the tester but has also editing rights to the configuration settings of a project.
       **Action Libraries** | Make sure that the action libraries **Core** and **Mendix** are included. Please note that without libraries, it is not possible to select actions for the test script. For more information on action libraries, see [Standard Actions Reference](/ats/refguide/rg-version-1/standard-actions-reference).
 

--- a/content/ats/howtos/ht-version-2/ats-and-ci-cd-2.md
+++ b/content/ats/howtos/ht-version-2/ats-and-ci-cd-2.md
@@ -136,7 +136,7 @@ Using the CI/CD API key and the unique ID of the CI/CD template you can execute 
 * Know how to configure CI/CD in ATS:
   * Configure a CI/CD Template in ATS
   * Create the CI/CD API key in ATS
-  * Find your AppID in Mendix Sprintr
+  * Find your AppID in the Mendix Developer Portal
 
 ## 5.2 Adding an Extra Step in Jenkins on a Linux Server
 

--- a/content/ats/howtos/ht-version-2/connect-stories-to-testcases-2.md
+++ b/content/ats/howtos/ht-version-2/connect-stories-to-testcases-2.md
@@ -7,7 +7,7 @@ tags: ["ATS", "testing"]
 
 ## 1 Introduction
 
-Mendix ATS is a testing tool designed for automated testing of Mendix applications. With your automated tests, you want to test functionalities of the application. Descriptions of those functionalities are in your User Stories. As you want to test those functionalities, ATS has the ability to retrieve User Stories from the Mendix Sprintr project. In ATS you can link the retrieved User Stories to test cases and test suites. This is useful for you and your team to see what can be tested automatically and which functionalities are covered by a test case. Additionally linking user stories to test cases and test suites is useful for stakeholders. By linking them, you can show that the functionalities build in the sprint are tested.
+Mendix ATS is a testing tool designed for automated testing of Mendix applications. With your automated tests, you want to test functionalities of the application. Descriptions of those functionalities are in your User Stories. As you want to test those functionalities, ATS has the ability to retrieve User Stories from the Mendix Developer Portal project. In ATS you can link the retrieved User Stories to test cases and test suites. This is useful for you and your team to see what can be tested automatically and which functionalities are covered by a test case. Additionally linking user stories to test cases and test suites is useful for stakeholders. By linking them, you can show that the functionalities build in the sprint are tested.
 
 **This how-to will teach you how to do the following**
 
@@ -31,7 +31,7 @@ The following steps describe how you can set your Mendix API Key in ATS:
 2. Open the app where you want to add the Mendix API Key.
 3. Inside your app click the profile menu and click **Show Test Settings**.
 
-{{% alert type="info" %}} **Show Test Settings** is only present if you have SCRUM Master rights in the Mendix Sprintr project {{% /alert %}}
+{{% alert type="info" %}} **Show Test Settings** is only present if you have SCRUM Master rights in the Mendix Developer Portal project {{% /alert %}}
 
 ![](attachments/configure-a-selenium-hub-2/show-test-settings.png)
 
@@ -43,7 +43,7 @@ Clicking **Set API Key** opens the **Mendix API Key** Dialog:
 
 ![](attachments/connect-stories-to-testcases-2/mendix-api-key-dialog.png)
 
-5. To retrieve your Mendix API Key open the project in Sprintr and click **API Keys**.
+5. To retrieve your Mendix API Key open the project in the Developer Portal and click **API Keys**.
 6. Click **Create API Key**
 7. Enter an API Key name in the **API key name** field and click Generate API Key. 
 8. Copy the API Key and paste it into the **Mendix API Key** field in ATS.
@@ -51,17 +51,17 @@ Clicking **Set API Key** opens the **Mendix API Key** Dialog:
 
 ![](attachments/connect-stories-to-testcases-2/mendix-api-key-filled-e.png)
 
-You have set the Mendix API Key. ATS can now retrieve the User Stories from the Mendix Sprintr project.
+You have set the Mendix API Key. ATS can now retrieve the User Stories from the Mendix Developer Portal project.
 
 ![](attachments/connect-stories-to-testcases-2/set-mendix-api-key.png)
 
 ## 4 Retrieve User Stories in ATS
 
-The following steps explain how to retrieve user stories from the Mendix Sprintr project in ATS:
+The following steps explain how to retrieve user stories from the Mendix Developer Portal project in ATS:
 
 1. Open your project in ATS and go to **Test Cases**.
 2. Click the **Stories** tab.
-3. Click the **Refresh button** to retrieve the User Stories from Sprintr:
+3. Click the **Refresh button** to retrieve the User Stories from the Developer Portal:
 
 ![](attachments/connect-stories-to-testcases-2/go-to-stories-tab-e.png)
 

--- a/content/ats/howtos/ht-version-2/getting-started-2.md
+++ b/content/ats/howtos/ht-version-2/getting-started-2.md
@@ -43,7 +43,7 @@ You are now on the **Settings** page. Here you add environments and selenium hub
 
 {{% alert type="info" %}}
 
-Only the App admin and SCRUM master have the rights to edit the settings. You set the roles in sprintr.
+Only the App admin and SCRUM master have the rights to edit the settings. You set the roles in the Developer Portal.
 
 {{% /alert %}}
 

--- a/content/ats/refguide/rg-version-1/projects.md
+++ b/content/ats/refguide/rg-version-1/projects.md
@@ -27,11 +27,11 @@ The name of the project/library.
 
 **Mendix Project ID**
 
-The project ID of the Mendix sprintr project that you want to get your stories from.
+The project ID of the Mendix Developer Portal project that you want to get your stories from.
 
 **Mendix API Key**
 
-The API key that you created in your sprintr project for ATS.
+The API key that you created in your Developer Portal project for ATS.
 
 **Project Users**
 
@@ -55,6 +55,6 @@ The **Project Dashboard** is the first page you see when you open a project.
 
 There are three sections on the dashboard. The top-left section (1) shows you the number of all the test cases and their results. The lower-left section (2) shows a condensed view of the test results from the last seven days. The right section (3) shows you a detailed view of all the test cases and test suites.
 
-## Sprintr integration
+## Developer Portal integration
 
-Projects in ATS can be connected to sprintr projects by Mendix. If done so, ATS will fetch all sprints and user stories from the project. This allows you to connect your test cases to user stories.
+Projects in ATS can be connected to Developer Portal projects by Mendix. If this is done, ATS will fetch all sprints and user stories from the project. This allows you to connect your test cases to user stories.

--- a/content/howtogeneral/tips/migrating-your-mendix-database.md
+++ b/content/howtogeneral/tips/migrating-your-mendix-database.md
@@ -62,13 +62,13 @@ In order to export a PostgreSQL database, refer to either the [pg_dump](https://
 
 ### 2.2 How to upload an exported PostgreSQL database to the Mendix cloud database
 
-Use Cloud Portal to upload the migrated, exported database backup to the . This can be accessed using the Nodes page in Sprintr: select your app and environment, click Details, click on the Backup tab and use the Upload Data button to upload your Database using the file chooser to select the exported database file from your local file system.This will stop and clear your existing environment.
+Use Cloud Portal to upload the migrated, exported database backup to the . This can be accessed using the Nodes page in the Developer Portal: select your app and environment, click Details, click on the Backup tab and use the Upload Data button to upload your Database using the file chooser to select the exported database file from your local file system.This will stop and clear your existing environment.
 
 ## 3\. How to export a Mendix cloud database
 
 The same procedure can be used to export an existing Mendix cloud database, import it into an on-premise PostgreSQL source database and migrate that to an on-premise non-PostgreSQL target database.
 
-Export the Mendix cloud database via Cloud Portal. This can be accessed using the Nodes page in Sprintr: select your app and environment, click Details, click on the Backup tab, select an existing Backup from the list, and click the Download Backup button to download the database to your local file system using the Database URL shown in the dialogue. A fresh backup with recent data could also be created first using the Create Backup button.
+Export the Mendix cloud database via Cloud Portal. This can be accessed using the Nodes page in the Developer Portal: select your app and environment, click Details, click on the Backup tab, select an existing Backup from the list, and click the Download Backup button to download the database to your local file system using the Database URL shown in the dialogue. A fresh backup with recent data could also be created first using the Create Backup button.
 
 ### 3.1 How to import into on-premise PostgreSQL database
 

--- a/content/refguide/team-server-faq.md
+++ b/content/refguide/team-server-faq.md
@@ -16,11 +16,11 @@ Storage space is unlimited for projects connected to a commercial license. 1 GB 
 
 ### How do I access the Team Server?
 
-The Team Server is delivered as a plugin to sprintr. Start using the Team Server in your sprintr project by activating the plugin or by creating a new Team Server project in the Mendix Desktop Modeler.
+The Team Server is delivered as a plugin to the Developer Portal. Start using the Team Server in your Developer Portal project by activating the plugin or by creating a new Team Server project in the Mendix Desktop Modeler.
 
 ### What access controls come standard with the Team Server?
 
-The Team Server gives you all the controls you need to manage who has access. Just toggle access on and off for each sprintr project member. Once activated, they can use their MxID to access the Team Server from within the Mendix Desktop Modeler.
+The Team Server gives you all the controls you need to manage who has access. Just toggle access on and off for each Developer Portal project member. Once activated, they can use their MxID to access the Team Server from within the Mendix Desktop Modeler.
 
 ### How secure is the Team Server?
 
@@ -46,4 +46,4 @@ Resolving a conflict can be done in by using the 'Use mine' and 'Use theirs' but
 
 ### How can I access the history of my project?
 
-The history of the project is a list of all revisions that have been committed in reverse chronological order. The history form quickly shows you revision number, date, time, author and message of each revision; it can be accessed from within the Mendix Desktop Modeler as well as sprintr. [Read more](version-control-scenarios)
+The history of the project is a list of all revisions that have been committed in reverse chronological order. The history form quickly shows you revision number, date, time, author and message of each revision; it can be accessed from within the Mendix Desktop Modeler as well as the Developer Portal. [Read more](version-control-scenarios)

--- a/content/refguide/version-control-concepts.md
+++ b/content/refguide/version-control-concepts.md
@@ -27,7 +27,7 @@ Before you can start working on a Team Server project you have to download it to
 
 ## Upload to Team Server
 
-If you have an existing project and you want to start using version control, you have to upload the project to the Team Server. You can upload to a new project or you can select an existing project that is Team Server enabled but does not store an actual Modeler project yet. Uploading to a new project also creates a sprintr™ project.
+If you have an existing project and you want to start using version control, you have to upload the project to the Team Server. You can upload to a new project or you can select an existing project that is Team Server enabled but does not store an actual Modeler project yet. Uploading to a new project also creates a Developer Portal project.
 
 ## Status
 
@@ -59,7 +59,7 @@ Sending changes to the repository is called 'committing'. The idea is that you c
 Committing results in a new revision in the repository. You can add the following information to a commit which will be attached to the newly created revision:
 A textual message. You can enter this message in the Modeler when committing and it should be a summary of the changes you made.
 
-A list of sprintr™ stories that relate to the commit. Our advice is to keep commits small and this means that a commit probably relates to one story. The Modeler only shows stories that are currently 'Running' and will not change the state of the sprintr™ story. Setting the status to 'Done' is the responsibility of the team and depends on your definition of done.
+A list of Developer Portal stories that relate to the commit. Our advice is to keep commits small and this means that a commit probably relates to one story. The Modeler only shows stories that are currently 'Running' and will not change the state of the Developer Portal story. Setting the status to 'Done' is the responsibility of the team and depends on your definition of done.
 
 ![](attachments/modeler-core/2018-02-21_13-50-03.png)
 
@@ -94,7 +94,7 @@ Resolving a conflict can be done in by using the 'Use mine' and 'Use theirs' but
 
 ## History
 
-The history of the project is a list of all revisions that have been committed in reverse chronological order (newest is at top of list). The history form quickly shows you revision number, date, time, author and message of each revision. By selecting a revision you can view additional details such as related sprintr™ stories, changed documents, Modeler version and changes on disk. Icons summarize the kinds of changes that happened in the project; whether there are model changes, disk changes and whether the project was upgraded to a new Modeler version can quickly be checked by looking at the icons.
+The history of the project is a list of all revisions that have been committed in reverse chronological order (newest is at top of list). The history form quickly shows you revision number, date, time, author and message of each revision. By selecting a revision you can view additional details such as related Developer Portal stories, changed documents, Modeler version and changes on disk. Icons summarize the kinds of changes that happened in the project; whether there are model changes, disk changes and whether the project was upgraded to a new Modeler version can quickly be checked by looking at the icons.
 
 ![](attachments/modeler-core/2018-02-21_14-06-46.png)
 

--- a/content/refguide/version-control-scenarios.md
+++ b/content/refguide/version-control-scenarios.md
@@ -7,7 +7,7 @@ This page describes some common scenarios of working in the Modeler with version
 
 ## Starting A Project
 
-To start a new project with version control you simply choose 'New Project' in the Modeler and make sure that the Team Server option is enabled. Creating such a project creates a Team Server repository and a sprintr™ project. Also a working copy is created and opened so that you can immediately start working.
+To start a new project with version control you simply choose 'New Project' in the Modeler and make sure that the Team Server option is enabled. Creating such a project creates a Team Server repository and a Developer Portal project. Also a working copy is created and opened so that you can immediately start working.
 
 ![](attachments/modeler-core/2018-03-02_11-11-18.png)
 
@@ -17,7 +17,7 @@ If someone else has already created a Team Server enabled project you can join i
 
 {{% alert type="warning" %}}
 
-If you already have a sprintr™ project that was created by hand, you can enable the Team Server for that project in sprintr™ by adding the Team Server plugin.
+If you already have a Developer Portal project that was created by hand, you can enable the Team Server for that project in the Developer Portal by adding the Team Server plugin.
 
 {{% /alert %}}
 


### PR DESCRIPTION
Changed for current documentation - not for previous versions or release notes.
No proofreading done