### PR TITLE
Decimal formatting update [7.15]

### DIFF
--- a/content/refguide/columns-document-template.md
+++ b/content/refguide/columns-document-template.md
@@ -19,7 +19,7 @@ A column can show its contexts as text (default) or as image.
 | Text | Show the contents of the connected attribute as a text. |
 | Image | Show the image of the enumeration value. |
 
-### Decimal precision (only for numeric attributes)
+### Decimal precision (only for decimal attributes)
 
 The precision of a value is defined by the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 

--- a/content/refguide/columns-document-template.md
+++ b/content/refguide/columns-document-template.md
@@ -10,7 +10,7 @@ parent: "data-grid-document-template"
 
 The caption of a column is the text that appears as a header above the rows. This is a translatable text. See [Internationalization](translatable-texts).
 
-### Enumeration Format (only for attributes of type Enumeration)
+### Enumeration Format (Only for Attributes of the Enumeration Type)
 
 A column can show its contexts as text (default) or as image.
 
@@ -19,19 +19,19 @@ A column can show its contexts as text (default) or as image.
 | Text | Show the contents of the connected attribute as a text. |
 | Image | Show the image of the enumeration value. |
 
-### Decimal precision (only for decimal attributes)
+### Decimal Precision (Only for Decimal Attributes)
 
 The precision of a value is defined by the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 
 _Default value:_ 2
 
-### Group digits (only for numeric attributes)
+### Group Digits (Only for Numeric Attributes)
 
 For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property defines whether the end user will see these groups, or not.
 
 _Default value:_ False
 
-### Date format (only for attributes of type DateTime)
+### Date Format (Only for Attributes of the DateTime Type)
 
 The date format determines whether the date part, the time part or both are shown. How the date and time parts are formatted depends on the localization of the user using the application. Alternatively, as of version 2.5.3 you can completely customize the format of the date and/or time by supplying a date format string.
 
@@ -39,7 +39,7 @@ Possible values: 'Date', 'Time', 'Date and time' and in 2.5.3 'Custom'.
 
 _Default value:_ Date
 
