### PR TITLE
Add description of keyboard shortcuts to switch languages

### DIFF
--- a/content/refguide/menus.md
+++ b/content/refguide/menus.md
@@ -51,9 +51,9 @@ In the **Version Control** menu, you can view and/or manipulate settings on the 
 | **Select Previous Language** | Makes the previous language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> |
 | **Select Next Language** | Makes the next language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>L</kbd> |
 | **Language Settings** | Opens the **Project Settings** dialog box to the **Languages** tab so that you can adjust the language configuration of the app project. | |
-| **Batch Replace** | Opens a dialog window in which you can correct texts within one language. This is useful to check whether texts presented to the user are consistent. |   |
-| **Batch Translate** | Opens a dialog window in which you can quickly translate many texts from one language to another. |   |
-| **Language Operations** | Opens a dialog window in which you can copy, move, swap, or delete all translations in a given language for selected modules. |   |
+| **Batch Replace** | Opens a dialog box in which you can correct texts within one language. This is useful for checking whether the texts presented to the user are consistent. |   |
+| **Batch Translate** | Opens a dialog box in which you can quickly translate many texts from one language to another. |   |
+| **Language Operations** | Opens a dialog box in which you can copy, move, swap, or delete all the translations in a given language for selected modules. |   |
 
 ## 9 Help Menu {#help}
 

--- a/content/refguide/menus.md
+++ b/content/refguide/menus.md
@@ -47,7 +47,9 @@ In the **Version Control** menu, you can view and/or manipulate settings on the 
 
 | Menu Item | Description | Shortcut Key |
 | --- | --- | --- |
-| **Current Language** | Displays the current language of your app project. | |
+| **Current Language** | Displays the current language of your app project and allows you to make another language the current language. | |
+| **Select Previous Language** | Makes the previous language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> |
+| **Select Next Language** | Makes the next language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>L</kbd> |
 | **Language Settings** | Opens the **Project Settings** dialog box to the **Languages** tab so that you can adjust the language configuration of the app project. | |
 | **Batch Replace** | Opens a dialog window in which you can correct texts within one language. This is useful to check whether texts presented to the user are consistent. |   |
 | **Batch Translate** | Opens a dialog window in which you can quickly translate many texts from one language to another. |   |

--- a/content/refguide/translatable-texts.md
+++ b/content/refguide/translatable-texts.md
@@ -8,14 +8,12 @@ tags: ["studio pro"]
 
 All texts that are presented to the end-user can be translated to different languages. Examples include [labels](label), the captions of [buttons](button-widgets) and [data grid](data-grid) columns, [menu items](menu#menu-item) and [messages](show-message) that are sent from a [microflow](microflows).
 
-Studio Pro makes it really easy to translate your application to another language. You can add a language in the [project settings](project-settings) and then switch to that language by selecting it in the [Language](menus) menu, by using the drop-down in the lower-right corner of Studio Pro's main window, or with the <kbd>Ctrl</kbd>+<kbd>L</kbd> keyboard shortcut, which cycles through the languages of you app.
+Studio Pro makes it easy to translate your application into another language. You can add a language in the [Project Settings](project-settings) and then switch to that language by selecting it in the [Language](menus#language) menu, by using the drop-down in the lower-right corner of Studio Pro's main window, or with the <kbd>Ctrl</kbd>+<kbd>L</kbd> keyboard shortcut, which cycles through the languages of you app.
 
-For texts that have not been translated yet, the text in the default language is shown between pointy brackets. For example, a caption can be shown as '&lt;Name&gt;'. This means that the caption has not been translated yet and was 'Name' in the default language. By simply typing the text in the currently selected language (e.g. 'Naam' in Dutch) the caption has been translated.
+For texts that have not been translated yet, the text in the default language is shown between angle brackets. For example, a caption can be shown as `&lt;Name&gt;`. This means that the caption has not been translated yet and was `Name` in the default language. By simply typing the text in the currently selected language (for example, `Naam` in Dutch), the caption will be translated.
 
 {{% alert type="info" %}}
-
 To ease the translation of many texts a Batch Translate feature can be found in the Tools menu. By using this feature you can quickly translate all occurrences of a word to a word in another language. It is even possible to export all texts to Excel and later import the translations again.
-
 {{% /alert %}}
 
 If a text has not been translated when you run the application the text in the default language will be used. In this way, you can translate parts of the application and see the results immediately.

--- a/content/refguide/translatable-texts.md
+++ b/content/refguide/translatable-texts.md
@@ -8,7 +8,9 @@ tags: ["studio pro"]
 
 All texts that are presented to the end-user can be translated to different languages. Examples include [labels](label), the captions of [buttons](button-widgets) and [data grid](data-grid) columns, [menu items](menu#menu-item) and [messages](show-message) that are sent from a [microflow](microflows).
 
-Studio Pro makes it really easy to translate your application to another language. You can add a language in the [project settings](project-settings) and then you can switch to that language using the drop-down in the toolbar. For texts that have not been translated yet the text in the default language is shown between pointy brackets. For example, a caption can be shown as '<Name>'. This means that the caption has not been translated yet and was 'Name' in the default language. By simply typing the text in the currently selected language (e.g. 'Naam' in Dutch) the caption has been translated.
+Studio Pro makes it really easy to translate your application to another language. You can add a language in the [project settings](project-settings) and then switch to that language by selecting it in the [Language](menus) menu, by using the drop-down in the lower-right corner of Studio Pro's main window, or with the <kbd>Ctrl</kbd>+<kbd>L</kbd> keyboard shortcut, which cycles through the languages of you app.
+
+For texts that have not been translated yet, the text in the default language is shown between pointy brackets. For example, a caption can be shown as '&lt;Name&gt;'. This means that the caption has not been translated yet and was 'Name' in the default language. By simply typing the text in the currently selected language (e.g. 'Naam' in Dutch) the caption has been translated.
 
 {{% alert type="info" %}}
 

--- a/content/refguide7/desktop-modeler-overview.md
+++ b/content/refguide7/desktop-modeler-overview.md
@@ -157,7 +157,9 @@ Using items in the menu bar of the Modeler, you can create new projects, deploy 
 
 | Menu Item | Description | Shortcut Key |
 | --- | --- | --- |
-| Current Language | Displays the current language of your app project. | |
+| Current Language | Displays the current language of your app project and allows you to make another language the current language. | |
+| Select Previous Language | Makes the previous language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> |
+| Select Next Language | Makes the next language of your app project the current language. | <kbd>Ctrl</kbd>+<kbd>L</kbd> |
 | Language Settings | Opens the **Project Settings** dialog box to the **Languages** tab so that you can adjust the language configuration of the app project. | |
 | Batch Replace | Opens a form in which you can correct texts within one language. This is useful to check whether texts presented to the user are consistent. |   |
 | Batch Translate | Opens a form in which you can quickly translate many texts from one language to another. |   |


### PR DESCRIPTION
This updates the Studio Pro documentation to describe the new keyboard
shortcuts to cycle through the languages available in the project, and
the new dropdown control in the lower-right of the main window that can
be used to select a different language.

This feature is added to Studio Pro version 8.6.0.