### PR TITLE
Clarify configurations are local

### DIFF
--- a/content/refguide/configuration.md
+++ b/content/refguide/configuration.md
@@ -7,7 +7,7 @@ tags: ["studio pro", "configurations", "configuration"]
 
 ## 1 Introduction
 
-A configuration is a group of settings. To access configurations, open the **Project Explorer** > **Project** > **Settings** > the **Configuration** tab. 
+A configuration is a group of settings which are applied when running your project locally. To access configurations, open the **Project Explorer** > **Project** > **Settings** > the **Configuration** tab. 
 
 You can define any number of configurations. The active configuration, as in, the one that will be used when running your application, is determined by the drop-down in the toolbar of Studio Pro.
 

--- a/content/refguide/configuration.md
+++ b/content/refguide/configuration.md
@@ -7,7 +7,7 @@ tags: ["studio pro", "configurations", "configuration"]
 
 ## 1 Introduction
 
-A configuration is a group of settings which are applied when running your project locally. To access configurations, open the **Project Explorer** > **Project** > **Settings** > the **Configuration** tab. 
+A configuration is a group of settings that are applied when running your app project locally. To access configurations, open the **Project Explorer** > **Project** > **Settings** > the **Configuration** tab. 
 
 You can define any number of configurations. The active configuration, as in, the one that will be used when running your application, is determined by the drop-down in the toolbar of Studio Pro.
 


### PR DESCRIPTION
Clarifying that configurations are only used when running locally. The runtime settings and constant values are in no way deployed to the Cloud.