### PR TITLE
Add 'Alerts for environment'

### DIFF
--- a/content/developerportal/settings/manage-deeplinks.md
+++ b/content/developerportal/settings/manage-deeplinks.md
@@ -35,7 +35,7 @@ To create a deep link, you need the App ID, Story ID, or Feedback Item Nr for th
 If you want to provide links directly to a specific element in your app project in the Developer Portal, follow these steps:
 
 1. Paste the URL to the Developer in your browser's address bar (as in, `https://sprintr.home.mendix.com/` or `https://cloud.home.mendix.com/`).
-2. Paste the desired App ID, Story ID, or Feedback Item Number after the final slash.
+2. Paste the desired App ID, Environment ID, Story ID, or Feedback Item Number after the final slash.
 
 The following deep links can be used:
 
@@ -47,6 +47,7 @@ The following deep links can be used:
 * Environments for app: `https://cloud.home.mendix.com/link/deploy/<appID>`
 * Metrics for app: `https://cloud.home.mendix.com/link/metrics/<appID>`
 * Alerts for app: `https://cloud.home.mendix.com/link/monitor/<appID>`
+* Alerts for environment: `https://cloud.home.mendix.com/link/monitor/<appID>/<envID>`
 * Logs for app: `https://cloud.home.mendix.com/link/logs/<appID>`
 
 ## 4 Read More


### PR DESCRIPTION
It was never documented, but definitely supported:
Linking to a specific environment's alerts by referring to its Environment ID

Note that this is not supported for logs or metrics, just alerts. 