### PR TITLE
Added escape quote

### DIFF
--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -7,7 +7,7 @@ description: "Describes the functions for converting and inspecting strings in M
 
 These are functions to convert and inspect [strings](data-types). Note that these functions never change the string itself, they only return a new value.
 
-Strings are surrounded by quotes. If the string contains a quote, it should be escaped by another quote. For example: `'this isn't funny'`.
+Strings are surrounded by quotes. If the string contains a quote, it should be escaped by another quote. For example: `'this isn''t funny'`.
 
 ## toLowerCase
 


### PR DESCRIPTION
If the string contains a quote, it should be escaped by another quote. In the example this wasn't the case: the string contains a quote (isn't), this should be escaped (isn''t).