### PR TITLE
Fix broken URL in 6.10.md

### DIFF
--- a/content/releasenotes/studio-pro/6.10.md
+++ b/content/releasenotes/studio-pro/6.10.md
@@ -27,7 +27,7 @@ description: "The release notes for Mendix Modeler version 6.10 (including all p
 
 ### Fixes
 
-* We fixed an issue where the list of ignored files kept growing with every branch that you created. In extreme cases, this caused the Modeler to crash while merging. To prevent crashes in projects that already have large ignore lists, the feature that automatically resolves conflicts on ignore lists has been disabled. From now on, conflicts on ignore lists will be rare, because the ignore list will be changed less often. If you still encounter conflicts on the `svn:ignore` property, they have to be resolved by using TortoiseSVN. For more information, see [Merge Problems and the 'svn:ignore' Story](https://forum.mendixcloud.com/link/questions/92813 for more information) on the Mendix Forum. (Ticket 78557)
+* We fixed an issue where the list of ignored files kept growing with every branch that you created. In extreme cases, this caused the Modeler to crash while merging. To prevent crashes in projects that already have large ignore lists, the feature that automatically resolves conflicts on ignore lists has been disabled. From now on, conflicts on ignore lists will be rare, because the ignore list will be changed less often. If you still encounter conflicts on the `svn:ignore` property, they have to be resolved by using TortoiseSVN. For more information, see [Merge Problems and the 'svn:ignore' Story](https://forum.mendixcloud.com/link/questions/92813) for more information on the Mendix Forum. (Ticket 78557)
 
 ### Improvements
 


### PR DESCRIPTION
This'll fix the broken link to the Merge Problems and the 'svn:ignore' Story forum post.