### PR TITLE
Rename roles to privileges in oracle.md

### DIFF
--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -27,18 +27,14 @@ Selecting DISTINCT attributes of the string type with a size greater than 2000 c
 
 ## 3 Required Privileges
 
-The Mendix runtime will require a user with roles with the following privileges to set up and maintain the Mendix database on Oracle:
+The Mendix Runtime will require a user with roles with the following privileges to set up and maintain the Mendix database on Oracle:
 
-* create tables
-* drop tables
-* create indexes
-* create sequences
-* create, read, update and delete data
+* Create tables
+* Drop tables
+* Create indexes
+* Create sequences
+* Create, read, update, and delete data
 
-## 4 Known Issues
+## 4 Known Issue
 
-### 4.1 Numeric Conversion
-
-There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows.
-
-This problem is fixed in Oracle 11.2.0.4. See [https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).
+There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows. This problem is fixed in Oracle 11.2.0.4. For more information, see [this Oracle page](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [Strange behavior on Oracle CAST to NVARCHAR2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -25,9 +25,9 @@ It is not possible to sort, group, or use aggregate functions such as `count()` 
 
 Selecting DISTINCT attributes of the string type with a size greater than 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you run into this limitation, you may encounter an exception in the logs with a message like this: **Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small**.
 
-## 3 Required Roles
+## 3 Required Privileges
 
-The Mendix runtime will require the following roles to set up and maintain the Mendix database on Oracle:
+The Mendix runtime will require a user with roles with the following privileges to set up and maintain the Mendix database on Oracle:
 
 * create tables
 * drop tables


### PR DESCRIPTION
While a DB user has roles, what we need are the privileges those roles can offer. Which combination of roles provides thsoe privileges should not be a concern to the Mendix Runtime.

Therefore, I'm asking to rename this bit.