### PR TITLE
Update Platform SDK docs to use built-in Promises

### DIFF
--- a/content/apidocs-mxsdk/mxsdk/creating-your-first-script.md
+++ b/content/apidocs-mxsdk/mxsdk/creating-your-first-script.md
@@ -45,7 +45,7 @@ After setting up all the prerequisites, you can start writing a first script tha
     function loadDomainModel(workingCopy: OnlineWorkingCopy): Promise<domainmodels.DomainModel> {
         const dm = workingCopy.model().allDomainModels().filter(dm => dm.containerAsModule.name === 'MyFirstModule')[0];
 
-        return new Promise((resolve, reject) => dm.load(resolve));
+        return dm.load();
     }
 
     main();


### PR DESCRIPTION
In Mendix Model SDK `4.18` we're exposing Promises to the outside world, so let's use that in our documentation as well.