### PR TITLE
Update docs for ActionButton's new property `Role Type`

### DIFF
--- a/content/refguide/button-properties.md
+++ b/content/refguide/button-properties.md
@@ -18,6 +18,7 @@ An example of button properties is represented in the image below:
 
 Button properties consist of the following sections:
 
+* [Accessibility](#accessibility) (only for web buttons when [Render Mode](#RenderMode) is Link)
 * [Common](#common) 
 * [Design Properties](#design)
 * [Events](#events)
@@ -25,27 +26,50 @@ Button properties consist of the following sections:
 * [Items](#items) (only for a drop-down button)
 * [Visibility](#visibility)
 
-### 2.1 Common Section {#common}
+### 2.1 Accessibility Section {#accessibility}
+
+{{% alert type="info" %}}
+
+The **Accessibility** section is only shown for web buttons when [Render Mode](#RenderMode) is Link.
+
+{{% /alert %}}
+
+#### 2.1.1 Role Type {#RoleType}
+
+The **Role type** property determines the aria-role attribute value that will be rendered with the button's HTML. Aria-roles can be used to improve accessibility because devices such as screen readers interpret this and present the semantics of the role to end-users. Possible options are the following: 
+
+* Button (default)
+* Checkbox
+* Link
+* Menu item
+* Menu item checkbox
+* Menu item radio
+* Option
+* Radio
+* Switch
+* Tab
+
+### 2.2 Common Section {#common}
 
 {{% snippet file="refguide/common-section-link.md" %}}
 
-### 2.2 Design Properties Section {#design}
+### 2.3 Design Properties Section {#design}
 
 {{% snippet file="refguide/design-section-link.md" %}} 
 
-### 2.3 Events Section {#events}
+### 2.4 Events Section {#events}
 
 {{% snippet file="refguide/events-section-link.md" %}}
 
-### 2.4 General Section {#general}
+### 2.5 General Section {#general}
 
-#### 2.4.1 Caption {#caption}
+#### 2.5.1 Caption {#caption}
 
 The **Caption** property defines a text that will be shown on the button. The caption can contain parameters that are written between braces, e.g. {1}.  
 
 For more information on using parameters, see the [Parameters]() section below. 
 
-#### 2.4.2 Parameters {#parameters}
+#### 2.5.2 Parameters {#parameters}
 
 Parameters are attributes the value of which will be displayed. To view **Parameters**, do one of the following:
 
@@ -65,7 +89,7 @@ Parameters have the following settings:
 
     ![Parameter Settings](attachments/button-widgets/button-parameter-settings.png)
 
-##### 2.4.2.1 Adding New Parameters
+##### 2.5.2.1 Adding New Parameters
 
 To add parameters, do the following:
 
@@ -83,7 +107,7 @@ To add parameters, do the following:
 
     ![Parameter Example](attachments/button-widgets/button-parameter-example.png)
 
-##### 2.4.2.2 Performing Other Actions on Parameters
+##### 2.5.2.2 Performing Other Actions on Parameters
 
 In addition to adding new parameters, you can perform the following actions on parameters:
 
@@ -97,11 +121,11 @@ In addition to adding new parameters, you can perform the following actions on p
 
     ![Parameter Actions](attachments/button-widgets/button-parameter-actions.png)
 
-#### 2.4.3 Tooltip
+#### 2.5.3 Tooltip
 
 The **Tooltip** property determines a text end-users will see in the tooltip that appears when they hover over the button. The tooltip text is translatable. For more information on translatable texts, see [Language Menu](translatable-texts). If the tooltip is not specified, no tooltip will be shown when hovering over the button.
 
-#### 2.4.4 Icon {#icon}
+#### 2.5.4 Icon {#icon}
 
 The **Icon** property determines the icon that will be shown in front of the caption of the button. Possible options are: 
 
@@ -111,7 +135,7 @@ The **Icon** property determines the icon that will be shown in front of the cap
 
 Glyphicons come from the Bootstrap Halflings collection. The advantages of a glyphicon over a bitmap image are that they are scalable, look sharp on high-resolution screens, and their color can be changed by changing the font color. The advantage of an image icon is that it can have multiple colors.
 
-#### 2.4.5 Render Mode
+#### 2.5.5 Render Mode {#RenderMode}
 
 Defines the way the button will be shown to the end-user. Possible options are the following:
 
@@ -120,7 +144,7 @@ Defines the way the button will be shown to the end-user. Possible options are t
 
 *Default render mode:* Button
 
-#### 2.4.6 Button Style
+#### 2.5.6 Button Style
 
 The **Button style** property applies a predefined styling to the button. Possible options are the following:
 
@@ -132,13 +156,13 @@ The **Button style** property applies a predefined styling to the button. Possib
 * Warning
 * Danger
 
-#### 2.4.7 Disabled During Action
+#### 2.5.7 Disabled During Action
 
 This property is only shown when **Call a microflow** or **Call a nanoflow** is selected as the [on-click event](on-click-event). Selecting **Disabled during action** disables the button until the action is completed or failed.
 
 Default: *true*
 
-### 2.5 Items Section {#items}
+### 2.6 Items Section {#items}
 
 {{% alert type="info" %}}
 
@@ -166,7 +190,7 @@ Each item has the following properties:
     ![Properties of Items](attachments/button-widgets/items-properties.png)
 
 
-#### 2.5.1 Adding New Items
+#### 2.6.1 Adding New Items
 
 To add items to a drop-down buttons, do the following:
 
@@ -185,7 +209,7 @@ To add items to a drop-down buttons, do the following:
   
 
 
-### 2.6 Visibility Section {#visibility}
+### 2.7 Visibility Section {#visibility}
 
 {{% snippet file="refguide/visibility-section-link.md" %}}
 


### PR DESCRIPTION
Web ActionButton's get a configuration for aria-role, exported to the client widget when render type is "Link". This assists users in building accessible applications as ActionButtons can be configured with different aria-roles that will be interpreted by screenreaders.

MX9: https://gitlab.rnd.mendix.com/appdev/appdev/-/merge_requests/6484