### PR TITLE
Sprintr 10.8.1 Releasenotes

### DIFF
--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -13,6 +13,12 @@ For release notes on Mendix Cloud and deployment options, see [Deployment](deplo
 
 ## 2020
 
+### October 8th, 2020
+
+#### Fixes
+
+* We fixed an issue where team members would not be displayed in the [App Team](/developerportal/collaborate/team) overview
+
 ### October 4th, 2020
 
 #### Improvements

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -13,7 +13,7 @@ For release notes on Mendix Cloud and deployment options, see [Deployment](deplo
 
 ## 2020
 
-### October 8th, 2020
+### October 9th, 2020
 
 #### Fixes
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -17,7 +17,7 @@ For release notes on Mendix Cloud and deployment options, see [Deployment](deplo
 
 #### Fixes
 
-* We fixed an issue where team members would not be displayed in the [App Team](/developerportal/collaborate/team) overview
+* We fixed an issue where team members were not displayed in the [App Team](/developerportal/collaborate/team) overview.
 
 ### October 4th, 2020
 

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -8,7 +8,7 @@
 	<li><a href="https://docs.mendix.com/releasenotes/studio/8.7-and-above">Studio 8.7 & Above</a> – Oct 6th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/make-it-native-app">Make It Native App 2.1.0 / 2.2.0</a> – May 15th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/native-template">Native Template 5.0.1</a> – Aug 26th, 2020</li>
-	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 9th, 2020</li>
+	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 8th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/developer-portal/deployment">Deployment</a> – Oct 5th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/data-hub">Data Hub</a> – Oct 1st, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/app-store">App Store</a> – May 6th, 2020</li>

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -8,7 +8,7 @@
 	<li><a href="https://docs.mendix.com/releasenotes/studio/8.7-and-above">Studio 8.7 & Above</a> – Oct 6th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/make-it-native-app">Make It Native App 2.1.0 / 2.2.0</a> – May 15th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/native-template">Native Template 5.0.1</a> – Aug 26th, 2020</li>
-	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 4th, 2020</li>
+	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 9th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/developer-portal/deployment">Deployment</a> – Oct 5th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/data-hub">Data Hub</a> – Oct 1st, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/app-store">App Store</a> – May 6th, 2020</li>

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -8,7 +8,7 @@
 	<li><a href="https://docs.mendix.com/releasenotes/studio/8.7-and-above">Studio 8.7 & Above</a> – Oct 6th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/make-it-native-app">Make It Native App 2.1.0 / 2.2.0</a> – May 15th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/mobile/native-template">Native Template 5.0.1</a> – Aug 26th, 2020</li>
-	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 8th, 2020</li>
+	<li><a href="https://docs.mendix.com/releasenotes/developer-portal">Developer Portal</a> – Oct 9th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/developer-portal/deployment">Deployment</a> – Oct 5th, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/data-hub">Data Hub</a> – Oct 1st, 2020</li>
 	<li><a href="https://docs.mendix.com/releasenotes/app-store">App Store</a> – May 6th, 2020</li>


### PR DESCRIPTION
Releasenotes for Sprintr 10.8.1. Scheduled release on Friday 9 October.