### PR TITLE
Only blocking users after 3 failed login attempts when project level …

### DIFF
--- a/content/refguide/login-behavior.md
+++ b/content/refguide/login-behavior.md
@@ -7,7 +7,7 @@ tags: ["Runtime", "login", "studio pro"]
 
 ## 1 Default Login Behavior
 
-A user is blocked after 3 consecutive bad login attempts, regardless of the time between the login attempts. The failed login count is reset after a successful login attempt or when a blocked user is unblocked.
+A user is blocked after 3 consecutive bad login attempts, regardless of the time between the login attempts. The failed login count is reset after a successful login attempt or when a blocked user is unblocked. Blocking users only occurs when the project security level is set to 'Production'.
 
 Users are unblocked each time the cluster manager runs, and at that point, the failed login count is also reset to 0. By default, the cluster manager runs every 5 minutes. This interval can be changed using the [Runtime customization](custom-settings) `ClusterManagerActionInterval` setting.
 


### PR DESCRIPTION
…security is Production.

This change will apply from Mendix 8.7.x onwards. For older versions user blocking is based on the 'DTAPMode' configuration value: users are only blocked when it is set to 'production'.