### PR TITLE
Mendix Cloud: Deprecate the X-Client-Certificate header

### DIFF
--- a/content/developerportal/deploy/mendix-cloud-request-headers.md
+++ b/content/developerportal/deploy/mendix-cloud-request-headers.md
@@ -38,6 +38,8 @@ The following headers are set by the Mendix Cloud. If any of these are present i
 | **SSL-Cipher**                              | `ECDHE-RSA-AES256-GCM-SHA384`                                | The TLS ciphers used for the HTTPS connection. |
 | **SSL-Client-S-DN**                         | `CN=Hans van Kranenburg,OU=RnD,O=Mendix,C=NL`                | The Subject DN string of the client certificate for an established TLS connection according to [RFC 2253](https://tools.ietf.org/html/rfc2253). |
 
+There can be additional headers set by the Mendix Cloud, not being documented in the list above. The presence of these headers and the values they have must not be relied on. They are not subject to the deprecation handling as shown below.
+
 ### 2.3 Deprecated request headers inserted by the Mendix Cloud
 
 The following headers are set by the Mendix Cloud, but are deprecated and will be removed in the future.

--- a/content/developerportal/deploy/mendix-cloud-request-headers.md
+++ b/content/developerportal/deploy/mendix-cloud-request-headers.md
@@ -8,7 +8,7 @@ tags: ["Deploy", "Mendix Cloud", "headers", "HTTP Request Headers", "X-Real-IP",
 
 ## 1 Introduction
 
-All applications running in the Mendix Cloud are accessed using the HTTPS protocol. Using this protocol, a lot of individual requests are sent to the application. Examples of these requests are "execute this XPath request", "execute this Microflow", or "please provide the layout of this page".
+All applications running in the Mendix Cloud are accessed using the HTTPS protocol. Using this protocol, a lot of individual requests are sent to the application. Examples of these requests are "execute this XPath query", "execute this Microflow", or "please provide the layout of this page".
 
 ## 2 HTTP Request Headers
 

--- a/content/developerportal/deploy/mendix-cloud-request-headers.md
+++ b/content/developerportal/deploy/mendix-cloud-request-headers.md
@@ -38,7 +38,7 @@ The following headers are set by the Mendix Cloud. If any of these are present i
 | **SSL-Cipher**                              | `ECDHE-RSA-AES256-GCM-SHA384`                                | The TLS ciphers used for the HTTPS connection. |
 | **SSL-Client-S-DN**                         | `CN=Hans van Kranenburg,OU=RnD,O=Mendix,C=NL`                | The Subject DN string of the client certificate for an established TLS connection according to [RFC 2253](https://tools.ietf.org/html/rfc2253). |
 
-There can be additional headers set by the Mendix Cloud, not being documented in the list above. The presence of these headers and the values they have must not be relied on. They are not subject to the deprecation handling as shown below.
+There may be additional headers set by the Mendix Cloud, which are not documented in the list above. The presence of these headers, and the values they have, must not be relied on. They are for internal use only and are not subject to the deprecation handling described below.
 
 ### 2.3 Deprecated request headers inserted by the Mendix Cloud
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -14,6 +14,13 @@ For updates on the status of Mendix Cloud V4, Mendix Cloud V3, and other deploym
 
 ## 2019
 
+### Jun 15th, 2019
+
+#### Mendix Cloud Announcement
+
+* All stable HTTP Request Headers set by the Mendix Cloud are documented on the page about [Mendix Cloud HTTP Request Headers](developerportal/deploy/mendix-cloud-request-headers).
+* The `X-Client-Certificate` Request Header that is currently present is deprecated and will be removed in a later stage. Any application relying on this header must switch to the new `SSL-Client-S-DN` header. See the previously mentioned documentation page for more information.
+
 ### June 6th, 2019
 
 #### App Store Improvements

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -14,12 +14,12 @@ For updates on the status of Mendix Cloud V4, Mendix Cloud V3, and other deploym
 
 ## 2019
 
-### Jun 15th, 2019
+### June 15th, 2019
 
 #### Mendix Cloud Announcement
 
-* All stable HTTP Request Headers set by the Mendix Cloud are documented on the page about [Mendix Cloud HTTP Request Headers](developerportal/deploy/mendix-cloud-request-headers).
-* The `X-Client-Certificate` Request Header that is currently present is deprecated and will be removed in a later stage. Any application relying on this header must switch to the new `SSL-Client-S-DN` header. See the previously mentioned documentation page for more information.
+* All **HTTP Request Headers** set by the Mendix Cloud which available to app developers are documented in [Mendix Cloud HTTP Request Headers](/developerportal/deploy/mendix-cloud-request-headers).
+* The `X-Client-Certificate` request header that is currently present is deprecated and will be removed in a later stage. Any application relying on this header must switch to the new `SSL-Client-S-DN` header. See the previously mentioned documentation for more information.
 
 ### June 6th, 2019
 


### PR DESCRIPTION
Hi, it's me again.

Here's the actual release notes change for deprecating the http header (which led to documenting the headers in the first place).

Also, two improvements for the http headers page itself.

I'm not sure about the choice for the word 'stable' in the release notes. The meaning has to be: "these ones are documented and you can be sure we won't just change them". Maybe there's a better word.

Thanks.