-### Custom date format (only for attributes of type DateTime)
+### Custom Date Format (Only for Attributes of the DateTime Type)
 
 If you choose 'Custom' as the date format (see above) the custom date format determines the way date and/or time are formatted. The custom date format is a string that follows the rules described in
 [http://download.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html](http://download.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html).
@@ -55,6 +55,6 @@ results in the following text
 
 ## Data Source Properties
 
-### Attribute (path)
+### Attribute (Path)
 
 The attribute (path) property specifies the attribute whose value will be displayed in the column. It can be an attribute of the grid entity, or it can be an attribute of an associated entity. The path over which an associated object is accessed is referred to as an attribute path. The path can follow multiple associations of type reference, and at the end (optionally) one of type reference set. If you show a reference set in a column the values will be separated by a comma.

--- a/content/refguide/columns.md
+++ b/content/refguide/columns.md
@@ -4,21 +4,19 @@ parent: "data-grid"
 ---
 ## Common Properties
 
-
-
 {{% snippet file="refguide/Class+Property.md" %}}
 
 {{% snippet file="refguide/Style+Property.md" %}}
 
 ## Data Source Properties
 
-### Attribute (path)
+### Attribute (Path)
 
 The attribute (path) property specifies the attribute's value that will be displayed in this column. It can be an attribute of the grid entity, or it can be an attribute of an associated entity, in which case we speak of an attribute path. The path can follow multiple associations of type reference, and at the end (optionally) one of type reference set. If you show a reference set in a column the values will be separated by a comma.
 
 ## Formatting Properties
 
-### Enumeration format (only for attributes of type Enumeration)
+### Enumeration Format (Only for Attributes of the Enumeration Type)
 
 A column connected to an attribute of type enumeration can show its contexts as text (default) or as image.
 
@@ -27,19 +25,19 @@ A column connected to an attribute of type enumeration can show its contexts as 
 | Text | Show the caption text of the enumeration. |
 | Image | Show the image of the enumeration value. |
 
-### Decimal precision (only for decimal attributes)
+### Decimal Precision (Only for Decimal Attributes)
 
 The precision of a value is defined the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 
 _Default value:_ 2
 
-### Group digits (only for numeric attributes)
+### Group Digits (Only for Numeric Attributes)
 
 For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property defines whether the end user will see these groups, or not.
 
 _Default value:_ False
 
-### Date format (only for attributes of type DateTime)
+### Date Format (Only for Attributes of the Type DateTime)
 
 The date format determines whether the date part, the time part or both are shown. How the date and time parts are formatted depends on the localization of the user using the application.
 
@@ -92,7 +90,7 @@ The caption of a column is the text that appears as a header above the rows. Thi
 
 The editable property indicates whether the values of the column will be editable in-line, i.e. without opening a page with a data view. In-line editing allows the data grid to behave like you would expect from a spreadsheet application.
 
-### Aggregate function
+### Aggregate Function
 
 The values in a column can be aggregated in several ways. The aggregate function determines the way in which the values are aggregated. The aggregate will be shown at the bottom of the column that precedes by the aggregate caption (see below).
 
@@ -111,7 +109,7 @@ Note that all objects will be taken into account, and not just the ones on the c
 
 {{% /alert %}}
 
-### Aggregate caption
+### Aggregate Caption
 
 The aggregate caption is the text that appears in front of the computed value. This is a translatable text. See [Translatable Texts](translatable-texts).
 
@@ -121,7 +119,7 @@ The aggregate caption is the text that appears in front of the computed value. T
 
 {{% /alert %}}
 
-### Show tooltip
+### Show Tooltip
 
 This property determines whether the tooltip page is shown as the mouse is hovered over this column. The tooltip page can be configured on the [Data grid](data-grid).
 

--- a/content/refguide/columns.md
+++ b/content/refguide/columns.md
@@ -27,7 +27,7 @@ A column connected to an attribute of type enumeration can show its contexts as 
 | Text | Show the caption text of the enumeration. |
 | Image | Show the image of the enumeration value. |
 
-### Decimal precision (only for numeric attributes)
+### Decimal precision (only for decimal attributes)
 
 The precision of a value is defined the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 

--- a/content/refguide/data-grid.md
+++ b/content/refguide/data-grid.md
@@ -3,7 +3,6 @@ title: "Data grid"
 parent: "data-widgets"
 ---
 
-
 The data grid shows a list of objects in a grid. For example, a data grid can show all the orders a customer has placed. Using controls provided by the data grid you can browse, search and edit those objects.
 
 {{% alert type="info" %}}
@@ -13,7 +12,7 @@ A data grid showing accounts.
 
 {{% /alert %}}
 
-# Common properties
+# Common Properties
 
 {{% snippet file="refguide/Name+Property.md" %}}
 
@@ -23,9 +22,9 @@ A data grid showing accounts.
 
 {{% snippet file="refguide/Tab+index+Property.md" %}}
 
-## General properties
+## General Properties
 
-### Show control bar
+### Show Control Bar
 
 This property indicates whether the control bar will be visible in the end user interface. The control bar also includes the paging buttons.
 
@@ -37,7 +36,7 @@ Even if the control bar is invisible there can still be a default button that is
 
 _Default value:_ True
 
-### Show paging buttons
+### Show Paging Buttons
 
 This property indicates with the buttons to page through the information in the grid are visible. Only hide these buttons if you are sure that there will never be more objects than the number of rows of the grid. Note that hiding the control bar also hides the paging buttons.
 
@@ -45,19 +44,19 @@ _Default value:_ True
 
 {{% snippet file="refguide/Column+Width+Properties.md" %}}
 
-### Number of rows
+### Number of Rows
 
 With this property you can change the number of rows that will be shown in one page. See also the property 'Show empty rows'.
 
 _Default value:_ 20
 
-### Show empty rows
+### Show Empty Rows
 
 If you choose to show empty rows there will always be the grid will always show the same number of rows (see 'Number of rows') even if there are less objects to show on the page.
 
 _Default value:_ False
 
-### Selection mode
+### Selection Mode
 
 The selection mode determines whether and how the user can select items in the grid.
 
@@ -71,13 +70,13 @@ The selection mode determines whether and how the user can select items in the g
 
 _Default value:_ Single selection
 
-### Select first
+### Select First
 
 This property indicates whether the first item will be selected initially. This is especially useful if there is a data view listening to this grid.
 
 _Default value:_ False
 
-### Default button trigger
+### Default Button Trigger
 
 The default button can be triggered by a single or a double click on a row.
 
@@ -88,17 +87,17 @@ The default button can be triggered by a single or a double click on a row.
 
 _Default value:_ Double click
 
-### Refresh time (in seconds)
+### Refresh Time (in Seconds)
 
 If the refresh time is non-zero, the data grid will refresh its contents every given number of seconds. For example, a task list could be refreshed every minute so that you know when new tasks arrive. By default the refresh time is zero and this means that the grid will not automatically refresh itself.
 
 _Default value:_ 0
 
-### Tooltip page
+### Tooltip Page
 
 A tooltip page is a page that appears when you hover your mouse over a row. The tooltip page should consist of a data view on the same entity as the data grid. Besides creating and connecting a tooltip page you also have to specify on which columns the tooltip will appear. See the property 'Show tooltip' of [data grid columns](columns).
 
-## Data source properties
+## Data Source Properties
 
 The data source determines which objects will be shown in the data grid. For general information about data sources, see [Data Sources](data-sources).
 
@@ -106,7 +105,7 @@ The data source determines which objects will be shown in the data grid. For gen
 
 The data grid supports the following types of data sources: [Database Source](database-source), [XPath Source](xpath-source), [Association Source](association-source), [Microflow Source](microflow-source). The database and XPath sources retrieve objects from the database and supports searching and sorting. The database source can also be used in [offline](offline) applications. The association source follows an association from the enclosing data view to get to the objects. Finally, the microflow source calculates the list of objects by executing a microflow.
 
-### Other properties
+### Other Properties
 
 See the corresponding data source for its properties:
 
@@ -115,7 +114,7 @@ See the corresponding data source for its properties:
 *   [Microflow source](microflow-source)
 *   [Association source](association-source)
 
-## Visibility properties
+## Visibility Properties
 
 {{% snippet file="refguide/Visibility+Property.md" %}}
 
@@ -127,7 +126,7 @@ See the corresponding data source for its properties:
 
 #### Common Properties
 
-### Class property
+### Class Property
 
 The class property allows you to specify a cascading style sheet (CSS) class for the widget. This class will be applied to the widget in the browser and the widget will get the corresponding styling. The class should be a class from the theme that is used in the project. It overrules the default styling of the widget.
 
@@ -141,7 +140,7 @@ Note that the styling is applied in the following order:
 
 {{% /alert %}}
 
-### Style property
+### Style Property
 
 The style property allows you to specify additional CSS styling. If a class is also specified, this styling is applied _after_ the class.
 
@@ -160,7 +159,7 @@ The attribute (path) property specifies the attribute's value that will be displ
 
 ### Formatting Properties
 
-#### Enumeration format (only for attributes of type Enumeration)
+#### Enumeration Format (Only for Attributes of Type Enumeration)
 
 A column connected to an attribute of type enumeration can show its contexts as text (default) or as image.
 
@@ -169,19 +168,19 @@ A column connected to an attribute of type enumeration can show its contexts as 
 | Text | Show the caption text of the enumeration. |
 | Image | Show the image of the enumeration value. |
 
-#### Decimal precision (only for decimal attributes)
+#### Decimal Precision (Only for Decimal Attributes)
 
 The precision of a value is defined the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 
 _Default value:_ 2
 
-#### Group digits (only for numeric attributes)
+#### Group Digits (Only for Numeric Attributes)
 
 For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property defines whether the end user will see these groups, or not.
 
 _Default value:_ False
 
-#### Date format (only for attributes of type DateTime)
+#### Date Format (Only for Attributes of Type DateTime)
 
 The date format determines whether the date part, the time part or both are shown. How the date and time parts are formatted depends on the localization of the user using the application.
 
@@ -230,7 +229,7 @@ The caption of a column is the text that appears as a header above the rows. Thi
 
 The editable property indicates whether the values of the column will be editable in-line, i.e. without opening a page with a data view. In-line editing allows the data grid to behave like you would expect from a spreadsheet application.
 
-#### Aggregate function
+#### Aggregate Function
 
 The values in a column can be aggregated in several ways. The aggregate function determines the way in which the values are aggregated. The aggregate will be shown at the bottom of the column that precedes by the aggregate caption (see below).
 
@@ -249,7 +248,7 @@ Note that all objects will be taken into account, and not just the ones on the c
 
 {{% /alert %}}
 
-#### Aggregate caption
+#### Aggregate Caption
 
 The aggregate caption is the text that appears in front of the computed value. This is a translatable text. See [Translatable Texts](translatable-texts).
 
@@ -259,25 +258,25 @@ The aggregate caption is the text that appears in front of the computed value. T
 
 {{% /alert %}}
 
-#### Show tooltip
+#### Show Tooltip
 
 This property determines whether the tooltip page is shown as the mouse is hovered over this column. The tooltip page can be configured on the data grid.
 
 _Default value:_ False
 
-## Control bar
+## Control Bar
 
 The control bar of the template grid, data grid, and reference set selector allows you to manipulate the objects displayed by means of buttons. By default, both grids will be created with a new, edit, and delete button in the control bar. The control bar can also include a number of selection options and spreadsheet export buttons, as well as microflow buttons for custom actions.
 
 See [Control Bar](control-bar).
 
-## Search bar (for data source types 'Database' and 'XPath')
+## Search Bar (for the Database and XPath Data Source Types)
 
 The search bar contains search fields that allow the end-user to quickly find the information he or she needs.
 
 See [Search Bar](search-bar).
 
-## Sort bar (for data source type 'Database' and 'XPath')
+## Sort Bar (for the Database and XPath Data Source Types)
 
 The sort bar contains a number of sort items. Each sort item specifies what attribute to sort on and in what direction (ascending or descending). First the contents of the grid will be sorted on the first item; if two rows are the same with respect to this sort item the second item will be used et cetera. For example, if you have sort items for name and age and two people have the same name they will be sorted on their age.
 

--- a/content/refguide/data-grid.md
+++ b/content/refguide/data-grid.md
@@ -169,7 +169,7 @@ A column connected to an attribute of type enumeration can show its contexts as 
 | Text | Show the caption text of the enumeration. |
 | Image | Show the image of the enumeration value. |
 
-#### Decimal precision (only for numeric attributes)
+#### Decimal precision (only for decimal attributes)
 
 The precision of a value is defined the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point).
 

