### PR TITLE
Pointing to the correct function dateTime-creation

### DIFF
--- a/content/refguide/date-creation.md
+++ b/content/refguide/date-creation.md
@@ -1,26 +1,26 @@
 ---
-title: "Date creation"
+title: "Date Creation"
 parent: "expressions"
 ---
 
-Date-objects for a certain date can be created by using [parseDateTime](parse-and-format-date-function-calls). This takes a Date-string and a format-string as parameters and returns a Date-object. See the [parseDateTime](parse-and-format-date-function-calls) for more details.
+Date-type variables for a certain date can be created by using [parseDateTime](parse-and-format-date-function-calls). This takes a date string and a format string as parameters and returns a date-type variable. For more details, see [parseDateTime](parse-and-format-date-function-calls).
 
-Date-variables of type string can be created with the `dateTime` and `dateTimeUTC` functions. The difference between the two is that `dateTime` uses the calendar of the session used in this function call and `dateTimeUTC` uses the UTC calendar. The system session runs as UTC by default but this can be configured in the [project settings](project-settings).
+String variables representing a date can be created with the `dateTime` and `dateTimeUTC` functions. The difference between these two functions is that `dateTime` uses the calendar of the session used in the function call, and `dateTimeUTC` uses the UTC calendar. The system session runs as UTC by default, but this can be configured in the [Project Settings](project-settings).
 
-These functions takes between one and 6 input parameters and returns a string. These represent, in order:
+These functions take between 1 and 6 input parameters and return a string. These represent, in order:
 
-1.  years
-    Type: Integer, four digits and greater than 1799
-2.  months
-    Type: Integer, between 1 and 12
-3.  days
-    Type: Integer, between 1 and 31
-4.  hours
-    Type: Integer, between 0 and 23
-5.  minutes
-    Type: Integer, between 0 and 59
-6.  seconds
-    Type: Integer, between 0 and 59
+1. Years
+    * Type: integer, four digits, and greater than 1799
+2. Months
+    * Type: integer, between 1 and 12
+3. Days
+    * Type: integer, between 1 and 31
+4. Hours
+    * Type: integer, between 0 and 23
+5. Minutes
+    * Type: integer, between 0 and 59
+6. Seconds
+     * Type: integer, between 0 and 59
 
 One parameter:
 
@@ -28,7 +28,7 @@ One parameter:
 dateTime(2007)
 ```
 
-returns
+returns: 
 
 ```java
 "Mon Jan 01 00:00:00 CET 2007"
@@ -40,7 +40,7 @@ Two parameters:
 dateTime(2007, 1)
 ```
 
-returns
+return: 
 
 ```java
 "Mon Jan 01 00:00:00 CET 2007"
@@ -52,7 +52,7 @@ Three parameters:
 dateTime(2007, 1, 1)
 ```
 
-returns
+return:
 
 ```java
 "Mon Jan 01 00:00:00 CET 2007"
@@ -64,7 +64,7 @@ Four parameters:
 dateTime(2007, 1, 1, 1)
 ```
 
-returns
+return:
 
 ```java
 "Mon Jan 01 01:00:00 CET 2007"
@@ -76,7 +76,7 @@ Five parameters:
 dateTime(2007, 1, 1, 1, 1)
 ```
 
-returns
+return:
 
 ```java
 "Mon Jan 01 01:01:00 CET 2007"
@@ -88,9 +88,8 @@ Six parameters:
 dateTime(2007, 1, 1, 1, 1, 1)
 ```
 
-returns
+return:
 
 ```java
 "Mon Jan 01 01:01:01 CET 2007"
 ```
-

--- a/content/refguide/date-creation.md
+++ b/content/refguide/date-creation.md
@@ -3,10 +3,11 @@ title: "Date creation"
 parent: "expressions"
 ---
 
+Date-objects for a certain date can be created by using [parseDateTime](parse-and-format-date-function-calls). This takes a Date-string and a format-string as parameters and returns a Date-object. See the [parseDateTime](parse-and-format-date-function-calls) for more details.
 
-Dates can be created with the `dateTime` and `dateTimeUTC` functions. The difference between the two is that `dateTime` uses the calendar of the session used in this function call and `dateTimeUTC` uses the UTC calendar. The system session runs as UTC by default but this can be configured in the [project settings](project-settings).
+Date-variables of type string can be created with the `dateTime` and `dateTimeUTC` functions. The difference between the two is that `dateTime` uses the calendar of the session used in this function call and `dateTimeUTC` uses the UTC calendar. The system session runs as UTC by default but this can be configured in the [project settings](project-settings).
 
-These functions takes between one and 6 input parameters. These represent, in order:
+These functions takes between one and 6 input parameters and returns a string. These represent, in order:
 
 1.  years
     Type: Integer, four digits and greater than 1799
@@ -92,3 +93,4 @@ returns
 ```java
 "Mon Jan 01 01:01:01 CET 2007"
 ```
+


### PR DESCRIPTION
Prevent people from starting with dateTime-function when they what to get a DateTime-object for a date of choice. Like [this forumquestion](https://forum.mendixcloud.com/link/questions/93358)