### PR TITLE
Fixes code in the example of differences

### DIFF
--- a/content/refguide/moving-from-7-to-8.md
+++ b/content/refguide/moving-from-7-to-8.md
@@ -201,7 +201,7 @@ In this example we have a Java action called `LogMessage`, which has a parameter
         public java.lang.Boolean executeAction() throws Exception
         {
             // BEGIN USER CODE
-            Core.getLogger("MyLogger").info(this.Message);
+            Core.getLogger("MyLogger").info(this.MessageParameter1);
             // END USER CODE
         }
 ```


### PR DESCRIPTION
I believe the parameter inside "executeAction" in the first example was also supposed to be `this.MessageParameter1`, as that is the name of the field generated by Mendix 7.