### PR TITLE
Enumerations: prefix with "Enum"

### DIFF
--- a/content/howto/general/dev-best-practices.md
+++ b/content/howto/general/dev-best-practices.md
@@ -198,7 +198,15 @@ For integrations, you have the following types of microflow:
 | Layout                                    | **Lay_**  |
 | Snippet                                   | **Snip_** |
 
-#### 3.5.2 Pages
+#### 3.5.2 Enumerations
+
+[Enumeration](refguide/enumerations) should be identified with a prefix.
+
+| Document Type                             | Prefix    |
+|-------------------------------------------|-----------|
+| Enumeration                               | **Enum_** |
+
+#### 3.5.3 Pages
 
 Pages use a **suffix** to indicate their use.
 
@@ -221,7 +229,7 @@ Pages that are used as a tooltip page should have the suffix **_Tooltip**.
 | Select multiple objects | _MultiSelect |
 | Tooltip | _Tooltip |
 
-#### 3.5.3 Integration Documents
+#### 3.5.4 Integration Documents
 
 Documents used to support integration should have the prefixes listed below.
 

--- a/content/howto/general/dev-best-practices.md
+++ b/content/howto/general/dev-best-practices.md
@@ -200,7 +200,7 @@ For integrations, you have the following types of microflow:
 
 #### 3.5.2 Enumerations
 
-[Enumeration](refguide/enumerations) should be identified with a prefix.
+[Enumerations](/refguide/enumerations) should be identified with a prefix.
 
 | Document Type                             | Prefix    |
 |-------------------------------------------|-----------|


### PR DESCRIPTION
I am unaware of any reason as to why enumerations are not mentioned here upto now, but since in every project I have been in so far enumerations are commonly prefixed with "Enum_" it only seems logical to have it mentioned here as well.