### PR TITLE
Client doc reorg

### DIFF
--- a/content/apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets.md
+++ b/content/apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets.md
@@ -1,6 +1,7 @@
 ---
 title: "Client APIs Available to Pluggable Widgets"
-category: "API Documentation"
+parent: "pluggable-widgets"
+menu_order: 10
 description: A guide for understanding the client APIs available to pluggable widgets.
 tags: ["Widget", "Pluggable",  "JavaScript"]
 ---

--- a/content/apidocs-mxsdk/apidocs/index.md
+++ b/content/apidocs-mxsdk/apidocs/index.md
@@ -59,9 +59,7 @@ Part of the AppCloudServices module.
 
 Understand pluggable widgets, how they extend app functionality, and how they can be built to interact with Mendix's APIs:
 
-* [Pluggable Widgets](pluggable-widgets)
-* [Client APIs Available to Pluggable Widgets](client-apis-for-pluggable-widgets)
-* [Pluggable Widget Property Types](property-types-pluggable-widgets)
+* [Pluggable Widgets API](pluggable-widgets)
 
 ## 10 Profile API
 

--- a/content/apidocs-mxsdk/apidocs/property-types-pluggable-widgets.md
+++ b/content/apidocs-mxsdk/apidocs/property-types-pluggable-widgets.md
@@ -1,6 +1,7 @@
 ---
 title: "Pluggable Widget Property Types"
-category: "API Documentation"
+parent: "pluggable-widgets"
+menu_order: 20
 description: A guide for understanding pluggable widgets' property types.
 tags: ["Widget", "Pluggable", "Custom", "JavaScript", "React"]
 ---


### PR DESCRIPTION
Reorganizing the client API docs to have a parent and 2 children. Without this change, Client/Pluggable API docs are scattered around the giant API space.