### PR TITLE
Document parameterized actions of db-connector

### DIFF
--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -36,14 +36,18 @@ These are the prerequisites for using this connector:
 
 ### 3.1 Usage
 
-Once you have imported the Database Connector into your app project, you will have **Database Connector** available in the **Toolbox**. The connector supports two actions: **Execute query** and **Execute statement**. To use either of these in your Mendix application, drag them into your microflow. Next, provide all the arguments for the selected action and choose the output result name.
+Once you have imported the Database Connector into your app project, you will have **Database Connector** available in the **Toolbox**. The connector supports four actions: **Execute query**, **Execute statement**, **Execute parameterized query**, and **Execute parameterized statement**. To use any of these in your Mendix application, drag them into your microflow. Next, provide all the arguments for the selected action and choose the output result name.
+
+The actions **Execute query** and **Execute parameterized query** should be used for querying objects with a **SELECT** SQL command, whereas **Execute statement** and **Execute parameterized statement** should be used for all other commands (for instance, **INSERT**, **UPDATE**, or **DELETE**).
+
+For both queries and statement, the difference between the parameterized and the regular versions are that for the former takes a string template parameter while the latter takes a fully formed SQL command string with no placeholders.
 
 ### 3.2 Results
 
 These are the results of the actions:
 
-* **Execute query** –  a list of objects of the row type, which is also the output of the `SELECT SQL` query
-* **Execute statement** – either an integer or a long value, which usually represents the amount of affected rows
+* **Execute query** and **Execute parameterized query** – a list of objects of the row type, which is also the output of the `SELECT SQL` query
+* **Execute statement** and **Execute parameterized statement** – either an integer or a long value, which usually represents the amount of affected rows
 
 ## 4 Best Practices
 

--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -36,11 +36,11 @@ These are the prerequisites for using this connector:
 
 ### 3.1 Usage
 
-Once you have imported the Database Connector into your app project, you will have **Database Connector** available in the **Toolbox**. The connector supports four actions: **Execute query**, **Execute statement**, **Execute parameterized query**, and **Execute parameterized statement**. To use any of these in your Mendix application, drag them into your microflow. Next, provide all the arguments for the selected action and choose the output result name.
+Once you have imported the Database Connector into your app project, you will have the **Database Connector** available in the **Toolbox**. The connector supports four actions: **Execute query**, **Execute statement**, **Execute parameterized query**, and **Execute parameterized statement**. To use any of these in your Mendix application, drag them into your microflow. Next, provide all the arguments for the selected action and choose the output result name.
 
-The actions **Execute query** and **Execute parameterized query** should be used for querying objects with a **SELECT** SQL command, whereas **Execute statement** and **Execute parameterized statement** should be used for all other commands (for instance, **INSERT**, **UPDATE**, or **DELETE**).
+The **Execute query** and **Execute parameterized query** actions should be used for querying objects with a `SELECT` SQL command. The **Execute statement** and **Execute parameterized statement** actions should be used for all other commands (for instance, `INSERT`, `UPDATE`, or `DELETE`).
 
-For both queries and statement, the difference between the parameterized and the regular versions are that for the former takes a string template parameter while the latter takes a fully formed SQL command string with no placeholders.
+For both queries and statements, the difference between the parameterized and regular versions are that the parameterized version takes a string template parameter, while the regular version takes a fully formed SQL command string with no placeholders.
 
 ### 3.2 Results
 

--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -46,7 +46,7 @@ For both queries and statements, the difference between the parameterized and re
 
 These are the results of the actions:
 
-* **Execute query** and **Execute parameterized query** – a list of objects of the row type, which is also the output of the `SELECT SQL` query
+* **Execute query** and **Execute parameterized query** – a list of objects of the row type, which is also the output of the `SELECT` SQL query
 * **Execute statement** and **Execute parameterized statement** – either an integer or a long value, which usually represents the amount of affected rows
 
 ## 4 Best Practices

--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -42,7 +42,9 @@ The **Execute query** and **Execute parameterized query** actions should be used
 
 For both queries and statements, the difference between the parameterized and regular versions are that the parameterized version takes a string template parameter, while the regular version takes a fully formed SQL command string with no placeholders.
 
-Note: The parameterized actions are only available with Database Connector versions 3.0.0 and higher. For these, it is necessary to use Mendix 8.6.0.
+{{% alert type="info" %}}
+The parameterized actions are only available with Database Connector versions 3.0.0 and above. For these, it is necessary to use Mendix [8.6.0](/releasenotes/studio-pro/8.6#860).
+{{% /alert %}}
 
 ### 3.2 Results
 

--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -42,6 +42,8 @@ The **Execute query** and **Execute parameterized query** actions should be used
 
 For both queries and statements, the difference between the parameterized and regular versions are that the parameterized version takes a string template parameter, while the regular version takes a fully formed SQL command string with no placeholders.
 
+Note: The parameterized actions are only available with Database Connector versions 3.0.0 and higher. For these, it is necessary to use Mendix 8.6.0.
+
 ### 3.2 Results
 
 These are the results of the actions:


### PR DESCRIPTION
To be released with Mendix 8.8.0, the new Database-connector now has two extra actions:
- Execute Parameterized Query
- Execute Parameterized Statement

These are similar to the vanilla versions, but take string templates as input in place of a regular (user formatted) string.