### PR TITLE
Updated hybrid mobile SSO page with JS code fix

### DIFF
--- a/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -87,8 +87,10 @@ MxApp.onConfigReady(function(config) {
                     code: "document.cookie;"
                 }, function(values) {
                     var value = values[0] + ";";
-                    var token = new RegExp('AUTH_TOKEN=([^;]+);', 'g').exec(value)[1];
-                    window.localStorage.setItem("mx-authtoken", token);
+                    var token = new RegExp('AUTH_TOKEN=([^;]+);', 'g').exec(value);
+                    if (token && token.length > 1) {
+                        window.localStorage.setItem("mx-authtoken", token[1]);
+                    }
                     
                     samlWindow.close();
 


### PR DESCRIPTION
Only set auth token when successfully found. This prevents hybrid widget issues by always closing the InnAppBrowser even if the auth token is not present due to misconfigured or outdated SAML module. This will at least allow users to use the app with cordova widgets.