### PR TITLE
Update java-actions.md

### DIFF
--- a/content/refguide/java-actions.md
+++ b/content/refguide/java-actions.md
@@ -12,7 +12,7 @@ tags: ["studio pro"]
 With Java actions you can extend the functionality of your application in situations where it would be hard to implement this functionality in microflows. You can call a Java action from a microflow using the [Java action call](java-action-call).
 
 {{% alert type="info" %}}
-Each Java action defined in Studio Pro corresponds to a file *{name of Java action}.java* in the subdirectory *javasource{module name}/actions* of the project directory.
+Each Java action defined in Studio Pro corresponds to a file *{name of Java action}.java* in the subdirectory *javasource/{module name}/actions* of the project directory.
 
 The skeletons of these *.java* files are generated automatically when you deploy for Eclipse (in the **Project** menu). For more information about creating the Java code in these files, see [Java Programming](java-programming).
 {{% /alert %}}


### PR DESCRIPTION
A slash (/) is missing between the words 'javasource' and '{module name}' in the below sentence on this page. This can be confusing and misleading for some people.

Each Java action defined in Studio Pro corresponds to a file {name of Java action}.java in the subdirectory javasource{module name}/actions of the project directory.