### PR TITLE
Update 7.23.md with a typo-fix, and putting "we fixed" in the fixes

### DIFF
--- a/content/releasenotes/desktop-modeler/7.23.md
+++ b/content/releasenotes/desktop-modeler/7.23.md
@@ -13,6 +13,7 @@ description: "The release notes for Mendix Desktop Modeler version 7.23 (includi
 ### New Features
 
 * In [published OData services](/refguide/published-odata-services), clients can now use the `not` operator (as in `$filter=not substringof('j', Name)`).
+* The **List operation** activity is now supported in nanoflows.
 
 ### Improvements
 
@@ -26,16 +27,16 @@ description: "The release notes for Mendix Desktop Modeler version 7.23 (includi
 * It is now possible to set the render mode of a container widget as one of the HTML5 section tags (for example, `main`, `section`, `header`, `footer`).
 * We improved the accessibility of pop-up windows and pages in pop-up layouts.
 * Syncing files for offline apps is much faster now! We only synchronize changed files, which saves a lot of network traffic and time. In addition, resiliency to network failures during file download has been improved: the offline database is not updated with changes from the server until all network operations are completed.
-* The **List operation** activity is now supported in nanoflows.
 * We improved the build time of your project. This was possible by replacing Bnd for packaging the Java part of the project.
-* We fixed the issue with the **Get Started** pane which was not display anything when a user was not signed in.
-* We fixed an issue where some technical details (the **Mics** panel) were displayed in Java actions properties.
 * When reverting a renamed Java action, dataset, or consumed app service, the associated files are also renamed. When reverting a renamed module, files in this module are moved.
 * We support the custom setting `DatabaseJdbcUrl` for PostgreSQL databases too (this setting was already supported for the other database types). 
-* We fixed an issue where a database failover could lead to a Jetty ThreadPool exhaustion, preventing requests from being handled and causing the system to report a "low on resources" warning.
+
 
 ### Fixes
 
+* We fixed the issue with the **Get Started** pane which was not display anything when a user was not signed in.
+* We fixed an issue where some technical details (the **Mics** panel) were displayed in Java actions properties.
+* We fixed an issue where a database failover could lead to a Jetty ThreadPool exhaustion, preventing requests from being handled and causing the system to report a "low on resources" warning.
 * We added a missing consistency check for the **Aggregate list** action, so your aggregate action will not fail in runtime if you are using an attribute that does not belong to the selected entity. (Ticket 77198)
     * **Conversion fix**: For a selected attribute on the **Aggregate list** action that cannot be found as a part of the entity of the input variable, we now change it to an attribute with the same name if it exists on the entity. This conversion ensures that users will not get consistency errors.
 * <a name="78468"></a>We fixed an issue where it was not possible to commit after merging in a branch. (Tickets 78468, 78322, 79166, 78542, 76785, 77955, 77245)
@@ -61,7 +62,7 @@ description: "The release notes for Mendix Desktop Modeler version 7.23 (includi
 * We improved performance when [importing](/refguide/import-mappings) content in which an attribute value is at the end of the payload.
 * We fixed an issue in [export mappings](/refguide/export-mappings) where mapping different specializations of an entity resulted in an error. (Ticket 76307)
 * We fixed an issue in [XML import mappings](/refguide/import-mappings) where the mapping failed because `find by key` was used for a key that was the content of an XML node. (Ticket 76438)
-* We fixed an issue in the [message definition editor](/refguide/message-definition) where filtering expended the tree so far that the Modeler could become unresponsive. (Ticket 77195)
+* We fixed an issue in the [message definition editor](/refguide/message-definition) where filtering expanded the tree so far that the Modeler could become unresponsive. (Ticket 77195)
 * We fixed an issue in the [message definition editor](/refguide/message-definition) where after changing the association, the **Refresh** button did not fix the consistency error. (Ticket 77187)
 * We fixed an issue where the debugger shortcut keys (for example, <kbd>Alt</kbd>+<kbd>F6</kbd>) were not working. (Ticket 78125)
 * We fixed an issue where the **Mendix Console Log** application was crashing while showing a dialog box. 


### PR DESCRIPTION
- Expended vs Expanded
- "We fixed" suggests a bug fix, which can of course be considered as an improvement, but better fits in the fixes section
- A new activity type in nanoflows counts as a new feature to me