### PR TITLE
Editable "Inherited from snippet call" (8.13)

### DIFF
--- a/content/refguide/common-widget-properties.md
+++ b/content/refguide/common-widget-properties.md
@@ -147,7 +147,8 @@ The editable property indicates whether the end-user will be able to change the 
 
 | Value       | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
-| Default *(default)*    | The value is editable if security allows it (as in, if the user that is signed in has write access to the selected attribute). |
+| Default     | The value is editable if security allows it (as in, if the user that is signed in has write access to the selected attribute). *(Default value for widgets outside a snippet)* |
+| Inherited from snippet call | Set to `Default` or `Never` by the containing data container of the snippet call. *(Default value for widgets inside a snippet)* |
 | Never       | The value is never editable.                                 |
 | Conditionally | The value is editable if the specified condition holds (see below). |
 

--- a/content/refguide/common-widget-properties.md
+++ b/content/refguide/common-widget-properties.md
@@ -148,7 +148,7 @@ The editable property indicates whether the end-user will be able to change the 
 | Value       | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
 | Default     | The value is editable if security allows it such as if the user that is signed in has write access to the selected attribute (default value for widgets outside a snippet). |
-| Inherited from snippet call | Set to `Default` or `Never` by the containing data container of the snippet call (default value for widgets inside a snippet). |
+| Inherited from snippet call | Set to **Default** or **Never** by the containing data container of the snippet call (default value for widgets inside a snippet). |
 | Never       | The value is never editable.                                 |
 | Conditionally | The value is editable if the specified condition holds (see below). |
 

--- a/content/refguide/common-widget-properties.md
+++ b/content/refguide/common-widget-properties.md
@@ -147,8 +147,8 @@ The editable property indicates whether the end-user will be able to change the 
 
 | Value       | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
-| Default     | The value is editable if security allows it (as in, if the user that is signed in has write access to the selected attribute). *(Default value for widgets outside a snippet)* |
-| Inherited from snippet call | Set to `Default` or `Never` by the containing data container of the snippet call. *(Default value for widgets inside a snippet)* |
+| Default     | The value is editable if security allows it such as if the user that is signed in has write access to the selected attribute (default value for widgets outside a snippet). |
+| Inherited from snippet call | Set to `Default` or `Never` by the containing data container of the snippet call (default value for widgets inside a snippet). |
 | Never       | The value is never editable.                                 |
 | Conditionally | The value is editable if the specified condition holds (see below). |
 


### PR DESCRIPTION
The option "Inherited from snippet call" was added to the Editable property in 8.13 to clarify the behaviour inside snippets, similar to earlier improvements made to the Read-only style property. (WTF-511)