### PR TITLE
Sprintr release 10.5.1

### DIFF
--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -13,6 +13,10 @@ For release notes on Mendix Cloud and deployment options, see [Deployment](deplo
 
 ## 2020
 
+### July 27th, 2020
+
+* We fixed a bug where under certain circumstances email notifications on feedback issues were not sent.
+
 ### July 13th, 2020
 
 #### Improvements

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -13,9 +13,11 @@ For release notes on Mendix Cloud and deployment options, see [Deployment](deplo
 
 ## 2020
 
-### July 27th, 2020
+### July 28th, 2020
 
-* We fixed a bug where under certain circumstances email notifications on feedback issues were not sent.
+#### Fixes
+
+* We fixed an issue where email notifications on [feedback](/developerportal/collaborate/feedback) items were not sent under certain circumstances.
 
 ### July 13th, 2020
 

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -6,7 +6,7 @@
   <ul style="list-style-type:circle;">
 	<li><a href="https://docs.mendix.com/releasenotes/studio-pro/8.11">Studio Pro 8.11.1</a> – July 23rd, 2020</li>	
 	<li><a href="https://docs.mendix.com/releasenotes/studio/8.7-and-above">Studio</a> – July 14th, 2020</li>
-	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – July 13th, 2020</li>
+	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – July 28th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/developer-portal/deployment">Deployment</a> – July 22nd, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/app-store">App Store</a> – May 6th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/make-it-native-app">Make It Native App 2.1.0 / 2.2.0</a> – May 15th, 2020</li>


### PR DESCRIPTION
These are the release notes for an unplanned update, scheduled for Tuesday 27 July.