### PR TITLE
Adding service node

### DIFF
--- a/content/howto/mobile/setting-up-native-push-notifications.md
+++ b/content/howto/mobile/setting-up-native-push-notifications.md
@@ -127,15 +127,20 @@ android:launchMode="singleTop"
 
 ```
 <application ...>
-<receiver android:name="io.invertase.firebase.notifications.RNFirebaseNotificationReceiver"/>
-<receiver android:enabled="true" android:exported="true"  android:name="io.invertase.firebase.notifications.RNFirebaseNotificationsRebootReceiver">
+ <receiver android:name="io.invertase.firebase.notifications.RNFirebaseNotificationReceiver"/>
+ <receiver android:enabled="true" android:exported="true"  android:name="io.invertase.firebase.notifications.RNFirebaseNotificationsRebootReceiver">
   <intent-filter>
     <action android:name="android.intent.action.BOOT_COMPLETED"/>
     <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
     <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
     <category android:name="android.intent.category.DEFAULT" />
   </intent-filter>
-</receiver>
+ </receiver>
+ <service android:name="io.invertase.firebase.messaging.RNFirebaseMessagingService">
+  <intent-filter>
+   <action android:name="com.google.firebase.MESSAGING_EVENT" />
+  </intent-filter>
+ </service>
 </application>
 ```
 


### PR DESCRIPTION
The <service> node is missing in the text, even though it is shown in the image. Leaving out this part causes the OnReceive event of the Notifications widget not to be triggered when the app is in the foreground. Adding the <service> node, as it is shown in the image, resolves this issue. The <service> node was listed in an older version of this document, but probably got deleted by accident.
See also ticket #101377.