### PR TITLE
Align refguide with a snippet

### DIFF
--- a/content/refguide/common-widget-properties.md
+++ b/content/refguide/common-widget-properties.md
@@ -99,7 +99,7 @@ When selected, this shows the widget while a particular attribute has a certain 
 
 ##### Based on Expression {#visibility-based-on-expression}
 
-When selected, this shows the widget while a provided [expression](expressions) evaluates to true. The object of the containing data view is available inside an expression as a `$currentObject` variable.
+When selected, this shows the widget while a provided [expression](expressions) evaluates to true. The object of the containing data view is available inside an expression as a `$currentObject` variable. In Mendix 8.1 and above, the expression can access objects of all the data containers enclosing that data container widget. These objects are available under the name of the widget they originate from (for example, `$dataView1`).
 
 Note that the expression is evaluated in the browser, and hence, we advise against using "secret" values (like access keys) in it. In particular, we disallow usages of [constants](constants). Also, client-side expressions currently do not support all the functions that are available in the microflows. Please refer to an autocomplete list to know what functions are supported in your version.
 


### PR DESCRIPTION
Due to changes in a snippet in https://github.com/mendix/docs/pull/1870/
Refguide has a page that should be aligned with it. 