### PR TITLE
Update documentation for "Refresh in client" option (to be merged for 7.19)

### DIFF
--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -5,7 +5,7 @@ parent: "object-activities"
 
 ## 1 Introduction
 
-A change object can be used to change the members of an object. This can be done with or without committing and with or without events.
+The Change object activity can be used to change the members of an object. This can be done with or without committing and with or without events.
 
 {{% alert type="info" %}}
 
@@ -27,6 +27,8 @@ The properties are configured as below.
 See [Microflow Element Common Properties](microflow-element-common-properties) for properties that all microflow activities share (for example, caption). This page only describes the properties specific to the action.
 
 {{% /alert %}}
+
+If the microflow is called from the client, [input widgets](input-widgets) showing the changed object's attributes will be refreshed automatically. This includes updating their visibility and editability [conditions](conditions).
 
 ## 2 Input Properties
 
@@ -62,15 +64,10 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-Refresh in client defines whether pages that use the entity of the object being changed are refreshed.
-
-| Option | Description |
-| --- | --- |
-| Yes | Objects of same entity are refreshed in the user's browser |
-| No | Objects of same entity are not refreshed in the user's browser |
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
 
 {{% alert type="warning" %}}
-Nanoflows do not have the refresh in client option. All the changes made in a nanoflow refresh the client by default.
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option. It behaves as if set to _Yes_ if Commit type is set to _Yes_ and _No_ if Commit type is set to _No_.
 {{% /alert %}}
 
 _Default value_: No

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -47,19 +47,19 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-If the microflow is called from the client, the change is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
+If the microflow is called from the client, the change is not reflected in the client if **Refresh in client** is set to *No*. If set to *Yes*, the object is refreshed across the client, which includes reloading the relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-As of 7.19.0, changed attribute values are always reflected in the client. If the object is committed, the object is refreshed from the runtime, which includes updating virtual attributes. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
+As of 7.19.0, changed attribute values are always reflected in the client. If the object is committed, the object is refreshed from the Mendix Runtime, which includes updating virtual attributes. [Data sources](data-sources) are only reloaded if **Refresh in client** is set to *Yes*.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. It always reflects changed attribute values in the client, including [conditions](conditions).
+When inside a [nanoflow](nanoflows), the Change object action does not have the **Refresh in client option** available, and the refresh behavior depends on the **Commit type** option. It always reflects the changed attribute values in the client, including [conditions](conditions).
 
-If **Commit type** is set to *Yes*, the object is refreshed across the client as if Refresh in client was set to *Yes*.
+If **Commit type** is set to *Yes*, the object is refreshed across the client as if **Refresh in client** was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -47,7 +47,7 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+When set and the microflow is called from the client, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
 
 {{% alert type="info" %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -67,4 +67,4 @@ _Default value_: No
 
 ### 3.3 Change Members
 
-You can specify a list of changes that will be applied to the object. Values for members are specified with [expressions](expressions) and should be of the same type as the member. For a reference set association, it is also possible to add and remove (instead of only setting the member). For **add**, an object or a list of objects can be added to the currently associated objects. For **remove**, an object or a list of objects can be removed from the currently associated objects.
+You can specify a list of changes that to apply to the object. Values for members are specified with [expressions](expressions) and should be of the same type as the member. For a reference set association, it is also possible to add and remove (instead of only setting the member). For **add**, an object or a list of objects can be added to the currently associated objects. For **remove**, an object or a list of objects can be removed from the currently associated objects.

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -51,15 +51,15 @@ When set and the microflow is called from the client, Refresh in client will cau
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the Commit type option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions).
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions).
 
