### PR TITLE
Release notes for Private Cloud Operator 1.1.1

### DIFF
--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -182,7 +182,7 @@ When you reconfigure your namespace with databases or storage, you will add new 
 You can return to this initial question from any of the other questions by choosing the option **Go back to the start** where it is available.
 
 {{% alert type="info" %}}
-At the moment, the configuration script does not validate input values. Configuration can be verified by deploying by deploying a sample app.
+The configuration script does not currently validate input values. Configuration can be verified by deploying a sample app.
 {{% /alert %}}
 
 #### 3.4.2 Pick a database type
@@ -192,15 +192,15 @@ At the moment, the configuration script does not validate input values. Configur
 **Postgres** will enable you to enter the values to configure a PostgreSQL database. You will need to provide all the information about your PostgreSQL database such as plan name, host, port, database, user, and password.
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists, you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-To connect to an Azure PostgreSQL server, the _Enforce SSL connection_ option has to be disabled and the Kubernetes cluster should be added to the list of allowed hosts in the firewall. For the database name, use `postgres`.
+To connect to an Azure PostgreSQL server, the `Enforce SSL connection` option has to be disabled and the Kubernetes cluster must be added to the list of allowed hosts in the firewall. For the database name, use `postgres`.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-To connect to an Amazon RDS database, the VPC and firewall should be configured to allow connections to the database from the Kubernetes cluster.
+To connect to an Amazon RDS database, the VPC and firewall must be configured to allow connections to the database from the Kubernetes cluster.
 {{% /alert %}}
 
 **Ephemeral** will enable you to quickly set up your environment and deploy your app, but any data you store in the database will be lost when you restart your environment.
@@ -208,29 +208,29 @@ To connect to an Amazon RDS database, the VPC and firewall should be configured 
 **SQL Server** will enable you to enter the values to configure a Microsoft SQL Server database. You will need to provide all the information about your SQL Server database such as plan name, host, port, user, and password. 
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-To connect to an Azure PostgreSQL server, the Kubernetes cluster should be added to the list of allowed hosts in the firewall.
+To connect to an Azure PostgreSQL server, the Kubernetes cluster must be added to the list of allowed hosts in the firewall.
 {{% /alert %}}
 
 {{% alert type="info" %}}
 For Azure SQL databases, additional parameters are required to specify the database elastic pool name, tier, service objective and maximum size.
 {{% /alert %}}
 
-**Dedicated JDBC** will enable you to enter the [database configuration parameters](/refguide/custom-settings) for an existing database directly as supported by the Mendix Runtime.
+**Dedicated JDBC** will enable you to enter the [database configuration parameters](/refguide/custom-settings) for an existing database directly, as supported by the Mendix Runtime.
 
 {{% alert type="info" %}}
 A dedicated JDBC database cannot be used by more than one Mendix app.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+Configuration parameters will not be validated and will be provided to the Mendix app as-is. If the arguments are not valid or there is an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
