### PR TITLE
Changed GET to POST

### DIFF
--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -772,7 +772,7 @@ URL: https://deploy.mendix.com/api/1/apps/<AppId>/environments/<Mode>/settings/
 **Example Request**
 
 ```json
-GET /api/1/apps/calc/environments/acceptance/settings/ 
+POST /api/1/apps/calc/environments/acceptance/settings/ 
 Host: deploy.mendix.com
 
 Content-Type: application/json


### PR DESCRIPTION
Section 3.14.2 Request falsely states GET request, it should be POST

ACTUAL:
GET /api/1/apps/calc/environments/acceptance/settings/
Host: deploy.mendix.com

EXPECTED:
POST /api/1/apps/calc/environments/acceptance/settings/
Host: deploy.mendix.com