### PR TITLE
RefGuide Link Edits

### DIFF
--- a/content/howto/mobile/hybrid-mobile.md
+++ b/content/howto/mobile/hybrid-mobile.md
@@ -9,7 +9,7 @@ tags: ["mobile", "hybrid"]
 
 A Mendix hybrid app is a web application which runs inside a container that can be installed as a native app on your device. Hybrid apps can be deployed using the Mendix Platform, their containers enable native capabilities like camera and GPS app functions, and they can be published to the Apple App Store and Google Play. 
 
-## 2 Documents in This Sub-Category
+## 2 Documents in This Section
 
 * [Include Push Notifications](push-notifications)
 * [Configure the Mendix Feedback Widget for iOS](feedback-widget-ios)

--- a/content/howto/mobile/native-mobile.md
+++ b/content/howto/mobile/native-mobile.md
@@ -11,7 +11,7 @@ As of Mendix 8, it is possible to build fully native mobile apps. Native mobile 
 
 You build Mendix native mobile apps the same way you build web or hybrid apps. You can use familiar elements such as pages, widgets, nanoflows, JavaScript actions, and microflows to put together your app. However, there are some differences between building native apps and hybrid apps. For example, the set of available widgets (and their properties) is slightly different. In addition, native styling is based on JavaScript instead of SASS/CSS. 
 
-## 2 Documents in This Sub-Category
+## 2 Documents in This Section
 
 * [Get Started with Native Mobile](getting-started-with-native-mobile)
 * [Work with Parallels](using-mendix-studio-pro-on-a-mac)

--- a/content/howto/mobile/push-notifications.md
+++ b/content/howto/mobile/push-notifications.md
@@ -51,7 +51,7 @@ Earlier versions of the Mendix Push Notifications Connector supported Google Clo
 
 For more information on contributing to this repository, see [How to Contribute to a GitHub Repository](../collaboration-requirements-management/contribute-to-a-github-repository).
 
-## 7 Documents in This Sub-Category
+## 7 Documents in This Section
 
 * [Implement Push Notifications](implementation-guide)
 * [Send Push Notifications](sending-push-notifications)

--- a/content/howto7/mobile/push-notifications.md
+++ b/content/howto7/mobile/push-notifications.md
@@ -51,7 +51,7 @@ Earlier versions of the Mendix Push Notifications Connector supported Google Clo
 
 For more information on contributing to this repository, see [How to Contribute to a GitHub Repository](../collaboration-requirements-management/contribute-to-a-github-repository).
 
-## 7 Documents in This Sub-Category
+## 7 Documents in This Section
 
 * [How to Implement Push Notifications](implementation-guide)
 * [How to Send Push Notifications](sending-push-notifications)

--- a/content/refguide/application-logic.md
+++ b/content/refguide/application-logic.md
@@ -7,5 +7,8 @@ tags: ["studio pro"]
 
  Application logic in Mendix can be implemented via microflows and nanoflows. Explore the documentation for details on microflow and nanoflow definitions, properties, and usages.
 
- * [Microflows](microflows)
- * [Nanoflows](nanoflows)
+* [Microflows](microflows) – covers how to use microflows to express the logic of your application, as well as the following:
+	* [Microflow Properties](microflow)
+	* [Mendix Assist](mx-assist-studio-pro)
+* [Nanoflows](nanoflows) – describes how to use nanoflows to express your application's logic, and details nanoflows' offline capabilities and faster processing speed as well as the following:
+	* [Nanoflow Properties](nanoflow)

--- a/content/refguide/application-logic.md
+++ b/content/refguide/application-logic.md
@@ -5,10 +5,16 @@ description: "Presents an overview of documentation on microflows and nanoflows.
 tags: ["studio pro"]
 ---
 
- Application logic in Mendix can be implemented via microflows and nanoflows. Explore the documentation for details on microflow and nanoflow definitions, properties, and usages.
+Application logic in Mendix can be implemented via microflows and nanoflows. Explore the documentation for details on microflow and nanoflow definitions, properties, and usages.
 
-* [Microflows](microflows) – covers how to use microflows to express the logic of your application, as well as the following:
-	* [Microflow Properties](microflow)
-	* [Mendix Assist](mx-assist-studio-pro)
-* [Nanoflows](nanoflows) – describes how to use nanoflows to express your application's logic, and details nanoflows' offline capabilities and faster processing speed as well as the following:
-	* [Nanoflow Properties](nanoflow)
+* [Microflows](microflows)
+* [Nanoflows](nanoflows)
+* [Activities](activities)
+* [Splits](splits)
+* [Events](events)
+* [Annotation](annotation)
+* [Parameter](parameter)
+* [Loop](loop)
+* [Sequence Flow](sequence-flow)
+* [Expressions](expressions)
+* [Microflow Element Common Properties](microflow-element-common-properties)

