### PR TITLE
Add anchor for reference from release note

### DIFF
--- a/content/ats/refguide/rg-version-1/data-management.md
+++ b/content/ats/refguide/rg-version-1/data-management.md
@@ -66,7 +66,7 @@ To export items from the repository, do the following:
 
 Data is exported from the repository.
 
-## 3 Test Data
+## 3 Test Data<a name='test-data'></a>
 
 ### 3.1 Creating Data Sets
 


### PR DESCRIPTION
Reference in release note 1.6 refers to a non-existent anchor.