### PR TITLE
Additional step in managing-app-signing-keys

### DIFF
--- a/content/refguide7/managing-app-signing-keys.md
+++ b/content/refguide7/managing-app-signing-keys.md
@@ -98,5 +98,5 @@ After creating the keystore file, upload it to Adobe PhoneGap Build on your [acc
 2. Select the keystore file, fill in a title for the key, and fill in the alias that you noted down in the previous step. 
 3. After uploading the keystore file, unlock the key. Click the yellow lock icon on the right of the key and fill in both the keystore and the key passwords. The key is now ready to be used by your build job.
 4. In the [Developer Portal](https://sprintr.home.mendix.com/index.html), navigate to **Deploy > Mobile app**, and click the **Publish for Mobile App Stores** button. Then click the **Start PhoneGap Build job** button.
-5. Once the app has been built for the first time, go back to [Adobe PhoneGap Build](https://build.phonegap.com/). Click your app name to go to the detailed build configuration.
-6. On the **Builds** tab, select your key in the Android build item. This will automatically rebuild the app using the key. From now on, the [Developer Portal](https://sprintr.home.mendix.com/index.html) will automatically use this key to build the app.
+5. Once the app has been built for the first time, go back to [Adobe PhoneGap Build](https://build.phonegap.com/). Click your app's name to view its build details.
+6. Under the **Builds** tab, select your key in the Android build drop-down menu. This will automatically rebuild the app using the key. From now on, the [Developer Portal](https://sprintr.home.mendix.com/index.html) will automatically use this key to build the app.

--- a/content/refguide7/managing-app-signing-keys.md
+++ b/content/refguide7/managing-app-signing-keys.md
@@ -98,3 +98,5 @@ After creating the keystore file, upload it to Adobe PhoneGap Build on your [acc
 2. Select the keystore file, fill in a title for the key, and fill in the alias that you noted down in the previous step. 
 3. After uploading the keystore file, unlock the key. Click the yellow lock icon on the right of the key and fill in both the keystore and the key passwords. The key is now ready to be used by your build job.
 4. In the [Developer Portal](https://sprintr.home.mendix.com/index.html), navigate to **Deploy > Mobile app**, and click the **Publish for Mobile App Stores** button. Then click the **Start PhoneGap Build job** button.
+5. Once the app has been built for the first time, go back to [Adobe PhoneGap Build](https://build.phonegap.com/). Click your app name to go to the detailed build configuration.
+6. On the **Builds** tab, select your key in the Android build item. This will automatically rebuild the app using the key. From now on, the [Developer Portal](https://sprintr.home.mendix.com/index.html) will automatically use this key to build the app.


### PR DESCRIPTION
The process for managing android keys in managing-app-signing-keys was not complete: the automated process does not automatically select the uploaded key. Added two steps to the howto section to add this.