### PR TITLE
Update changing-things-in-the-model.md

### DIFF
--- a/content/apidocs-mxsdk/mxsdk/changing-things-in-the-model.md
+++ b/content/apidocs-mxsdk/mxsdk/changing-things-in-the-model.md
@@ -27,7 +27,6 @@ import {domainmodels} from "mendixmodelsdk";
 function createEntity(domainModel : domainmodels.DomainModel, entityName : string, attributeName : string) {
     const newEntity = domainmodels.Entity.createIn(domainModel);
 	newEntity.name = entityName;
-	domainModel.entities.push(newEntity);
 
 	// location on the canvas in the Mendix Studio Pro:
 	newEntity.location = { 'x': 100, 'y': 100 };


### PR DESCRIPTION
In code sample for section 2 removed "domainModel.entities.push(newEntity)". This line was causing an error stating that it attempted adding an already existing element to "domainModel.entities". This is because "newEntity" is added to domainModel.entities at creation:
"const newEntity = domainmodels.Entity.createIn(domainModel)"
