### PR TITLE
Documentation on Oracle user/schema creation

### DIFF
--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -22,7 +22,6 @@ When setting-up perform the following steps:
    * CREATE TABLE
      This should ensure that the account has sufficient privileges to create the structure needed to represent the domain model and to create, query, and modify data.
 3. Ensure that the user has been granted enough quotas to create the resources they need, or give them an unlimited grant (for example, `GRANT UNLIMITED TABLESPACE TO mendix` where `mendix` is the user/schema that you have created).
-   {{% /alert %}}
 
 {{% alert type="info" %}}
 During the creation of the Mendix database, the number of structural modifications made will be dependent on the size of your domain model. If this number is quite large, or if there is a large structural change, it may be prudent to increase the value of `OPEN_CURSORS`.

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -7,28 +7,26 @@ tags: ["studio pro", "database", "oracle"]
 
 ## 1 Introduction
 
-The behavior of Mendix using an Oracle database has some minor differences when compared with using a PostgreSQL database. These differences are documented below.
+There are some minor differences in how Mendix behaves when using an Oracle database in comparision to using a PostgreSQL database. This document describes these differences.
 
-## 2 Setting up a user for Mendix
+## 2 Setting Up a User for Mendix
 
-When setting up an integration with an Oracle backend it is sensible to create a user/schema with an appropriate amount of privileges. In Mendix, we use a single user to update the schema-structure (e.g. tables, indices) and to do DML statements. The former is done when Mendix is starting up and synchronizing the model with the storage structure, and the latter is done in normal runtime operations. To setup do the following:
+When setting up an integration with an Oracle backend it is recommended that a user/schema is created with the appropriate number of privileges. In Mendix, we use a single user to update the schema-structure (for example, tables and indices) and to make DML statements. The former is done when Mendix is starting up and synchronizing the model with the storage structure, and the latter is done in normal runtime operations. 
 
-1. Create a new user and schema for Mendix with profile "DEFAULT". 
-2. Grant the user the following privileges
-- CREATE SESSION
-- CREATE SEQUENCE
-- CREATE TABLE
+When setting-up perform the following steps:
 
-This should give the account sufficient privileges to create the structure needed to represent the domain model, and to create, query and modify data.
+1. Create a new user and schema for Mendix with the profile "DEFAULT". 
+2. Grant the user the following privileges:
+   * CREATE SESSION
+   * CREATE SEQUENCE
+   * CREATE TABLE
+     This should ensure that the account has sufficient privileges to create the structure needed to represent the domain model and to create, query, and modify data.
+3. Ensure that the user has been granted enough quotas to create the resources they need, or give them an unlimited grant (for example, `GRANT UNLIMITED TABLESPACE TO mendix` where `mendix` is the user/schema that you have created).
+   {{% /alert %}}
 
 {{% alert type="info" %}}
-3. Ensure the user has been granted enough quotas to create the resources they need, or give them an unlimited grant (e.g. `GRANT UNLIMITED TABLESPACE TO mendix` where 'mendix' is the created user/schema)
+During the creation of the Mendix database, the number of structural modifications made will be dependent on the size of your domain model. If this number is quite large, or if there is a large structural change, it may be prudent to increase the value of `OPEN_CURSORS`.
 {{% /alert %}}
-
-{{% alert type="info" %}}
-During the creation of the Mendix database, the amount of structural modifications made will be dependent on the size of your domain model. If this is quite large, or if there is a large structural change, it may be prudent to increase the value of `OPEN_CURSORS`
-{{% /alert %}}
-
 
 ## 2 Unlimited and Very Long Strings
 
@@ -38,11 +36,10 @@ The majority of differences between PostgreSQL and Oracle are in how they handle
 
 Oracle does not support unlimited strings or strings with a specified size greater than 2000 characters when using the equal (`=`) or not equal (`!=`) operators in XPath constraints. However, it does support functions including `contains()`, `starts-with()`, and `ends-with()`.
 
-### 2.2 Sorting, Grouping and Aggregating
+### 2.2 Sorting, Grouping, and Aggregating
 
 It is not possible to sort, group, or use aggregate functions such as `count()` on unlimited strings or strings with a specified length greater than 2000 characters. This is because such long or unlimited strings are implemented with the data type CLOB. Consider decreasing the length of the string attribute or removing it from data grids.
 
 ### 2.3 Selecting DISTINCT Attribute
 
 Selecting DISTINCT attributes of the string type with a size greater than 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you run into this limitation, you may encounter an exception in the logs with a message like this: **Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small**.
