### PR TITLE
Update 7.18.md

### DIFF
--- a/content/releasenotes/studio-pro/7.18.md
+++ b/content/releasenotes/studio-pro/7.18.md
@@ -14,6 +14,15 @@ description: "The release notes for Mendix Desktop Modeler version 7.18 (includi
 
 * We fixed an out-of-memory issue on cluster slaves caused by persistent session objects. (Ticket 80910)
 
+### Known Issues
+
+* Unpacking and opening project packages (*.mpk* files) does not work when double-clicking in Windows Explorer. (Ticket 68263)
+  	* Fixed in [7.19.0](7.19#68263).
+* There is a known issue with PostgreSQL support where transactions fail on the error “out of shared memory.” (Ticket 68224)
+	* Fixed in [7.19.0](7.19#68224).
+* There is a known issue where string values are not implicitly converted to numerical values. Among others, this leads to errors during XML imports where entities have a numeric value as a key. (Ticket 69811)
+	* Fixed in [7.19.0](7.19#69811).
+
 ## 7.18.3 {#7183}
 
 **Release date: December 20th, 2018**
@@ -24,6 +33,15 @@ description: "The release notes for Mendix Desktop Modeler version 7.18 (includi
 
 * We fixed an issue where closing the current page and opening a new one from a microflow resulted in going to the previous page. (Tickets 66534, 76966)
 * We fixed an issue where clicking a microflow button twice was possible even if **Disabled during action** was set to true. (Ticket 76020)
+
+### Known Issues
+
+* Unpacking and opening project packages (*.mpk* files) does not work when double-clicking in Windows Explorer. (Ticket 68263)
+  	* Fixed in [7.19.0](7.19#68263).
+* There is a known issue with PostgreSQL support where transactions fail on the error “out of shared memory.” (Ticket 68224)
+	* Fixed in [7.19.0](7.19#68224).
+* There is a known issue where string values are not implicitly converted to numerical values. Among others, this leads to errors during XML imports where entities have a numeric value as a key. (Ticket 69811)
+	* Fixed in [7.19.0](7.19#69811).
 
 ## 7.18.2  {#7182}
 
@@ -36,6 +54,15 @@ description: "The release notes for Mendix Desktop Modeler version 7.18 (includi
 * You can now configure the maximum number of concurrent connections for REST service calls and web service calls by adding `http.client.MaxConnectionsPerRoute` and `http.client.MaxConnectionsTotal` in your [custom settings](/refguide7/custom-settings).
 * We upgraded our internal server Jetty to 9.4.12.
 
+### Known Issues
+
+* Unpacking and opening project packages (*.mpk* files) does not work when double-clicking in Windows Explorer. (Ticket 68263)
+  	* Fixed in [7.19.0](7.19#68263).
+* There is a known issue with PostgreSQL support where transactions fail on the error “out of shared memory.” (Ticket 68224)
+	* Fixed in [7.19.0](7.19#68224).
+* There is a known issue where string values are not implicitly converted to numerical values. Among others, this leads to errors during XML imports where entities have a numeric value as a key. (Ticket 69811)
+	* Fixed in [7.19.0](7.19#69811).
+	
 ## 7.18.1 {#7181}
 
 **Release date: September 18th, 2018**


### PR DESCRIPTION
Not sure why the known issues are missing for 7.18.2+, seems incorrect to me. Even checked one of the issues with the assiocated R&D team and they confirmed it was not actually backported to 7.18.2.