### PR TITLE
Small fixes in Private Cloud documentation

### DIFF
--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -633,6 +633,7 @@ The following rights are available to the cluster creator, and members of a name
 * Manage own environments – user can create and manage an environment in any namespace in the cluster
 
 The following actions require the appropriate access to the namespace **and** access to the app environment as a team member with appropriate authorization:
+
 * Deploy App – user can deploy a new app to the environment or start and stop existing apps
 * Scale App – user can change the number of replicas
 * Edit App Constants

--- a/content/developerportal/deploy/private-cloud-deploy.md
+++ b/content/developerportal/deploy/private-cloud-deploy.md
@@ -484,20 +484,20 @@ After manually removing the StorageInstance, you'll need to manually clean up an
 
 If you attempt to deploy an app with security not set to production into a production environment you will not get an error, however the deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 
-### 6.5 ApplicationRootURL Needs to be Set Manually
+### 6.5 ApplicationRootUrl Needs to be Set Manually
 
 In some cases, your Mendix app will need to know its own URL - for example when using SSO or sending emails.
 
-For this to work properly, you need to set the [ApplicationRootURL](/refguide/custom-settings#2-general-settings) **Custom Runtime Setting** in the **Runtime** tab to the app's URL.
+For this to work properly, you need to set the [ApplicationRootUrl](/refguide/custom-settings#2-general-settings) **Custom Runtime Setting** in the **Runtime** tab to the app's URL.
 
 To add this setting:
 
 1. Copy the **App URL** value from the **General** tab.
 2. Switch to the **Runtime** tab.
-3. Add a **Custom Runtime Setting**: use `ApplicationRootURL` as the **Setting** name and the URL you copied from **App URL** as the **New value**.
+3. Add a **Custom Runtime Setting**: use `ApplicationRootUrl` as the **Setting** name and the URL you copied from **App URL** as the **New value**.
 
 {{% alert type="info" %}}
-If you change **App URL** in the **General** tab, you should update the `ApplicationRootURL` value as well.
+If you change **App URL** in the **General** tab, you should update the `ApplicationRootUrl` value as well.
 {{% /alert %}}
 
 ## 7 Troubleshooting

--- a/content/developerportal/deploy/private-cloud-operator.md
+++ b/content/developerportal/deploy/private-cloud-operator.md
@@ -304,11 +304,11 @@ Names beginning **mendix-** cannot be used for your own apps as they are reserve
 
 All names beginning **openshift-** are reserved for use by OpenShift if you are deploying to an OpenShift cluster.
 
-### 4.2 ApplicationRootURL Needs to be Set Manually
+### 4.2 ApplicationRootUrl Needs to be Set Manually
 
 In some cases, your Mendix app will need to know its own URL - for example when using SSO or sending emails.
 
-For this to work properly, you need to set the [ApplicationRootURL variable](https://docs.mendix.com/refguide/custom-settings#2-general-settings) in `customConfiguration` to the app's URL. For example: 
+For this to work properly, you need to set the [ApplicationRootUrl variable](https://docs.mendix.com/refguide/custom-settings#2-general-settings) in `customConfiguration` to the app's URL. For example: 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
 kind: MendixApp
@@ -316,15 +316,15 @@ metadata:
   name: example-mendixapp
 spec:
   runtime:
-    # Add the ApplicationRootURL value here
+    # Add the ApplicationRootUrl value here
     customConfiguration: |-
       {
-        "ApplicationRootURL": "https://myapp1-dev.mendix.example.com"
+        "ApplicationRootUrl": "https://myapp1-dev.mendix.example.com"
       }
 ```
 
 {{% alert type="info" %}}
-If you change `appURL`, you should also update the `ApplicationRootURL` value.
+If you change `appURL`, you should also update the `ApplicationRootUrl` value.
 
-Note that the `appURL` is a domain name (without a schema or path), while `ApplicationRootURL` should be a HTTP URL with an http:// or https:// prefix.
+Note that the `appURL` is a domain name (without a schema or path), while `ApplicationRootUrl` should be a HTTP URL with an http:// or https:// prefix.
 {{% /alert %}}


### PR DESCRIPTION
A few small changes to Private Cloud documentation. There's no target date for this PR, and it can be published at any convenient time.

* Changed `ApplicationRootURL` to `ApplicationRootUrl` - so that the Mendix Runtime properly handles this parameter.
* Added a line break in private-cloud-cluster.md so that the list is properly formatted.