-If Commit type is set to _Yes_, then additionally [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+If **Commit type** is set to *Yes*, then additionally [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -49,10 +49,10 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
 
 {{% alert type="warning" %}}
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option. It behaves as if set to _Yes_ if Commit type is set to _Yes_ and _No_ if Commit type is set to _No_.
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option. It behaves as if set to *Yes* if the **Commit type** is set to **Yes** and *No* if the **Commit type** is set to **No**.
 {{% /alert %}}
 
 _Default value_: No

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -47,17 +47,17 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, [input widgets](input-widgets) showing the changed object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions).
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes (including their [conditions](conditions)).
 
 If **Commit type** is set to *Yes*, then additionally [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
 
@@ -67,4 +67,4 @@ _Default value_: No
 
 ### 3.3 Change Members
 
-You can specify a list of changes that will be applied to the object. Values for members are specified with [expressions](expressions) and should be of the same type as the member. For a reference set association it is also possible to add and remove instead of only set the member. With 'add' an object or a list of objects can be added to the currently associated objects. With 'remove' an object or a list of objects can be removed from the currently associated objects.
+You can specify a list of changes that will be applied to the object. Values for members are specified with [expressions](expressions) and should be of the same type as the member. For a reference set association, it is also possible to add and remove (instead of only setting the member). For **add**, an object or a list of objects can be added to the currently associated objects. For **remove**, an object or a list of objects can be removed from the currently associated objects.

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -9,21 +9,6 @@ The Change object activity can be used to change the members of an object. This 
 
 {{% alert type="info" %}}
 
-Before a customer is saved you want to make sure all characters of the zip code are capitals. You do this by creating an [event handler](event-handlers) for the entity 'Customer'. The flow that is used as event handler is shown below. It consists of a parameter and a change object activity. The parameter contains the current customer being saved.
-
-![](attachments/819203/918094.png)
-
-The properties are configured as below.
-
-| Property | Value | Reason |
-| --- | --- | --- |
-| Object | InputCustomer (Module.Customer) | The change activity applies to the current customer being saved |
-| Commit type | No | The object is changed before commit and the changes are still 'remembered' by the server when it is committed |
-| Refresh in client | No | Objects of the entity 'Customer' are automatically refreshed by the server when a object is committed in a form |
-| Change member action _set_ on _zipcode_ | toUpperCase($InputCustomer/zipcode) | An [expression](expressions) can be used to set all characters to upper case (capitals) |
-
-{{% /alert %}}{{% alert type="info" %}}
-
 See [Microflow Element Common Properties](microflow-element-common-properties) for properties that all microflow activities share (for example, caption). This page only describes the properties specific to the action.
 
 {{% /alert %}}

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -51,7 +51,7 @@ When set and the microflow is called from the client, Refresh in client will cau
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -47,19 +47,19 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-When set and the microflow is called from the client, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+If the microflow is called from the client, the change is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, [input widgets](input-widgets) showing the changed object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
+As of 7.19.0, changed attribute values are always reflected in the client. If the object is committed, the object is refreshed from the runtime, which includes updating virtual attributes. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. It always refreshes [input widgets](input-widgets) showing the changed object's attributes (including their [conditions](conditions)).
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. It always reflects changed attribute values in the client, including [conditions](conditions).
 
-If **Commit type** is set to *Yes*, then [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
+If **Commit type** is set to *Yes*, the object is refreshed across the client as if Refresh in client was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -57,9 +57,9 @@ For input widgets, this setting behaves differently as of 7.19.0. For Mendix ver
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes (including their [conditions](conditions)).
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. It always refreshes [input widgets](input-widgets) showing the changed object's attributes (including their [conditions](conditions)).
 
-If **Commit type** is set to *Yes*, then additionally [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+If **Commit type** is set to *Yes*, then [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/change-object.md
+++ b/content/refguide/change-object.md
@@ -13,8 +13,6 @@ See [Microflow Element Common Properties](microflow-element-common-properties) f
 
 {{% /alert %}}
 
-If the microflow is called from the client, [input widgets](input-widgets) showing the changed object's attributes will be refreshed automatically. This includes updating their visibility and editability [conditions](conditions).
-
 ## 2 Input Properties
 
 ### 2.1 Object
@@ -49,10 +47,20 @@ _Default value:_ No
 
 ### 3.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the changed object.
+
+{{% alert type="info" %}}
+
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+
+{{% /alert %}}
 
 {{% alert type="warning" %}}
-When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option. It behaves as if set to *Yes* if the **Commit type** is set to **Yes** and *No* if the **Commit type** is set to **No**.
+
+When inside a [nanoflow](nanoflows), the Change object action does not have the Refresh in client option and the refresh behavior depends on the Commit type option. It will always refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions).
+
+If Commit type is set to _Yes_, then additionally [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+
 {{% /alert %}}
 
 _Default value_: No

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -37,7 +37,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, [input widgets](input-widgets) showing the changed object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
 
 {{% /alert %}}
 
@@ -49,7 +49,7 @@ When committing a large number of objects, we recommend that you do not enable '
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It will refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It refreshes [input widgets](input-widgets), showing the changed object's attributes (including their [conditions](conditions)). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -35,6 +35,12 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
 
+{{% alert type="info" %}}
+
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+
+{{% /alert %}}
+
 {{% alert type="warning" %}}
 
 When committing a large number of objects, we recommend that you do not enable 'Refresh in client' because it can slow things down.
@@ -43,7 +49,7 @@ When committing a large number of objects, we recommend that you do not enable '
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It behaves as if set to _Yes_.
+When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It will refresh [input widgets](input-widgets) showing the changed object's attributes including their [conditions](conditions). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -33,7 +33,7 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 ### 3.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -33,7 +33,7 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 ### 3.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
+When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
 
 {{% alert type="info" %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -37,7 +37,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -37,7 +37,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the changed object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -33,11 +33,11 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 ### 3.2 Refresh in Client
 
-If the microflow is called from the client, the commit is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
+If the microflow is called from the client, the change is not reflected in the client if **Refresh in client** is set to *No*. If set to *Yes*, the object is refreshed across the client, which includes reloading the relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-As of 7.19.0, all attribute values are reflected in the client, including virtual ones, even if Refresh in client is set to *No*.
+As of 7.19.0, all attribute values are reflected in the client, including virtual ones, even if **Refresh in client** is set to *No*.
 
 {{% /alert %}}
 
@@ -49,7 +49,7 @@ When committing a large number of objects, we recommend that you do not enable '
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the object is refreshed across the client as if Refresh in client was set to *Yes*.
+When inside a [nanoflow](nanoflows), the object is refreshed across the client as if **Refresh in client** was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -33,11 +33,11 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 ### 3.2 Refresh in Client
 
-When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
+If the microflow is called from the client, the commit is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, [input widgets](input-widgets) showing the changed object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
+As of 7.19.0, all attribute values are reflected in the client, including virtual ones, even if Refresh in client is set to *No*.
 
 {{% /alert %}}
 
@@ -49,7 +49,7 @@ When committing a large number of objects, we recommend that you do not enable '
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It refreshes [input widgets](input-widgets), showing the changed object's attributes (including their [conditions](conditions)). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
+When inside a [nanoflow](nanoflows), the object is refreshed across the client as if Refresh in client was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/committing-objects.md
+++ b/content/refguide/committing-objects.md
@@ -33,14 +33,7 @@ Nanoflows do not have this property. Committing while running in an online app s
 
 ### 3.2 Refresh in Client
 
-This property specifies whether pages that use the entity of the object(s) being committed are refreshed.
-
-| Option | Description |
-| --- | --- |
-| Yes | Objects of same entity are refreshed in the user's browser. |
-| No | Objects of same entity are not refreshed in the user's browser. |
-
-_Default value_: No
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the committed object.
 
 {{% alert type="warning" %}}
 
@@ -50,6 +43,8 @@ When committing a large number of objects, we recommend that you do not enable '
 
 {{% alert type="warning" %}}
 
-Nanoflows do not have this property. All the changes made in a nanoflow refresh the client by default.
+When inside a [nanoflow](nanoflows), the Commit object action does not have the Refresh in client option. It behaves as if set to _Yes_.
 
 {{% /alert %}}
+
+_Default value_: No

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -5,7 +5,7 @@ parent: "object-activities"
 
 ## 1 Introduction 
 
-The create-object action can be used to create an object.
+The Create object action can be used to create an object.
 
 {{% alert type="info" %}}
 
@@ -19,22 +19,33 @@ See [Microflow Element Common Properties](microflow-element-common-properties) f
 
 The entity of which you want to create an object.
 
-### 2.2 Refresh in Client
+### 2.2 Commit Type
 
-This property specifies whether pages that use the entity of the object being created are refreshed.
+Commit type defines the way the object is committed.
 
 | Option | Description |
 | --- | --- |
-| Yes | Objects of same entity are refreshed in the user's browser. |
-| No | Objects of same entity are not refreshed in the user's browser. |
-
-_Default value_: No
+| Yes with event handlers | The object is saved in the database and the [event handlers](event-handlers) are triggered |
+| Yes without event handlers | The object is saved in the database, but the [event handlers](event-handlers) are not triggered |
+| No | The object is changed without being saved in the database |
 
 {{% alert type="warning" %}}
 
-Nanoflows do not have this property. All the changes made in a nanoflow refresh the client by default.
+Nanoflows do not support committing changes without events. Committing while running in an online app sends a commit request to the Mendix Runtime and runs the events. If a Create object action is used in an offline app, the changes are committed to the offline database.
 
 {{% /alert %}}
+
+_Default value:_ No
+
+### 2.3 Refresh in Client
+
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
+
+{{% alert type="warning" %}}
+When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option. It behaves as if set to _Yes_ if Commit type is set to _Yes_ and _No_ if Commit type is set to _No_.
+{{% /alert %}}
+
+_Default value_: No
 
 ### 2.3 Initialize Members
 

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -21,13 +21,13 @@ The entity of which you want to create an object.
 
 ### 2.2 Commit Type
 
-Commit type defines the way the object is committed.
+The **Commit type** defines the way the object is committed.
 
 | Option | Description |
 | --- | --- |
-| Yes with event handlers | The object is saved in the database and the [event handlers](event-handlers) are triggered |
-| Yes without event handlers | The object is saved in the database, but the [event handlers](event-handlers) are not triggered |
-| No | The object is changed without being saved in the database |
+| Yes with event handlers | The object is saved in the database and the [event handlers](event-handlers) are triggered. |
+| Yes without event handlers | The object is saved in the database, but the [event handlers](event-handlers) are not triggered. |
+| No | The object is changed without being saved in the database. |
 
 {{% alert type="warning" %}}
 
@@ -39,10 +39,10 @@ _Default value:_ No
 
 ### 2.3 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
 
 {{% alert type="warning" %}}
-When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option. It behaves as if set to _Yes_ if Commit type is set to _Yes_ and _No_ if Commit type is set to _No_.
+When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option. It behaves as if set to _Yes_ if the **Commit type** is set to **Yes** and *No* if the **Commit type** is set to *No*.
 {{% /alert %}}
 
 _Default value_: No

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -39,7 +39,7 @@ _Default value:_ No
 
 ### 2.3 Refresh in Client
 
-If the microflow is called from the client, [data sources](data-sources) don't reload, unless Refresh in client is set to *Yes*.
+If the microflow is called from the client, [data sources](data-sources) do not reload, unless **Refresh in client** is set to *Yes*.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -39,7 +39,7 @@ _Default value:_ No
 
 ### 2.3 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
+When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -39,11 +39,11 @@ _Default value:_ No
 
 ### 2.3 Refresh in Client
 
-When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
+If the microflow is called from the client, [data sources](data-sources) don't reload, unless Refresh in client is set to *Yes*.
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. If **Commit type** is set to *Yes*, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
+When inside a [nanoflow](nanoflows), the Create object action reloads [data sources](data-sources) as if Refresh in client was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -43,7 +43,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option and the refresh behavior depends on the Commit type option. If Commit type is set to _Yes_, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. If **Commit type** is set to *Yes*, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -42,7 +42,9 @@ _Default value:_ No
 When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the created object.
 
 {{% alert type="warning" %}}
-When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option. It behaves as if set to _Yes_ if the **Commit type** is set to **Yes** and *No* if the **Commit type** is set to *No*.
+
+When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option and the refresh behavior depends on the Commit type option. If Commit type is set to _Yes_, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+
 {{% /alert %}}
 
 _Default value_: No

--- a/content/refguide/create-object.md
+++ b/content/refguide/create-object.md
@@ -43,7 +43,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option and the refresh behavior depends on the **Commit type** option. If **Commit type** is set to *Yes*, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the changed object.
+When inside a [nanoflow](nanoflows), the Create object action does not have the Refresh in client option, and the refresh behavior depends on the **Commit type** option. If **Commit type** is set to *Yes*, [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the changed object.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -27,11 +27,11 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 ### 3.1 Refresh in Client
 
-When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
+If the microflow is called from the client, the deletion is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the deletion is reflected across the client, which includes reloading of relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, data views showing the deleted object and input widgets showing its attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, they are always refreshed.
+As of 7.19.0, deletions are always reflected in the client. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -4,12 +4,12 @@ parent: "object-activities"
 ---
 
 {{% alert type="info" %}}
-This activity can only be used in microflows, not in nanoflows.
+This action can only be used in microflows, not in nanoflows.
 {{% /alert %}}
 
 ## 1 Introduction
 
-Delete Object can be used to delete one or more objects.
+Delete object can be used to delete one or more objects.
 
 {{% alert type="info" %}}
 
@@ -27,11 +27,6 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 ### 3.1 Refresh in Client
 
-Refresh in client defines whether pages that use the entity of the object being deleted are refreshed.
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
 
-| Option | Description |
-| --- | --- |
-| Yes | Objects of same entity are refreshed in the user's browser. |
-| No | Objects of same entity are not refreshed in the user's browser. |
-
-_Default value:_ No
+_Default value_: No

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -31,7 +31,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.18.0.
+For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.18.0.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -31,7 +31,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.19.0.
+For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, data views showing the deleted object and input widgets showing its attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, they are always refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -31,7 +31,7 @@ When set, Refresh in client will cause [data grids](data-grid), [template grids]
 
 {{% alert type="info" %}}
 
-For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.18.0.
+For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.19.0.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -29,4 +29,10 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
 
+{{% alert type="info" %}}
+
+For [data views](data-view) and [input widgets](input-widgets), this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, Data views showing the deleted object and input widgets showing its attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). They will always be refreshed with 7.18.0.
+
+{{% /alert %}}
+
 _Default value_: No

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -27,6 +27,6 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 ### 3.1 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
 
 _Default value_: No

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -27,11 +27,11 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 ### 3.1 Refresh in Client
 
-If the microflow is called from the client, the deletion is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the deletion is reflected across the client, which includes reloading of relevant [data sources](data-sources).
+If the microflow is called from the client, the deletion is not reflected in the client if **Refresh in client** is set to *No*. If set to *Yes*, the deletion is reflected across the client, which includes reloading relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-As of 7.19.0, deletions are always reflected in the client. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
+As of 7.19.0, deletions are always reflected in the client. [Data sources](data-sources) are only reloaded if **Refresh in client** is set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/deleting-objects.md
+++ b/content/refguide/deleting-objects.md
@@ -27,7 +27,7 @@ The variable that refers to the object or list of objects that will be deleted. 
 
 ### 3.1 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
+When set, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the deleted object(s).
 
 {{% alert type="info" %}}
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -29,7 +29,7 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
 
 _Default value_: No
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -33,7 +33,7 @@ When set and the microflow is called from the client, Refresh in client will cau
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -29,12 +29,18 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
+When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
 
-_Default value_: No
+{{% alert type="info" %}}
+
+For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to _No_, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+
+{{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It behaves as if set to _Yes_.
+When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It will refresh [input widgets](input-widgets) showing the rolled back object's attributes including their [conditions](conditions). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the rolled back object.
 
 {{% /alert %}}
+
+_Default value_: No

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -33,7 +33,7 @@ When set and the microflow is called from the client, Refresh in client will cau
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.18.0. Before 7.18.0, if this setting was set to *No*, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.18.0, input widgets and their conditions will always be refreshed.
+For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
 
 {{% /alert %}}
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -9,7 +9,7 @@ The Rollback object action can be used to undo changes (that have not been commi
 
 {{% alert type="info" %}}
 
-When the Rollback object action is performed in a sub-microflow it will roll back the changes in both the sub-microflow as well as its parent microflow.
+When the Rollback object action is performed in a sub-microflow, it rolls back the changes in both the sub-microflow as well as its parent microflow.
 
 {{% /alert %}}
 
@@ -19,7 +19,7 @@ See [Microflow Element Common Properties](microflow-element-common-properties) f
 
 {{% /alert %}}
 
-If the microflow is called from the client, [input widgets](input-widgets) showing the rolled back object's attributes will be refreshed automatically. This includes updating their visibility and editability [conditions](conditions).
+If the microflow is called from the client, [input widgets](input-widgets) showing the rolled back object's attributes are refreshed automatically. This includes updating their visibility and editability [conditions](conditions).
 
 ## 2 Input Properties
 
@@ -29,17 +29,17 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-When set and the microflow is called from the client, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
+When set and the microflow is called from the client, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
 
 {{% alert type="info" %}}
 
-For input widgets, this setting behaves differently as of 7.19.0. Before 7.19.0, if this setting was set to *No*, [input widgets](input-widgets) showing the rolled back object's attributes wouldn't be refreshed, including their visibility and editability [conditions](conditions). Since 7.19.0, input widgets and their conditions will always be refreshed.
+For [input widgets](input-widgets), this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, input widgets showing the rolled back object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It will refresh [input widgets](input-widgets) showing the rolled back object's attributes including their [conditions](conditions). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) will be refreshed if they show the entity of the rolled back object.
+When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It refreshes [input widgets](input-widgets) showing the rolled back object's attributes (including their [conditions](conditions)). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the rolled back object.
 
 {{% /alert %}}
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -5,11 +5,11 @@ parent: "object-activities"
 
 ## 1 Introduction
 
-The rollback-object action can be used to undo changes (that have not been committed) that were made to the object in the part of the flow preceding the activity. Furthermore, it deletes objects that have been created but have never been committed.
+The Rollback object action can be used to undo changes (that have not been committed) that were made to the object in the part of the flow preceding the activity. Furthermore, it deletes objects that have been created but have never been committed.
 
 {{% alert type="info" %}}
 
-When the rollback-object action is performed in a sub-microflow it will roll back the changes in the sub-microflow as well as its parent microflow.
+When the Rollback object action is performed in a sub-microflow it will roll back the changes in both the sub-microflow as well as its parent microflow.
 
 {{% /alert %}}
 
@@ -19,6 +19,8 @@ See [Microflow Element Common Properties](microflow-element-common-properties) f
 
 {{% /alert %}}
 
+If the microflow is called from the client, [input widgets](input-widgets) showing the rolled back object's attributes will be refreshed automatically. This includes updating their visibility and editability [conditions](conditions).
+
 ## 2 Input Properties
 
 ### 2.1 Object
@@ -27,17 +29,12 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-This property specifies whether forms that use the entity of the object being rolled back are refreshed.
-
-| Option | Description |
-| --- | --- |
-| Yes | Objects of same entity are refreshed in the user's browser. |
-| No | Objects of same entity are not refreshed in the user's browser. |
+When set, Refresh in client will cause [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector) and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
 
 _Default value_: No
 
 {{% alert type="warning" %}}
 
-Nanoflows do not have this property. The rollback object activity in a nanoflow refreshes the client by default.
+When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It behaves as if set to _Yes_.
 
 {{% /alert %}}

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -5,7 +5,7 @@ parent: "object-activities"
 
 ## 1 Introduction
 
-The Rollback object action can be used to undo changes (that have not been committed) that were made to the object in the part of the flow preceding the activity. Furthermore, it deletes objects that have been created but have never been committed.
+The Rollback object action can be used to undo changes (that have not been committed) made to the object in the part of the flow preceding the activity. Furthermore, it deletes objects that have been created but never committed.
 
 {{% alert type="info" %}}
 
@@ -29,17 +29,17 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-If the microflow is called from the client, the rollback is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
+If the microflow is called from the client, the rollback is not reflected in the client if **Refresh in client** is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-As of 7.19.0, rolled back attribute values are always reflected in client. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
+As of 7.19.0, rolled back attribute values are always reflected in client. [Data sources](data-sources) are only reloaded if **Refresh in client** is set to *Yes*.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Rollback object action reloads [data sources](data-sources) as if Refresh in client was set to *Yes*.
+When inside a [nanoflow](nanoflows), the Rollback object action reloads [data sources](data-sources) as if **Refresh in client** was set to *Yes*.
 
 {{% /alert %}}
 

--- a/content/refguide/rollback-object.md
+++ b/content/refguide/rollback-object.md
@@ -29,17 +29,17 @@ Object defines the object that needs to be rolled back.
 
 ### 2.2 Refresh in Client
 
-When set and the microflow is called from the client, Refresh in client causes [data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) to be refreshed if they show the entity of the rolled back object.
+If the microflow is called from the client, the rollback is not reflected in the client if Refresh in client is set to *No*. If Refresh in client is set to *Yes*, the object is refreshed across the client, which includes reloading of relevant [data sources](data-sources).
 
 {{% alert type="info" %}}
 
-For [input widgets](input-widgets), this setting behaves differently as of 7.19.0. For Mendix versions below 7.19.0, if this setting is set to *No*, input widgets showing the rolled back object's attributes are not refreshed (including their visibility and editability [conditions](conditions)). For version 7.19.0 and above, input widgets and their conditions are always refreshed.
+As of 7.19.0, rolled back attribute values are always reflected in client. [Data sources](data-sources) are only reloaded if Refresh in client is set to *Yes*.
 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 
-When inside a [nanoflow](nanoflows), the Rollback object action does not have the Refresh in client option. It refreshes [input widgets](input-widgets) showing the rolled back object's attributes (including their [conditions](conditions)). [Data grids](data-grid), [template grids](template-grid), [list views](list-view), [reference selectors](reference-selector), [reference set selectors](reference-set-selector), and [input reference set selectors](input-reference-set-selector) are refreshed if they show the entity of the rolled back object.
+When inside a [nanoflow](nanoflows), the Rollback object action reloads [data sources](data-sources) as if Refresh in client was set to *Yes*.
 
 {{% /alert %}}
 


### PR DESCRIPTION
We change behavior of "Refresh in client" option in several microflow actions and made the documentation of those actions a bit more explicit.

We also removed a hard-to-understand example from change object action. This example looked as coming out of nowhere without any introduction. Also, other actions do not have such examples. We remove it so be aligned with them. If you don't like it, please feel free to revert the last commit.

This PR should be merged with 7.18 release