### PR TITLE
Add updateDate to recommendations

### DIFF
--- a/_gulp/htmlproofer.js
+++ b/_gulp/htmlproofer.js
@@ -319,11 +319,16 @@ const writeUpdateFeed = files => new Promise(async (resolve, reject) => {
       const title = file.seoTitle.replace(' | Mendix Documentation', '');
       const basePath = file.basePath.replace('index.html', '').replace('.html','');
       const url = 'https://' + normalizeSafe(`docs.mendix.com${basePath}`);
+      const m = moment(file.time, 'YYYY-DD-MMTHH:mm:ssZZ');
+
+      const updateDate =  m._isValid ? m.toDate() : null;
+
       return {
         id: `docs-${sha1(url)}`,
         title,
-        url
-      }
+        url,
+        date: updateDate
+      };
     });
   const updateFiles = _.chain(files)
     .filter(file => file.time !== null && !!file.seoTitle)


### PR DESCRIPTION
This is for a technical POC where we need to parse a complete list of all updated items (instead of only the last 20 in the feed.xml). Can be merged safely if PR build succeeds. Will add an extra `date` field to [recommendations.json](https://docs.mendix.com/recommendations.json)