### PR TITLE
Improvement/loading page

### DIFF
--- a/_assets/styles/_sass/components/_sidebarmenu.scss
+++ b/_assets/styles/_sass/components/_sidebarmenu.scss
@@ -63,6 +63,8 @@ $active-color: $color-black;
 
   @include element('loader') {
     display: none;
+    transition: all 0.4s ease-in-out;
+    overflow: hidden;
 
     .svg {
       margin: auto auto;

--- a/_assets/styles/main.scss
+++ b/_assets/styles/main.scss
@@ -1,6 +1,8 @@
 @import "_sass/core/variables";
 @import "_sass/core/helpers";
 
+@import "_sass/mx-components/mxdock";
+
 @import "_sass/background";
 
 @import "_sass/base";

--- a/themes/mendix/layouts/partials/base/foot.html
+++ b/themes/mendix/layouts/partials/base/foot.html
@@ -2,6 +2,7 @@
 {{ partial "mx-general/footer-new" . }}
 <!-- <script src="//cdnjs.cloudflare.com/ajax/libs/jspdf/1.3.4/jspdf.min.js" integrity="sha256-vIL0pZJsOKSz76KKVCyLxzkOT00vXs+Qz4fYRVMoDhw=" crossorigin="anonymous"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js" integrity="sha256-c3RzsUWg+y2XljunEQS0LqWdQ04X1D3j22fd/8JCAKw=" crossorigin="anonymous"></script> -->
+<script src="https://dock-static.mendix.com/main.js" async></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.10.0/css/lightbox.min.css" integrity="sha256-auPoJwk/+RK6KSkib92Dkq1Y5hEkZvKtvSwucs15Skg=" crossorigin="anonymous" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.10.0/js/lightbox.min.js" integrity="sha256-DiHJ7hbvMejsMyP76bpVWacb5HSHQ2sQlrJV8n7KEvA=" crossorigin="anonymous" defer></script>

--- a/themes/mendix/layouts/partials/mx-general/header-new.html
+++ b/themes/mendix/layouts/partials/mx-general/header-new.html
@@ -1,2 +1,5 @@
-<div id="mx-dock-header"></div>
-<script src="https://dock-static.mendix.com/main.js" async></script>
+<div id="mx-dock-header">
+    <div class="BaseContainer">
+        <div id="mx-header"></div>
+    </div>
+</div>

--- a/themes/mendix/layouts/partials/sidebar.html
+++ b/themes/mendix/layouts/partials/sidebar.html
@@ -7,17 +7,17 @@
         <div class="menu" data-source="howto.json"></div>
         <div class="menu" data-source="studio.json"></div>
         <div class="menu" data-source="developerportal.json"></div>
-		<div class="menu" data-source="appstore.json"></div>
+        <div class="menu" data-source="appstore.json"></div>
         <div class="menu" data-source="partners.json"></div>
         <div class="menu" data-source="apidocs-mxsdk.json"></div>
         <div class="menu" data-source="addons.json"></div>
-		<div class="seperator"></div>
-		<div class="menu menu--deprecated" data-source="refguide7.json"></div>
+        <div class="seperator"></div>
+        <div class="menu menu--deprecated" data-source="refguide7.json"></div>
         <div class="menu menu--deprecated" data-source="howto7.json"></div>
-		<div class="menu menu--deprecated" data-source="studio7.json"></div>
+        <div class="menu menu--deprecated" data-source="studio7.json"></div>
         <div class="menu menu--deprecated" data-source="refguide6.json"></div>
         <div class="menu menu--deprecated" data-source="howto6.json"></div>
-		<div class="menu menu--draft" data-source="product-naming.json"></div>
+        <div class="menu menu--draft" data-source="product-naming.json"></div>
       </div>
       <div class="col-md-12 sidebar-menu__loader">
         <svg class="svg" width="200" height="200">

--- a/themes/mendix/layouts/partials/sidebar.html
+++ b/themes/mendix/layouts/partials/sidebar.html
@@ -19,7 +19,7 @@
         <div class="menu menu--deprecated" data-source="howto6.json"></div>
 		<div class="menu menu--draft" data-source="product-naming.json"></div>
       </div>
-      <div class="col-md-12 sidebar-menu__loader" style="transition: all 0.4s ease-in-out">
+      <div class="col-md-12 sidebar-menu__loader">
         <svg class="svg" width="200" height="200">
           <circle cx="100" cy="100" r="50"></circle>
         </svg>


### PR DESCRIPTION
- Improving loader, no more scroll bars while loading sidemenu
- Moved new header script to bottom of the page and add the correct element to the top, so it doesn't bog down building the page any further. It should now display a correct top bar while it is not loaded (so the page doesn't jump).