### PR TITLE
Updated Emulate Cloud Security documentation

### DIFF
--- a/content/refguide7/configuration.md
+++ b/content/refguide7/configuration.md
@@ -88,11 +88,11 @@ When you set the Java heap setting to 'Custom', you can specify the amount of he
 
 ### Emulate cloud security
 
-Projects hosted in the Mendix Cloud have to adhere to much stricter security policies than hosting it on your own server. Turning on this switch emulates that behavior. A security policy will be enforced, which will allow you to test your Java actions and verify that they will also run in the cloud. 
+Projects hosted in the Mendix Cloud have to adhere to much stricter security policies than those hosted on your own server. Turning this switch on emulates that behavior. A security policy will be enforced which will allow you to test your Java actions and verify that they will also run in the cloud. 
 
 {{% alert type="warning" %}}
 
-This option is been removed from version 7.21.0 and above, see [release notes](/releasenotes/studio-pro/7.21) for more information. 
+This option is been removed from version 7.21.0 and above, see [release notes](/releasenotes/studio-pro/7.21#62223) for more information. 
 
 {{% /alert %}}
 

--- a/content/refguide7/configuration.md
+++ b/content/refguide7/configuration.md
@@ -88,7 +88,13 @@ When you set the Java heap setting to 'Custom', you can specify the amount of he
 
 ### Emulate cloud security
 
-Projects hosted in the Mendix Cloud have to adhere to much stricter security policies than hosting it on your own server. Turning on this switch emulates that behavior. A security policy will be enforced, which will allow you to test your Java actions and verify that they will also run in the cloud.
+Projects hosted in the Mendix Cloud have to adhere to much stricter security policies than hosting it on your own server. Turning on this switch emulates that behavior. A security policy will be enforced, which will allow you to test your Java actions and verify that they will also run in the cloud. 
+
+{{% alert type="warning" %}}
+
+This option is been removed from version 7.21.0 and above, see [release notes](/releasenotes/studio-pro/7.21) for more information. 
+
+{{% /alert %}}
 
 ### Extra JVM parameters
 

--- a/content/refguide7/configuration.md
+++ b/content/refguide7/configuration.md
@@ -92,7 +92,7 @@ Projects hosted in the Mendix Cloud have to adhere to much stricter security pol
 
 {{% alert type="warning" %}}
 
-This option is been removed from version 7.21.0 and above, see [release notes](/releasenotes/studio-pro/7.21#62223) for more information. 
+This option is removed from versions 7.21.0 and above, see [release notes](/releasenotes/studio-pro/7.21#62223) for more information. 
 
 {{% /alert %}}
 

--- a/content/releasenotes/studio-pro/7.21.md
+++ b/content/releasenotes/studio-pro/7.21.md
@@ -57,7 +57,7 @@ With list views and template grids getting such attention, we could not leave da
 * We fixed an issue in the [call web service action](/refguide7/call-web-service-action) where a different result type of an operation did not cause a consistency error. (Ticket 69720)
 * We fixed an issue in [published REST services](/refguide7/published-rest-service) where posting to an operation with a find-by-key microflow threw an error.
 * In the Mendix Cloud, you can now specify the web service names and REST host names for which you do not want client certificates using the `ClientCertificateUsages` custom setting. (Ticket 66497)
-* We removed the **Emulate cloud security** option from the Desktop Modeler. It gave incorrect errors for older cloud deployments, and it is irrelevant for the current cloud deployment. (Ticket 62223)
+* We removed the **Emulate cloud security** option from the Desktop Modeler. It gave incorrect errors for older cloud deployments, and it is irrelevant for the current cloud deployment. (Ticket <a name="62223"></a>62223)
 * When you save file documents in S3 or Azure, you can now [configure timeouts](/refguide7/custom-settings) for connecting to the storage service. (Ticket 68718)
 
 ### Known Issues


### PR DESCRIPTION
Added an alert to say that emulate cloud security option is been removed from version 7.21.0 and above, so that people don't need to keep searching for this option in 7.21.0 and above versions.