### PR TITLE
lost an array dereference in a recent commit

### DIFF
--- a/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -90,14 +90,14 @@ MxApp.onConfigReady(function(config) {
                     var token = new RegExp('AUTH_TOKEN=([^;]+);', 'g').exec(value);
                     var authPromise = new Promise(function(resolve, reject) {
                         if (token && token.length > 1) {
-                            window.localStorage.setItem("mx-authtoken", token);
+                            window.localStorage.setItem("mx-authtoken", token[1]);
 							
                             window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, function (fs) {
                                 fs.root.getFile(".mx-token", { create: true, exclusive: false }, function (fileEntry) {
                                     fileEntry.createWriter(function (fileWriter) {
                                         fileWriter.onwriteend = resolve;
                                         fileWriter.onerror = reject;
-                                        fileWriter.write(token);
+                                        fileWriter.write(token[1]);
                                     });
                                 }, reject);
                             }, reject);


### PR DESCRIPTION
In a recent commit, we lost a dereference when `token` is used. The variable `token` is an array, so when we need use it, we have to use the second value in the array. So it should be `token[1]`