### PR TITLE
Removed note that JSON structures support null

### DIFF
--- a/content/refguide/json-structures.md
+++ b/content/refguide/json-structures.md
@@ -76,7 +76,6 @@ Each JSON property is composed of a key ("name") and a value ("John"). If the va
 *   true or false. Converted into an attribute of type Boolean.
 *   "1985-04-12T23:20:50.52Z". Converted into an attribute of type DateTime.
 *   12.50\. Converted into an attribute of type Decimal.
-*   null. Converted into an  attribute of type String.
 
 ### 2.2 JSON Arrays
 

--- a/content/refguide7/json-structures.md
+++ b/content/refguide7/json-structures.md
@@ -75,7 +75,6 @@ Each JSON property is composed of a key ("name") and a value ("John"). If the va
 *   true or false. Converted into an attribute of type Boolean.
 *   "1985-04-12T23:20:50.52Z". Converted into an attribute of type DateTime.
 *   12.50\. Converted into an attribute of type Decimal.
-*   null. Converted into an  attribute of type String.
 
 ### 2.2 JSON Arrays
 


### PR DESCRIPTION
JSON structures tolerate null, but you can't use the attributes (because it cannot determine the type).
The refguide said it was supported, which is then technically not the case. So that should be removed