### PR TITLE
Update "Inherited from Snippets" Widget Prop

### DIFF
--- a/content/refguide/common-widget-properties.md
+++ b/content/refguide/common-widget-properties.md
@@ -150,6 +150,7 @@ The editable property indicates whether the end-user will be able to change the 
 | Default *(default)*    | The value is editable if security allows it (as in, if the user that is signed in has write access to the selected attribute). |
 | Never       | The value is never editable.                                 |
 | Conditionally | The value is editable if the specified condition holds (see below). |
+|  Inherited from snippet call | The value, which comes from a widget inside a snippet, is editable if security allows it. |
 
 ### 5.2 Condition
 


### PR DESCRIPTION
This PR updates documentation in accordance with the new editable prop for widgets called from snippets https://mendix.atlassian.net/browse/TW-1097

No screenshots in documentation need to be updated, since all screenshots which show widget props show the "default" value next to all widgets' editable props. This default state remains unchanged.