### PR TITLE
Remove "not supported" from the documentation

### DIFF
--- a/content/refguide/json-structures.md
+++ b/content/refguide/json-structures.md
@@ -23,8 +23,6 @@ When you paste or modify the JSON snippet, it is automatically checked for valid
 
 You cannot press "OK" without making the JSON valid.
 
-JSON snippets with `:`, `^`, or `|` in property names are currently not supported.
-
 {{% /alert %}}
 
 ### 1.2 Format


### PR DESCRIPTION
Having "not supported" in the documentation is not maintainable. When you have one, then you should have the complete list, which is difficult to come up with. It is better to document what we support instead, assume the rest is not supported.