### PR TITLE
Release notes for Private Cloud Mendix Agent 1.1.1.

### DIFF
--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -131,7 +131,7 @@ Upgrading the Mendix Gateway Agent is only possible if the cluster was originall
 
 {{% /alert %}}
 
-Before upgrading to the Mendix Gateway Agent v1.1.1, first [upgrade](#operator-latest) the Mendix Operator to version v1.1.0
+Before upgrading to the Mendix Gateway Agent v1.1.1, first [upgrade](#operator-latest) the Mendix Operator to version v1.1.1
 and set the `OPERATOR_NAMESPACE` variable in your Bash terminal as described above.
 
 Run the following command to switch to the Mendix Agent version 1.1.1:

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -12,7 +12,7 @@ This document describes how an existing installation of Mendix for Private Cloud
 
 ## 2 Upgrade steps
 
-### 2.1 Upgrading to Mendix Operator v1.1.0{#operator-v1.1.0}
+### 2.1 Upgrading to Mendix Operator v1.1.0{#operator-latest}
 
 This process will take about 15 to 30 minutes.
 During the upgrade process, the Mendix Operator will have to be stopped and will not process any changes.
@@ -121,7 +121,7 @@ kubectl -n $OPERATOR_NAMESPACE delete --all statefulsets
 
 These StatefulSets were replaced with deployments when the new version of the Operator was started.
 
-### 2.2 Upgrading to Mendix Gateway Agent v1.1.0{#agent-v1.1.0}
+### 2.2 Upgrading to Mendix Gateway Agent v1.1.1{#agent-latest}
 
 {{% alert type="info" %}}
 
@@ -131,11 +131,11 @@ Upgrading the Mendix Gateway Agent is only possible if the cluster was originall
 
 {{% /alert %}}
 
-Before upgrading to the Mendix Gateway Agent v1.1.0, first [upgrade](#operator-v1.1.0) the Mendix Operator to version v1.1.0
+Before upgrading to the Mendix Gateway Agent v1.1.1, first [upgrade](#operator-latest) the Mendix Operator to version v1.1.0
 and set the `OPERATOR_NAMESPACE` variable in your Bash terminal as described above.
 
-Run the following command to switch to the Mendix Operator version 1.1.0:
+Run the following command to switch to the Mendix Agent version 1.1.1:
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-agent -p \
-  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-agent","image":"quay.io/digital_ecosystems/kubernetes-agent:1.1.0"}]}}}}'
+  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-agent","image":"quay.io/digital_ecosystems/kubernetes-agent:1.1.1"}]}}}}'
 ```

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -10,11 +10,19 @@ These release notes cover changes to [Mendix Cloud](/developerportal/deploy/mend
 
 ## 2020
 
+### June 10th, 2020
+
+#### Mendix for Private Cloud — Mendix Gateway Agent v1.1.1
+
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#agent-latest).
+
+* We have fixed a regression which caused unusually high CPU usage.
+
 ### June 8th, 2020
 
 #### Mendix for Private Cloud — Mendix Operator v1.1.0
 
-To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-v1.1.0).
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
 
 * Mendix apps now run as Kubernetes Deployments instead of StatefulSets. This will allow you to use rolling updates, reducing downtime. In addition, this helps avoid situations where a StatefulSet might become stuck and stop processing any changes.
 * We now allow you to set Kubernetes resource requirements in addition to resource limits. Apps no longer require the maximum amount of CPU and memory, improving utilization of cluster resources.
@@ -26,7 +34,7 @@ To upgrade an existing installation of Private Cloud to this version, follow the
 
 #### Mendix for Private Cloud — Mendix Gateway Agent v1.1.0
 
-To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#agent-v1.1.0).
+To upgrade an existing installation of Private Cloud to the latest version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#agent-latest).
 
 * We have improved the reliability of event processing and cluster authentication.
 


### PR DESCRIPTION
We found a regression in the Agent 1.1.0 released on Monday and would like to have release a hotfix (1.1.1) on Wednesday.
* Added release notes for Agent 1.1.1
* Recommending customers to upgrade to latest version of Operator & Agent - instead of allowing to switch to any version
