### PR TITLE
Update contribute-copyright-footer.html

### DIFF
--- a/themes/mendix/layouts/partials/contribute-copyright-footer.html
+++ b/themes/mendix/layouts/partials/contribute-copyright-footer.html
@@ -3,7 +3,7 @@
         <div class="row">
         <div class="col-xs-12">
             <span class="pull-left footer_text">Want to contribute to our documentation? <a href="/developerportal/community-tools/contribute-to-the-mendix-documentation" title="Want to contribute to our documentation?">Start here!</a></span>
-            <span class="pull-right footer_text">Copyright &copy; {{ dateFormat "2006" now }} Mendix. Documentation licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</span>
+            <span class="pull-right footer_text">Copyright &copy; {{ dateFormat "2006" now }} Mendix Technology B.V.. Documentation licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</span>
         </div>
         </div>
     </div>


### PR DESCRIPTION
In accordance with the footer (see bottom) the legal name should be changed from ‘Mendix’ to ‘Mendix Technology B.V.’. I think this only applies to the legal footer, not the content.