### PR TITLE
Added extra info to associations in microflows

### DIFF
--- a/content/releasenotes/studio-pro/8.10.md
+++ b/content/releasenotes/studio-pro/8.10.md
@@ -29,6 +29,8 @@ You can always read a value of an object's association in a microflow expression
 
 Today, we are making your life slightly easier. You can now follow the association right inside your expressions by writing `$variable/Module.Association/Module.TargetEntity/Attribute` to get a referenced object's attribute. And you do not have to stop there, because you can follow two or more associations and go wild! You also do not have to check the specific attribute, as you can stop at `$variable/Module.Association/Module.TargetEntity`, which can be handy for verifying that the associated entity exists and is indeed of a `TargetEntity` type.
 
+The usage of this feature will always act like a retrieve by association. That means, if the object is already in the cache, the system will use the cached version. If the cached version has uncommitted changes, you will get the value from the uncommitted object. If the object is not yet in the cache, the system will retrieve it from the database. If you use this association in multiple actions, the system will only retrieve it from database once and work with the cached version in following expressions.
+
 For now, this feature is available only in microflows and rules, but not in nanoflows or on pages.
 
 ### Improvements

--- a/content/releasenotes/studio-pro/8.10.md
+++ b/content/releasenotes/studio-pro/8.10.md
@@ -29,7 +29,7 @@ You can always read a value of an object's association in a microflow expression
 
 Today, we are making your life slightly easier. You can now follow the association right inside your expressions by writing `$variable/Module.Association/Module.TargetEntity/Attribute` to get a referenced object's attribute. And you do not have to stop there, because you can follow two or more associations and go wild! You also do not have to check the specific attribute, as you can stop at `$variable/Module.Association/Module.TargetEntity`, which can be handy for verifying that the associated entity exists and is indeed of a `TargetEntity` type.
 
-The usage of this feature will always act like a retrieve by association. That means, if the object is already in the cache, the system will use the cached version. If the cached version has uncommitted changes, you will get the value from the uncommitted object. If the object is not yet in the cache, the system will retrieve it from the database. If you use this association in multiple actions, the system will only retrieve it from database once and work with the cached version in following expressions.
+Usage of this feature always acts like a retrieve by association. This means that if the object is already in the cache, the system will use the cached version. If the cached version has uncommitted changes, you will get the value from the uncommitted object. If the object is not yet in the cache, the system will retrieve it from the database. If you use this association in multiple actions, the system will only retrieve it from database once and work with the cached version in following expressions.
 
 For now, this feature is available only in microflows and rules, but not in nanoflows or on pages.
 


### PR DESCRIPTION
I added some extra information to the associations in microflows section. This info is extremely important for developers. A developer needs to know if this is using the DB version or the cached version (including uncommitted changes).
It is also important to know the retrieve behaviour, because this can affect the performance of the application.