### PR TITLE
Developer Portal lives on https://home.mendix.com/

### DIFF
--- a/content/developerportal/index.md
+++ b/content/developerportal/index.md
@@ -5,7 +5,7 @@ notoc: true
 
 ## 1 Developer Portal
 
-The [Mendix Developer Portal](https://sprintr.home.mendix.com/) is a platform for Mendix developers to use to collaborate, deploy, and manage their apps, company, and users.
+The [Mendix Developer Portal](https://home.mendix.com/) is a platform for Mendix developers to use to collaborate, deploy, and manage their apps, company, and users.
 
 The Developer Portal consists of the sections described below.
 


### PR DESCRIPTION
... and not on sprintr.home.mendix.com. Latter is technical host, former is canonical location.