### PR TITLE
Remove known issue and add corresponding fix

### DIFF
--- a/content/releasenotes/desktop-modeler/7.18.md
+++ b/content/releasenotes/desktop-modeler/7.18.md
@@ -62,7 +62,7 @@ You can now group the parameters of [Java actions](https://docs.mendix.com/refgu
 
 * We have fixed an issue about the high DPI scaling of the Desktop Modeler Version Selector and removed the old splash screen. (Ticket 50101)
 * We fixed the Team Server connection issues that occurred after switching an account or changing your password. (Ticket 67205)
-* We fixed the issues with committing and updating that occurred after a time-out of an hour; the error details would mention `SvnOperationCanceledException`. (Ticket 67735)
+* <a name="67735"></a>We fixed the issues with committing and updating that occurred after a time-out of an hour (the error details mentioned `SvnOperationCanceledException`). (Ticket 67735)
 * We fixed the behavior of the **Team Server App** drop-down menu so that it no longer closes when navigating with the keyboard. Also, the list of branches will not contain duplicates anymore.
 * We fixed an issue that occurred when opening a project that was created online. When syncing with the Web Modeler, the Desktop Modeler complained about there already being local changes. No more.
 * <a name="67014"></a>When a **Create** button was placed on a data grid with a specialization configured as an entity, the generalization would be instantiated instead. The button creates the correct entity again. (Ticket 67014)

--- a/content/releasenotes/desktop-modeler/7.18.md
+++ b/content/releasenotes/desktop-modeler/7.18.md
@@ -62,6 +62,7 @@ You can now group the parameters of [Java actions](https://docs.mendix.com/refgu
 
 * We have fixed an issue about the high DPI scaling of the Desktop Modeler Version Selector and removed the old splash screen. (Ticket 50101)
 * We fixed the Team Server connection issues that occurred after switching an account or changing your password. (Ticket 67205)
+* We fixed the issues with committing and updating that occurred after a time-out of an hour; the error details would mention `SvnOperationCanceledException`. (Ticket 67735)
 * We fixed the behavior of the **Team Server App** drop-down menu so that it no longer closes when navigating with the keyboard. Also, the list of branches will not contain duplicates anymore.
 * We fixed an issue that occurred when opening a project that was created online. When syncing with the Web Modeler, the Desktop Modeler complained about there already being local changes. No more.
 * <a name="67014"></a>When a **Create** button was placed on a data grid with a specialization configured as an entity, the generalization would be instantiated instead. The button creates the correct entity again. (Ticket 67014)
@@ -78,7 +79,3 @@ You can now group the parameters of [Java actions](https://docs.mendix.com/refgu
 * We fixed an issue where sorting on the search field in a data grid resulted in a database exception. (Ticket 64852)
 * We fixed a bug in the behavior of `COUNT` on an attribute aggregate query. Previously, when a count on an attribute was defined along with other aggregate functions, count was always rendered as `COUNT(*)`. As of this release, attribute-specific aggregate functions are always rendered in terms of an associated attribute. As this may change the result of the `COUNT` aggregate function in your application, a temporary custom property has been introduced called `DataStorage.CountOnAttribute`. Setting this property to **False** will allow you to fall back to the old `COUNT` behavior. We plan to remove the `DataStorage.CountOnAttribute` custom property in Mendix version 8.
 * We upgraded the HSQLDB (built-in database) driver version from 2.3.4 to 2.4.1.
-
-### Known Issues
-
-* Updates or commits to the Team Server can result in an error dialog box. When doing a commit or update to the Team Server after more than 1 hour following the last Team Server connection, you will get an error dialog box with the details panel showing `SvnOperationCanceledException` info. This can be solved by retrying the update or commit action again. (Ticket 67051)


### PR DESCRIPTION
Note that the ticket number in the known issue in 7.17.2 was incorrect. One ticket about the time-out issue I could find was 67735, but there might be more. Ticket 67051 is a specific laptop that cannot access the team server, probably because it is configured in the wrong way.