### PR TITLE
Update Getting Started With Native Mobile

### DIFF
--- a/content/howto/mobile/getting-started-with-native-mobile.md
+++ b/content/howto/mobile/getting-started-with-native-mobile.md
@@ -8,21 +8,23 @@ tags: ["native", "mobile", "developer", "test"]
 
 ## 1 Introduction
 
-To use Mendix Studio Pro's native app capabilities, you can either start using a Blank app or download the [Native Mobile Quickstart](https://appstore.home.mendix.com/link/app/109511/) app from the Mendix App Store. This how-to uses the latter, because it is optimized to quickly build a native mobile app. Out of the box this app gives you a native page, a native phone profile to enable native device navigation, a native layout with menus, and native widgets and actions which leverage device capabilities.
+{{% todo %}} With next release, also Mention that also possible using blank app or add to existing project, and how to (because Atlas needs to be updated) {{% /todo %}}
+
+To use Mendix Studio Pro's native app capabilities, you can use the [Native Mobile Quickstart](https://appstore.home.mendix.com/link/app/109511/) app from the Mendix App Store. This app is optimized to quickly build a native mobile app. Out of the box, this app gives you a native page, a native phone profile to enable native device navigation, a native layout with menus, and native widgets and actions which leverage device capabilities.
 
 The Native Mobile Quickstart app also includes four modules:
 
 * **Administration** – helps you manage users
 * **Atlas UI Resources package** – allows for app styling
-* **Nanoflow Commons** – helps model out client-side logic
-* **Native Mobile Actions** – contains JavaScript actions specific to native mobile apps
+* **Nanoflow Commons** – contains generic useful nanoflow actions
+* **Native Mobile Actions** – contains various native widgets and nanoflow actions that leverage device capabilities
 
 ## 2 Prerequisites {#prerequisites}
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
 * Have a mobile device to test your native app 
-* For information on browser and device requirements, see [System Requirements](/refguide/system-requirements)
+* For information on device requirements, see [System Requirements](/refguide/system-requirements)
 * If you wish to use an emulator for Android mobile testing, install a product such as [Bluestacks](https://www.bluestacks.com/nl/index.html) or [Genymotion](https://www.genymotion.com/) (your emulator must have Google Play services supported)
 
 ## 3 Creating a New Project Based on the Quickstart App{#quickstartapp}
@@ -61,27 +63,29 @@ To start a new app based on a template, follow these steps:
 
 At this point you have a running native app. To view your app on a mobile device, however, you need to download the Make It Native app.
 
-### 3.2 Downloading the Make It Native App
+### 3.2 Downloading and Installing the Make It Native App
 
-To view your app on a mobile device, you must install the Make It Native app. The sections below describe two options for doing this.
-
-{{% todo %}}[replace screenshot below with two app store screens when they get new logos?]{{% /todo %}}
-
-#### Option 1: Use the App Store for Your Device
-
-Download the Make It Native app from [Google Play](https://play.google.com/store/apps/details?id=com.mendix.developerapp) (coming soon for iOS) and install it on your mobile device:
-
-{{% image_container width="500" %}}![native app on googleplay](attachments/getting-started-with-native-mobile/make-it-native-googleplay.png){{% /image_container %}}
-
-#### Option 2: Using Mendix Studio Pro
-
-{{% todo %}}[The two app store buttons mentioned below do not exist yet. Update with pic later.]{{% /todo %}}
+{{% todo %}}The sections below describe two options for doing this. #### Option 2: Using Mendix Studio Pro NOT AVAILABLE YET, SO REMOVE (INCLUDING INTRO)
 
 Alternatively, you can navigate to the Make It Native app using Mendix Studio Pro: 
 
 1. In Mendix Studio Pro, click the drop-down menu next to the **View button**, and then click **View in the Mendix App**.
-2. This will bring up a dialog box. In the **Native mobile** tab, click either **Go to play store** or **Go to app store** to be brought to the Google Play or Apple App Store pages for the Make It Native app.
-3. In the iOS or Android app store, you can download the Make It Native app to your device of choice.
+2. This will bring up a dialog box. In the **Native mobile** tab, click either **Go to play store** or **Go to app store** to be brought to the Google Play Store or Apple App Store pages for the Make It Native app.
+3. In the iOS or Android app store, you can download the Make It Native app to your device.{{% /todo %}}
+
+{{% todo %}}[replace screenshot below with two app store screens when they get new logos?]{{% /todo %}}
+
+{{% todo %}}Remove alert when app is added to Apple App store {{% /todo %}}
+
+To view your app on a mobile device (or emulator), you must download and install the Make It Native app. You can download the Make It Native app from [Google Play](https://play.google.com/store/apps/details?id=com.mendix.developerapp) (coming soon for iOS) and install it on your mobile device:
+
+{{% image_container width="500" %}}![native app on googleplay](attachments/getting-started-with-native-mobile/make-it-native-googleplay.png){{% /image_container %}}
+
+{{% alert type="info" %}}
+
+The iOS version of the Make It Native app will be released soon. If you need to test on an iOS device, please contact [Danny Roest](mailtodanny.roest@mendix.com) to access the app via Apple's TestFlight.
+
+{{% /alert %}}
 
 ### 3.3 Viewing Your App on Your Testing Device
 

--- a/content/howto/mobile/getting-started-with-native-mobile.md
+++ b/content/howto/mobile/getting-started-with-native-mobile.md
@@ -77,7 +77,7 @@ Alternatively, you can navigate to the Make It Native app using Mendix Studio Pr
 
 {{% todo %}}Remove alert when app is added to Apple App store {{% /todo %}}
 
-To view your app on a mobile device (or emulator), you must download and install the Make It Native app. You can download the Make It Native app from [Google Play](https://play.google.com/store/apps/details?id=com.mendix.developerapp) (coming soon for iOS) and install it on your mobile device:
+To view your app on a mobile device (or emulator), you must download and install the Make It Native app. You can download the Make It Native app from [Google Play](https://play.google.com/store/apps/details?id=com.mendix.developerapp) and install it on your mobile device:
 
 {{% image_container width="500" %}}![native app on googleplay](attachments/getting-started-with-native-mobile/make-it-native-googleplay.png){{% /image_container %}}
 


### PR DESCRIPTION
I worked with Danny yesterday to update this document. A few features planned for release will take a little longer to finish, and the language has been changed to reflect that:

* **1 Introduction** – changed per Danny to have more feature-accurate language
* **2 Prerequisites** – browser requirement removed
* **3.2 Downloading and Installing the Make It Native App** – iOS section commented out (as a todo). Mendix believed we would have a running iOS version of this app. However, the App Store has not gotten back to us and we are in the dark as to when the iOS version of the Make It Native app will be approved.

Please let me know if the way I used todo comments in 3.2 is too messy. Maybe there is a cleaner solution.