### PR TITLE
App Service deprecation update

### DIFF
--- a/content/developerportal/deploy/app-services.md
+++ b/content/developerportal/deploy/app-services.md
@@ -9,7 +9,7 @@ tags: ["Developer Portal", "App Services", "Deploy"]
 ## 1 Introduction
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [published web service](/refguide/published-web-services) or a [published REST service](/refguide/published-rest-services) instead.
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](/refguide/published-web-services) and [published REST services](/refguide/published-rest-services).
 {{% /alert %}}
 
 The **App Services** page provides an overview of possible resources that can be published to the [Mendix App Store](https://appstore.home.mendix.com/):

--- a/content/howto/integration/publish-data-to-other-mendix-apps-using-an-app-service.md
+++ b/content/howto/integration/publish-data-to-other-mendix-apps-using-an-app-service.md
@@ -7,7 +7,7 @@ tags: ["integration", "publish"]
 ---
 
 {{% alert type="info" %}}
-App services are deprecated marked for removal. Use a [published web service](/refguide/published-web-services) or a [published REST service](/refguide/published-rest-services) instead.
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](/refguide/published-web-services) and [published REST services](/refguide/published-rest-services).
 {{% /alert %}}
 
 ## 1 Introduction

--- a/content/refguide/actions.md
+++ b/content/refguide/actions.md
@@ -7,7 +7,7 @@ tags: ["studio pro"]
 ## 1 Introduction
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [published web service](published-web-services) or a [published REST service](published-rest-services) instead.
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](ublished-web-services) and [published REST services](published-rest-services).
 {{% /alert %}}
 
 Actions provide the actual microflow actions of the app service. Once an app service version is set to **Consumable**, its parameters and return type are no longer editable, as they are part of the app service contract.

--- a/content/refguide/actions.md
+++ b/content/refguide/actions.md
@@ -7,7 +7,7 @@ tags: ["studio pro"]
 ## 1 Introduction
 
 {{% alert type="info" %}}
-App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](ublished-web-services) and [published REST services](published-rest-services).
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](published-web-services) and [published REST services](published-rest-services).
 {{% /alert %}}
 
 Actions provide the actual microflow actions of the app service. Once an app service version is set to **Consumable**, its parameters and return type are no longer editable, as they are part of the app service contract.

--- a/content/refguide/consumed-app-services.md
+++ b/content/refguide/consumed-app-services.md
@@ -6,7 +6,7 @@ tags: ["studio pro"]
 ---
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [consumed web service](consumed-web-services) to consume existing app services.
+App services are deprecated and from version 8.18, are no longer supported. Use a [consumed web service](consumed-web-services) to consume existing app services.
 {{% /alert %}}
 
 App services are a way of connecting Mendix applications to each other. An app service can be imported and its content can be used. As for now, app services provide the following content:

--- a/content/refguide/published-app-service.md
+++ b/content/refguide/published-app-service.md
@@ -5,7 +5,7 @@ tags: ["studio pro"]
 ---
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [published web service](published-web-services) or a [published REST service](published-rest-services) instead.
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](published-web-services) and [published REST services](published-rest-services).
 {{% /alert %}}
 
 ## 1 General Tab

--- a/content/refguide/published-app-services.md
+++ b/content/refguide/published-app-services.md
@@ -8,7 +8,7 @@ tags: ["studio pro"]
 ## 1 Introduction
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [published web service](published-web-services) or a [published REST service](published-rest-services) instead.
+App services are deprecated and from version 8.18, are no longer supported. They are replaced by [published web services](published-web-services) and [published REST services](published-rest-services).
 {{% /alert %}}
 
 An app service can be created via **File** > **New Document**.

--- a/content/refguide/select-app-service.md
+++ b/content/refguide/select-app-service.md
@@ -5,7 +5,7 @@ tags: ["studio pro"]
 ---
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [consumed web service](consumed-web-services) to consume existing app services.
+App services are deprecated and from version 8.18, are no longer supported. Use a [consumed web service](consumed-web-services) to consume existing app services.
 {{% /alert %}}
 
 ## Source

--- a/content/refguide/settings.md
+++ b/content/refguide/settings.md
@@ -5,7 +5,7 @@ tags: ["studio pro"]
 ---
 
 {{% alert type="info" %}}
-App services are deprecated and marked for removal. Use a [consumed web service](consumed-web-services) to consume existing app services.
+App services are deprecated and from version 8.18, are no longer supported. Use a [consumed web service](consumed-web-services) to consume existing app services.
 {{% /alert %}}
 
 In the settings screen, you see the version of the app service, its icon and a short description. Three tabs are selectable: 'Actions', 'Settings' and 'Documentation'.


### PR DESCRIPTION
These changes should be synchronized with 8.18 release

Starting from version 8.18.0 app services are no longer supported