### PR TITLE
Clarify that regular expression resources can only be used in validation rules

### DIFF
--- a/content/refguide/expressions.md
+++ b/content/refguide/expressions.md
@@ -31,7 +31,7 @@ An overview of the operators which can be used in expressions is shown below.
 
 ### 1.2 Regular Expressions
 
-For details on regular expressions, sub-expressions, and quantifiers, see [Regular Expressions](regular-expressions).
+[Regular Expression](regular-expressions) resource documents cannot be used in expressions. However, the format of regular expressions, sub-expressions, and quantifiers used in regular expression strings used within expressions are the same as those described in the [Expression](regular-expressions#expression) section of *Regular Expressions*.
 
 ## 2 Unary Expressions
 

--- a/content/refguide/modules.md
+++ b/content/refguide/modules.md
@@ -22,7 +22,7 @@ Furthermore, a module can contain many different types of documents. Each type o
 | --- | --- | --- |
 | [Pages](pages) | [Data view](data-view), [Data grid](data-grid), [Table](table), [Text box](text-box) | Forms are used to create a user interface for the end-user. They are composed of components that are called widgets. |
 | [Microflows](microflows) | [Activities](activities), [Sequence Flow](sequence-flow) | Microflows describe the the logic of your application. They are composed of activities that manipulate objects, interact with the client etcetera. |
-| [Enumerations](enumerations) |   | An enumeration is a set of predefined values, for example: in a webshop, an enumeration called MemberType could have the values Gold and Silver. |
+| [Enumerations](enumerations) |   | An enumeration is a set of predefined values, for example: in a web shop, an enumeration called MemberType could have the values Gold and Silver. |
 
 ## 3 Page Resources
 
@@ -41,7 +41,7 @@ Furthermore, a module can contain many different types of documents. Each type o
 | [Datasets](data-sets) | A dataset can be used for reporting and is defined using either an OQL query or a custom Java action. |
 | [Document Templates](document-templates) | Document Templates are used to model a template needed as input for a document export action which can generate all kinds of documents based on application data. They are composed much in the same way as Forms. |
 | [Java Actions](java-actions) | With Java actions you can extend the functionality of your application in situations where it would be hard to implement this functionality in microflows. You can call a Java action from a microflow. |
-| [Regular Expressions](regular-expressions) | A regular expression describes a set of criteria that a string can match. |
+| [Regular Expressions](regular-expressions) | A regular expression is used by [validation rules](validation-rules) on an entity to describe a set of criteria that a string can match. |
 | [Rules](rules) | A rule defines a set of criteria, with a certain input the rule will result in a Boolean or enumeration depending on the criteria met. It can be called from a decision to determine the direction the microflow should go once the decision is reached. |
 | [Scheduled Events](scheduled-events) | A scheduled event is used to execute a microflow at a certain point in time. You can also schedule it to repeat after a given time. For example, a scheduled event can run every morning at 6 A.M. |
 

--- a/content/refguide/regular-expressions.md
+++ b/content/refguide/regular-expressions.md
@@ -8,7 +8,7 @@ tags: ["studio pro", "regular expressions", "regular expression"]
 
 ## 1 Introduction
 
-A regular expression describes a set of criteria that a string can match. In the [validation rules](validation-rules) of an entity a regular expression can be used to validate whether an attribute of type String matches these criteria.
+A regular expression resource document is used in the [validation rules](validation-rules) of an entity to describe a set of criteria that a string must match.
 
 A regular expression has the properties described below.
 
@@ -22,7 +22,7 @@ The name can be used to refer to the regular expression from a [validation rule]
 
 This is for documentation purpose only; it is not visible in the end-user application that you are modeling.
 
-## 3 Expression
+## 3 Expression{#expression}
 
 The expression defines the criteria that a string should be checked against in a [formal, internationally standardized regular expression language](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html).
 
@@ -40,6 +40,8 @@ These are the criteria:
 * Between the digits and the letters there can be a space, as expressed by the subexpression which consists of a space and a question mark; the question mark indicates that the space is optional
 
 {{% /alert %}}
+
+The following sections give a summary of regular expressions that can be used in Mendix. This description also applies to regular expression strings used in functions such as *isMatch()*.
 
 ### 3.1 Subexpressions
 
@@ -92,5 +94,5 @@ The following quantifiers can be used:
 
 ## 4 Read More
 
-* [Class Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#matches-java.lang.String-java.lang.CharSequence-)
-* [Using Regular Expressions in Java](http://www.regular-expressions.info/java.html)
+* [Class Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#matches-java.lang.String-java.lang.CharSequence-) – information from the Oracle Java SE documentation
+* [Using Regular Expressions in Java](http://www.regular-expressions.info/java.html)  – information about regular expressions in Java from the *Regular-Expressions.info* website

--- a/content/refguide/resources.md
+++ b/content/refguide/resources.md
@@ -34,7 +34,7 @@ The **Resources** category contain various document types that can be used in di
 | [Enumeration](enumerations) | Domain model                           | Enumerations are used to define attributes of an enumeration type. |
 | [Dataset](data-sets) | Pages                                  | Datasets define the data shown in reporting widgets.        |
 | [Constant](constants) | Microflow expressions and Consumed web services | Constants are used to define configuration values.           |
-| [Regular expression](regular-expressions) | Domain model                           | Regular expressions define criteria that a string should match and are used in validation rules to identify whether a string attribute type matches these criteria. |
+| [Regular expression](regular-expressions) | Domain model                           | Regular expressions are used in validation rules to define criteria that a string should match to pass the validation. They cannot be used in other places which require regular expressions (for example, the *isMatch()* function). |
 | [Scheduled event](scheduled-events) | Microflows                     | Scheduled events let the runtime execute a microflow at a specific moment in time. |
 | [Document template](document-templates) | Microflows                             | Document template is used to format the document in a client and to download or print it. |
 

--- a/content/refguide/string-function-calls.md
+++ b/content/refguide/string-function-calls.md
@@ -368,9 +368,13 @@ Checks to see if a string matches a given regular expression.
 * Regular expression to match
     * Type: string
 
+{{% alert type="info" %}}
+The regular expression must be provided as a string. Although it uses the same format for regular expressions, you cannot use a [regular expression](regular-expressions) resource document in this function.
+{{% /alert %}}
+
 {{% alert type="warning" %}}
 
-Please note that this function call uses a [regular expression](regular-expressions) language provided by the current platform:
+Please note that this function call uses the regular expression language provided by the current platform:
 
 * When used inside a [microflow](microflow) – Java's regular expressions (for details, see [Class Pattern documentation](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html))
 * When used in the client – JavaScript's regular expressions (for details, see [Regular Expressions documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions))
@@ -419,9 +423,13 @@ Replaces all occurrences of a regular expression with another string.
 * The string to be substituted for each match (this does not support backreferences, substitutions, or captures)
     * Type: string
 
+{{% alert type="info" %}}
+The regular expression must be provided as a string. Although it uses the same format for regular expressions, you cannot use a [regular expression](regular-expressions) resource document in this function.
+{{% /alert %}}
+
 {{% alert type="warning" %}}
 
-Please note that this function call uses a [regular expression](regular-expressions) language provided by the current platform:
+Please note that this function call uses the regular expression language provided by the current platform:
 
 * When used inside [microflows](microflows) – Java's regular expressions (for details, see [Class Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html))
 * When used in the client – JavaScript's regular expressions (for details, see [Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions))
@@ -469,9 +477,13 @@ Replaces the first occurrence of the regular expression with a replacement strin
 * The string to be substituted for the first match (this does not support backreferences, substitutions, or captures)
     * Type: string
 
+{{% alert type="info" %}}
+The regular expression must be provided as a string. Although it uses the same format for regular expressions, you cannot use a [regular expression](regular-expressions) resource document in this function.
+{{% /alert %}}
+
 {{% alert type="warning" %}}
 
-Please note that this function call uses a [regular expression](regular-expressions) language provided by the current platform:
+Please note that this function call uses the regular expression language provided by the current platform:
 
 * When used inside a [microflow](microflow) – Java's regular expressions (for details, see [Class Pattern documentation](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html))
 * When used in the client – JavaScript's regular expressions (for details, see [Regular Expressions documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions))

--- a/content/refguide/validation-rules.md
+++ b/content/refguide/validation-rules.md
@@ -59,7 +59,7 @@ The rule defines which condition an attribute should satisfy.
 | Unique | The value of this attribute must be different from the values of this attribute in all other objects of the same entity. |
 | Equals | The attribute value needs to be equal to a specified value or equal to the value of another attribute of the same object. |
 | Range | The attribute value needs to be greater than or equal to, less than or equal to, or between two values. The values are either specified fixed values or values of other attributes of the same object. |
-| Regular expression | The attribute needs to match a [regular expression](regular-expressions). |
+| Regular expression | The attribute needs to match a regular expression stored in a [regular expression](regular-expressions) resource. |
 | Maximum length | The attribute may have no more than the specified number of characters. |
 
 {{% alert type="info" %}}


### PR DESCRIPTION
There was confusion over the purpose of the regular expression documentation (https://docs.mendix.com/refguide/regular-expressions)

It was used to:
1. Describe a regular expression resource which can only be used in entity validation rules
2. Explain the structure of a regular expression used in both regular expression resources and in the regular expression strings used as parameters to microflow and nanoflow expressions.

Reference: JIRA issue https://mendix.atlassian.net/browse/TW-1053