### PR TITLE
Update dev-best-practices.md

### DIFF
--- a/content/howto/general/dev-best-practices.md
+++ b/content/howto/general/dev-best-practices.md
@@ -145,7 +145,7 @@ For attributes, you can choose to store the value in the database or to calculat
 | On change event           | OCh\_{Purpose}   | Input widgets   |
 | On leave event            | OLe\_{Purpose}   | Input widgets   |
 | Data source               | DS\_{Purpose}    | Data view, list view, data grid, template grid |
-| Microflow/action button   | ACT\_{Purpose} or IVK\_{Purpose} | Menu item, Navigation item, Microflow and Action button, Drop-down button<br />(“IVK\_” is used historically) |
+| Action button             | Act\_{Purpose}   | Menu item, navigation item, microflow and action button, drop-down button<br />(“IVK\_” is used historically) |
 
 #### 3.4.4 Validation Microflows
 


### PR DESCRIPTION
Prefix ACT is the only prefix that does not conform to camelcase. So better is Act. 
IVK is historic, so should no longer be allowed as suggested prefix