### PR TITLE
Update charts-any-configuration.md - click events

### DIFF
--- a/content/refguide/charts-any-configuration.md
+++ b/content/refguide/charts-any-configuration.md
@@ -107,6 +107,10 @@ The **Any Chart** widget supports two sorts of event, related to the points plot
 Events will be triggered by hovering over or clicking on the points plotted on the chart. Clicks on other parts of the chart will NOT trigger an event.
 {{% /alert %}}
 
+{{% alert type="info" %}}
+Preventing the hover even from triggerring will also prevent the click event from triggering. This includes setting the layout parameter "hovermode" to "false" and setting the data parameter "hoverinfo" to "skip".
+{{% /alert %}}
+
 When an event occurs, plotly will return a JSON object as described here: https://plot.ly/javascript/plotlyjs-events/#event-data. This JSON data is stored in a string attribute of an entity object which is passed to **Any Data**. The JSON contains raw data from the chart which has been plotted, such as the x and y coordinates of the point, and needs to be interpreted in the microflow which is triggered by the event.
 
 ### Event entity


### PR DESCRIPTION
Added an info box to explain the relation between hover events and click events, making it clear that preventing hover events from triggering will also prevent click events from triggering. That information does not seem to be clearly documented anywhere (including the plot.ly docs). Based on the issue in this Forum question: https://forum.mendixcloud.com/link/questions/95755

Andries Smit mentioned that it might be good to add this info to the documentation