### PR TITLE
Add Native Builder release notes and warning for version 3.2.1

### DIFF
--- a/content/howto/mobile/deploying-native-app.md
+++ b/content/howto/mobile/deploying-native-app.md
@@ -7,7 +7,7 @@ tags: ["native", "mobile", "deploy", "native-builder", "builder", "appcenter"]
 ---
 
 {{% alert type="warning" %}}
-Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes required to accomodate Github's transition of using **main** instead of **master** for naming the default branch for new repositories. 
+Please update to Native Builder v3.2.1. Native Builder v3.2.1 includes the fixes required to addresses GitHub's transition from using **master** to using **main** as its default repository branch name. 
 {{% /alert %}}
 
 ## 1 Introduction

--- a/content/howto/mobile/deploying-native-app.md
+++ b/content/howto/mobile/deploying-native-app.md
@@ -6,6 +6,10 @@ description: Describes how to deploy your first Mendix native mobile app with th
 tags: ["native", "mobile", "deploy", "native-builder", "builder", "appcenter"]
 ---
 
+{{% alert type="warning" %}}
+Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes required to accomodate Github's transition of using **main** instead of **master** for naming the default branch for new repositories. 
+{{% /alert %}}
+
 ## 1 Introduction
 
 This how-to will teach you how to go from a blank slate to an app running on a device.

--- a/content/refguide/native-builder.md
+++ b/content/refguide/native-builder.md
@@ -6,7 +6,7 @@ tags: ["native", "mobile", "deploy", "native-builder", "builder", "appcenter"]
 ---
 
 {{% alert type="warning" %}}
-Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes required to accomodate Github's transition of using **main** instead of **master** for naming the default branch for new repositories. 
+Please update to Native Builder v3.2.1. Native Builder v3.2.1 includes the fixes required to addresses GitHub's transition from using **master** to using **main** as its default repository branch name. 
 {{% /alert %}}
 
 ## 1 Introduction

--- a/content/refguide/native-builder.md
+++ b/content/refguide/native-builder.md
@@ -5,6 +5,10 @@ menu_order: 70
 tags: ["native", "mobile", "deploy", "native-builder", "builder", "appcenter"]
 ---
 
+{{% alert type="warning" %}}
+Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes required to accomodate Github's transition of using **main** instead of **master** for naming the default branch for new repositories. 
+{{% /alert %}}
+
 ## 1 Introduction
 
 The Native Builder takes your Mendix project containing a native profile and packages a native mobile app for iOS and Android. To learn more about using the Native Builder, see [How to Deploy your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).

--- a/content/releasenotes/mobile/native-builder.md
+++ b/content/releasenotes/mobile/native-builder.md
@@ -11,6 +11,20 @@ The [Native Builder](/refguide/native-builder) is a command line input tool whic
 
 We are heavily invested in streamlining the experience of building your apps and are continuously improving upon the tool's capabilities. For more information on using the Native Builder, see [How To Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).
 
+{{% alert type="warning" %}}
+Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes required to accomodate Github's transition of using **main** instead of **master** for naming the default branch for new repositories. 
+{{% /alert %}}
+
+## 3.2.1
+
+**Release date: October 5th, 2020**
+
+### Improvements
+
+This release accomodates GitHub's transition from using *master* to using *main* for naming the default branch of a new repository.
+
+This release of the CLI is mandatory as new project's created with the CLI will fail at the repository creation step. 
+
 ## 3.2.0
 
 **Release date: February 5th, 2020**

--- a/content/releasenotes/mobile/native-builder.md
+++ b/content/releasenotes/mobile/native-builder.md
@@ -21,9 +21,9 @@ Please update to Native Builder v3.2.1. Version 3.2.1 includes the fixes require
 
 ### Improvements
 
-This release accomodates GitHub's transition from using *master* to using *main* for naming the default branch of a new repository.
+This release addresses GitHub's transition from using **master** to using **main** as its default repository branch name.
 
-This release of the CLI is mandatory as new project's created with the CLI will fail at the repository creation step. 
+Using this CLI release is **mandatory**, as new projects created with the CLI will fail at the repository creation step for older CLI versions. 
 
 ## 3.2.0
 


### PR DESCRIPTION
@ConnorLand The warning tries to imply that the 3.2.1 update is required for smooth operation.
I am also trying to explain the reason that is that GitHub names the default branch of a new repository "main" instead of "master" since October 1st