### PR TITLE
UP-160: TLS v1.0 and v1.1 disabled for Mendix Cloud v4

### DIFF
--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -12,9 +12,9 @@ For updates on the status of Mendix Cloud V4, Mendix Cloud V3, and other deploym
 
 ### January 28th, 2019
 
-#### TLS v1.0 and v1.1 disabled for Mendix Cloud v4
+#### TLS v1.0 & v1.1 Disabled for Mendix Cloud v4
 
-* We have implemented a change on our Cloud v4 infrastructure so that incoming connections which do not support TLS v1.2 or higher will stop working. This effectively means that TLS v1.0 and v1.1 are disabled, and Mendix Cloud v4 now has an [A+ rating at SSL Labs again](https://www.ssllabs.com/ssltest/index.html).
+* We have implemented a change on our Mendix Cloud v4 infrastructure so that incoming connections that do not support TLS v1.2 or higher will stop working. This effectively means that TLS v1.0 and v1.1 are disabled, and Mendix Cloud v4 now has an [A+ rating at SSL Labs](https://www.ssllabs.com/ssltest/index.html) again.
 
 ### January 24th, 2019
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -10,6 +10,12 @@ For updates on the status of Mendix Cloud V4, Mendix Cloud V3, and other deploym
 
 ## 2019
 
+### January 28th, 2019
+
+#### TLS v1.0 and v1.1 disabled for Mendix Cloud v4
+
+* We have implemented a change on our Cloud v4 infrastructure so that incoming connections which do not support TLS v1.2 or higher will stop working. This effectively means that TLS v1.0 and v1.1 are disabled, and Mendix Cloud v4 now has an [A+ rating at SSL Labs again](https://www.ssllabs.com/ssltest/index.html).
+
 ### January 24th, 2019
 
 #### IBM Watson Connector Suite Improvements


### PR DESCRIPTION
See also: https://status.mendix.com/incidents/681y6gbr20qz