### PR TITLE
Clarified that web service users cannot acces REST services

### DIFF
--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -114,6 +114,8 @@ If authentication is required, you can select which authentication methods you w
     xmlHttp.send(null);
     ```
 
+Note that web service users cannot access REST services.
+
 ### 3.3 Allowed Roles
 
 The allowed roles define which [module role](module-role) a user must have to be able to access the service. This option is only available when **Requires authentication** is set to **Yes**.

--- a/content/refguide/published-rest-service.md
+++ b/content/refguide/published-rest-service.md
@@ -114,7 +114,9 @@ If authentication is required, you can select which authentication methods you w
     xmlHttp.send(null);
     ```
 
-Note that web service users cannot access REST services.
+{{% alert type="warning" %}}
+Web service users cannot access REST services.
+{{% /alert %}}
 
 ### 3.3 Allowed Roles
 

--- a/content/refguide/published-rest-services.md
+++ b/content/refguide/published-rest-services.md
@@ -32,7 +32,9 @@ If you don't want basic authentication, there are two options:
 * You can choose to have [no authentication](published-rest-service#authentication) for specific published REST services, or
 * When you [allow anonymous users](project-security#anonymous-users) to your app, all published REST services become available without authentication
 
-For more details, see [Published REST Routing](published-rest-routing).
+Note that web service users cannot access REST services.
+
+For more details, see [Published REST Routing](published-rest-routing) or [Published REST Security](published-rest-service#authentication).
 
 ## <a name="interactive-documentation"></a>4 Documentation
 

--- a/content/refguide/published-rest-services.md
+++ b/content/refguide/published-rest-services.md
@@ -32,9 +32,11 @@ If you don't want basic authentication, there are two options:
 * You can choose to have [no authentication](published-rest-service#authentication) for specific published REST services, or
 * When you [allow anonymous users](project-security#anonymous-users) to your app, all published REST services become available without authentication
 
+{{% alert type="warning" %}}
 Note that web service users cannot access REST services.
+{{% /alert %}}
 
-For more details, see [Published REST Routing](published-rest-routing) or [Published REST Security](published-rest-service#authentication).
+For more details, see [Published REST Routing](published-rest-routing) and section [3.1 Requires Authentication](published-rest-service#authentication) in *Published REST Service*.
 
 ## <a name="interactive-documentation"></a>4 Documentation
 


### PR DESCRIPTION
Several people have tried using web service users to access REST services. That doesn't work by design, but the refguide was not explicit about that.