### PR TITLE
Clarify "mobile apps" to "hybrid mobile apps" when applicable

### DIFF
--- a/content/howto/mobile/debug-a-mobile-app.md
+++ b/content/howto/mobile/debug-a-mobile-app.md
@@ -12,7 +12,7 @@ Mendix has great tools for debugging web applications, including the offline and
 
 **This how-to will teach you how to do the following:**
 
-* Build and run a Mendix mobile app that connects to your local development machine
+* Build and run a hybrid Mendix mobile app that connects to your local development machine
 * Debug the mobile app using Mendix debugging tools, Chrome DevTools and the Safari Web Inspector
 
 ## 2 Prerequisites
@@ -25,7 +25,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## 3 Mendix and PhoneGap <a name="MendixAndPhonegap"></a>
 
-Before we begin, it’s important to understand how Mendix Hybrid Mobile apps work, and the relationship between the Mendix application and the PhoneGap service. [Adobe PhoneGap](https://phonegap.com/) provides a way for users to create mobile applications using web technologies, like Mendix. PhoneGap (PG) essentially creates a wrapper for a Mendix application that is recognized and treated like a native application by mobile platforms. All your application’s logic, appearance, and functionality are controlled by Mendix. PhoneGap then, in a way, *translates* these aspects of your application into a language that can be understood by Android and iOS. That being said, there are some facets of your application’s configuration that need to be configured in the PhoneGap application and not in Mendix. We’ll return to this a little later.
+Before we begin, it’s important to understand how hybrid Mendix mobile apps work, and the relationship between the Mendix application and the PhoneGap service. [Adobe PhoneGap](https://phonegap.com/) provides a way for users to create mobile applications using web technologies, like Mendix. PhoneGap (PG) essentially creates a wrapper for a Mendix application that is recognized and treated like a native application by mobile platforms. All your application’s logic, appearance, and functionality are controlled by Mendix. PhoneGap then, in a way, *translates* these aspects of your application into a language that can be understood by Android and iOS. That being said, there are some facets of your application’s configuration that need to be configured in the PhoneGap application and not in Mendix. We’ll return to this a little later.
 
 The basic function of the PhoneGap app is to ensure that all the necessary libraries (called PhoneGap Plugins) are loaded and available to the application, and then initialize the Mendix application from a target URL. As soon as the Mendix app has been initialized, the app’s Mendix logic then takes over. There are a couple of benefits that we, as Mendix developers, gain from the fact that the PhoneGap app initializes based on a URL: One, changes that we make to the application logic do not require a full rebuild of both the Mendix app and the PhoneGap app (just the Mendix one); and two, that we can instruct the PhoneGap app to initialize based on an IP address (rather than the production URL) and debug a mobile application running locally on our laptop, in order to further increase the speed of our iterations.
 

--- a/content/howto/mobile/deploy-your-first-hybrid-mobile-app.md
+++ b/content/howto/mobile/deploy-your-first-hybrid-mobile-app.md
@@ -18,7 +18,7 @@ Besides boasting native functionality, another major advantage of a hybrid mobil
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
-* Install the Mendix Mobile app on you device, which makes it easy to see a hybrid application in action without the need to get it approved in the Mendix App Store (for details and download links, see [Getting the Mendix App](/refguide/getting-the-mendix-app) in the *Mendix Studio Pro Guide*)
+* Install the hybrid Mendix mobile app on you device, which makes it easy to see a hybrid application in action without the need to get it approved in the Mendix App Store (for details and download links, see [Getting the Mendix App](/refguide/getting-the-mendix-app) in the *Mendix Studio Pro Guide*)
 
 ## 3 Opening a Hybrid Example App
 
@@ -45,11 +45,11 @@ To open a hybrid example app, follow these steps:
 
     ![](attachments/18448692/18581184.png)
 
-5. Open the Mendix Mobile app on your device and select **Scan QR Code**:
+5. Open the hybrid Mendix mobile app on your device and select **Scan QR Code**:
 
     ![](attachments/18448692/18581190.png)
 
-6. Scan the QR code on the screen with the Mendix Mobile app:
+6. Scan the QR code on the screen with your hybrid Mendix mobile app:
 
     ![](attachments/18448692/18581189.png)
 

--- a/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -25,9 +25,9 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## 3 Context
 
-### 3.1 Mendix Mobile Apps, Hybrid Apps, Cordova, and PhoneGap Build
+### 3.1 Hybrid Apps, Cordova, and PhoneGap Build
 
-Mendix apps can be viewed in mobile web browsers. However, some features of mobile devices cannot be accessed through HTML and JavaScript. Also, if you want to publish your app in the Apple App Store or Google Play Store, you have to wrap your app in a native shell. Mendix uses [Cordova](https://cordova.apache.org/) to do this. Cordova creates a native wrapper around a web application and provides access to native functionality through a JavaScript API. These apps are called hybrid apps, because they are a hybrid of a web and a native app. To create binaries of your app, Mendix leverages PhoneGap Build so that you do not need to install software (Android SDK, XCode) for this.
+Hybrid Mendix apps can be viewed in mobile web browsers. However, some features of mobile devices cannot be accessed through HTML and JavaScript. Also, if you want to publish your app in the Apple App Store or Google Play Store, you have to wrap your app in a native shell. Mendix uses [Cordova](https://cordova.apache.org/) to do this. Cordova creates a native wrapper around a web application and provides access to native functionality through a JavaScript API. These apps are called hybrid apps, because they are a hybrid of a web and a native app. To create binaries of your app, Mendix leverages PhoneGap Build so that you do not need to install software (Android SDK, XCode) for this.
 
 ### 3.2 How Authentication Against an IdP Works<a name="how"></a>
 

--- a/content/howto/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
+++ b/content/howto/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
@@ -6,7 +6,7 @@ tags: ["mobile", "app store", "phonegap"]
 ---
 ## 1 Introduction
 
-Once you have finished developing a Mendix mobile application, you will want to make it available as an app for mobile platforms such as Apple iOS and Google Android. We make it possible to produce platform-specific native apps. For more details on deploying platform-specific apps, see [Mobile App](/developerportal/deploy/mobileapp).
+Once you have finished developing a hybrid Mendix mobile application, you will want to make it available as an app for mobile platforms such as Apple iOS and Google Android. We make it possible to produce platform-specific native apps. For more details on deploying platform-specific apps, see [Mobile App](/developerportal/deploy/mobileapp).
 
 The hybrid mobile app publishing process is based on Adobe PhoneGap. We have integrated the [Adobe PhoneGap Build](https://build.phonegap.com/) service into Mendix to provide support for automatically building the required hybrid mobile packages. Instead of worrying about technical details, you can focus on what matters most: rapidly developing an app to support your business processes.
 

--- a/content/refguide/developing-hybrid-mobile-apps.md
+++ b/content/refguide/developing-hybrid-mobile-apps.md
@@ -6,9 +6,9 @@ tags: ["studio pro"]
 
 ## 1 Introduction
 
-Mendix apps can simply be viewed in mobile web browsers. However, some features of mobile devices cannot be accessed through HTML and JavaScript. Also, if you want to publish your app on the Apple App Store, Google Play, or Microsoft Phone Store, you have to wrap your app in a native shell. We use [PhoneGap](http://phonegap.com/) to do this. PhoneGap creates a native wrapper around a web application and provides access to native functions through a JavaScript API. 
+Hybrid Mendix apps can simply be viewed in mobile web browsers. However, mobile device features cannot be accessed through HTML and JavaScript. Also, if you want to publish your hybrid app on the Apple App Store, Google Play, or Microsoft Phone Store, you have to wrap your app in a native shell. We use [PhoneGap](http://phonegap.com/) to do this. PhoneGap creates a native wrapper around a web application and provides access to native functions through a JavaScript API. 
 
-These apps are also called "hybrid" apps because they are a hybrid of a web and a native app. Mendix facilitates the creation of hybrid mobile apps in a number of ways.
+These apps are called "hybrid" apps because they are a hybrid of a web and a native app. Mendix facilitates the creation of hybrid mobile apps in a number of ways.
 
 ## 2 The Mendix Mobile App
 

--- a/content/refguide/getting-the-mendix-app.md
+++ b/content/refguide/getting-the-mendix-app.md
@@ -5,7 +5,7 @@ tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
-The **Mendix** mobile app is a free app that allows you to collaborate with your app project team and test the apps you develop with Mendix on your device.
+The **Mendix** mobile app is a free app that allows you to collaborate with your app project team and test the hybrid apps you develop with Mendix on your device.
 
 You can get the Mendix mobile app on your mobile device by downloading it from your device's app store. You will need to do this once for every device you're developing on.
 


### PR DESCRIPTION
**Hybrid Mobile** docs mention "mobile apps" when they actually mean "hybrid mobile apps". This distinction is key. With this PR:

* instances of "mobile apps" have been clarified to "hybrid mobile apps"