### PR TITLE
Update java-programming.md to fix a typo

### DIFF
--- a/content/refguide/java-programming.md
+++ b/content/refguide/java-programming.md
@@ -37,7 +37,7 @@ The executeAction method throws all exceptions that occur. This means you can do
 In the Java code that you write for your Java actions, you can use the Mendix Java library.
 
 {{% alert type="info" %}}
-You can find the Javadoc at [apidocs.mendix.com](http://apidocs.mendix.com/7/runtime/) or in the directory you in which installed Mendix (for example, *C:\Program Files\Mendix\8.0.0\runtime\javado*).
+You can find the Javadoc at [apidocs.mendix.com](http://apidocs.mendix.com/7/runtime/) or in the directory you in which installed Mendix (for example, *C:\Program Files\Mendix\8.0.0\runtime\javadoc*).
 {{% /alert %}}
 
 This library is automatically added to your libraries when you imported your project into Eclipse, and it is called *mxruntime.jar*.


### PR DESCRIPTION
In section 3, there was a letter "c" missing from the end of the file path to the javadoc. Was "C:\Program Files\Mendix\8.0.0\runtime\javado" and should be C:\Program Files\Mendix\8.0.0\runtime\javadoc.