### PR TITLE
Added style limitation to native SVG doc

### DIFF
--- a/content/refguide/native-svg.md
+++ b/content/refguide/native-svg.md
@@ -25,7 +25,7 @@ SVGs can contain several kinds of elements. However, not all of them are support
 * Video
 * JavaScript code 
 * CDATA elements
-* `<style />` tags and `style` attributes, please use regular properties instead
+* `<style />` tags and `style` attributes (please use regular properties instead)
 
 We suggest manually removing these elements from your SVGs, or using the tools mentioned in [Optimizing SVGs](#optimizing) above to ensure their compatibility. 
 

--- a/content/refguide/native-svg.md
+++ b/content/refguide/native-svg.md
@@ -25,6 +25,7 @@ SVGs can contain several kinds of elements. However, not all of them are support
 * Video
 * JavaScript code 
 * CDATA elements
+* `<style />` tags and `style` attributes, please use regular properties instead
 
 We suggest manually removing these elements from your SVGs, or using the tools mentioned in [Optimizing SVGs](#optimizing) above to ensure their compatibility. 
 


### PR DESCRIPTION
Unfortunately, native SVGs currently don't support the `style` tag and element. I've added documentation to clarify this.