### PR TITLE
Add known issue about performance of delete action

### DIFF
--- a/content/releasenotes/studio-pro/8.14.md
+++ b/content/releasenotes/studio-pro/8.14.md
@@ -22,6 +22,7 @@ description: "The release notes for Mendix Studio Pro version 8.14 (including al
 
 * When you update a [consumed OData service](/refguide/consumed-odata-service) with a new version from [Mendix Data Hub](https://hub.mendix.com) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app project and opening it again fixes this issue.
+* In certain situations, there is a performance degradation regarding the 'delete' microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.
 
 ## 8.14.0 {#8140}
 
@@ -132,3 +133,4 @@ Next to that, we now enable closing one or more pages as part of the [Show page]
 
 * When you update a [consumed OData service](/refguide/consumed-odata-service) with a new version from [Mendix Data Hub](https://hub.mendix.com) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app project and opening it again fixes this issue.
+* In certain situations, there is a performance degradation regarding the 'delete' microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.

--- a/content/releasenotes/studio-pro/8.14.md
+++ b/content/releasenotes/studio-pro/8.14.md
@@ -3,6 +3,7 @@ title: "8.14"
 parent: "8"
 description: "The release notes for Mendix Studio Pro version 8.14 (including all patches) with details on new features, bug fixes, and known issues."
 #ki: "When you update a consumed OData service" - DML-889
+#ki: "In certain situations" - RUN-2562
 #When updating, remember to update the Latest Mendix Releases file
 ---
 
@@ -22,7 +23,7 @@ description: "The release notes for Mendix Studio Pro version 8.14 (including al
 
 * When you update a [consumed OData service](/refguide/consumed-odata-service) with a new version from [Mendix Data Hub](https://hub.mendix.com) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app project and opening it again fixes this issue.
-* In certain situations, there is a performance degradation regarding the 'delete' microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.
+* In certain situations, there is a performance degradation regarding the [Delete object(s)](/refguide/deleting-objects) microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.
 
 ## 8.14.0 {#8140}
 
@@ -133,4 +134,4 @@ Next to that, we now enable closing one or more pages as part of the [Show page]
 
 * When you update a [consumed OData service](/refguide/consumed-odata-service) with a new version from [Mendix Data Hub](https://hub.mendix.com) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app project and opening it again fixes this issue.
-* In certain situations, there is a performance degradation regarding the 'delete' microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.
+* In certain situations, there is a performance degradation regarding the [Delete object(s)](/refguide/deleting-objects) microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.


### PR DESCRIPTION
In certain situations, there is a performance degradation regarding the 'delete' microflow activity and the corresponding Java API. This occurs when there are microflow variables containing large lists of entities in scope. The fix for this will follow shortly.