### PR TITLE
Hide menus and search for print

### DIFF
--- a/_assets/styles/_sass/_base.scss
+++ b/_assets/styles/_sass/_base.scss
@@ -74,6 +74,22 @@ a {
 
 }
 
+@media print {
+
+  .input-group.search-group {
+    display: none;
+  }
+
+  .sidebar-menu__content {
+    display: none;
+  }
+
+  #mx-dock-footer {
+    display: none;
+  }
+
+}
+
 :not(pre) > code {
   color: $color-code-font;
   background: $color-code-background;


### PR DESCRIPTION
When printing a documentation page, the search input and menus are not relevant and could be excluded.
The change will only affect the print layout and have not effect on the web pages.