### PR TITLE
Specify required pg_dump version

### DIFF
--- a/content/developerportal/operate/restore-backup.md
+++ b/content/developerportal/operate/restore-backup.md
@@ -123,10 +123,8 @@ This contains the *db.backup* file. This is a PostgreSQL dump file created using
 
 {{% alert type="warning" %}}
 If the dump does not use the *custom format* then the restore will fail.
-{{% /alert %}}
 
-{{% alert type="warning" %}}
-If the dump is created with a version of pg_dump more recent than 9.6.17 then the restore will fail.
+The dump must be created with pg_dump version 9.6.17 or below. If it is created with a later version, then the restore will fail.
 {{% /alert %}}
 
 ### tree folder

--- a/content/developerportal/operate/restore-backup.md
+++ b/content/developerportal/operate/restore-backup.md
@@ -125,6 +125,10 @@ This contains the *db.backup* file. This is a PostgreSQL dump file created using
 If the dump does not use the *custom format* then the restore will fail.
 {{% /alert %}}
 
+{{% alert type="warning" %}}
+If the dump is created with a version of pg_dump more recent than 9.6.17 then the restore will fail.
+{{% /alert %}}
+
 ### tree folder
 
 This contains the files which are stored in external file storage. Each file is stored in a second level location:


### PR DESCRIPTION
The version of pg_dump bundled with recent PostgreSQL versions will set the archiver version header to 1.14. This will cause an error when restoring the database on our end, which fails the restore process.