### PR TITLE
Delete todo

### DIFF
--- a/content/howto/mobile/getting-started-with-native-mobile.md
+++ b/content/howto/mobile/getting-started-with-native-mobile.md
@@ -8,9 +8,7 @@ tags: ["native", "mobile", "developer", "test"]
 
 ## 1 Introduction
 
-{{% todo %}} With next release, also Mention that also possible using blank app or add to existing app project, and how to (because Atlas needs to be updated) {{% /todo %}}
-
-To use Mendix Studio Pro's native app capabilities, you can use the [Native Mobile Quickstart](https://appstore.home.mendix.com/link/app/109511/) app from the Mendix App Store. This app is optimized to quickly build a native mobile app. Out of the box, this app gives you a native page, a native phone profile to enable native device navigation, a native layout with menus, and native widgets and actions which leverage device capabilities.
+To use Mendix Studio Pro's native app capabilities, you can use the [Native Mobile Quickstart](https://appstore.home.mendix.com/link/app/109511/) app from the Mendix App Store. This app is optimized to quickly build a native mobile app. Out of the box, this app gives you a native page, a native phone profile to enable native device navigation, a native layout with menus, and native widgets and actions which leverage device capabilities. It is also possible to make native apps by starting a project using the Blank App template, or **MORE DETAILS HERE PLZ** 
 
 The Native Mobile Quickstart app also includes four modules:
 


### PR DESCRIPTION
I needed to delete this todo, because Docs can't have those stick around forever: 

{{% todo %}} With next release, also Mention that also possible using blank app or add to existing app project, and how to (because Atlas needs to be updated) {{% /todo %}}

I have started trying to include this information in the doc, but I am unclear how much information is needed. Does this doc need another section? I hope we can limit the new info to a few sentences, and maybe some links to the Atlas/Dom migration docs if need be.