### PR TITLE
Update parse-and-format-date-function-calls.md

### DIFF
--- a/content/refguide/parse-and-format-date-function-calls.md
+++ b/content/refguide/parse-and-format-date-function-calls.md
@@ -75,7 +75,7 @@ returns:
 To get '1987-12-31T23:59:00', you need to concatenate two formatDateTime[UTC] functions:
 
 ```java
-formatDateTime($object/Date1,'yyyy-MM-DD') + 'T' + formatDateTime($object/Date1,'HH:mm:ss')
+formatDateTime($object/Date1,'yyyy-MM-dd') + 'T' + formatDateTime($object/Date1,'HH:mm:ss')
 ``` 
 
 ## formatTime[UTC]


### PR DESCRIPTION
Example for formatDateTime has "day in month", but syntax uses "day in year". Corrected the syntax.