### PR TITLE
Release notes for 12-12 release of dev portal

### DIFF
--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -9,9 +9,10 @@ tags: ["developer portal", "cloud environments", "Mendix Cloud", "SAP", "IBM", "
 ### December 12th, 2018
 
 #### Improvements
-* Improved the performance of the My Apps page for users who are a member of a large number of apps.
-* Updated look and feel of the My Company's Apps page to be more in line with the My Apps page.
-* Improved the look and feel of emails being sent by the developer portal.
+
+* We improved the performance of the **My Apps** page for users who are a member of a large number of App Teams.
+* We updated the look and feel of the **My Company's Apps** page to be more in line with the **My Apps** page.
+* We improved the look and feel of the emails that are being sent by the Developer Portal.
 
 #### Fixes
 * Fixed broken deeplink to the Stories page of an app.

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -15,7 +15,8 @@ tags: ["developer portal", "cloud environments", "Mendix Cloud", "SAP", "IBM", "
 * We improved the look and feel of the emails that are being sent by the Developer Portal.
 
 #### Fixes
-* Fixed broken deeplink to the Stories page of an app.
+
+* We fixed the broken deeplink to the **Stories** page of your app.
 
 ### December 1st, 2018
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -6,6 +6,16 @@ tags: ["developer portal", "cloud environments", "Mendix Cloud", "SAP", "IBM", "
 
 ## 2018
 
+### December 12th, 2018
+
+#### Improvements
+* Improved the performance of the My Apps page for users who are a member of a large number of apps.
+* Updated look and feel of the My Company's Apps page to be more in line with the My Apps page.
+* Improved the look and feel of emails being sent by the developer portal.
+
+#### Fixes
+* Fixed broken deeplink to the Stories page of an app.
+
 ### December 1st, 2018
 
 #### Fixes


### PR DESCRIPTION
These are the release notes for the Sprintr release on 12-12. Release should go live in the morning, so any moment after 8 AM CET would be safe to make them public.