### PR TITLE
Update microflow naming conventions

### DIFF
--- a/content/howtogeneral/bestpractices/dev-best-practices.md
+++ b/content/howtogeneral/bestpractices/dev-best-practices.md
@@ -136,13 +136,16 @@ In your integrations you have the following type of documents:
 
 | Event Type                                | Prefix |
 |-------------------------------------------|--------|
-| Published web service operation microflow | WOP\_  |
-| Published app service operation microflow | AOP\_  |
-| Import mapping                            | INM\_  |
-| Export mapping                            | EXM\_  |
+| Consumed web service opeation microflow   | CWS\_  |
+| Published web service operation microflow | PWS\_  |
+| Published app service operation microflow | PAS\_  |
+| Published rest service operation microflow| PRS\_  |
+| Import mapping                            | X2D\_  |
+| Export mapping                            | D2X\_  |
 | XML schema                                | XML\_  |
 | JSON Structure                            | JSON\_ |
 | Deeplink                                  | DL\_   |
+
 
 ### 3.6 Scheduled Events
 


### PR DESCRIPTION
I think CWS_ and PWS_ are more covenient names for consumed and published webservices, D2X_ and X2D_ for export and import mapping, and PAS_ and PRS_ for published app and rest services.