--- a/content/refguide/dynamic-label-document-template.md
+++ b/content/refguide/dynamic-label-document-template.md
@@ -27,19 +27,19 @@ The contents MUST be valid XHTML to render without errors.
 
 _Default value:_ False
 
-### Decimal precision (only for decimal attributes)
+### Decimal Precision (Only for Decimal Attributes)
 
 The precision of a value is defined by the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point) that will be rendered in the widget.
 
 _Default value:_ 2
 
-### Group digits (only for numeric attributes)
+### Group Digits (Only for Numeric Attributes)
 
 For ease of reading, numbers with many digits in front of the decimal separator may be divided into groups using a delimiter. This property defines whether the end user will see these groups, or not.
 
 _Default value:_ False
 
-### Date format (only for attributes of type DateTime)
+### Date Format (Only for Attributes of the DateTime Type)
 
 The date format determines whether the date part, the time part or both are shown. How the date and time parts are formatted depends on the localization of the user using the application. Alternatively, as of version 2.5.3 you can completely customize the format of the date and/or time by supplying a date format string.
 
@@ -47,7 +47,7 @@ Possible values: 'Date', 'Time', 'Date and time' and in 2.5.3 'Custom'.
 
 _Default value:_ Date
 
-### Custom date format (only for attributes of type DateTime)
+### Custom Date Format (Only for Attributes of the DateTime Type)
 
 If you choose 'Custom' as the date format (see above) the custom date format determines the way date and/or time are formatted. The custom date format is a string that follows the rules described in
 [http://download.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html](http://download.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html).

--- a/content/refguide/dynamic-label-document-template.md
+++ b/content/refguide/dynamic-label-document-template.md
@@ -27,7 +27,7 @@ The contents MUST be valid XHTML to render without errors.
 
 _Default value:_ False
 
-### Decimal precision (only for numeric attributes)
+### Decimal precision (only for decimal attributes)
 
 The precision of a value is defined by the number of digits that is used to express that value. This property indicates the number of decimal places (the number of digits following the decimal point) that will be rendered in the widget.
 

--- a/content/refguide/reference-selector.md
+++ b/content/refguide/reference-selector.md
@@ -85,17 +85,7 @@ See [Opening Pages](opening-pages) for more details.
 
 ## Formatting Properties
 
-### Decimal Precision (Only for Numeric Attributes)
-
-The precision of a value describes the number of digits that are used to express that value. This property indicates the number of decimal places (the number of digits following the point).
-
-_Default value:_ 2
-
-### Group Digits (Only for Numeric Attributes)
-
-For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property determines whether or not such a delimiter is used. Which delimiter is used depends on the language of the end user.
-
-_Default value:_ No
+{{% snippet file="refguide/Numeric+Formatting+Properties.md" %}}
 
 ### Date Format (Only for Attributes of Type Date and Time)
 

--- a/content/refguide/text-box.md
+++ b/content/refguide/text-box.md
@@ -17,17 +17,7 @@ A text box must be placed in a data view or template grid and connected to an at
 
 ## General Properties
 
-### Decimal Precision (Only for Numeric Attributes)
-
-The precision of a value describes the number of digits that are used to express that value. This property indicates the number of decimal places (the number of digits following the point).
-
-_Default value:_ 2
-
-### Group Digits (Only for Numeric Attributes)
-
-For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property indicates whether the end user will see these groups.
-
-_Default value:_ False
+{{% snippet file="refguide/Numeric+Formatting+Properties.md" %}}
 
 ### Show as Password (Only for Attributes of the String or HashString Type)
 

--- a/snippets/refguide/Numeric+Formatting+Properties.md
+++ b/snippets/refguide/Numeric+Formatting+Properties.md
@@ -2,23 +2,24 @@
 
 <div class="alert alert-info">
 
-Introduced in Mendix 7.15. In prior version Decimal mode can not be set and always Fixed.
+Introduced in Mendix 7.15. In prior versions, Decimal mode could not be set and was always Fixed.
 
 </div>
 
 <div class="alert alert-info">
 
-Only for Decimal, Float (deprecated) and Currency (deprecated) attribute types.
+This mode only applies to the Decimal, Float (deprecated), and Currency (deprecated) attribute types.
 
 </div>
 
-If set to _Fixed_ decimal part always will be displayed with number of places specified in the **Decimal precision** property. Value will be rounded to the nearest decimal if length of the decimal part in the attribute value exceding number of decimal places.
+If set to _Fixed_, the decimal part always will be displayed with the number of places specified in the **Decimal precision** property. The value will be rounded to the nearest decimal if the length of the decimal part in the attribute value exceeds the number of decimal places.
 
-If set to _Auto_ whole decimal part of the attribute value will be displayed. No decimal part will be be displayed if the attribute value is an integer.
+If set to _Auto_, the whole decimal part of the attribute value will be displayed. No decimal part will be be displayed if the attribute value is an integer.
 
 _Default value:_ Fixed
 
 #### Examples
+
 | Value    | Fixed (2)  | Fixed (4)    | Auto     |
 | -------- | ---------- | ------------ | -------- |
 | 19.0     | 19.00      | 19.0000      | 19       |
@@ -27,13 +28,13 @@ _Default value:_ Fixed
 | 19.9999  | 20.00 (\*) | 19.9999      | 19.9999  |
 | 19.99999 | 20.00 (\*) | 20.0000 (\*) | 19.99999 |
 
-\* value is rounded to the nearest decimal with defined number of decimal places.
+**\*** The value is rounded to the nearest decimal with the defined number of decimal places.
 
-### Decimal precision
+### Decimal Precision
 
 <div class="alert alert-info">
 
-Only for Decimal, Float (deprecated) and Currency (deprecated) attribute types. Since Mendix 7.15 available only when Decimal mode is set to Fixed.
+This only applies to the Decimal, Float (deprecated), and Currency (deprecated) attribute types. From Mendix 7.15, this is available only when the Decimal mode is set to Fixed.
 
 </div>
 
@@ -43,6 +44,6 @@ _Default value:_ 2
 
 ### Group Digits
 
-For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property indicates whether the end user will see these groups.
+For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property indicates whether the user will see these groups.
 
 _Default value:_ False

--- a/snippets/refguide/Numeric+Formatting+Properties.md
+++ b/snippets/refguide/Numeric+Formatting+Properties.md
@@ -28,7 +28,7 @@ _Default value:_ Fixed
 | 19.9999  | 20.00 (\*) | 19.9999      | 19.9999  |
 | 19.99999 | 20.00 (\*) | 20.0000 (\*) | 19.99999 |
 
-**\*** The value is rounded to the nearest decimal with the defined number of decimal places.
+\* The value is rounded to the nearest decimal with the defined number of decimal places.
 
 ### Decimal Precision
 

--- a/snippets/refguide/Numeric+Formatting+Properties.md
+++ b/snippets/refguide/Numeric+Formatting+Properties.md
@@ -1,0 +1,48 @@
+### Decimal mode
+
+<div class="alert alert-info">
+
+Introduced in Mendix 7.15. In prior version Decimal mode can not be set and always Fixed.
+
+</div>
+
+<div class="alert alert-info">
+
+Only for Decimal, Float (deprecated) and Currency (deprecated) attribute types.
+
+</div>
+
+If set to _Fixed_ decimal part always will be displayed with number of places specified in the **Decimal precision** property. Value will be rounded to the nearest decimal if length of the decimal part in the attribute value exceding number of decimal places.
+
+If set to _Auto_ whole decimal part of the attribute value will be displayed. No decimal part will be be displayed if the attribute value is an integer.
+
+_Default value:_ Fixed
+
+#### Examples
+| Value    | Fixed (2)  | Fixed (4)    | Auto     |
+| -------- | ---------- | ------------ | -------- |
+| 19.0     | 19.00      | 19.0000      | 19       |
+| 19.99    | 19.99      | 19.9900      | 19.99    |
+| 19.9944  | 19.99 (\*) | 19.9944      | 19.9944  |
+| 19.9999  | 20.00 (\*) | 19.9999      | 19.9999  |
+| 19.99999 | 20.00 (\*) | 20.0000 (\*) | 19.99999 |
+
+\* value is rounded to the nearest decimal with defined number of decimal places.
+
+### Decimal precision
+
+<div class="alert alert-info">
+
+Only for Decimal, Float (deprecated) and Currency (deprecated) attribute types. Since Mendix 7.15 available only when Decimal mode is set to Fixed.
+
+</div>
+
+The precision of a value describes the number of digits that are used to express that value. This property indicates the number of decimal places (the number of digits following the point).
+
+_Default value:_ 2
+
+### Group Digits
+
+For ease of reading, numbers with many digits before the decimal separator may be divided into groups using a delimiter. This property indicates whether the end user will see these groups.
+
+_Default value:_ False


### PR DESCRIPTION
 - Introduce decimal formatting mode auto for text box and reference selector.
 - Change `numeric` to `decimal` because **Decimal precision** property is not available for the Integer attribute type, but Decimal, Float and Currency.