### PR TITLE
Delete mobile os requirement duplication

### DIFF
--- a/content/refguide/getting-the-mendix-app.md
+++ b/content/refguide/getting-the-mendix-app.md
@@ -9,10 +9,7 @@ The **Mendix** mobile app is a free app that allows you to collaborate with your
 
 You can get the Mendix Mobile app on your mobile device by downloading it from your device's app store. You will need to do this once for every device you're developing on.
 
-Currently, the following mobile operating systems are supported by the Mendix Mobile app:
-
-* iOS version 9 and above
-* Android version 5.0 and above
+For information on which mobile operating systems are supported by the Mendix Mobile app, see the [Mobile Operating Systems](system-requirements#mobileos) section of *System Requirements*.
 
 To download the Mendix Mobile app, search for "Mendix" in your device's app store, or select one of the download links below:
 

--- a/content/refguide/system-requirements.md
+++ b/content/refguide/system-requirements.md
@@ -101,7 +101,7 @@ Jetty is built into the [Mendix Runtime](runtime), so an application server is n
 
 Using a hybrid preview is not the same as using an emulator. A hybrid preview only shows a resized view of an app to give an impression of what that app might look like on a mobile device. Some hybrid app functionality will not be supported in this browser view. Full tests always need to be done on a device or emulator. Offline apps can only be previewed in Google Chrome.
 
-## 7 Mobile Operating Systems
+## 7 Mobile Operating Systems {#mobileos}
 
 For Mendix apps and the [Mendix Mobile app](getting-the-mendix-app):
 


### PR DESCRIPTION
Danny noticed that "Getting the Mendix App" contained the mobile OS requirements for the Mendix mobile app. This information is already available in System Requirements, so I replaced the duplicated information with a link to System Requirements.