### PR TITLE
Adds info about how to commit association changes.

### DIFF
--- a/content/refguide/reference-set-selector.md
+++ b/content/refguide/reference-set-selector.md
@@ -37,6 +37,8 @@ The reference set selector looks a lot like a [data grid](data-grid) and consequ
 *   The **Add** button adds an association to an existing object. You will need to specify the page which opens when you want to add a new association. For more information, see [Add Button](control-bar#add-button).
 *   The **Remove** button removes the association to an object, but does not change or delete the object itself
 
+Note that you will need to have a **Save** button surrounding your reference set selector to save the association changes.  
+
 ## 2 Properties
 
 An example of reference set selector properties is represented in the image below:

--- a/content/refguide/reference-set-selector.md
+++ b/content/refguide/reference-set-selector.md
@@ -37,7 +37,10 @@ The reference set selector looks a lot like a [data grid](data-grid) and consequ
 *   The **Add** button adds an association to an existing object. You will need to specify the page which opens when you want to add a new association. For more information, see [Add Button](control-bar#add-button).
 *   The **Remove** button removes the association to an object, but does not change or delete the object itself
 
-Note that you will need to have a **Save** button surrounding your reference set selector to save the association changes.  
+{{% alert type="info" %}}
+You must explicitly commit the object in the data view containing your reference set selector to save the association changes. This can be done, for example, by having a **Save** button for the object in the data view (as shown for the *Customer* entity in the picture above).
+{{% /alert %}}
+
 
 ## 2 Properties
 

--- a/content/refguide/reference-set-selector.md
+++ b/content/refguide/reference-set-selector.md
@@ -41,7 +41,6 @@ The reference set selector looks a lot like a [data grid](data-grid) and consequ
 You must explicitly commit the object in the data view containing your reference set selector to save the association changes. This can be done, for example, by having a **Save** button for the object in the data view (as shown for the *Customer* entity in the picture above).
 {{% /alert %}}
 
-
 ## 2 Properties
 
 An example of reference set selector properties is represented in the image below:


### PR DESCRIPTION
The Add and Remove buttons don't commit the changes on their own.
It is expected that the surrounding object (the Customer data view
as shown in the docs right above this text) has a Save button.
When the user saves the changes, the association changes that were
done from the Add and Remove buttons are committed.

Since this may not be apparently obvious, I added a short note in the
docs.