### PR TITLE
Rename to Mendix native apps

### DIFF
--- a/content/howto/mobile/using-mendix-studio-pro-on-a-mac.md
+++ b/content/howto/mobile/using-mendix-studio-pro-on-a-mac.md
@@ -2,13 +2,13 @@
 title: "Work with Parallels"
 parent: "native-mobile"
 menu_order: 20
-description: "This how-to will allow you to start making native Mendix apps on your Mac device."
+description: "This how-to will allow you to start making Mendix native apps on your Mac device."
 tags: ["Native", "Parallels", "Mac", "Mobile"]
 ---
 
 ## 1 Introduction
 
-Using Parallels, you can run Mendix Studio Pro on your Mac device using a Windows virtual machine. To start making native Mendix apps on your Mac, follow this how-to.
+Using Parallels, you can run Mendix Studio Pro on your Mac device using a Windows virtual machine. To start making Mendix native apps on your Mac, follow this how-to.
 
 **This how-to will teach you how to do the following:**
 

--- a/content/releasenotes/studio-pro/8.0.md
+++ b/content/releasenotes/studio-pro/8.0.md
@@ -42,7 +42,7 @@ The [Native Builder](/howto/mobile/native-builder) is a command line input tool 
 
 #### Mendix Native App Template
 
-Advanced users can now make direct use of our [Mendix Native App Template](http://github.com/mendix/native-template). This repository acts as a template for building native Mendix apps, and as a guide for users who want to include native Mendix functionality in their own apps. 
+Advanced users can now make direct use of our [Mendix Native App Template](http://github.com/mendix/native-template). This repository acts as a template for building Mendix native apps, and as a guide for users who want to include native Mendix functionality in their own apps. 
 
 The [Mendix Native App Template](http://github.com/mendix/native-template) is used by the [Native Builder],(/howto/mobile/native-mobile/native-builder) which means it will be consistently updated to support the latest native Mendix features.
 


### PR DESCRIPTION
This is in an effort to be more consistent with the ideal full title (Mendix native mobile apps). In doc sections which already make the "mobile" part clear, we can just write "Mendix native apps", but I still wanted to keep the word order consistent.