### PR TITLE
`JOIN ON` optional in OQL full syntax description

### DIFF
--- a/content/refguide/oql-from-clause.md
+++ b/content/refguide/oql-from-clause.md
@@ -20,7 +20,7 @@ FROM
     {
         { INNER | { { LEFT | RIGHT | FULL } [ OUTER ] } } JOIN
         entity_path [ [ AS ] from_alias ]
-        ON <constraint>
+        [ ON <constraint> ]
     } [ ,...n ]
 ```
 


### PR DESCRIPTION
In chapter 4 of the `OQL From Clause` page, one can read that the `ON <constraint>` case is optional. This should also be reflected as such in the full syntax example in chapter 1.