### PR TITLE
Client certificates in project settings

### DIFF
--- a/content/refguide/project-settings.md
+++ b/content/refguide/project-settings.md
@@ -199,7 +199,7 @@ Certificates are used to connect to web services over HTTPS when the following r
 
 These certificates can be imported into the Modeler using the **Import** button. Certificate authority files usually have a *.crt* extension, and client certifcates usually have a *.p12* or *.pfx* extension. After importing, use **View details** to acquire more information concerning the certificate.
 
-Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *ClientCertificateUsages*.
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords*, and *ClientCertificateUsages*.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide/project-settings.md
+++ b/content/refguide/project-settings.md
@@ -194,10 +194,12 @@ For each language, you can configure whether to check that all mandatory texts h
 
 Certificates are used to connect to web services over HTTPS when the following requirements are met:
 
-* The server uses a self-signed certificate authority
+* The server uses a self-signed certificate authority, and/or
 * A client certificate (certificate with a private key) is required
 
 These certificates can be imported into the Modeler using the **Import** button. Certificate authority files usually have a *.crt* extension, and client certifcates usually have a *.p12* or *.pfx* extension. After importing, use **View details** to acquire more information concerning the certificate.
+
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *ClientCertificateUsages*.
 
 {{% alert type="warning" %}}
 
@@ -213,7 +215,7 @@ Be aware that during local deployment, the certificate files will be located in 
 
 Certificates can be installed in the Windows Certificate Store using the **Install Certificate** wizard in the **View details** form. This can be useful when trying to access a WSDL-file using an *https* connection, which requires a client certificate.
 
-{{% /alert %}}<
+{{% /alert %}}
 {{% alert type="success" %}}
 
 When an SSLException occurs at runtime with the message `HelloRequest followed by an unexpected handshake message` or when a web service does not respond (Java 6 update 21 and above) when using the imported certificates, this is caused by either the client or server not being [RFC-5746](http://www.ietf.org/rfc/rfc5746.txt)-compatible.

--- a/content/refguide5/project-settings.md
+++ b/content/refguide5/project-settings.md
@@ -112,10 +112,12 @@ For each language you can configure whether to check that all mandatory texts ha
 
 Certificates are used to connect to web services over HTTPS when:
 
-*   The server uses a self-signed Certificate Authority.
+*   The server uses a self-signed Certificate Authority, and/or
 *   A client certificate (certificate with private key) is required.
 
 These certificates can be imported into the Modeler using the 'Import' button. Certificate Authority files usually have a .crt extension and client certifcates usually have a .p12 or a .pfx extension. After importing use 'View details' to acquire more information concerning the certificate.
+
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *WebServiceClientCertificates*.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide5/project-settings.md
+++ b/content/refguide5/project-settings.md
@@ -112,12 +112,12 @@ For each language you can configure whether to check that all mandatory texts ha
 
 Certificates are used to connect to web services over HTTPS when:
 
-*   The server uses a self-signed Certificate Authority, and/or
+*   The server uses a self-signed certificate authority, and/or
 *   A client certificate (certificate with private key) is required.
 
-These certificates can be imported into the Modeler using the 'Import' button. Certificate Authority files usually have a .crt extension and client certifcates usually have a .p12 or a .pfx extension. After importing use 'View details' to acquire more information concerning the certificate.
+These certificates can be imported into the Modeler using the 'Import' button. Certificate authority files usually have a .crt extension and client certifcates usually have a .p12 or a .pfx extension. After importing use 'View details' to acquire more information concerning the certificate.
 
-Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *WebServiceClientCertificates*.
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords*, and *WebServiceClientCertificates*.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide6/project-settings.md
+++ b/content/refguide6/project-settings.md
@@ -158,12 +158,12 @@ For each language you can configure whether to check that all mandatory texts ha
 
 Certificates are used to connect to web services over HTTPS when:
 
-*   The server uses a self-signed Certificate Authority, and/or
+*   The server uses a self-signed certificate authority, and/or
 *   A client certificate (certificate with private key) is required.
 
 These certificates can be imported into the Modeler using the 'Import' button. Certificate Authority files usually have a .crt extension and client certifcates usually have a .p12 or a .pfx extension. After importing use 'View details' to acquire more information concerning the certificate.
 
-Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *WebServiceClientCertificates*.
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords*, and *WebServiceClientCertificates*.
 
 {{% alert type="warning" %}}
 

--- a/content/refguide6/project-settings.md
+++ b/content/refguide6/project-settings.md
@@ -158,10 +158,12 @@ For each language you can configure whether to check that all mandatory texts ha
 
 Certificates are used to connect to web services over HTTPS when:
 
-*   The server uses a self-signed Certificate Authority.
+*   The server uses a self-signed Certificate Authority, and/or
 *   A client certificate (certificate with private key) is required.
 
 These certificates can be imported into the Modeler using the 'Import' button. Certificate Authority files usually have a .crt extension and client certifcates usually have a .p12 or a .pfx extension. After importing use 'View details' to acquire more information concerning the certificate.
+
+Client certificates added here will be used whenever a server accepts a client certificate. If you upload more than one client certificate, one of them will be chosen based on the requirements of the server. If you need more control over client certificates, you should not upload the certificates here, but use [custom settings](custom-settings) *ClientCertificates*, *ClientCertificatePasswords* and *WebServiceClientCertificates*.
 
 {{% alert type="warning" %}}
 


### PR DESCRIPTION
When a project needs client certificates to communicate over https, it wasn't clear when to use the project settings and when to use custom settings. I've clarified that (Ticket #66497)