### PR TITLE
add toLowerCase()

### DIFF
--- a/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/howto/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -89,7 +89,7 @@ MxApp.onConfigReady(function(config) {
             samlWindow.executeScript({
                 code: "window.location.href;"
             }, function(href) {
-                if (href[0].indexOf(window.mx.remoteUrl) == 0 && href[0].indexOf("SSO") == -1) {
+                if (href[0].toLowerCase().indexOf(window.mx.remoteUrl.toLowerCase()) == 0 && href[0].indexOf("SSO") == -1) {
                     samlWindow.executeScript({
                         code: "document.cookie;"
                     }, function(values) {


### PR DESCRIPTION
Added toLowerCase() to both the current location and remoteUrl. In testing with a client running on SAP cloud, the remoteURL used capital letters and the href did not. Adding toLowerCase() solved this issue.