### PR TITLE
Fix Dockerfile to account for the default node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,14 @@ RUN dpkg -i /tmp/hugo.deb \
 
 RUN npm i --force -g yarn
 
-# Based on guidance at http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html
-RUN useradd --user-group --create-home app
+# The node docker images by default provides a `node` user as the non-root user.
+# However, as we have configured `app` as the user for our needs, lets
+# update the `node` user's login, homedir and gid to match our custom user.
+# Without these changes, non-root user doesn't match the local host user's uid/gid.
+# More details can be found here:
+# https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
+RUN usermod -d /home/app -l app node
+RUN groupmod -n app node
 
 ENV HOME=/home/app
 WORKDIR $HOME


### PR DESCRIPTION
Node docker images provides a `node` user as the non-root user to run the docker containers.

However as we have configured `app` as the non-root user, it creates an additional user to the container, which doesn't map well to the local host user's uid and gid. Hence we simply modify the login and group details of the `node` user to match the `app` user for our purposes.

---
This PR is mainly to address the following errors I was getting when I tried to test my changes with a docker deployment.
```
app_1 | [16:33:04] [MENU BUILD] Building drafts: no
app_1 | [16:33:04] Starting 'clean:css'...
app_1 | [16:33:04] Starting 'clean:js'...
app_1 | [16:33:04] Finished 'clean:css' after 17 ms
app_1 | [16:33:04] Starting '<anonymous>'...
app_1 | [16:33:04] Finished 'clean:js' after 62 ms
app_1 | [16:33:04] Starting '<anonymous>'...
app_1 | [16:33:11] '<anonymous>' errored after 7.27 s
app_1 | [16:33:11] Error: EACCES: permission denied, mkdir '/home/app/docs/static/public/js'
app_1 | [16:33:11] 'build:js' errored after 7.35 s
app_1 | [16:33:12] The following tasks did not complete: build:menu, build:sass, <anonymous>
app_1 | [16:33:12] Did you forget to signal async completion?
app_1 | [16:33:12] 'serve' errored after 7.4 s
app_1 | error Command failed with exit code 1.
app_1 | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
docs_app_1 exited with code 1
```

I am testing these on an Ubuntu host (basically Ubuntu on WSL2).
Let me know if you would need more details.
