### PR TITLE
Corrected false instructions and repaired Broken link

### DIFF
--- a/content/howto/integration/expose-a-web-service.md
+++ b/content/howto/integration/expose-a-web-service.md
@@ -52,7 +52,7 @@ To create a published web service, follow these steps:
 
         ![](attachments/18448728/18581713.png)
 
-    * On the **Settings** tab, you can configure the other settings (for now leave the settings as they are; for details on these settings, see [Published Web Services](/refguide7/published-web-services) in the Mendix Reference Guide):
+    * On the **Settings** tab, you can configure the other settings. Do change them before publishing your webservice, especially the target namespace (for details on these settings, see [Published Web Services](/refguide/published-web-service) in the Mendix Reference Guide):
 
         ![](attachments/18448728/18581712.png)
 

--- a/content/howto/integration/expose-a-web-service.md
+++ b/content/howto/integration/expose-a-web-service.md
@@ -52,7 +52,7 @@ To create a published web service, follow these steps:
 
         ![](attachments/18448728/18581713.png)
 
-    * On the **Settings** tab, you can configure the other settings. Do change them before publishing your webservice, especially the target namespace (for details on these settings, see [Published Web Services](/refguide/published-web-service) in the Mendix Reference Guide):
+    * On the **Settings** tab, you can configure the other settings. Do change them before publishing your web service, especially the **Target namespace** (for details on these settings, see [Published Web Service](/refguide/published-web-service) in the Mendix Reference Guide):
 
         ![](attachments/18448728/18581712.png)
 


### PR DESCRIPTION
Corrected false instructions and repaired Broken link. Following the current instructions, a webservice will get published with www.example.com as target namespace, resulting in a warning in the modeler and solving it will give a breaking change to the webservice. You will have to get in touch every consumer about this change. Following the new instructions will prevent this. Would be even better if you would not be able to commit www.example.com, but that's a different story.