### PR TITLE
Added documentation for the new sync config option

### DIFF
--- a/content/refguide/navigation.md
+++ b/content/refguide/navigation.md
@@ -131,11 +131,8 @@ This deletes the profile. If [menu widgets](menu-widgets) are still referring to
 
 Only available on profiles supporting offline synchronization.
 
-This opens the **Customize offline synchronziation** dialog box that is used for overriding offline synchronization settings for specific entities. For each entity the download setting is shown. A default is automatically determined by analyzing the model, but can be overridden in which case the setting will appear in boldface. The download settings are one of the following:
+This opens the **Customize offline synchronziation** dialog box that is used for overriding offline synchronization settings for specific entities. For each entity the download setting is shown. A default is automatically determined by analyzing the model, but can be overridden in which case the setting will appear in boldface. For more details on the settings and when to use them, please check out the [offline-first](offline-first#customizable-synchronization) documentation.
 
-* All objects – download all objects of this entity type
-* By XPath – download only those objects matching the specified [XPath constraint](xpath-constraints) 
-* Nothing – download none of the objects of this entity type
   ![](attachments/navigation/customize-offline-synchronization.png)
 
 ## 5 Read More

--- a/content/refguide/navigation.md
+++ b/content/refguide/navigation.md
@@ -131,9 +131,9 @@ This deletes the profile. If [menu widgets](menu-widgets) are still referring to
 
 Only available on profiles supporting offline synchronization.
 
-This opens the **Customize offline synchronziation** dialog box that is used for overriding offline synchronization settings for specific entities. For each entity the download setting is shown. A default is automatically determined by analyzing the model, but can be overridden in which case the setting will appear in boldface. For more details on the settings and when to use them, please check out the [offline-first](offline-first#customizable-synchronization) documentation.
+This opens the **Customize offline synchronziation** dialog box that is used for overriding offline synchronization settings for specific entities. For each entity the download setting is shown. A default is automatically determined by analyzing the model, but can be overridden in which case the setting will appear in boldface. For more details on the settings and when to use them, see the [Offline-First Reference Guide](offline-first#customizable-synchronization).
 
-  ![](attachments/navigation/customize-offline-synchronization.png)
+![](attachments/navigation/customize-offline-synchronization.png)
 
 ## 5 Read More
 

--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -68,8 +68,8 @@ Depending on the use-case, more fine-grained synchronization controls might be r
 
 - All Objects, download all objects applying the regular security constraints.
 - By XPath, only download the objects that are matching the [XPath Constraints](xpath-constraints) in addition to the regular security constraints.
-- Nothing (clear data), don't download any objects automatically, but do clear the database when performing a synchronization. This can be useful in cases where the objects should only be uploaded, for example a `Feedback` entity.
-- Nothing (preserve data), don't download any objects automatically, and don't clear the database when performing a synchronization. This can be useful in cases where you want have full control over the download phase and should be used in combination with the [Sync to Device](sync-to-device) action.
+- Nothing (clear data), don't download any objects automatically, but do clear the data stored in the database for this entity when performing a synchronization. This can be useful in cases where the objects should only be uploaded, for example a `Feedback` entity.
+- Nothing (preserve data), don't download any objects automatically, and don't clear the data stored in the database for this entity when performing a synchronization. This can be useful in cases where you want have full control over the download phase and should be used in combination with the [Sync to Device](sync-to-device) action.
 
 If you have custom widgets or JavaScript actions which use an entity that cannot be detected by Studio Pro in your offline-first profile (because its only used in the code), you can use customizable synchronization to include such entities.
 

--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -62,11 +62,14 @@ After the download process (and thus synchronization) is completed, the widgets 
 
 ### 2.3 Customizable Synchronization {#customizable-synchronization}
 
-By default Mendix automatically determines which objects need to be synchronized as mentioned in [Synchronization](#synchronization).
+By default, Mendix automatically determines which objects need to be synchronized as mentioned in [Synchronization](#synchronization).
 
-Depending on the use-case, more fine-grained synchronization controls might be required. Therefore, an app's  synchronization configuration can be customized to override the default configuration. It is possible to limit what is downloaded by using [XPath Constraints](xpath-constraints), which is applied in addition to the security constraints.
+Depending on the use-case, more fine-grained synchronization controls might be required. Therefore, it is possible to change the download behaviour for an entity. You can choose between the following options:
 
-Furthermore, it is possible to disable downloads for an entity. This can be very useful in cases where the objects should only be uploaded, for example a `Feedback` entity.
+- All Objects, download all objects applying the regular security constraints.
+- By XPath, only download the objects that are matching the [XPath Constraints](xpath-constraints) in addition to the regular security constraints.
+- Nothing (clear data), don't download any objects automatically, but do clear the database when performing a synchronization. This can be useful in cases where the objects should only be uploaded, for example a `Feedback` entity.
+- Nothing (preserve data), don't download any objects automatically, and don't clear the database when performing a synchronization. This can be useful in cases where you want have full control over the download phase and should be used in combination with the [Sync to Device](sync-to-device) action.
 
 If you have custom widgets or JavaScript actions which use an entity that cannot be detected by Studio Pro in your offline-first profile (because its only used in the code), you can use customizable synchronization to include such entities.
 

--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -66,10 +66,10 @@ By default, Mendix automatically determines which objects need to be synchronize
 
 Depending on the use-case, more fine-grained synchronization controls might be required. Therefore, it is possible to change the download behaviour for an entity. You can choose between the following options:
 
-- All Objects, download all objects applying the regular security constraints.
-- By XPath, only download the objects that are matching the [XPath Constraints](xpath-constraints) in addition to the regular security constraints.
-- Nothing (clear data), don't download any objects automatically, but do clear the data stored in the database for this entity when performing a synchronization. This can be useful in cases where the objects should only be uploaded, for example a `Feedback` entity.
-- Nothing (preserve data), don't download any objects automatically, and don't clear the data stored in the database for this entity when performing a synchronization. This can be useful in cases where you want have full control over the download phase and should be used in combination with the [Sync to Device](sync-to-device) action.
+* **All Objects** — download all objects applying the regular security constraints
+* **By XPath** — only download the objects which match the [XPath Constraints](xpath-constraints) in addition to the regular security constraints
+* **Nothing (clear data)** — do not download any objects automatically, but do clear the data stored in the database for this entity when performing a synchronization (this can be useful in cases where the objects should only be uploaded, for example a `Feedback` entity)
+* **Nothing (preserve data)** — do not download any objects automatically, and do not clear the data stored in the database for this entity when performing a synchronization  (this can be useful in cases where you want have full control over the download phase and should be used in combination with the [Sync to device](sync-to-device) activity)
 
 If you have custom widgets or JavaScript actions which use an entity that cannot be detected by Studio Pro in your offline-first profile (because its only used in the code), you can use customizable synchronization to include such entities.
 

--- a/content/refguide/sync-to-device.md
+++ b/content/refguide/sync-to-device.md
@@ -61,6 +61,7 @@ sync to device activity will remove it from the offline database, if found.
 
 When adding **Sync to device** to a microflow consider the following:
 
+* This action should be used in combination with the [**Nothing (preserve data)**](offline-first#customizable-synchronization) option to make sure your data is not cleared during a synchronize action
 * Sync to device action works in an append mode, it does not replace all data in the database.
 Any existing data is kept and only objects that are sent to the client are affected.
 * Syncing the same object or list multiple times will sync it only once. The latest commited state will be synced.


### PR DESCRIPTION
Documentation for the new sync config option: "Nothing (preserve data)" that should be used in conjunction with the "Sync to device" action.