### PR TITLE
Fixed casing on "Mendix mobile app"

### DIFF
--- a/content/refguide/getting-the-mendix-app.md
+++ b/content/refguide/getting-the-mendix-app.md
@@ -7,11 +7,11 @@ tags: ["studio pro"]
 
 The **Mendix** mobile app is a free app that allows you to collaborate with your app project team and test the apps you develop with Mendix on your device.
 
-You can get the Mendix Mobile app on your mobile device by downloading it from your device's app store. You will need to do this once for every device you're developing on.
+You can get the Mendix mobile app on your mobile device by downloading it from your device's app store. You will need to do this once for every device you're developing on.
 
-For information on which mobile operating systems are supported by the Mendix Mobile app, see the [Mobile Operating Systems](system-requirements#mobileos) section of *System Requirements*.
+For information on which mobile operating systems are supported by the Mendix mobile app, see the [Mobile Operating Systems](system-requirements#mobileos) section of *System Requirements*.
 
-To download the Mendix Mobile app, search for "Mendix" in your device's app store, or select one of the download links below:
+To download the Mendix mobile app, search for "Mendix" in your device's app store, or select one of the download links below:
 
 * [Download for iOS](https://itunes.apple.com/app/mendix/id458058946?mt=8)
 * [Download for Android](https://play.google.com/store/apps/details?id=com.mendix.SprintrMobile)


### PR DESCRIPTION
This document contained multiple instances of "Mendix Mobile app". The glossary casing dictates it should be "Mendix mobile app". These instances have been corrected.