### PR TITLE
Change in SNV version suggestions.

### DIFF
--- a/content/refguide6/version-control-scenarios.md
+++ b/content/refguide6/version-control-scenarios.md
@@ -128,7 +128,10 @@ We advise you to always commit and update inside the Modeler because in this way
 ### TortoiseSVN and Subclipse
 
 If you are doing more advanced changes to files like adding Java actions or resources to your project, you will have to install TortoiseSVN on your computer and perform some operations yourself. You can download it for free at [http://tortoisesvn.tigris.org/](http://tortoisesvn.tigris.org/).
-Mendix Studio Pro uses the Subversion 1.9 working copy. Previous versions of the Mendix Desktop Modeler used a Subversion 1.7 working copy. These working copy versions are NOT compatible.
+
+{{% alert type="warning" %}}
+[Mendix Studio Pro](/releasenotes/studio-pro/8.0) version 8 and above uses the Subversion 1.9 working copy. Mendix Desktop Modeler uses a Subversion 1.7 working copy. These working copy versions are NOT compatible.
+{{% /alert %}}
 
 Also, if you are developing Java actions using Eclipse, we advise you to install Subclipse to help you with version control of Java files. You can download Subclipse from the Eclipse Marketplace inside Eclipse or from [http://subclipse.tigris.org/](http://subclipse.tigris.org/)
 

--- a/content/refguide6/version-control-scenarios.md
+++ b/content/refguide6/version-control-scenarios.md
@@ -127,7 +127,8 @@ We advise you to always commit and update inside the Modeler because in this way
 
 ### TortoiseSVN and Subclipse
 
-If you are doing more advanced changes to files like adding Java actions or resources to your project, you will have to install TortoiseSVN on your computer and perform some operations yourself. You can download it for free at [http://tortoisesvn.tigris.org/](http://tortoisesvn.tigris.org/) (choose version 1.7)
+If you are doing more advanced changes to files like adding Java actions or resources to your project, you will have to install TortoiseSVN on your computer and perform some operations yourself. You can download it for free at [http://tortoisesvn.tigris.org/](http://tortoisesvn.tigris.org/).
+Mendix Studio Pro uses the Subversion 1.9 working copy. Previous versions of the Mendix Desktop Modeler used a Subversion 1.7 working copy. These working copy versions are NOT compatible.
 
 Also, if you are developing Java actions using Eclipse, we advise you to install Subclipse to help you with version control of Java files. You can download Subclipse from the Eclipse Marketplace inside Eclipse or from [http://subclipse.tigris.org/](http://subclipse.tigris.org/)
 


### PR DESCRIPTION
Previous is noted version 1.7, this is outdated.
Mendix Studio Pro uses the Subversion 1.9 working copy. Previous versions of the Mendix Desktop Modeler used a Subversion 1.7 working copy. These working copy versions are NOT compatible.