### PR TITLE
Gulp/Sass feedback 491652

### DIFF
--- a/content/howto/front-end/sass-eight.md
+++ b/content/howto/front-end/sass-eight.md
@@ -72,7 +72,7 @@ To prepare your app project, follow these steps:
 
 	At this point, you are ready to start working with Sass.
 
-9.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change). You will only have to do this ONCE when you set it up for your project :
+9.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change). You will only have to do this *once* when you set it up for your project :
 
 	![](attachments/set-up-sass/selected-ignore.png)
 

--- a/content/howto/front-end/sass-eight.md
+++ b/content/howto/front-end/sass-eight.md
@@ -72,7 +72,7 @@ To prepare your app project, follow these steps:
 
 	At this point, you are ready to start working with Sass.
 
-9.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change). You will only have to do this *once* when you set it up for your project :
+9.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change). You will only have to do this *once* when you set it up for your project:
 
 	![](attachments/set-up-sass/selected-ignore.png)
 

--- a/content/howto/front-end/sass-eight.md
+++ b/content/howto/front-end/sass-eight.md
@@ -42,21 +42,22 @@ Before starting this how-to, make sure you have completed the following prerequi
 To prepare your app project, follow these steps:
 
 1. Open the [app project directory](../general/show-project-directory) (via **Project** > **Show Project Directory in Explorer** in Studio Pro).
-2.  Unpack the *Gulp.zip* file into your main app project folder. You will then see a *Gulpfile* and *package* file that look like this:
+1.  Unpack the *Gulp.zip* file into your main app project folder. You will then see a *Gulpfile* and *package* file that look like this:
 
 	![](attachments/set-up-sass/unpack.png)
 
 	After you have unpacked the *Gulp.zip* into your app project folder, you can remove the *zip* file.
-3.  Open **Windows PowerShell**:
+1.  Open **Windows PowerShell** as an administrator:
 
 	![](attachments/set-up-sass/powershell.png)
 
-4.  Copy the address as text from your main project folder and paste it into Powershell:
+1.  Copy the address as text from your main project folder and paste it into Powershell:
 
 	![](attachments/set-up-sass/copy.png)
 
-5.  Provide the directory for your app project folder in PowerShell: `cd ‘directory for your app project folder’`
-6.  Write `npm install` or use `npm install gulp-cli -g`:
+1.  Provide the directory for your app project folder in PowerShell: `cd ‘directory for your app project folder’`
+1.  Adjust permissions by writing `Set-ExecutionPolicy -ExecutionPolicy ByPass -Scope CurrentUser` then pressing <kbd>Enter</kbd> .
+1.  Write `npm install` or use `npm install gulp-cli -g` with your app running locally on Studio Pro:
 
 	![](attachments/set-up-sass/write-install.png)
 
@@ -65,13 +66,13 @@ To prepare your app project, follow these steps:
 	{{% alert type="info" %}}You should do this for each new app project! That way, you will not have to repeat the installation step whenever you reopen the app project and Powershell.
 	{{% /alert %}}
 
-7.  Write `gulp dev`. Your screen should then look like this:
+1.  Write `gulp dev`. Your screen should then look like this:
 
 	![](attachments/set-up-sass/gulp-dev.png)
 
 	At this point, you are ready to start working with Sass.
 
-8.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change) :
+1.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change) :
 
 	![](attachments/set-up-sass/selected-ignore.png)
 
@@ -85,7 +86,7 @@ To prepare your app project, follow these steps:
 	
 	If you need to remove an item from the ignore list, right-click it and select **TortoiseSVN** > **Remove from ignore list**.
 
-9.  Open your app project in Studio Pro, then click **Run Locally** and **View**.
+1.  Open your app project in Studio Pro, then click **Run Locally** and **View**.
 
 ## 4  Setting Up Your Sass Files
 

--- a/content/howto/front-end/sass-eight.md
+++ b/content/howto/front-end/sass-eight.md
@@ -42,22 +42,22 @@ Before starting this how-to, make sure you have completed the following prerequi
 To prepare your app project, follow these steps:
 
 1. Open the [app project directory](../general/show-project-directory) (via **Project** > **Show Project Directory in Explorer** in Studio Pro).
-1.  Unpack the *Gulp.zip* file into your main app project folder. You will then see a *Gulpfile* and *package* file that look like this:
+2.  Unpack the *Gulp.zip* file into your main app project folder. You will then see a *Gulpfile* and *package* file that look like this:
 
 	![](attachments/set-up-sass/unpack.png)
 
 	After you have unpacked the *Gulp.zip* into your app project folder, you can remove the *zip* file.
-1.  Open **Windows PowerShell** as an administrator:
+3.  Open **Windows PowerShell** as an administrator:
 
 	![](attachments/set-up-sass/powershell.png)
 
-1.  Copy the address as text from your main project folder and paste it into Powershell:
+4.  Copy the address as text from your main project folder and paste it into Powershell:
 
 	![](attachments/set-up-sass/copy.png)
 
