### PR TITLE
Remove known issue for ticket 93998.

### DIFF
--- a/content/releasenotes/studio-pro/8.6.md
+++ b/content/releasenotes/studio-pro/8.6.md
@@ -200,8 +200,6 @@ Because many users have indicated that copying and pasting microflows between ap
 
 * The first deployment of an app project with a native mobile profile takes approximately one minute longer than usual, as the first deployment needs to build up a cache. On consecutive deployments, this time is reduced.
 	* Fixed in [8.10.0](8.10#211).
-* Export mappings that use XML choice or XML inheritance throw exceptions during runtime. (Ticket 93998)
-	* Fixed in [8.7.0](8.7#93998).
 * MySQL 8.0 cannot be used with the default authentication plugin as of this moment. Mendix uses the open-source [MariaDB](https://mariadb.com/) driver to connect, which has not yet added support. We will include the updated driver as soon as it is [released](https://jira.mariadb.org/browse/CONJ-663). To resolve this issue, you may consider using the [previous default plugin](https://mysqlserverteam.com/upgrading-to-mysql-8-0-default-authentication-plugin-considerations/) until the driver has been updated.
 	* Fixed in [8.6.5](8.6#1530).
 * Downloading private content in the App Store available in Studio Pro has been temporarily disabled due to a security risk. Please see this issue described in the [App Store release notes](../app-store/index#private-fix) for more information, details about where to find your private content, and plans for future version-specific fixes.


### PR DESCRIPTION
Ticket 93998 is working as expected in Mendix 8.6.6. The bug was likely to be introduced in 8.7.0 but it was fixed in the later version.