### PR TITLE
Update export-project-package-dialog.md

### DIFF
--- a/content/refguide/export-project-package-dialog.md
+++ b/content/refguide/export-project-package-dialog.md
@@ -1,4 +1,4 @@
----
+Project---
 title: "Export Project Package"
 parent: "dialogs"
 ---
@@ -16,7 +16,7 @@ When creating a project package from you app, it's possible to include a data sn
 
 ### Existing snapshot
 
-Select this option when you want to include an existing snapshot in the package. This option is only available when a snapshot is already present. Snapshots can be created by going to *Team > Add snapshot of data*.
+Select this option when you want to include an existing snapshot in the package. This option is only available when a snapshot is already present. Snapshots can be created by going to *Project > More Versioning > Add snapshot of data*.
 
 ### Existing snapshot
 

--- a/content/refguide/export-project-package-dialog.md
+++ b/content/refguide/export-project-package-dialog.md
@@ -1,23 +1,26 @@
-Project---
+---
 title: "Export Project Package"
 parent: "dialogs"
 ---
-Use this dialog to export the current app to a Mendix project package (.mpk) file. This is useful, for example, if you want to give someone the entire app, or if you need to provide a test app when submitting a ticket.
 
-Project packages can be imported again into a new app using the [Import Project Package](import-project-package-dialog) dialog.
+## 1 Introduction
 
-## Package destination
+Use this dialog box to export the current app to a Mendix project package (*.mpk*) file. This is useful, for example, if you want to give someone the entire app, or if you need to provide a test app when submitting a ticket.
+
+Project packages can be imported again into a new app using the [Import Project Package](import-project-package-dialog) dialog box
+
+## 2 Package Destination
 
 Use this field to choose the directory where the project package file will be created. The default location is a directory called *packages* inside the project directory.
 
-## Export data
+## 3 Export Data
 
-When creating a project package from you app, it's possible to include a data snapshot. This snapshot contains the data from the local database, and any files you uploaded while running the app locally.
+When creating a project package from you app, it is possible to include a data snapshot. This snapshot contains data from the local database and any files you uploaded while running the app locally.
 
-### Existing snapshot
+### 4 Existing Snapshot
 
-Select this option when you want to include an existing snapshot in the package. This option is only available when a snapshot is already present. Snapshots can be created by going to *Project > More Versioning > Add snapshot of data*.
+Select this option when you want to include an existing snapshot in the package. This option is only available when a snapshot is already present. Snapshots can be created via **Project** > **More Versioning** > **Add Snapshot of Data**.
 
-### Existing snapshot
+### 5 Existing Snapshot
 
-Select this option if you want to create a new snapshot to include in the package. This option becomes available after you run the app locally at least once, because the local database will created when running the app for the first time.
+Select this option if you want to create a new snapshot to include in the package. This option becomes available after you run the app locally at least once, because a local database will be created when running the app for the first time.


### PR DESCRIPTION
There is no more Team menu in the desktop version of the Modeler since version 7. But there are still references to it in the documentation and even in the Modeler, in this very dialog, under the option "New snapshot from current database"