### PR TITLE
Added warning on long-running microflows.

### DIFF
--- a/content/refguide6/custom-settings.md
+++ b/content/refguide6/custom-settings.md
@@ -214,6 +214,8 @@ This parameter specifies the number of threads the thread pool can assign to exe
 
 The default value should be more than enough for most use cases. If your application experiences extremely high load and it runs out of threads you can try to increase this number.
 
+Also note that one could deplete the thread pool with long-running microflows. If each available thread is busy executing an long-running microflow, then other microflows will be 'starved' and will not start to execute until the long-running microflows are finished. They could even experience time-outs before they start executing or exhaust the number of available connections.
+
 {{% alert type="success" %}}
 
 If you want to inspect the configuration being used, you can set the system or config property 'akka.log-config-on-start' to 'on'. This will then print the complete configuration at INFO level when the actor system is started.

--- a/content/refguide6/custom-settings.md
+++ b/content/refguide6/custom-settings.md
@@ -214,10 +214,10 @@ This parameter specifies the number of threads the thread pool can assign to exe
 
 The default value should be more than enough for most use cases. If your application experiences extremely high load and it runs out of threads you can try to increase this number.
 
-Also note that one could deplete the thread pool with long-running microflows. If each available thread is busy executing an long-running microflow, then other microflows will be 'starved' and will not start to execute until the long-running microflows are finished. They could even experience time-outs before they start executing or exhaust the number of available connections.
+{{% alert type="info" %}}
+It is important to note that you can deplete the thread pool with long-running microflows. If each available thread is busy executing a long-running microflow, then other microflows will be "starved" and will not start to execute until the long-running microflows are finished. These microflows may even experience time-outs before they start executing or exhaust the number of available connections.
+{{% /alert %}}
 
 {{% alert type="success" %}}
-
 If you want to inspect the configuration being used, you can set the system or config property 'akka.log-config-on-start' to 'on'. This will then print the complete configuration at INFO level when the actor system is started.
-
 {{% /alert %}}


### PR DESCRIPTION
Relates to ticket: https://mendixsupport.zendesk.com/agent/tickets/91651