### PR TITLE
Prefix is not always needed

### DIFF
--- a/content/howto/general/dev-best-practices.md
+++ b/content/howto/general/dev-best-practices.md
@@ -106,7 +106,7 @@ Generally, [microflow](/refguide/microflows) names should include the type of ev
 
 There are exceptions, such as where there is no main entity, or there is another reason to use a different name to improve understandability. The important thing is to make sure the name of the microflow clearly indicates its purpose.
 
-To easily find and recognize the purpose of a microflow, you can use standard prefixes. Common purposes or events and their standard prefixes are listed below. If a microflow is triggered by several events you can consider using more than one prefix.
+To easily find and recognize the purpose of a microflow, you can use standard prefixes. Common purposes or events and their standard prefixes are listed below. If a microflow is triggered by several events you can consider using more than one prefix. If a microflow does not comply to any of the next subparagraphs, it should not have a prefix.
 
 #### 3.4.1 Entity Event Microflows
 

--- a/content/howto/general/dev-best-practices.md
+++ b/content/howto/general/dev-best-practices.md
@@ -106,7 +106,7 @@ Generally, [microflow](/refguide/microflows) names should include the type of ev
 
 There are exceptions, such as where there is no main entity, or there is another reason to use a different name to improve understandability. The important thing is to make sure the name of the microflow clearly indicates its purpose.
 
-To easily find and recognize the purpose of a microflow, you can use standard prefixes. Common purposes or events and their standard prefixes are listed below. If a microflow is triggered by several events you can consider using more than one prefix. If a microflow does not comply to any of the next subparagraphs, it should not have a prefix.
+To easily find and recognize the purpose of a microflow, you can use standard prefixes. Common purposes or events and their standard prefixes are listed below. If a microflow is triggered by several events, consider using more than one prefix. If a microflow does not comply to any of the patterns listed below, it should not have a prefix.
 
 #### 3.4.1 Entity Event Microflows
 


### PR DESCRIPTION
In several projects every microflow has a prefix and I have gotten used to that and it is informative in most cases. ASu_ make it clear to me that this is only to be used AfterStartup of the application, OCh indicates that... well anyway, it is useful. One thing though: every microflow that does not match any of the paragraphs 3.4.1 to 3.4.8 sort of by default gets a default prefix: SUB. To make it even worse, this has changed over the years from IVK_ to SUB_ to ACT_ with or without caps. Thus resulting in lots of microflows having a meaningless prefix. I was fine with that until Lennert Krebbers challanged this. He convinced me that it is better to not have a prefix, if no logic prefix is to be determined. Therefor this suggestion for a small addition to the naming standards. Best regards!