### PR TITLE
Remove known issue of unsupported DB version

### DIFF
--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -34,7 +34,3 @@ The Mendix Runtime will require a user with roles with the following privileges 
 * Create indexes
 * Create sequences
 * Create, read, update, and delete data
-
-## 4 Known Issue
-
-There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows. This problem is fixed in Oracle 11.2.0.4. For more information, see [this Oracle page](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [Strange behavior on Oracle CAST to NVARCHAR2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).

--- a/content/refguide7/oracle.md
+++ b/content/refguide7/oracle.md
@@ -21,11 +21,3 @@ It is not possible to sort, group, or use aggregate functions such as `count()` 
 ### 2.3 Selecting DISTINCT Attribute
 
 Selecting DISTINCT attributes of the string type with a size greater than 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you run into this limitation, you may encounter an exception in the logs with a message like this: **Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small**.
-
-## 3 Known Issues
-
-### 3.1 Numeric Conversion
-
-There is a known bug in older versions of Oracle 11.2 where converting numeric attributes to string attributes with a length greater than 80 leads to corrupted data on existing rows.
-
-This problem is fixed in Oracle 11.2.0.4. See [https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8](https://support.oracle.com/epmos/faces/DocumentDisplay?id=9949330.8) and [http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2](http://stackoverflow.com/questions/16735793/strange-behavior-on-oracle-cast-to-nvarchar2).


### PR DESCRIPTION
We do not support Oracle older than 12.2 in either Mendix 7 or 8, so I think it's good to remove the reference to known issues that do not affect currently supported versions.