### PR TITLE
Document change of User Role for Admin(MxAdmin) account

### DIFF
--- a/content/developerportal/deploy/environments-details.md
+++ b/content/developerportal/deploy/environments-details.md
@@ -44,7 +44,7 @@ The view of the **General** tab depends on the Mendix Cloud version on which the
 
 At the bottom of the page there are three overview sections. These are described below in the [Overviews](#overviews) section.
 
-### 2.1 Actions
+### 2.1 Actions{#actions}
 
 On the right side of the screen, you can find the following action buttons:
 
@@ -52,7 +52,7 @@ On the right side of the screen, you can find the following action buttons:
 * **Start/Stop Application**
 * **Clear Environment** *(only visible if your application is stopped)* – this clears, after confirmation, all data from your database and file storage, and removes your app from this environment — you should do this if you want to deploy a different app to this environment, it is not necessary if you are restoring a backup of the same app
 * **Show Logged in Users** 
-* **Change Admin Password** – this changes the password for the local app user `MxAdmin` — the new password is applied immediately, without the need for a restart and will also force the MxAdmin user to pick up any new roles assigned in the app deployment package (see []())
+* **Change Admin Password** – this changes the password for the local [administrator](/refguide/administrator) account — the new password is applied immediately, without the need for a restart and will also force the administrator to pick up any new roles assigned in the app deployment package — see the [User Role](/refguide/administrator#user-role) section of *Administrator* for more information
 
 #### 2.1.1 Logging and Debugging in Mendix Cloud v4
 

--- a/content/developerportal/deploy/environments-details.md
+++ b/content/developerportal/deploy/environments-details.md
@@ -52,7 +52,7 @@ On the right side of the screen, you can find the following action buttons:
 * **Start/Stop Application**
 * **Clear Environment** *(only visible if your application is stopped)* – this clears, after confirmation, all data from your database and file storage, and removes your app from this environment — you should do this if you want to deploy a different app to this environment, it is not necessary if you are restoring a backup of the same app
 * **Show Logged in Users** 
-* **Change Admin Password** – this changes the password for the local [administrator](/refguide/administrator) account — the new password is applied immediately, without the need for a restart and will also force the administrator to pick up any new roles assigned in the app deployment package — see the [User Role](/refguide/administrator#user-role) section of *Administrator* for more information
+* **Change Admin Password** – this changes the password for the inbuilt [administrator](/refguide/administrator) account — the new password is applied immediately, without the need for a restart and will also force the administrator to pick up any new roles assigned in the app deployment package — see the [User Role](/refguide/administrator#user-role) section of *Administrator* for more information
 
 #### 2.1.1 Logging and Debugging in Mendix Cloud v4
 

--- a/content/developerportal/deploy/environments-details.md
+++ b/content/developerportal/deploy/environments-details.md
@@ -52,7 +52,7 @@ On the right side of the screen, you can find the following action buttons:
 * **Start/Stop Application**
 * **Clear Environment** *(only visible if your application is stopped)* – this clears, after confirmation, all data from your database and file storage, and removes your app from this environment — you should do this if you want to deploy a different app to this environment, it is not necessary if you are restoring a backup of the same app
 * **Show Logged in Users** 
-* **Change Admin Password**
+* **Change Admin Password** – this changes the password for the local app user `MxAdmin` — the new password is applied immediately, without the need for a restart and will also force the MxAdmin user to pick up any new roles assigned in the app deployment package (see []())
 
 #### 2.1.1 Logging and Debugging in Mendix Cloud v4
 

--- a/content/refguide/administrator.md
+++ b/content/refguide/administrator.md
@@ -50,11 +50,15 @@ The user role assigned to the Administrator. For more information, see [User Rol
 Default: *Administrator*
 
 {{% alert type="info" %}}
-
 The administrator is always created and has the System.Administrator role by default. The System.Administrator role allows users of your application to be managed. 
-For Free Apps, the user that created the application automatically has this role by default as well so you can use it to manage your users in that environment.
-This role may be helpful in case you have exceeded your user license restriction in which case you can use any user that has this System.Administrator role to sign in to manage your users.
 
+For Free Apps, the user that created the application automatically has this role by default as well so you can use it to manage your users in that environment.
+
+This role may be helpful in case you have exceeded your user license restriction in which case you can use any user that has this System.Administrator role to sign in to manage your users.
+{{% /alert %}}
+
+{{% alert type="warning" %}}
+When your app is not deployed locally, for example to the Mendix Cloud, changes to the user role of the administrator account will not be applied until the administrator password is changed. See the [actions](/developerportal/deploy/environments-details#actions) section of *Environment Detail* for instructions on changing the admin password.
 {{% /alert %}}
 
 ## 3 Read More


### PR DESCRIPTION
Changes of role are only applied when the admin account password is changed.
