### PR TITLE
Add debugger shortcuts

### DIFF
--- a/content/howto/monitoring-troubleshooting/debug-microflows.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows.md
@@ -76,7 +76,7 @@ Breakpoints are points in a microflow where the application will halt execution.
 
     ![](attachments/18448571/18580008.png)
     
-5. You have the following options on this pane:  
+5. You have the following options on this pane (see available shortcut keys in [Studio Pro Overview](../../refguide/studio-pro-overview#9-debugger-shortcut-keys)):
     * Click **Step into** or **Step over** to move to the next step in the microflow (note that the difference between **Step into** and **Step over** is only noticeable if you run into a call microflow activity or a loop)
         * **Step into** means that the debugger steps into the sub microflow or loop
         * **Step over** moves the debugger to the next step in the same microflow

--- a/content/howto/monitoring-troubleshooting/debug-microflows.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows.md
@@ -68,7 +68,7 @@ Breakpoints are points in a microflow where the application will halt execution.
 
     ![](attachments/18448571/18580010.png)
 
-4. Open the **Debugger** pane from the **View** menu:
+4.  Open the **Debugger** pane from the **View** menu:
 
     ![](attachments/18448571/18580009.png)
 
@@ -76,12 +76,14 @@ Breakpoints are points in a microflow where the application will halt execution.
 
     ![](attachments/18448571/18580008.png)
     
-5. You have the following options on this pane (see available shortcut keys in [Studio Pro Overview](../../refguide/studio-pro-overview#9-debugger-shortcut-keys)):
+5. You have the following options on this pane:
     * Click **Step into** or **Step over** to move to the next step in the microflow (note that the difference between **Step into** and **Step over** is only noticeable if you run into a call microflow activity or a loop)
         * **Step into** means that the debugger steps into the sub microflow or loop
         * **Step over** moves the debugger to the next step in the same microflow
     * Click **Step out** to instruct the debugger to leave the sub microflow or loop (this is basically the opposite of **Step Into**)
     * Click **Continue** to instruct the debugger to continue until it reaches another breakpoint
+    
+For details on available shortcut keys, see the [Debugger Shortcut Keys](/refguide/studio-pro-overview#debugger-shortcuts) section of *Studio Pro Overview*.
 
 ## 6 Variables Viewer
 

--- a/content/refguide/studio-pro-overview.md
+++ b/content/refguide/studio-pro-overview.md
@@ -229,14 +229,13 @@ The following shortcut keys are available in the microflow editor:
 | <kbd>Shift</kbd> when resizing an activity | When resizing the entity, by holding <kbd>Shift</kbd> , the microflow component will stay centered at its current position and will expand equally in all directions. |
 | <kbd>Ctrl</kbd> when selecting multiple activities | When pressing the <kbd>Ctrl</kbd>, you can select additional microflow components. Clicking a selected component while holding <kbd>Ctrl</kbd> will deselect it. |
 
+## 9 Microflow Debugger Shortcut Keys {##debugger-shortcuts}
 
-## 9 Debugger Shortcut Keys
-
-The following shortcut keys are available for the the debugger:
+The following shortcut keys are available for the the microflow debugger:
 
 | Key | Description |
 | --- | --- |
-| <kbd>Alt</kbd> + <kbd>F5</kbd> | *Step into*. Moves the debugger into the sub microflow or loop.  |
-| <kbd>Alt</kbd> + <kbd>F6</kbd> | *Step over*. Moves the debugger to the next step in the same microflow |
-| <kbd>Alt</kbd> + <kbd>F7</kbd> | *Step out*. Instructs the debugger to leave the sub microflow or loop  |
-| <kbd>Alt</kbd> + <kbd>F8</kbd> | *Continue*. Instructs the debugger to continue until it reaches another breakpoint. |
+| <kbd>Alt</kbd> + <kbd>F5</kbd> | *Step into* – moves the debugger into the sub-microflow or loop.  |
+| <kbd>Alt</kbd> + <kbd>F6</kbd> | *Step over* – moves the debugger to the next step in the same microflow. |
+| <kbd>Alt</kbd> + <kbd>F7</kbd> | *Step out* – instructs the debugger to leave the sub-microflow or loop.  |
+| <kbd>Alt</kbd> + <kbd>F8</kbd> | *Continue* – instructs the debugger to continue until it reaches another breakpoint. |

--- a/content/refguide/studio-pro-overview.md
+++ b/content/refguide/studio-pro-overview.md
@@ -236,7 +236,7 @@ The following shortcut keys are available for the the debugger:
 
 | Key | Description |
 | --- | --- |
-| <kbd>Alt</kbd> + <kbd>F5</kbd> | *Step into*. Moves the dubugger into the sub microflow or loop.  |
+| <kbd>Alt</kbd> + <kbd>F5</kbd> | *Step into*. Moves the debugger into the sub microflow or loop.  |
 | <kbd>Alt</kbd> + <kbd>F6</kbd> | *Step over*. Moves the debugger to the next step in the same microflow |
 | <kbd>Alt</kbd> + <kbd>F7</kbd> | *Step out*. Instructs the debugger to leave the sub microflow or loop  |
 | <kbd>Alt</kbd> + <kbd>F8</kbd> | *Continue*. Instructs the debugger to continue until it reaches another breakpoint. |

--- a/content/refguide/studio-pro-overview.md
+++ b/content/refguide/studio-pro-overview.md
@@ -228,3 +228,15 @@ The following shortcut keys are available in the microflow editor:
 | <kbd>End</kbd> | Highlights and focus on an end event in the current microflow. If there are multiple end events, clicking **End** multiple times will toggle between the different events. |
 | <kbd>Shift</kbd> when resizing an activity | When resizing the entity, by holding <kbd>Shift</kbd> , the microflow component will stay centered at its current position and will expand equally in all directions. |
 | <kbd>Ctrl</kbd> when selecting multiple activities | When pressing the <kbd>Ctrl</kbd>, you can select additional microflow components. Clicking a selected component while holding <kbd>Ctrl</kbd> will deselect it. |
+
+
+## 9 Debugger Shortcut Keys
+
+The following shortcut keys are available for the the debugger:
+
+| Key | Description |
+| --- | --- |
+| <kbd>Alt</kbd> + <kbd>F5</kbd> | *Step into*. Moves the dubugger into the sub microflow or loop.  |
+| <kbd>Alt</kbd> + <kbd>F6</kbd> | *Step over*. Moves the debugger to the next step in the same microflow |
+| <kbd>Alt</kbd> + <kbd>F7</kbd> | *Step out*. Instructs the debugger to leave the sub microflow or loop  |
+| <kbd>Alt</kbd> + <kbd>F8</kbd> | *Continue*. Instructs the debugger to continue until it reaches another breakpoint. |


### PR DESCRIPTION
Noticed that we don't mention debugger shortcuts anywhere in the docs. Now we do.