### PR TITLE
[for 7.20] Fix documentation ("Show control bar" property of the data grid)

### DIFF
--- a/content/refguide/data-grid.md
+++ b/content/refguide/data-grid.md
@@ -31,7 +31,7 @@ This property indicates whether the control bar buttons will be visible in the e
 
 {{% alert type="warning" %}}
 
-Even if the control bar buttons are invisible there can still be a default button that is triggered by (double) clicking a row. See the property 'Default button trigger' and [data grid buttons](control-bar) for more information.
+Even if the control bar buttons are invisible, there can still be a default button that is triggered by (double) clicking a row. For more information, see the property [Default Button Trigger](#dbt) and [Data Grid Buttons](control-bar).
 
 {{% /alert %}}
 
@@ -77,7 +77,7 @@ This property indicates whether the first item will be selected initially. This 
 
 _Default value:_ False
 
-#### Default Button Trigger
+#### <a name="dbt"></a>Default Button Trigger
 
 The default button can be triggered by a single or a double click on a row.
 

--- a/content/refguide/data-grid.md
+++ b/content/refguide/data-grid.md
@@ -25,13 +25,13 @@ A data grid showing accounts.
 
 ### General Properties
 
-#### Show Control Bar
+#### Show Control Bar Buttons
 
-This property indicates whether the control bar will be visible in the end user interface. The control bar also includes the paging buttons.
+This property indicates whether the control bar buttons will be visible in the end user interface.
 
 {{% alert type="warning" %}}
 
-Even if the control bar is invisible there can still be a default button that is triggered by (double) clicking a row. See the property 'Default button trigger' and [data grid buttons](control-bar) for more information.
+Even if the control bar buttons are invisible there can still be a default button that is triggered by (double) clicking a row. See the property 'Default button trigger' and [data grid buttons](control-bar) for more information.
 
 {{% /alert %}}
 
@@ -39,7 +39,7 @@ _Default value:_ True
 
 #### Show Paging Buttons
 
-This property indicates with the buttons to page through the information in the grid are visible. Only hide these buttons if you are sure that there will never be more objects than the number of rows of the grid. Note that hiding the control bar also hides the paging buttons.
+This property indicates with the buttons to page through the information in the grid are visible. Only hide these buttons if you are sure that there will never be more objects than the number of rows of the grid.
 
 _Default value:_ True
 


### PR DESCRIPTION
- Fix documentation as the actual behavior differs. Hiding control bar (buttons) is not affecting paging buttons, they are still shown.
- Rename "Show control bar" to "Show control bar buttons" in the modeler.