### PR TITLE
Corrected "EndsWith" call

### DIFF
--- a/content/refguide6/string-function-calls.md
+++ b/content/refguide6/string-function-calls.md
@@ -304,7 +304,7 @@ Whether the original string ends with the substring
 Type: Boolean
 
 ```java
-startsWith('thisismystring', 'ring')
+endsWith('thisismystring', 'ring')
 ```
 
 returns:


### PR DESCRIPTION
There was a copy and paste type. in the endswith section, startswith was used.