-1.  Provide the directory for your app project folder in PowerShell: `cd ‘directory for your app project folder’`
-1.  Adjust permissions by writing `Set-ExecutionPolicy -ExecutionPolicy ByPass -Scope CurrentUser` then pressing <kbd>Enter</kbd> .
-1.  Write `npm install` or use `npm install gulp-cli -g` with your app running locally on Studio Pro:
+5.  Provide the directory for your app project folder in PowerShell: `cd ‘directory for your app project folder’`
+6.  Adjust permissions by writing `Set-ExecutionPolicy -ExecutionPolicy ByPass -Scope CurrentUser` then pressing <kbd>Enter</kbd> .
+7.  Write `npm install` or use `npm install gulp-cli -g` with your app running locally on Studio Pro:
 
 	![](attachments/set-up-sass/write-install.png)
 
@@ -66,13 +66,13 @@ To prepare your app project, follow these steps:
 	{{% alert type="info" %}}You should do this for each new app project! That way, you will not have to repeat the installation step whenever you reopen the app project and Powershell.
 	{{% /alert %}}
 
-1.  Write `gulp dev`. Your screen should then look like this:
+8.  Write `gulp dev`. Your screen should then look like this:
 
 	![](attachments/set-up-sass/gulp-dev.png)
 
 	At this point, you are ready to start working with Sass.
 
-1.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change) :
+9.  You also need to add the following selected items into the ignore list of TortoiseSVN for each new app project (or else your app project will take too long to commit a change). You will only have to do this ONCE when you set it up for your project :
 
 	![](attachments/set-up-sass/selected-ignore.png)
 
@@ -83,10 +83,10 @@ To prepare your app project, follow these steps:
 	You will receive a confirmation when the items have been added to the ignore list. You can also double-check via TortoiseSVN:
 
 	![](attachments/set-up-sass/check-ignore.png)
-	
+
 	If you need to remove an item from the ignore list, right-click it and select **TortoiseSVN** > **Remove from ignore list**.
 
-1.  Open your app project in Studio Pro, then click **Run Locally** and **View**.
+10.  Open your app project in Studio Pro, then click **Run Locally** and **View**.
 
 ## 4  Setting Up Your Sass Files
 
@@ -133,7 +133,7 @@ To import all the sub-folders and files you have created, write this:
 \@import "base/login";
 ```
 
-After you import everything, you are finally ready to Sass! 
+After you import everything, you are finally ready to Sass!
 
 ## 5 Working with Sass
 
@@ -149,14 +149,14 @@ color: green;
 }
 ```
 
-To implement this in your app project, open the project in Mendix Studio Pro. You can find the defined class names in almost every element (for example, titles and subtitles). In this example, double-click the title **Event App** in Studio Pro, and you can see that the name has the standard class name for Studio Pro. 
+To implement this in your app project, open the project in Mendix Studio Pro. You can find the defined class names in almost every element (for example, titles and subtitles). In this example, double-click the title **Event App** in Studio Pro, and you can see that the name has the standard class name for Studio Pro.
 
 ![](attachments/set-up-sass/class-name.png)
 
-You can remove **spacing-outer-bottom-medium**, as that is a variable that contains defined styling code. If you do not remove this, you will probably have trouble later in the app project if you, for example, want to position your title somewhere else. 
+You can remove **spacing-outer-bottom-medium**, as that is a variable that contains defined styling code. If you do not remove this, you will probably have trouble later in the app project if you, for example, want to position your title somewhere else.
 
 {{% alert type="info" %}}
-The inline styling is used in this example. That is because the inline styling will always overrule your code in VSC. 
+The inline styling is used in this example. That is because the inline styling will always overrule your code in VSC.
 {{% /alert %}}
 
 ### 5.1 Seeing Your Changes
@@ -184,7 +184,6 @@ Practice the routine above a few times and you will master it in no time. In add
 * Make sure Powershell is working properly, or else your code will not be registered Studio Pro
 * Use the following to install gulp for each new project:
 	* `npm install`
-	* `npm install dev`
 	* `npm install gulp-cli -g`
 	* If the commands above do not work, you can also use `npm run dev`, though keep in mind you are not installing the gulp
 * Make sure the app project is running locally in Studio Pro (you will not be able to see your changes if the app is not running)


### PR DESCRIPTION
I got some feedback recently from someone with an @us.epiuse.com email:

* Step 3 - Powershell needs to be run as admin
* Step 6 - Before running "npm" and "gulp dev" permissions have to be adjusted with "Set-ExecutionPolicy -ExecutionPolicy ByPass -Scope CurrentUser"
* Step 6 - Highlight before instructing user to run "gulp dev" that IF the user does not have an app running locally in Studio Pro prior to running gulp dev, their browser will try to load a page that will fail and powershell will show an error (I spent hours trying to figure this out thinking I had missed something). I did not realize this until I gave up on gulp and tried Calypso (https://docs.mendix.com/howto/front-end/calypso) only to realize it's a gulp wrapper but has additional instructions that clarify how to use it.
* Highlight that TortoiseSVN is optional and not required to run gulp.
TurtoiseSVN instruction need to be revised as well. There are steps missing or unwritten assumptions.

I have tried to implement all that feedback in this PR. However I am not sure how to note that TortoiseSVN is optional.

@JelteMX if you could validate the tech of my PR's diff, as well as advise on the Tortoise point, I would appreciate it.

Thank you.
