### PR TITLE
Selecting DISTINCT attribute of type CLOB is not supported by Oracle and DB2

### DIFF
--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -3,7 +3,7 @@ title: "DB2"
 parent: "data-storage"
 ---
 
-Mendix 6.10 and above supports running on IBM DB2 databases.
+Running on IBM DB2 databases has been supported since Mendix 6.10.
 
 ## Page Size of the Table Space
 
@@ -52,6 +52,7 @@ According to the [IBM DB2 documentation](https://www.ibm.com/support/knowledgece
 According to the [IBM DB2 documentation](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.admin.perf.doc/doc/c0004121.html), non-blocking read-isolated queries are not supported by DB2\. The default behavior of DB2 is that when one user is retrieving rows from a table and another user is making modifications on the same table at the same time, then those modifications will show up in the data in the retrieve query (which means database reads are not isolated). Configuring a stricter transaction isolation level to prevent this behavior puts locks on those same rows (which means concurrent database actions are blocking). Taking this limitation into account, preventing concurrent row modifications from being included in the result set of a data retrieve action is not supported when a Mendix application is using DB2 as a streaming OData datasource.
 
 ### Select DISTINCT attribute of type CLOB
-Selecting DISTINCT attributes of type String and size > 8168 characters is not supported by Mendix due to a known DB2 limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like:
+
+Selecting DISTINCT attributes of type String and size > 8168 characters is not supported by Mendix due to a known DB2 limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like this:
 
 `DB2 SQL Error: SQLCODE=-727, SQLSTATE=56098, SQLERRMC=2;-134;42907`

--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -53,6 +53,6 @@ According to the [IBM DB2 documentation](https://www.ibm.com/support/knowledgece
 
 ### Select DISTINCT attribute of type CLOB
 
-Selecting DISTINCT attributes of type String and size > 8168 characters is not supported by Mendix due to a known DB2 limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like this:
+Selecting DISTINCT attributes of type String and size > 8168 characters is not supported by Mendix due to a known DB2 limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter an exception in the logs with a message like this:
 
 `DB2 SQL Error: SQLCODE=-727, SQLSTATE=56098, SQLERRMC=2;-134;42907`

--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -50,3 +50,8 @@ According to the [IBM DB2 documentation](https://www.ibm.com/support/knowledgece
 ### Non-Blocking Read-Isolated Streaming with OData
 
 According to the [IBM DB2 documentation](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.admin.perf.doc/doc/c0004121.html), non-blocking read-isolated queries are not supported by DB2\. The default behavior of DB2 is that when one user is retrieving rows from a table and another user is making modifications on the same table at the same time, then those modifications will show up in the data in the retrieve query (which means database reads are not isolated). Configuring a stricter transaction isolation level to prevent this behavior puts locks on those same rows (which means concurrent database actions are blocking). Taking this limitation into account, preventing concurrent row modifications from being included in the result set of a data retrieve action is not supported when a Mendix application is using DB2 as a streaming OData datasource.
+
+### Select DISTINCT attribute of type CLOB
+Selecting DISTINCT attributes of type String and size > 8168 characters is not supported by Mendix due to a known DB2 limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like:
+
+`DB2 SQL Error: SQLCODE=-727, SQLSTATE=56098, SQLERRMC=2;-134;42907`

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -4,6 +4,15 @@ parent: "data-storage"
 ---
 ## Known issue
 
+### Numeric conversion
+
 There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows.
 
 This problem is fixed in Oracle 11.2.0.4\. See [https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).
+
+### Select DISTINCT attribute of type CLOB
+Selecting DISTINCT attributes of type String and size > 2000 is not supported by Mendix due to known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you encounter exception in the logs with the messag like: 
+
+`Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small`. 
+
+Bare in mind that you should not select DISTINCT attribute when it has type String and length > 2000.

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -11,8 +11,6 @@ There is a known bug in older versions of Oracle 11.2 where converting numeric a
 This problem is fixed in Oracle 11.2.0.4\. See [https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).
 
 ### Select DISTINCT attribute of type CLOB
-Selecting DISTINCT attributes of type String and size > 2000 is not supported by Mendix due to known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you encounter exception in the logs with the messag like: 
+Selecting DISTINCT attributes of type String and size > 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like:
 
-`Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small`. 
-
-Bare in mind that you should not select DISTINCT attribute when it has type String and length > 2000.
+`Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small`

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -2,15 +2,17 @@
 title: "Oracle"
 parent: "data-storage"
 ---
-## Known issue
 
-### Numeric conversion
+## Known Issues
+
+### Numeric Conversion
 
 There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows.
 
 This problem is fixed in Oracle 11.2.0.4\. See [https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).
 
-### Select DISTINCT attribute of type CLOB
-Selecting DISTINCT attributes of type String and size > 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter exception in the logs with a message like:
+### Select DISTINCT Attribute of Type CLOB
+
+Selecting DISTINCT attributes of type String and size > 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. When you run into this limitation, you may encounter an exception in the logs with a message like this:
 
 `Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small`


### PR DESCRIPTION
Selecting DISTINCT attribute of type CLOB is not supported by Oracle and DB2