### PR TITLE
Add NT 5.0.5 relase notes

### DIFF
--- a/content/releasenotes/mobile/native-template.md
+++ b/content/releasenotes/mobile/native-template.md
@@ -8,16 +8,18 @@ description: "Native Template release notes."
 
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [How to Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).
 
-## 4.2.3/5.0.5
+## 4.2.3 & 5.0.5
+
 **Release date: October 19th, 2020**
 
-# Improvements
+### Improvements
 
-With this release we are adding support for the new filesystem security rules added to Android 10 and newer. 
+* We added support for the new file system security rules added to Android v10 and above. 
 
 ### Fixes
-* Setting the legacy external storage flag to support Android 10 and later.
-* Added support for missing iPad icons.
+
+* We set the legacy external storage flag to support Android v10 and below.
+* We added support for missing iPad icons.
 
 ## 5.0.3 and 5.0.4
 

--- a/content/releasenotes/mobile/native-template.md
+++ b/content/releasenotes/mobile/native-template.md
@@ -8,7 +8,7 @@ description: "Native Template release notes."
 
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [How to Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).
 
-## 4.2.3 and 5.0.5
+## 5.0.5 and 4.2.3 
 
 **Release date: October 19th, 2020**
 
@@ -21,7 +21,7 @@ For more information on native mobile app development, see the [native-template]
 * We set the legacy external storage flag to support Android v10 and below.
 * We added support for missing iPad icons.
 
-## 5.0.3 and 5.0.4
+## 5.0.4 and 5.0.3 
 
 **Release date: October 9th, 2020**
 

--- a/content/releasenotes/mobile/native-template.md
+++ b/content/releasenotes/mobile/native-template.md
@@ -8,6 +8,17 @@ description: "Native Template release notes."
 
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [How to Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).
 
+## 4.2.3/5.0.5
+**Release date: October 19th, 2020**
+
+# Improvements
+
+With this release we are adding support for the new filesystem security rules added to Android 10 and newer. 
+
+### Fixes
+* Setting the legacy external storage flag to support Android 10 and later.
+* Added support for missing iPad icons.
+
 ## 5.0.3 and 5.0.4
 
 **Release date: October 9th, 2020**

--- a/content/releasenotes/mobile/native-template.md
+++ b/content/releasenotes/mobile/native-template.md
@@ -8,7 +8,7 @@ description: "Native Template release notes."
 
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [How to Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app).
 
-## 4.2.3 & 5.0.5
+## 4.2.3 and 5.0.5
 
 **Release date: October 19th, 2020**
 


### PR DESCRIPTION
4.2.3 is a backport for versions from Studio Pro 8.9 up to 12.0.