### PR TITLE
Include alert for static pages 

### DIFF
--- a/content/refguide/translatable-texts.md
+++ b/content/refguide/translatable-texts.md
@@ -92,7 +92,7 @@ There are two options to ensure that the language is changed:
     ![System Domain Model for User and Language](attachments/language/reload-with-state.png)
 
 {{% alert type="info" %}}
-The above only applies to pages _within_ your Mendix application, that is: pages that are created in Studio Pro. The labels for static pages, such as the _index.html_ and _login.html_ pages in the _theme_ folder of your project, are generated when you create a deployment package, using the default language of your project. The labels on those pages will not change for different users, but will always be the same.
+The above only applies to pages *within* your Mendix application (meaning, pages that are created in Studio Pro). The labels for static pages (such as the *index.html* and *login.html* pages in the **theme** folder of your app project) are generated when you create a deployment package using the default language of your project. The labels on those pages will not change for different users, they will always be the same.
 {{% /alert %}}
 
 ## 5 Read More

--- a/content/refguide/translatable-texts.md
+++ b/content/refguide/translatable-texts.md
@@ -91,6 +91,10 @@ There are two options to ensure that the language is changed:
 
     ![System Domain Model for User and Language](attachments/language/reload-with-state.png)
 
+{{% alert type="info" %}}
+The above only applies to pages _within_ your Mendix application, that is: pages that are created in Studio Pro. The labels for static pages, such as the _index.html_ and _login.html_ pages in the _theme_ folder of your project, are generated when you create a deployment package, using the default language of your project. The labels on those pages will not change for different users, but will always be the same.
+{{% /alert %}}
+
 ## 5 Read More
 
 * [How to Translate Your App Content](/howto/collaboration-requirements-management/translate-your-app-content) – a worked example of adding a translation 

--- a/content/refguide8/translatable-texts.md
+++ b/content/refguide8/translatable-texts.md
@@ -91,6 +91,10 @@ There are two options to ensure that the language is changed:
 
     ![System Domain Model for User and Language](attachments/language/reload-with-state.png)
 
+{{% alert type="info" %}}
+The above only applies to pages _within_ your Mendix application, that is: pages that are created in Studio Pro. The labels for static pages, such as the _index.html_ and _login.html_ pages in the _theme_ folder of your project, are generated when you create a deployment package, using the default language of your project. The labels on those pages will not change for different users, but will always be the same.
+{{% /alert %}}
+
 ## 5 Read More
 
 * [How to Translate Your App Content](/howto8/collaboration-requirements-management/translate-your-app-content) – a worked example of adding a translation 

--- a/content/refguide8/translatable-texts.md
+++ b/content/refguide8/translatable-texts.md
@@ -92,7 +92,7 @@ There are two options to ensure that the language is changed:
     ![System Domain Model for User and Language](attachments/language/reload-with-state.png)
 
 {{% alert type="info" %}}
-The above only applies to pages _within_ your Mendix application, that is: pages that are created in Studio Pro. The labels for static pages, such as the _index.html_ and _login.html_ pages in the _theme_ folder of your project, are generated when you create a deployment package, using the default language of your project. The labels on those pages will not change for different users, but will always be the same.
+The above only applies to pages *within* your Mendix application (meaning, pages that are created in Studio Pro). The labels for static pages (such as the *index.html* and *login.html* pages in the **theme** folder of your app project) are generated when you create a deployment package using the default language of your project. The labels on those pages will not change for different users, they will always be the same.
 {{% /alert %}}
 
 ## 5 Read More


### PR DESCRIPTION
Include alert to notify customers of difference in behavior for static pages. See https://mendixsupport.zendesk.com/agent/tickets/112989