### PR TITLE
Setting SameSite cookies outside Mendix Cloud

### DIFF
--- a/content/developerportal/deploy/running-in-iframe.md
+++ b/content/developerportal/deploy/running-in-iframe.md
@@ -1,0 +1,21 @@
+---
+title: "Iframes and Running Apps"
+parent: "general"
+menu_order: 40
+description: "Issues to take into consideration when running apps in an iframe"
+tags: ["iframe", "samesite", "cookies", "x-frame-options"]
+---
+
+## 1 Introduction
+
+By default, a Mendix app is blocked from running inside an iframe. This is to protect the end-user from attacks using *clickjacking*. There is more information on this in the [Adding HTTP Headers](/howto/security/best-practices-security#adding-http-header) section of *How To Implement Best Practices for App Security*.
+
+You can enable your app to run inside an iframe by setting the X-Frame-Options HTTP header for your node’s environment. For the Mendix Cloud, this can be done within the Mendix Developer Portal, as described in the [HTTP Headers](/developerportal/deploy/environments-details#http-headers) section of *Environment Details*.
+
+## 2 Resolving Browser Issues
+
+Most browsers have additional security to ensure that iframes are only allowed when they are from the same domain as the main page. If your app does not have the same domain as the main page containing the iframe, it will only run if the *SameSite* cookie is set to allow this. You can find a good explanation of SameSite cookies in [SameSite cookies explained](https://web.dev/samesite-cookies-explained/) on the *web.dev* website.
+
+When running your app in the Mendix Cloud, you can set the SameSite cookie through a custom runtime setting as explained in the [Running Your App in an Iframe](/developerportal/deploy/environments-details#iframe) section of *Environment Details*.
+
+If your app is deployed outside the Mendix Cloud (on premises, for example), then you will need to configure your webserver to set the SameSite cookie to the correct value.

--- a/content/howto/security/best-practices-security.md
+++ b/content/howto/security/best-practices-security.md
@@ -146,7 +146,7 @@ HTTP headers can add an additional layer of security and help you detect certain
 
 An example of an attack is when an application is embedded in an iframe. Applications that can be embedded within an iframe can be misused by attackers. By using an overlay, it could trick users into clicking buttons and make them perform actions within the application on their behalf without knowing it. This approach is called [clickjacking](https://www.owasp.org/index.php/Clickjacking).
 
-By sending a header to the user’s browser, it can block the use of the Mendix application within an iframe and avoid this type of attack. The header is set by default to block embedding within an iframe, but can be configured using [HTTP Headers](/developerportal/deploy/environments-details#http-headers) in your node’s environment details within the Mendix Developer Portal.
+By sending a header to the user’s browser, it can block the use of the Mendix application within an iframe and avoid this type of attack. The header is set by default to block embedding within an iframe, but can be configured using [HTTP Headers](/developerportal/deploy/environments-details#http-headers) in your node’s environment details within the Mendix Developer Portal. If you change this value, you will also need to ensure that *SameSite* cookies are set to the correct value. See [Iframes and Running Apps](/developerportal/deploy/running-in-iframe) for more information.
 
 ## 12 Maintaining a High Level of Project Hygiene
 


### PR DESCRIPTION
There was only information about SameSite cookies in relation to apps running in the Mendix Cloud.
Added a new document to explain a bit more about iframes and SameSite cookies as general information to allow customers using other deployment methods (on premises, SAP, private cloud) to benefit from iframes.

JIRA issue TW-1104