### PR TITLE
Add installation troubleshooting section

### DIFF
--- a/content/howto/general/install.md
+++ b/content/howto/general/install.md
@@ -63,7 +63,22 @@ Mendix Studio Pro needs to be installed on your computer before you can start bu
 
 	![](attachments/install/8.png)
 
-## 5 Read More
+## 5 Troubleshooting
+
+Some people run into problems when installing Studio Pro. A work-around can be to restart your system and install the prerequisites separately if you don't already have them installed. 
+
+The prerequisites are:
+
+* .NET Framework 4.7.2 (https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe)
+* AdoptOpenJDK 11 (https://cdn.mendix.com/installer/AdoptOpenJDK/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi)
+* Microsoft Visual C++ 2010 SP1 Redistributable Package (http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe)
+* Microsoft Visual C++ 2013 Redistributable Package (http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe)
+
+Based on the error message you get from the installer you can decide to install a separate prerequisite, or you can try to manually install them all.
+
+After that you can retry installing Studio Pro.
+
+## 6 Read More
 
 * [Studio Pro Overview](/refguide/studio-pro-overview)
 * [App Modeling](/refguide/modeling)

--- a/content/howto/general/install.md
+++ b/content/howto/general/install.md
@@ -65,7 +65,7 @@ Mendix Studio Pro needs to be installed on your computer before you can start bu
 
 ## 5 Troubleshooting
 
-Some people run into problems when installing Studio Pro. A work-around can be to restart your system and install the prerequisites separately if you don't already have them installed. 
+Some people run into problems when installing Studio Pro. One work-around is to restart your system and install the prerequisites separately if they are not already installed. 
 
 The prerequisites are:
 
@@ -74,7 +74,7 @@ The prerequisites are:
 * Microsoft Visual C++ 2010 SP1 Redistributable Package (http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe)
 * Microsoft Visual C++ 2013 Redistributable Package (http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe)
 
-Based on the error message you get from the installer you can decide to install a separate prerequisite, or you can try to manually install them all.
+Based on the error message you get from the installer you can decide to install a single prerequisite, or you can try to manually install them all.
 
 After that you can retry installing Studio Pro.
 

--- a/content/howto7/general/install-the-mendix-desktop-modeler.md
+++ b/content/howto7/general/install-the-mendix-desktop-modeler.md
@@ -68,7 +68,7 @@ This concludes the how-to about installing the Mendix Desktop Modeler.
 
 ## 5 Troubleshooting
 
-Some people run into problems when installing the Desktop Modeler. A work-around can be to restart your system and install the prerequisites separately if you don't already have them installed. 
+Some people run into problems when installing the Desktop Modeler. One work-around is to restart your system and install the prerequisites separately if they are not already installed. 
 
 For a 64-bit system the prerequisites are:
 
@@ -84,7 +84,7 @@ For a 32-bit system the prerequisites are:
 * Microsoft Visual C++ 2010 SP1 Redistributable Package (http://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe)
 * Microsoft Visual C++ 2013 Redistributable Package (http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe)
 
-Based on the error message you get from the installer you can decide to install a separate prerequisite, or you can try to manually install them all.
+Based on the error message you get from the installer you can decide to install a single prerequisite, or you can try to manually install them all.
 
 After that you can retry installing the Desktop Modeler.
 

--- a/content/howto7/general/install-the-mendix-desktop-modeler.md
+++ b/content/howto7/general/install-the-mendix-desktop-modeler.md
@@ -66,7 +66,29 @@ The Mendix Desktop Modeler needs to be installed on your computer before you can
 
 This concludes the how-to about installing the Mendix Desktop Modeler.
 
-## 5 Read More
+## 5 Troubleshooting
+
+Some people run into problems when installing the Desktop Modeler. A work-around can be to restart your system and install the prerequisites separately if you don't already have them installed. 
+
+For a 64-bit system the prerequisites are:
+
+* .NET Framework 4.6.2 (http://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe)
+* AdoptOpenJDK 8 (https://cdn.mendix.com/installer/AdoptOpenJDK/8/OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.msi)
+* Microsoft Visual C++ 2010 SP1 Redistributable Package (http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe)
+* Microsoft Visual C++ 2013 Redistributable Package (http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe)
+
+For a 32-bit system the prerequisites are:
+
+* .NET Framework 4.6.2 (http://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe)
+* AdoptOpenJDK 8 (https://cdn.mendix.com/installer/AdoptOpenJDK/8/OpenJDK8U-jdk_x86-32_windows_hotspot_8u202b08.msi)
+* Microsoft Visual C++ 2010 SP1 Redistributable Package (http://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe)
+* Microsoft Visual C++ 2013 Redistributable Package (http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe)
+
+Based on the error message you get from the installer you can decide to install a separate prerequisite, or you can try to manually install them all.
+
+After that you can retry installing the Desktop Modeler.
+
+## 6 Read More
 
 * [Desktop Modeler](/refguide7/desktop-modeler)
 * [Desktop Modeler Overview](/refguide7/desktop-modeler-overview)


### PR DESCRIPTION
Add an installation troubleshooting section for Mendix 7 and Mendix 8, because these problems recently surfaced more often. This can make life for the support team easier