@@ -244,6 +244,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 **Minio** will connect to a [MinIO](https://min.io/product/overview) S3-compatible object storage. You will need to provide all the information about your MinIO storage such as endpoint, access key, and secret key. The MinIO server needs to be a full-featured MinIO server and not a [MinIO Gateway](https://github.com/minio/minio/tree/master/docs/gateway).
 
 **S3 (create on-demand)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+
 ```json
 {
     "Version": "2012-10-17",
@@ -277,10 +278,11 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 ```
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 **S3 (existing bucket)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+
 ```json
 {
   "Version": "2012-10-17",
@@ -303,19 +305,19 @@ If the plan name already exists you will receive an error that it cannot be crea
 ```
 
 {{% alert type="info" %}}
-Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+Configuration parameters will not be validated and will be provided to the Mendix app as-is. If the arguments are not valid or there is an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 {{% /alert %}}
 
 {{% alert type="info" %}}
 
-If you select _Yes_ to the _Can this storage be used by multiple environments?_ question, all environments using that Storage Plan will be using the same Access and Secret keys and will have identical permissions. 
-Each app will be writing into its own directory inside the bucket.
+If you select *Yes* to the *Can this storage be used by multiple environments?* question, all environments using that Storage Plan will use the same Access and Secret keys and will have identical permissions. 
+Each app will write into its own directory inside the bucket.
 
-To avoid compromising security, answer _No_ to the _Can this storage be used by multiple environments?_ question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
+To avoid compromising security, answer *No* to the *Can this storage be used by multiple environments?* question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
@@ -325,20 +327,20 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 **Azure Blob storage Container (existing)** will connect to an existing Azure Blob storage Container with the provided storage account name and key. All apps will use the same Container bucket and account credentials. You will need to provide all the information about your Azure Blob storage such as plan name, account name, account key, and container name.
 
 {{% alert type="info" %}}
-Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+Configuration parameters will not be validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 {{% /alert %}}
 
 {{% alert type="info" %}}
 
-If you select _Yes_ to the _Can this storage be used by multiple environments?_ question, all environments using that Storage Plan will be using the same account name and account keys keys and will have identical permissions.
-All apps using will write into the same Azure Blob storage Container into its root directory.
+If you select *Yes* to the *Can this storage be used by multiple environments?* question, all environments using that Storage Plan will be using the same account name and account keys keys and will have identical permissions.
+All apps using will write into the root directory of same Azure Blob storage Container.
 
-To avoid compromising security, answer _No_ to the _Can this storage be used by multiple environments?_ question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
+To avoid compromising security, answer *No* to the *Can this storage be used by multiple environments?* question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
 
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -191,7 +191,35 @@ You can return to this initial question from any of the other questions by choos
 If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
+{{% alert type="info" %}}
+To connect to an Azure PostgreSQL server, the _Enforce SSL connection_ option has to be disabled and the Kubernetes cluster should be added to the list of allowed hosts in the firewall. For the database name, use `postgres`.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To connect to an Amazon RDS database, the VPC and firewall should be configured to allow connections to the database from the Kubernetes cluster.
+{{% /alert %}}
+
 **Ephemeral** will enable you to quickly set up your environment and deploy your app, but any data you store in the database will be lost when you restart your environment.
+
+**SQL Server** will enable you to enter the values to configure a Microsoft SQL Server database. You will need to provide all the information about your SQL Server database such as plan name, host, port, database, user, and password. 
+
+{{% alert type="info" %}}
+For Azure SQL databases, additional parameters are required to specify the database elastic pool name, tier, service objective and maximum size.
+{{% /alert %}}
+
+**Dedicated JDBC** will enable you to enter the [database configuration parameters](/refguide/custom-settings) for an existing database directly as supported by the Mendix Runtime.
+
+{{% alert type="info" %}}
+A dedicated JDBC database cannot be used by more than one Mendix app.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.1.0 or later.
+{{% /alert %}}
 
 #### 3.4.3 Pick a storage type
 
@@ -199,7 +227,7 @@ If the plan already exists you will receive an error that it cannot be created. 
 
 **Minio** will connect to a [MinIO](https://min.io/product/overview) S3-compatible object storage. You will need to provide all the information about your MinIO storage such as endpoint, access key, and secret key. The MinIO server needs to be a full-featured MinIO server and not a [MinIO Gateway](https://github.com/minio/minio/tree/master/docs/gateway).
 
-**Amazon S3** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+**Amazon S3 (on-demand)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 ```json
 {
     "Version": "2012-10-17",
@@ -234,6 +262,64 @@ If the plan already exists you will receive an error that it cannot be created. 
 
 {{% alert type="info" %}}
 If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+{{% /alert %}}
+
+**Amazon S3 (existing bucket)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps app will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<bucket_name>/*"
+      ]
+    }
+  ]
+}
+```
+
+{{% alert type="info" %}}
+If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same Access and Secret keys and will have identical permissions.
+
+Each environment will be writing into its own directory inside the bucket.
+
+To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.1.0 or later.
+{{% /alert %}}
+
+**Azure Blob storage Container (existing)** will connect to an existing Azure Blob storage Container with the provided storage account name and key. All apps app will use the same Container bucket and account credentials. You will need to provide all the information about your Amazon S3 storage such as plan name, account name, account key, and container name.
+
+{{% alert type="info" %}}
+
+If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same account name and account keys keys and will have identical permissions.
+
+All apps using this storage plan will write into the same Azure Blob storage Container into its root directory.
+
+To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+
+{{% /alert %}}
+
+{{% alert type="info" %}}
+If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.1.0 or later.
 {{% /alert %}}
 
 **Ephemeral** will enable you to quickly set up your environment and deploy your app, but any data objects you store will be lost when you restart your environment.
@@ -462,32 +548,6 @@ This section covers an issue which can arise where Mendix cannot recover automat
 ### 6.1 Status Reporting
 
 Under some circumstances changes in the status of the cluster, namespaces, and environments will not be updated automatically. To ensure you are seeing the current status, you may need to click the **Refresh** button on the screen (not the browser page refresh button).
-
-### 6.2 Agent Connection Status Not up to Date
-
-The namespace status may show as `Waiting for Connection`, even though the Agent is actually connected to the namespace. The Agent needs to be restarted to force it to reconnect.
-
-Run the following command in the namespace where the Mendix Operator is deployed:
-
-#### 6.2.1 OpenShift
-
-First go to the namespace using the command `oc config set-context --current --namespace={namespace}`, using the name of your namespace.
-
-```bash
-oc scale deployment mendix-agent --replicas=0 && \
-sleep 200 && \
-oc scale deployment mendix-agent --replicas=1
-
-```
-#### 6.2.2 Kubernetes
-
-First go to the namespace using the command `kubectl config set-context --current --namespace={namespace}`, using the name of your namespace.
-
-```bash
-kubectl scale deployment mendix-agent --replicas=0 && \
-sleep 200 && \
-kubectl scale deployment mendix-agent --replicas=1
-```
 
 ## 7 Containerized Mendix App Architecture{#containerized-architecture}
 

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -181,6 +181,10 @@ When you reconfigure your namespace with databases or storage, you will add new 
 
 You can return to this initial question from any of the other questions by choosing the option **Go back to the start** where it is available.
 
+{{% alert type="info" %}}
+At the moment, the configuration script does not validate input values. Configuration can be verified by deploying by deploying a sample app.
+{{% /alert %}}
+
 #### 3.4.2 Pick a database type
 
 ![](attachments/private-cloud-cluster/image17.png)
@@ -188,7 +192,7 @@ You can return to this initial question from any of the other questions by choos
 **Postgres** will enable you to enter the values to configure a PostgreSQL database. You will need to provide all the information about your PostgreSQL database such as plan name, host, port, database, user, and password.
 
 {{% alert type="info" %}}
-If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
@@ -201,7 +205,15 @@ To connect to an Amazon RDS database, the VPC and firewall should be configured 
 
 **Ephemeral** will enable you to quickly set up your environment and deploy your app, but any data you store in the database will be lost when you restart your environment.
 
-**SQL Server** will enable you to enter the values to configure a Microsoft SQL Server database. You will need to provide all the information about your SQL Server database such as plan name, host, port, database, user, and password. 
+**SQL Server** will enable you to enter the values to configure a Microsoft SQL Server database. You will need to provide all the information about your SQL Server database such as plan name, host, port, user, and password. 
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To connect to an Azure PostgreSQL server, the Kubernetes cluster should be added to the list of allowed hosts in the firewall.
+{{% /alert %}}
 
 {{% alert type="info" %}}
 For Azure SQL databases, additional parameters are required to specify the database elastic pool name, tier, service objective and maximum size.
@@ -214,7 +226,11 @@ A dedicated JDBC database cannot be used by more than one Mendix app.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
@@ -227,7 +243,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 **Minio** will connect to a [MinIO](https://min.io/product/overview) S3-compatible object storage. You will need to provide all the information about your MinIO storage such as endpoint, access key, and secret key. The MinIO server needs to be a full-featured MinIO server and not a [MinIO Gateway](https://github.com/minio/minio/tree/master/docs/gateway).
 
-**Amazon S3 (on-demand)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+**S3 (create on-demand)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 ```json
 {
     "Version": "2012-10-17",
@@ -261,10 +277,10 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 ```
 
 {{% alert type="info" %}}
-If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
-**Amazon S3 (existing bucket)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps app will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+**S3 (existing bucket)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
 ```json
 {
   "Version": "2012-10-17",
@@ -287,35 +303,42 @@ If the plan already exists you will receive an error that it cannot be created. 
 ```
 
 {{% alert type="info" %}}
-If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same Access and Secret keys and will have identical permissions.
-
-Each environment will be writing into its own directory inside the bucket.
-
-To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+
+If you select _Yes_ to the _Can this storage be used by multiple environments?_ question, all environments using that Storage Plan will be using the same Access and Secret keys and will have identical permissions. 
+Each app will be writing into its own directory inside the bucket.
+
+To avoid compromising security, answer _No_ to the _Can this storage be used by multiple environments?_ question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.1.0 or later.
 {{% /alert %}}
 
-**Azure Blob storage Container (existing)** will connect to an existing Azure Blob storage Container with the provided storage account name and key. All apps app will use the same Container bucket and account credentials. You will need to provide all the information about your Amazon S3 storage such as plan name, account name, account key, and container name.
+**Azure Blob storage Container (existing)** will connect to an existing Azure Blob storage Container with the provided storage account name and key. All apps will use the same Container bucket and account credentials. You will need to provide all the information about your Azure Blob storage such as plan name, account name, account key, and container name.
+
+{{% alert type="info" %}}
+Configuration parameters will not validated and will be provided to the Mendix app as-is. If the arguments are not valid or there's an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+{{% /alert %}}
 
 {{% alert type="info" %}}
 
-If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same account name and account keys keys and will have identical permissions.
+If you select _Yes_ to the _Can this storage be used by multiple environments?_ question, all environments using that Storage Plan will be using the same account name and account keys keys and will have identical permissions.
+All apps using will write into the same Azure Blob storage Container into its root directory.
 
-All apps using this storage plan will write into the same Azure Blob storage Container into its root directory.
-
-To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+To avoid compromising security, answer _No_ to the _Can this storage be used by multiple environments?_ question. This way, only one app will be able to use this Storage Plan, and attaching another app to the same storage plan will not be possible.
 
 {{% /alert %}}
 
 {{% alert type="info" %}}
-If the plan already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, which will now have the new configuration.
 {{% /alert %}}
 
 {{% alert type="info" %}}

--- a/content/developerportal/deploy/private-cloud-deploy.md
+++ b/content/developerportal/deploy/private-cloud-deploy.md
@@ -472,36 +472,6 @@ This section covers an issue which can arise where Mendix cannot recover automat
 
 Under some circumstances changes in the status of the environment and its apps will not be updated automatically. To ensure you are seeing the current status, you may need to click the **Refresh** button on the screen (not the browser page refresh button).
 
-### 7.2 Agent Connection Status Not up to Date
-
-Under certain conditions, the status of an environment in the Portal might become outdated and not reflect the environment state in the namespace. The Agent needs to be restarted to force it to resend the latest environment state to the Portal.
-
-You need to run the following command in the namespace where the Mendix Operator is deployed:
-
-#### 7.2.1 OpenShift
-
-First go to the namespace using the command `oc config set-context --current --namespace={namespace}`, using the name of your namespace.
-
-Now run the following command.
-
-```bash
-oc scale deployment mendix-agent --replicas=0 && \
-sleep 200 && \
-oc scale deployment mendix-agent --replicas=1
-
-```
-#### 7.2.2 Kubernetes
-
-First go to the namespace using the command `kubectl config set-context --current --namespace={namespace}`, using the name of your namespace.
-
-Now run the following command.
-
-```bash
-kubectl scale deployment mendix-agent --replicas=0 && \
-sleep 200 && \
-kubectl scale deployment mendix-agent --replicas=1
-```
-
 ## 8 How the Operator Deploys Your App {#how-operator-deploys}
 
 The Mendix Operator is another app within your private cloud namespace. It is triggered when you provide a CR file. The process looks like this:

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -76,6 +76,8 @@ The local image registry can be used in an OpenShift cluster. It is not possible
 
 Image pull authentication will be configured out of the box.
 
+OpenShift 4 registries doesn't need any configuration and will be configured automatically.
+
 For an OpenShift 3 registry, the pull URL should be set to `docker-registry.default.svc:5000`.
 The push URL should be set to `<registry ip>:5000` where `<registry ip>` can be obtained by running `oc get svc docker-registry -n default`.
 
@@ -115,12 +117,13 @@ The following managed PostgreSQL databases are supported:
 
 * [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) 
 * [Amazon Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/)
+* [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/).
 
 Amazon PostgreSQL instances require additional firewall configuration to allow connections from the Kubernetes cluster.
 
-Some managed PostgreSQL databases might have restrictions or require additional configuration.
+Azure PostgreSQL databases require additional firewall configuration and SSL to be disabled to allow connections from the Kubernetes cluster.
 
-[Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/) is not supported at the moment.
+Some managed PostgreSQL databases might have restrictions or require additional configuration.
 
 {{% alert type="info" %}}
 To use a PostgreSQL database, the Mendix Operator requires a master account with permissions to create new users and databases.
@@ -129,6 +132,7 @@ For every Mendix app environment, a new database schema and user (role) will be 
 {{% /alert %}}
 
 These features are currently not supported:
+
 * SSL/TLS
 * Custom CAs for SSL/TLS
 
@@ -151,6 +155,14 @@ Some managed SQL Server databases might have restrictions or require additional 
 To use a SQL Server database, the Mendix Operator requires a master account with permissions to create new users and databases.
 
 For every Mendix app environment, a new database, user and login will be created so that the app can only access its own data.
+{{% /alert %}}
+
+### 4.4 Dedicated JDBC database
+
+This allows to use an existing database (schema) [database configuration parameters](/refguide/custom-settings) directly as supported by the Mendix Runtime.
+
+{{% alert type="info" %}}
+A dedicated JDBC database cannot be used by more than one Mendix app.
 {{% /alert %}}
 
 ## 5 File storage
@@ -181,6 +193,8 @@ MinIO Gateway is not supported since running MinIO in gateway mode disables the 
 ### 5.3 Amazon S3
 
 [Amazon S3](https://aws.amazon.com/s3/) is supported.
+
+#### 5.3.1 Amazon S3 (create on-demand)
 
 {{% alert type="info" %}}
 For every Mendix app environment, a new bucket, IAM user and inline policy will be created so that the app can only access its own bucket.
@@ -219,6 +233,20 @@ To use S3, the Mendix Operator will need an IAM account with the following polic
     ]
 }
 ```
+
+### 5.3.2 Amazon S3 (existing bucket)
+
+The Mendix Operator can access an existing S3 bucket, with an existing IAM account access and secret key.
+
+{{% alert type="info" %}}
+
+If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same Access and Secret keys and will have identical permissions.
+
+Each environment will be writing into its own directory inside the bucket.
+
+To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+
+{{% /alert %}}
 
 ## 6 Networking
 

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -76,7 +76,7 @@ The local image registry can be used in an OpenShift cluster. It is not possible
 
 Image pull authentication will be configured out of the box.
 
-OpenShift 4 registries doesn't need any configuration and will be configured automatically.
+OpenShift 4 registries don't need any configuration and will be configured automatically.
 
 For an OpenShift 3 registry, the pull URL should be set to `docker-registry.default.svc:5000`.
 The push URL should be set to `<registry ip>:5000` where `<registry ip>` can be obtained by running `oc get svc docker-registry -n default`.
@@ -159,7 +159,7 @@ For every Mendix app environment, a new database, user and login will be created
 
 ### 4.4 Dedicated JDBC database
 
-This allows to use an existing database (schema) [database configuration parameters](/refguide/custom-settings) directly as supported by the Mendix Runtime.
+This allows you to use an existing database (schema) [database configuration parameters](/refguide/custom-settings) directly as supported by the Mendix Runtime.
 
 {{% alert type="info" %}}
 A dedicated JDBC database cannot be used by more than one Mendix app.
@@ -240,11 +240,11 @@ The Mendix Operator can access an existing S3 bucket, with an existing IAM accou
 
 {{% alert type="info" %}}
 
-If such Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same Access and Secret keys and will have identical permissions.
+If such a Storage Plan is shared by multiple environments, all environments using that Storage Plan be using the same Access and Secret keys and will have identical permissions.
 
 Each environment will be writing into its own directory inside the bucket.
 
-To avoid compromising security, this type of plan should not be allowed to be used by multiple environments.
+To avoid compromising security, this type of plan should not be used by multiple environments.
 
 {{% /alert %}}
 

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -147,7 +147,7 @@ These StatefulSets were replaced with deployments when the new version of the Op
 
 This procedure can only be used to upgrade from Mendix Operator v1.1.* to the latest version.
 
-To upgrade from Mendix Operator v1.0.* to the latest version, follow the [upgrade guide](#from-operator-1.0.x).
+To upgrade from Mendix Operator v1.0.* to the latest version, follow the [upgrade guide](#from-operator-1.0.x) above.
 
 {{% /alert %}}
 

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -10,15 +10,11 @@ tags: ["Upgrade", "Private Cloud", "Cluster", "Operator", "Deploy"]
 
 This document describes how an existing installation of Mendix for Private Cloud can be upgraded to the latest version.
 
-## 2 Upgrade steps
+Both the Mendix Operator and Mendix Agent should be upgraded at the same time.
 
-### 2.1 Upgrading to Mendix Operator v1.1.0{#operator-latest}
+## 2 Upgrading to Mendix Operator v1.1.1{#operator-latest}
 
-This process will take about 15 to 30 minutes.
-During the upgrade process, the Mendix Operator will have to be stopped and will not process any changes.
-Apps and Environments managed by the Operator will keep running during this process and will be restarted in the cleanup step.
-
-#### 2.1.1 Preparation
+### 2.1 Preparation
 
 Open a Bash-compatible terminal and set the target namespace where the Operator is currently installed:
 
@@ -28,7 +24,31 @@ OPERATOR_NAMESPACE={namespace where the Mendix Operator is installed}
 
 All the following commands require the `OPERATOR_NAMESPACE` variable to be set. When opening a new terminal, re-run this command again.
 
-#### 2.1.2 Stop the Operator
+Check the current version of the Operator by running the following command:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE get deployment mendix-operator -o=jsonpath='{.spec.template.spec.containers[].image}' 
+```
+
+* If the image name looks similar to `quay.io/digital_ecosystems/mendix-operator:1.1.{NUMBER}`, follow the upgrade guide from [Mendix Operator v1.1.*](#from-operator-1.1.x).
+
+* If the image name looks similar to `quay.io/digital_ecosystems/mendix-operator:1.0.{NUMBER}`, follow the upgrade guide from [Mendix Operator v1.0.*](#from-operator-1.0.x).
+
+### 2.2 Upgrading from Mendix Operator v1.0.*{#from-operator-1.0.x}
+
+{{% alert type="warning" %}}
+
+This procedure is only required when upgrading from Mendix Operator v1.0.* to the latest version.
+
+To upgrade from Mendix Operator v1.1.* to the latest version, follow the [simplified upgrade guide](#from-operator-1.1.x).
+
+{{% /alert %}}
+
+This process will take about 15 to 30 minutes.
+During the upgrade process, the Mendix Operator will have to be stopped and will not process any changes.
+Apps and Environments managed by the Operator will keep running during this process and will be restarted in the cleanup step.
+
+#### 2.2.1 Stop the Operator
 
 To stop the Operator, run the following command:
 
@@ -36,7 +56,7 @@ To stop the Operator, run the following command:
 kubectl -n $OPERATOR_NAMESPACE scale deployment mendix-operator --replicas=0
 ```
 
-#### 2.1.3 Upgrading the CRDs
+#### 2.2.2 Upgrading the CRDs
 
 Run the following command to upgrade to the latest version of CRDs:
 
@@ -44,16 +64,16 @@ Run the following command to upgrade to the latest version of CRDs:
 kubectl apply -f https://installergen.private-cloud.api.mendix.com/privatecloud/crds/v1
 ```
 
-#### 2.1.4 Upgrading the Mendix Operator Deployment
+#### 2.2.3 Upgrading the Mendix Operator Deployment
 
-Run the following command to switch to Mendix Operator version 1.1.0:
+Run the following command to switch to Mendix Operator version 1.1.1:
 
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-operator -p \
-  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-operator","image":"quay.io/digital_ecosystems/mendix-operator:1.1.0"}]}}}}'
+  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-operator","image":"quay.io/digital_ecosystems/mendix-operator:1.1.1"}]}}}}'
 ```
 
-#### 2.1.5 Updating the Mendix Operator Configuration
+#### 2.2.4 Updating the Mendix Operator Configuration
 
 Run the following commands to switch to the latest component versions:
 
@@ -93,7 +113,7 @@ kubectl -n $OPERATOR_NAMESPACE get storageplan --no-headers=true -o name | sed -
   xargs -I {} kubectl -n $OPERATOR_NAMESPACE patch storageplan {} --type=merge -p '{"spec":{"type":"on-demand"}}'
 ```
 
-#### 2.1.6 Start the Mendix Operator
+#### 2.2.5 Start the Mendix Operator
 
 To start the updated version of the Mendix Operator, run:
 
@@ -111,7 +131,7 @@ The StatefulSets should be cleaned up manually as documented in the [Cleanup pha
 
 {{% /alert %}}
 
-#### 2.1.7 Cleanup Phase{#cleanup-phase}
+#### 2.2.6 Cleanup Phase{#cleanup-phase}
 
 Delete StatefulSets from the Namespace where the Operator was installed:
 
@@ -121,7 +141,30 @@ kubectl -n $OPERATOR_NAMESPACE delete --all statefulsets
 
 These StatefulSets were replaced with deployments when the new version of the Operator was started.
 
-### 2.2 Upgrading to Mendix Gateway Agent v1.1.1{#agent-latest}
+### 2.3 Upgrading from Mendix Operator v1.1.*{#from-operator-1.1.x}
+
+{{% alert type="warning" %}}
+
+This procedure can only be used to upgrade from Mendix Operator v1.1.* to the latest version.
+
+To upgrade from Mendix Operator v1.0.* to the latest version, follow the [upgrade guide](#from-operator-1.0.x).
+
+{{% /alert %}}
+
+This process will take a few minutes.
+During the upgrade process, the Mendix Operator will be restarted.
+Apps and Environments managed by the Operator will be restarted after the upgrade process is completed.
+
+#### 2.3.1 Upgrading the Mendix Operator Deployment
+
+Run the following command to switch to Mendix Operator version 1.1.1:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-operator -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-operator","image":"quay.io/digital_ecosystems/mendix-operator:1.1.1"}]}}}}'
+```
+
+## 3 Upgrading to Mendix Gateway Agent v1.1.1{#agent-latest}
 
 {{% alert type="info" %}}
 
@@ -131,7 +174,7 @@ Upgrading the Mendix Gateway Agent is only possible if the cluster was originall
 
 {{% /alert %}}
 
-Before upgrading to the Mendix Gateway Agent v1.1.1, first [upgrade](#operator-latest) the Mendix Operator to version v1.1.1
+Before upgrading to the Mendix Gateway Agent v1.1.1, first [upgrade](#operator-latest) the Mendix Operator to the latest version
 and set the `OPERATOR_NAMESPACE` variable in your Bash terminal as described above.
 
 Run the following command to switch to the Mendix Agent version 1.1.1:

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -10,6 +10,18 @@ These release notes cover changes to [Mendix Cloud](/developerportal/deploy/mend
 
 ## 2020
 
+### June 19th, 2020
+
+#### Mendix for Private Cloud — Mendix Operator v1.1.1
+
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
+
+* We fixed an issue which incorrectly marked dedicated Storage Plans as being in use.
+* We changed the way the Operator updates Kubernetes Deployments to prevent a situation where two different versions of a Mendix application are running at the same moment.
+* We have added support for Azure PostgreSQL databases.
+* We have added support for using an existing JDBC database schema. This database can only be used by one environment and cannot be shared between environments.
+* We have added support for using an existing Azure Blob Storage Container or S3 bucket. Such a storage plan can be dedicated to one environment, or can be shared between multiple environments, with all environments using the same credentials.
+
 ### June 18th, 2020
 
 #### Mendix for Private Cloud

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -14,13 +14,15 @@ These release notes cover changes to [Mendix Cloud](/developerportal/deploy/mend
 
 #### Mendix for Private Cloud — Mendix Operator v1.1.1
 
-To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
+We released a new version of the Mendix for Private Cloud Operator.
 
 * We fixed an issue which incorrectly marked dedicated Storage Plans as being in use.
 * We changed the way the Operator updates Kubernetes Deployments to prevent a situation where two different versions of a Mendix application are running at the same moment.
 * We have added support for Azure PostgreSQL databases.
 * We have added support for using an existing JDBC database schema. This database can only be used by one environment and cannot be shared between environments.
 * We have added support for using an existing Azure Blob Storage Container or S3 bucket. Such a storage plan can be dedicated to one environment, or can be shared between multiple environments, with all environments using the same credentials.
+
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
 
 ### June 18th, 2020
 


### PR DESCRIPTION
New release of the Mendix Operator:
* new supported databases
* some common questions and remarks for existing databases and file storage
* how to upgrade to the latest Operator

We're hoping to release this on June 19 afternoon.