### PR TITLE
Update parse-and-format-date-function-calls.md

### DIFF
--- a/content/refguide/parse-and-format-date-function-calls.md
+++ b/content/refguide/parse-and-format-date-function-calls.md
@@ -173,7 +173,7 @@ the output is:
 
 ## 6 dateTimeToEpoch
 
-{{% alert type="warning" %}}This expression is available from Mendix 8.15 and above.{{% /alert %}}
+{{% alert type="warning" %}}This expression is only available in Mendix versions 8.15 and above.{{% /alert %}}
 
 Returns the number of milliseconds since January 1, 1970, 00:00:00 GMT to the date.
 
@@ -209,7 +209,7 @@ The output is:
 
 ## 7 epochToDateTime
 
-{{% alert type="warning" %}}This expression is available from Mendix 8.15 and above.{{% /alert %}}
+{{% alert type="warning" %}}This expression is only available in Mendix versions 8.15 and above.{{% /alert %}}
 
 Creates a Datetime that represents the specified number of milliseconds since January 1, 1970, 00:00:00 GMT.
 

--- a/content/refguide/parse-and-format-date-function-calls.md
+++ b/content/refguide/parse-and-format-date-function-calls.md
@@ -173,6 +173,8 @@ the output is:
 
 ## 6 dateTimeToEpoch
 
+{{% alert type="warning" %}}This expression is available from Mendix 8.15 and above.{{% /alert %}}
+
 Returns the number of milliseconds since January 1, 1970, 00:00:00 GMT to the date.
 
 ### 6.1 Input Parameters
@@ -206,6 +208,8 @@ The output is:
 ```
 
 ## 7 epochToDateTime
+
+{{% alert type="warning" %}}This expression is available from Mendix 8.15 and above.{{% /alert %}}
 
 Creates a Datetime that represents the specified number of milliseconds since January 1, 1970, 00:00:00 GMT.
 


### PR DESCRIPTION
Added information to dateTimeToEpoch and epochToDateTime indicating that they are only available from Mendix 8.15 onwards.