### PR TITLE
Trends V4 Change references to CPU credits to IOPS credits

### DIFF
--- a/content/developerportal/operate/trends-v4.md
+++ b/content/developerportal/operate/trends-v4.md
@@ -354,19 +354,19 @@ Value | Explanation
 **read** | Read ops on the disk holding the database. 
 **write** | Write ops on the disk holding the database.
 
-### 5.11 Database Burst Balance {#Trends-appmxdatabaseburstbalance}
+### 5.11 Database Burst Balance {#Trends-dbmxdatabaseburstbalance}
 
-The **Database burst balance** graph shows the number of credits accrued to support burstable performance. The metric is expressed as percentage; 100% means that the volume has accumulated the maximum number of credits.
+The **Database burst balance** graph shows the number of IOPS credits accrued to support burstable performance. The metric is expressed as percentage; 100% means that the volume has accumulated the maximum number of credits.
 
 ![](attachments/trends-v4/db-burst-balance.png)
 
 Apps running on Mendix Cloud V4 use AWS databases to store their data. These databases are **burstable**, which means that it has a specified performance baseline. See the AWS document [Overview of Monitoring Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MonitoringOverview.html) for more information.
 
-From the AWS documentation: *If a burstable performance instance uses fewer CPU resources than is required for baseline performance (such as when it is idle), the unspent CPU credits are accrued in the CPU credit balance. If a burstable performance instance needs to burst above the baseline performance level, it spends the accrued credits. The more credits that a burstable performance instance has accrued, the more time it can burst beyond its baseline when more performance is needed.*
+Burstable performance means that if you use fewer IOPS than is required for baseline performance (such as when it is idle), the unspent IOPS credits are accrued until they reach a maximum. If a burstable performance instance needs to burst above the baseline performance level, it spends the accrued credits. The more credits that a burstable performance instance has accrued, the more time it can burst beyond its baseline when more performance is needed.*
 
 You can find more details about the credit system in the official AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html.
 
-If your database uses a lot of CPU resources over a sustained period, this may impact your app's performance. If your database burst balance reduces consistently, you will need to ensure that there are periods when there is less activity so that the database burst balance can be restored.
+If your database uses a high level of IOPS over a sustained period, this may impact your app's performance. If your database burst balance reduces consistently, you will need to ensure that there are periods when there is less activity so that the database burst balance can be restored.
 
 For more information, see the *AWS Database blog* [Understanding Burst vs. Baseline Performance with Amazon RDS and GP2](https://aws.amazon.com/blogs/database/understanding-burst-vs-baseline-performance-with-amazon-rds-and-gp2/).
 

--- a/content/developerportal/operate/trends-v4.md
+++ b/content/developerportal/operate/trends-v4.md
@@ -354,9 +354,9 @@ Value | Explanation
 **read** | Read ops on the disk holding the database. 
 **write** | Write ops on the disk holding the database.
 
-### 5.11 Database Burst Balance {#Trends-dbmxdatabaseburstbalance}
+### 5.11 Database IOPS Burst Balance {#Trends-dbmxdatabaseburstbalance}
 
-The **Database burst balance** graph shows the number of IOPS credits accrued to support burstable performance. The metric is expressed as percentage; 100% means that the volume has accumulated the maximum number of credits.
+The **Database IOPS burst balance** graph shows the number of IOPS credits accrued to support burstable performance. The metric is expressed as percentage; 100% means that the volume has accumulated the maximum number of credits.
 
 ![](attachments/trends-v4/db-burst-balance.png)
 
@@ -364,7 +364,7 @@ Apps running on Mendix Cloud V4 use AWS databases to store their data. These dat
 
 Burstable performance means that if you use fewer IOPS than is required for baseline performance (such as when it is idle), the unspent IOPS credits are accrued until they reach a maximum. If a burstable performance instance needs to burst above the baseline performance level, it spends the accrued credits. The more credits that a burstable performance instance has accrued, the more time it can burst beyond its baseline when more performance is needed.*
 
-You can find more details about the credit system in the official AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html.
+You can find more details about the credit system in the official AWS documentation: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MonitoringOverview.html.
 
 If your database uses a high level of IOPS over a sustained period, this may impact your app's performance. If your database burst balance reduces consistently, you will need to ensure that there are periods when there is less activity so that the database burst balance can be restored.
 

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -14,13 +14,13 @@ These release notes cover changes to [Mendix Cloud](/developerportal/deploy/mend
 
 #### Mendix Cloud **v4**
 
-* We introduced a new graph in the **Trends** metrics for Mendix Cloud v4. This shows the **database burst balance**. See [Database Burst Balance](/developerportal/operate/trends-v4#Trends-appmxdatabaseburstbalance) in the *Trends in Mendix Cloud v4* document for more information.
+* We introduced a new graph in the **Trends** metrics for Mendix Cloud v4. This shows the **database burst balance**. See [Database Burst Balance](/developerportal/operate/trends-v4#Trends-dbmxdatabaseburstbalance) in the *Trends in Mendix Cloud v4* document for more information.
 * In Mendix Cloud v4 we introduced changes to the Access Restriction Profile (ARP) Certificate Authorities (CAs). These changes allow you to:
     * Have stricter access restrictions by allowing the selection of intermediate certificates instead of the root
     * Use different root certificates for each path
         {{% alert type="info" %}}Existing configurations will not be changed and environments can be restarted safely.<br/><br/>To migrate to the new ARPs, you must remove **all** existing ARPs and replace them with *clones* that you have edited using the latest Developer Portal.<br/>In other words **Clone** the existing ARPs, **Edit** the CAs, and **Apply** the new ARPs to all paths.{{% /alert %}}
         For more information see [How To Restrict Access for Incoming Requests](/developerportal/deploy/access-restrictions).
-        
+
     You will need to redeploy your app in order to apply the new ARP(s).
 
 ### May 1st, 2020


### PR DESCRIPTION
New graph refers to IOPS credits, not CPU credits.
Also changed anchor.