### PR TITLE
Use correct SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "community@mendix.com",
     "url": "https://docs.mendix.com/community/"
   },
-  "license": "CC BY 4.0.",
+  "license": "CC-BY-4.0",
   "devDependencies": {
     "algoliasearch": "^3.32.0",
     "async": "^2.6.2",


### PR DESCRIPTION
Fixed a warning while doing `npm install`
```warning package.json: License should be a valid SPDX license expression```
See: https://spdx.org/licenses/