### PR TITLE
Remove use the (optimized) implementation note

### DIFF
--- a/content/refguide/call-web-service-action.md
+++ b/content/refguide/call-web-service-action.md
@@ -103,10 +103,6 @@ Default: *No*
 
 ### 4.7 Proxy Configuration
 
-{{% alert type="info" %}}
-This feature is only available when you have configured web service calls to use the (optimized) implementation in the [project's runtime settings](project-settings).
-{{% /alert %}}
-
 In almost all cases, you can ignore this setting. **Use project settings** is a good default value.
 
 If desired, you can configure whether to use a proxy for the request. These are the choices:


### PR DESCRIPTION
Starting from Mendix 8 `use the (optimized) implementation` setting is no longer required in order to use proxy configuration. The menu options (radiobuttons) will be available immediately.