### PR TITLE
How to know which JDBC driver Mendix is using

### DIFF
--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -78,7 +78,7 @@ These are the results of the actions:
 * [SQLite](https://bitbucket.org/xerial/sqlite-jdbc/downloads/)
 
 {{% alert type="info" %}}
-If you intend to connect to SQL Server using integrated security, please be aware that the JDBC driver in the **userlib** folder needs to match the version supplied with the Mendix Platform.
+If you intend to connect to SQL Server using integrated security, please be aware that the JDBC driver in the **userlib** folder needs to match the version supplied with the Mendix Platform (see the `runtime/bundles/` folder inside Mendix installation directory).
 {{% /alert %}}
 
 ## 6 Developing This App Store Component

--- a/content/appstore/connectors/database-connector.md
+++ b/content/appstore/connectors/database-connector.md
@@ -78,7 +78,7 @@ These are the results of the actions:
 * [SQLite](https://bitbucket.org/xerial/sqlite-jdbc/downloads/)
 
 {{% alert type="info" %}}
-If you intend to connect to SQL Server using integrated security, please be aware that the JDBC driver in the **userlib** folder needs to match the version supplied with the Mendix Platform (see the `runtime/bundles/` folder inside Mendix installation directory).
+If you intend to connect to SQL Server using integrated security, please be aware that the JDBC driver in the **userlib** folder needs to match the version supplied with the Mendix Platform (via the **runtime/bundles/** folder inside the Mendix installation directory).
 {{% /alert %}}
 
 ## 6 Developing This App Store Component


### PR DESCRIPTION
Refer to the bundles folder as a way to find out which JDBC driver is used Internally by Mendix.