### PR TITLE
changed UX Best Practices menu order 

### DIFF
--- a/content/howto/ux/ux-best-practices.md
+++ b/content/howto/ux/ux-best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: "Implement Best Practices for UX Design"
 category: "UX"
-menu_order: 66
+menu_order: 9
 tags: ["ux", "ui", "ux designer", "user experience", "design", "menu", "button", "typography", "card"]
 ---
 


### PR DESCRIPTION
Changed menu order of "implement best practices" so it lies at the top of UX. Specifically, I changed its menu order value in the metadata to 9, because the top-most right now ("configure your theme") is at 10.