- 

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -11,7 +11,7 @@ There are some minor differences in how Mendix behaves when using an Oracle data
 
 ## 2 Setting Up a User for Mendix
 
-When setting up an integration with an Oracle backend it is recommended that a user/schema is created with the appropriate number of privileges. In Mendix, we use a single user to update the schema-structure (for example, tables and indices) and to make DML statements. The former is done when Mendix is starting up and synchronizing the model with the storage structure, and the latter is done in normal runtime operations. 
+When setting up an integration with an Oracle backend we recommend that you create a user/schema with the appropriate number of privileges. In Mendix, we use a single user to update the schema-structure (for example, tables and indices) and to make DML statements. The former is done when Mendix is starting up and synchronizing the model with the storage structure, and the latter is done in normal runtime operations. 
 
 When setting-up perform the following steps:
 
@@ -20,7 +20,7 @@ When setting-up perform the following steps:
    * CREATE SESSION
    * CREATE SEQUENCE
    * CREATE TABLE
-     This should ensure that the account has sufficient privileges to create the structure needed to represent the domain model and to create, query, and modify data.
+     This will ensure that the account has sufficient privileges to create the structure needed to represent the domain model and to create, query, and modify data.
 3. Ensure that the user has been granted enough quotas to create the resources they need, or give them an unlimited grant (for example, `GRANT UNLIMITED TABLESPACE TO mendix` where `mendix` is the user/schema that you have created).
 
 {{% alert type="info" %}}

--- a/content/refguide/oracle.md
+++ b/content/refguide/oracle.md
@@ -9,6 +9,27 @@ tags: ["studio pro", "database", "oracle"]
 
 The behavior of Mendix using an Oracle database has some minor differences when compared with using a PostgreSQL database. These differences are documented below.
 
+## 2 Setting up a user for Mendix
+
+When setting up an integration with an Oracle backend it is sensible to create a user/schema with an appropriate amount of privileges. In Mendix, we use a single user to update the schema-structure (e.g. tables, indices) and to do DML statements. The former is done when Mendix is starting up and synchronizing the model with the storage structure, and the latter is done in normal runtime operations. To setup do the following:
+
+1. Create a new user and schema for Mendix with profile "DEFAULT". 
+2. Grant the user the following privileges
+- CREATE SESSION
+- CREATE SEQUENCE
+- CREATE TABLE
+
+This should give the account sufficient privileges to create the structure needed to represent the domain model, and to create, query and modify data.
+
+{{% alert type="info" %}}
+3. Ensure the user has been granted enough quotas to create the resources they need, or give them an unlimited grant (e.g. `GRANT UNLIMITED TABLESPACE TO mendix` where 'mendix' is the created user/schema)
+{{% /alert %}}
+
+{{% alert type="info" %}}
+During the creation of the Mendix database, the amount of structural modifications made will be dependent on the size of your domain model. If this is quite large, or if there is a large structural change, it may be prudent to increase the value of `OPEN_CURSORS`
+{{% /alert %}}
+
+
 ## 2 Unlimited and Very Long Strings
 
 The majority of differences between PostgreSQL and Oracle are in how they handle very long, or unlimited length, strings.
@@ -24,19 +45,4 @@ It is not possible to sort, group, or use aggregate functions such as `count()` 
 ### 2.3 Selecting DISTINCT Attribute
 
 Selecting DISTINCT attributes of the string type with a size greater than 2000 characters is not supported by Mendix due to a known Oracle limitation of selecting DISTINCT columns with a CLOB data type. If you run into this limitation, you may encounter an exception in the logs with a message like this: **Error Msg = ORA-06502: PL/SQL: numeric or value error: character string buffer too small**.
-
-## 3 Required Privileges
-
-The following are the minimum privileges that have to be set for access to your Oracle DB: 
-
-* Create tables
-
-* Drop tables
-
-* Create indexes
-
-* Create sequences
-
-* Create, read, update, and delete data
-
-These are the requirements for a Mendix Database. The Database Administrator can specify the other access and permissions that are necessary to access the data.  
+ 


### PR DESCRIPTION
Improve the documentation on setting up Oracle by mentioning explicit privileges. These improvements were possible with the help of Dubai Municipality.