### PR TITLE
Update "Test the Implementation" With iOS Push Notification Section

### DIFF
--- a/content/howto/mobile/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/howto/mobile/setting-up-google-firebase-cloud-messaging-server.md
@@ -67,7 +67,7 @@ On this page, press **Generate new private key**. Store the resulting file in a 
 
 The file you just created gives API access to all available Firebase services for your app. If you want a more restrictive service account, click **Manage all service accounts** in the top-right of the screen, then create a service account that is restricted to using the Cloud Messaging functionality.
 
-## 6 Downloading the Google Services Config Files
+## 6 Downloading the Google Services Config Files {#downloading-the-google-services-config-files}
 
 In addition to the back-end configuration set up in the previous steps, you will need additional files that will be bundled as part of your mobile application. To obtain these, again click the cogwheel in the top-left of the screen and select **Project settings**. Then navigate to the **General** tab.
 

--- a/content/howto/mobile/testing-the-implementation.md
+++ b/content/howto/mobile/testing-the-implementation.md
@@ -7,7 +7,7 @@ tags: ["mobile", "push notification"]
 
 ## 1 Introduction
 
-Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether everything works correctly. As a prerequisite, you will need to build new versions of your mobile application. To build an app which supports push notifications, follow these instructions:
+Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether your push notifications work correctly. To begin testing your push notifications, you will need to build new versions of your mobile application:
 
 1. Navigate the [Mendix Portal](https://sprintr.home.mendix.com/index.html), then click on your app.
 2. Click **Deploy** > **Mobile App**.

--- a/content/howto/mobile/testing-the-implementation.md
+++ b/content/howto/mobile/testing-the-implementation.md
@@ -7,7 +7,11 @@ tags: ["mobile", "push notification"]
 
 ## 1 Introduction
 
-Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether your push notifications work correctly. To begin testing your push notifications, you will need to build new versions of your mobile application:
+Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether your push notifications work correctly. 
+
+## 2 Prerequisites
+
+To begin testing your push notifications, you will need to build new versions of your mobile application:
 
 1. Navigate the [Mendix Portal](https://sprintr.home.mendix.com/index.html), then click your app.
 2. Click **Deploy** > **Mobile App**.
@@ -21,17 +25,17 @@ To successfully use FCM push notifications, you must put the *google-services.js
 
 When you add these files, it causes the **PushNotifications** widget to register your device with FCM, and then share the FCM registration token with your Mendix back-end server. This means you must use FCM to send messages to your devices. 
 
-### 1.1 Using APNS Instead of FCM for iOS Devices
+### 2.1 Using APNS Instead of FCM for iOS Devices
 
 If you would like to use APNS instead of FCM for your iOS devices, then you will have to delete the reference to *GoogleService-info.plist* from *config.xml*. By doing this, you will not need to include the *GoogleService-info.plist* file, and can then use APNS to send messages to iOS devices.
 
-## 2 Building Your Mobile App
+## 3 Building Your Mobile App
 
 Now that you have set up your hybrid app for push notifications you may continue building it. by following the [hybrid app package documentation](https://github.com/mendix/hybrid-app-template/). Once you have a running app, continue to the section below. 
 
-## 3 Sending a Push Notification to a Device
+## 4 Sending a Push Notification to a Device
 
-Follow these steps to send a push notification to a device:
+Follow these steps to test and send a push notification to a device:
 
 1. Open your application in the browser and log in as administrator (for example, MxAdmin`).
 2. To be able to log in into your hybrid mobile application, you will need to create a new user. Typically, this can be done from the administration pages of your application. If you have anonymous access enabled, this step is of course not necessary.
@@ -41,3 +45,5 @@ Follow these steps to send a push notification to a device:
 	![](attachments/19955741/21168174.png)
 
 5. Fill in the title and the message in the form and press **Send**. Your device should receive a new push notification. If your hybrid mobile app is currently running in the foreground, the notification will be displayed in the app. Otherwise, it will be shown as a standard push notification.
+
+If you saw the notification, congratulations! By following this document, you have successfully tested push notifications on your device.

--- a/content/howto/mobile/testing-the-implementation.md
+++ b/content/howto/mobile/testing-the-implementation.md
@@ -17,7 +17,7 @@ Once you finish implementing the steps described in [How to Implement Push Notif
 
 This will give you a *.zip* project that you can use to customize your app according to the [hybrid app package documentation](https://github.com/mendix/hybrid-app-template/). The project contains a *config.xml* file that refers to *google-services.json* and *GoogleService-info.plist* files. 
 
-To successfully use FCM push notifications, you must put the *google-services.json* and *GoogleService-Info.plist* files – obtained in [Downloading the Google Services Config Files](setting-up-google-firebase-cloud-messaging-server#downloading-the-google-services-config-files) – in your app's **config** folder.
+To successfully use FCM push notifications, you must put the *google-services.json* and *GoogleService-Info.plist* files – obtained in the [Downloading the Google Services Config Files](setting-up-google-firebase-cloud-messaging-server#downloading-the-google-services-config-files) section of *Set Up the Google Firebase Cloud Messaging Server* – in your app's **config** folder.
 
 When you add these files, it causes the PushNotifications widget to register your device with FCM, and then share the FCM registration token with your Mendix backend server. This means you must use FCM to send messages to your devices. 
 

--- a/content/howto/mobile/testing-the-implementation.md
+++ b/content/howto/mobile/testing-the-implementation.md
@@ -5,13 +5,31 @@ menu_order: 60
 tags: ["mobile", "push notification"]
 ---
 
-## 1 Introuction
+## 1 Introduction
 
-Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether everything works correctly. As a prerequisite, you will need to build (new) versions of your mobile application. You can refer to the [hybrid app package documentation](https://github.com/mendix/hybrid-app-template/) for instructions. Please note that, during this process, you will need to put the *google-services.json* and *GoogleService-Info.plist* files in the config folder.
+Once you finish implementing the steps described in [How to Implement Push Notifications](implementation-guide), you need to test whether everything works correctly. As a prerequisite, you will need to build new versions of your mobile application. To build an app which supports push notifications, follow these instructions:
 
-Once you have your apps bulit and running, you can send your first push notifications. This can be done easily using the administration pages that should be included in your application (for details, see [Setting Up the Administration Pages](implementation-guide#setting) in *How to Implement Push Notifications*). 
+1. Navigate the [Mendix Portal](https://sprintr.home.mendix.com/index.html), then click on your app.
+2. Click **Deploy** > **Mobile App**.
+3. Make sure the check box **Permissions** > **Push Notifications** is selected.
+4. Click the **Publish for Mobile App Stores** button.
+5. Select the **Do it yourself** check box, make sure your preferred environment is selected, and then click the **Download Customizable Package** button. 
 
-## 2 Sending a Push Notification to a Device
+This will give you a *.zip* project that you can use to customize your app according to the [hybrid app package documentation](https://github.com/mendix/hybrid-app-template/). The project contains a *config.xml* file that refers to *google-services.json* and *GoogleService-info.plist* files. 
+
+To successfully use FCM push notifications, you must put the *google-services.json* and *GoogleService-Info.plist* files – obtained in [Downloading the Google Services Config Files](setting-up-google-firebase-cloud-messaging-server#downloading-the-google-services-config-files) – in your app's **config** folder.
+
+When you add these files, it causes the PushNotifications widget to register your device with FCM, and then share the FCM registration token with your Mendix backend server. This means you must use FCM to send messages to your devices. 
+
+### 1.1 Using APNS Instead of FCM for IOS Devices
+
+If you would like to use APNS instead of FCM for your iOS devices, then you will have to delete the reference to *GoogleService-info.plist* from *config.xml*. By doing this, you will not need to include the *GoogleService-info.plist* file, and can then use APNS to send messages to iOS devices.
+
+## 2 Building Your Mobile App
+
+Now that you have set up your hybrid app for push notifications you may continue building it. by following the [hybrid app package documentation](https://github.com/mendix/hybrid-app-template/). Once you have a running app, continue to the section below. 
+
+## 3 Sending a Push Notification to a Device
 
 Follow these steps to send a push notification to a device:
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -10,6 +10,12 @@ For updates on the status of Mendix Cloud V4, Mendix Cloud V3, and other deploym
 
 ## 2019
 
+### May 9th, 2019
+
+#### Fixes
+
+* We fixed an issue where the Mendix feedback widget stopped working for apps deployed to Mendix Cloud because of a change to HTTP Headers. (Ticket 83001)
+
 ### May 7th, 2019
 
 #### Improvements


### PR DESCRIPTION
**This PR contains the following changes:**

* Corrected, step-by-step text for the Introduction section
* A new section (Using APNS Instead of FCM for IOS Devices) which a Mendix employee suggested we include
* An anchor link to the [Downloading the Google Services Config Files](setting-up-google-firebase-cloud-messaging-server#downloading-the-google-services-config-files) section of _Set Up the Google Firebase Cloud Messaging Server_

**Questions**

* Should "iOS" be "IOS" as I typed it in a heading? 
* Is section 1.1 best as a sub-section, or would it be better as blue info text?