--- a/content/refguide/consistency-errors.md
+++ b/content/refguide/consistency-errors.md
@@ -15,10 +15,10 @@ Errors need to be solved before your app can be published. A consistency error c
 
 * [Pages](consistency-errors-pages) 
 * [Navigation](consistency-errors-navigation) 
-* Microflows
-* Domain Models
-* Integration
-* Security
+* [Microflows](microflows)
+* [Domain Model](domain-model)
+* [Integration](integration)
+* [Security](security)
 
 ##  2 Read More
 

--- a/content/refguide/domain-model.md
+++ b/content/refguide/domain-model.md
@@ -14,9 +14,9 @@ Here is a domain model that defines customers and orders. The line between them 
 
 ## Components
 
-*   [Entities](entities)
 *   [Associations](associations)
 *   [Annotations](annotations)
+*   [Entities](entities)
 
 ## Technical Appendix
 

--- a/content/refguide/hybrid-mobile.md
+++ b/content/refguide/hybrid-mobile.md
@@ -9,7 +9,7 @@ tags: ["mobile", "hybrid", "studio pro"]
 
 Mendix hybrid apps are web applications wrapped inside native app containers. The documents listed below will help you prepare, package, and customize your Mendix hybrid apps.
 
-## 2 Documents in This Sub-Category
+## 2 Documents in This Section
 
 * [Configuring Hybrid Mobile Apps To Run Offline](configuring-hybrid-mobile-apps-to-run-offline)
 * [Customizing Hybrid Mobile Apps](customizing-hybrid-mobile-apps)

--- a/content/refguide/integration.md
+++ b/content/refguide/integration.md
@@ -4,6 +4,7 @@ category: "App Modeling"
 tags: ["studio pro"]
 ---
 
+## 1 Introduction
 
 Integration with other applications (other than Mendix) can be done using REST or SOAP/Web Services. Mendix can import and export data from XML and JSON.
 
@@ -14,3 +15,13 @@ For [Call REST Service Action](call-rest-action) and JSON support in [Mapping Do
 {{% /alert %}}{{% alert type="info" %}}
 For [Call Web Service Action](call-web-service-action) and support for SOAP Web Services/XML, see [Consumed Web Services](consumed-web-services).
 {{% /alert %}}
+
+## 2 Other Documents in This Sub-Category
+
+* [Consumed App Services](consumed-app-services)
+* [HttpRequest & HttpResponse System Entities](http-request-and-response-entities)
+* [JSON Structures](json-structures)
+* [Message Definitions](message-definitions)
+* [Published App Services](published-app-services)
+* [Published OData Services](published-odata-services)
+* [XML Schemas](xml-schemas)

--- a/content/refguide/integration.md
+++ b/content/refguide/integration.md
@@ -16,7 +16,7 @@ For [Call REST Service Action](call-rest-action) and JSON support in [Mapping Do
 For [Call Web Service Action](call-web-service-action) and support for SOAP Web Services/XML, see [Consumed Web Services](consumed-web-services).
 {{% /alert %}}
 
-## 2 Other Documents in This Sub-Category
+## 2 Other Documents in This Section
 
 * [Consumed App Services](consumed-app-services)
 * [HttpRequest & HttpResponse System Entities](http-request-and-response-entities)

--- a/content/refguide/native-mobile.md
+++ b/content/refguide/native-mobile.md
@@ -10,6 +10,6 @@ frontpage_featured: true
 
 As of Mendix 8, it is possible to build fully native mobile apps. Native mobile apps differ from hybrid apps in that they do not render inside a web view. Instead, they use native UI elements. This enables fast performance, smooth animations, swipe gestures, and improved access to all native device capabilities.
 
-## 2 Documents in This Sub-Category
+## 2 Documents in This Section
 
 * [Native Styling](native-styling-refguide)


### PR DESCRIPTION
In **Studio Pro 8 Guide > App Modeling**, I think I found a few sub-categories to improve. One had broken links, and a few others were missing links to documents below them. I'm going to merge this myself, but I wanted to PR this with this explanation in case anyone sees changes in the shared component **App Modeling** and wondered what I did. 

This PR contains:

* Added links for **Guide > App Modeling > Application Logic** because some topics were mentioned in the intro text but not linked below
* Fixed links in **Guide > App Modeling > Consistency Errors**
* Fixed link order in **Guide > App Modeling > Domain Model**
* Added links in **Guide > App Modeling > Integration** (links already written in the doc were not duplicated)
* Changed "Sub-Category" to "Section" in my docs to be consistent with current style standards