### PR TITLE
Added the missing END keyword

### DIFF
--- a/content/refguide/oql-case-expression.md
+++ b/content/refguide/oql-case-expression.md
@@ -15,6 +15,7 @@ _Simple_
 CASE input_expression
 WHEN when_expression THEN result_expression [ ...n ]
 ELSE else_result_expression
+END
 ```
 
 _Extended_
@@ -22,7 +23,9 @@ _Extended_
 ```
 CASE
 WHEN boolean_expression 
-THEN result_expression [ ...n ] ELSE else_result_expression
+THEN result_expression [ ...n ] 
+ELSE else_result_expression
+END
 ```
 
 **input_expression**

--- a/content/refguide/oql-case-expression.md
+++ b/content/refguide/oql-case-expression.md
@@ -22,8 +22,7 @@ _Extended_
 
 ```
 CASE
-WHEN boolean_expression 
-THEN result_expression [ ...n ] 
+WHEN boolean_expression THEN result_expression [ ...n ] 
 ELSE else_result_expression
 END
 ```


### PR DESCRIPTION
The CASE expression syntax requires an END keyword at the end of the expression.