### PR TITLE
Update string-function-calls.md

### DIFF
--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -403,7 +403,7 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 NB searching an empty string:
 
-* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.8.0 it returns false. False is also the answer given by java.util.regex.Matcher.
+* `isMatch('', '.*[0-9].*')` returns false
 
 ## replaceAll
 

--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -403,7 +403,7 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 NB searching an empty string:
 
-* `isMatch('', '.*[0-9].*')` returns true
+* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.20.1 it returns false. False is more compliant with the 
 
 ## replaceAll
 

--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -403,7 +403,7 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 NB searching an empty string:
 
-* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.20.1 it returns false. False is also the answer given by java.util.regex.Matcher.
+* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.8.0 it returns false. False is also the answer given by java.util.regex.Matcher.
 
 ## replaceAll
 

--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -403,7 +403,7 @@ In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
 
 NB searching an empty string:
 
-* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.20.1 it returns false. False is more compliant with the 
+* `isMatch('', '.*[0-9].*')` used to return true in 7.0.2 and some older versions, but somewhere it changed and since 7.20.1 it returns false. False is also the answer given by java.util.regex.Matcher.
 
 ## replaceAll
 


### PR DESCRIPTION
This issue with IsMatch('', 'whatever') is pretty weird, should not have happened or at least be documented. But since it not in the release notes, nore in the docs of communuty commons, we should add it here.