### PR TITLE
Added an example of an unexpected returnvalue

### DIFF
--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -392,6 +392,8 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 * `isMatch('NLG 123.45', '[0-9]')` returns false
 * `isMatch('NLG 123.45', '.*[0-9].*')` returns true
+NB searching an empty string:
+* `isMatch('', '.*[0-9].*')` returns true
 
 ## replaceAll
 

--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -392,7 +392,9 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 * `isMatch('NLG 123.45', '[0-9]')` returns false
 * `isMatch('NLG 123.45', '.*[0-9].*')` returns true
+
 NB searching an empty string:
+
 * `isMatch('', '.*[0-9].*')` returns true
 
 ## replaceAll


### PR DESCRIPTION
NB searching an empty string:
* `isMatch('', '.*[0-9].*')` returns true