### PR TITLE
Update list-operation.md

### DIFF
--- a/content/refguide/list-operation.md
+++ b/content/refguide/list-operation.md
@@ -76,7 +76,7 @@ These operations takes a list and one or more members (attributes or association
 
 | Operation | Description | Result Type |
 | --- | --- | --- |
-| Sort | Allows you to sort a list based on a number of a attributes. The attributes are ordered to determine their priority while sorting. You cannot use associations to sort a list. | List |
+| Sort | Allows you to sort a list based on a number of a attributes. The attributes are ordered to determine their priority while sorting. You cannot use associations to sort a list. Sorting attributes from generalized entities is not allowed. | List |
 | Find | Find the first object of which the member has the given value. | Object |
 | Filter | Find all objects of which the member has the given value. | List |
 


### PR DESCRIPTION
Added the sentence "Sorting attributes from generalized entities is not allowed" in "Sort" row in 3.1.2 Member Inspections. We have a customer that tried to sort attributes from generalized entity giving him a runtime error. As we didn't have any message mention that, it's good to clients know this.