### PR TITLE
Add Appium testing documentation

### DIFF
--- a/content/howto/mobile/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/mobile/testing-mendix-native-apps-using-appium.md
@@ -1,7 +1,7 @@
 ---
-title: "Test Mendix Native Apps Using Appium"
-category: "Testing"
-menu_order: 50
+Title: "Test Mendix Native Apps Using Appium"
+parent: "build-native-apps"
+menu_order: 80
 #description: "Set a description with a maximum of 140 characters; this should describe what the goal of the document is, and it can be different from the document introduction; this is optional, and it can be removed"
 tags: ["test", "testing", "appium", "mobile", "native"]
 ---

--- a/content/howto/mobile/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/mobile/testing-mendix-native-apps-using-appium.md
@@ -1,5 +1,5 @@
 ---
-Title: "Test Mendix Native Apps Using Appium"
+title: "Test Mendix Native Apps Using Appium"
 parent: "build-native-apps"
 menu_order: 80
 #description: "Set a description with a maximum of 140 characters; this should describe what the goal of the document is, and it can be different from the document introduction; this is optional, and it can be removed"

--- a/content/howto/testing/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/testing/testing-mendix-native-apps-using-appium.md
@@ -22,9 +22,9 @@ Mendix lets you create native mobile apps for both Android and iOS from a single
 Before starting this how-to, make sure you have completed the following prerequisites:
 
 * Install [Appium Desktop](https://github.com/appium/appium-desktop)
-* Install, run, and fix any issues found by [Appiun-doctor](https://github.com/appium/appium-doctor)
+* Install, run, and fix any issues found by [appium-doctor](https://github.com/appium/appium-doctor)
 
-## 3 Understand how Studio (pro) widgets relate to your native app
+## 3 Understand How Widgets Relate to Your Native App
 
 TLDR: For each widget in the page editor of Studio (pro) the value of the name property will map to a property of the corresponding UI element in the native app. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property. `view-tag` properties can only be read with the Espresso Android driver.
 
@@ -35,16 +35,16 @@ The Espresso driver requires you to install instrumentation in your app to work.
 
 FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been merged to the react-native codebase and will be available from version 0.6.4 on. This means that once Mendix starts using that version (or higher) of react-native to create your native apps, it should also expose the value of a widget's name property as the Android native `resource-id` property. This is readable by the UiAutomator2 driver, eliminating the need for using the Espresso driver. There are pro's and con's to each driver, but the UiAutomator2 driver is the easiest to setup and start with and supports the most functionality.
 
-## 4 Setup Appium Desktop to spy on a Mendix native iOS app
+## 4 Set Up Appium Desktop to Spy on a Mendix Native iOS App
 
-* Build a native iOS app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
-* Build the WebDriverAgent project that is shipped with your Appium Desktop installation as described [here](http://appium.io/docs/en/advanced-concepts/wda-custom-server/) (For Appium Desktop, the WDA project can be found in: `/Applications/Appium.app/Contents/Resources/app/node_modules/appium/node_modules/appium-webdriveragent`)
-* Start Appium Desktop
-* Click `Start Server`
-* On the new screen, click the magnifier image on the top-right `Start Inspector Session`
-* On the new popup, add the following capabilities:
+1. Build a native iOS app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
+1. Build the WebDriverAgent project that is shipped with your Appium Desktop installation as described [here](http://appium.io/docs/en/advanced-concepts/wda-custom-server/) (For Appium Desktop, the WDA project can be found in: `/Applications/Appium.app/Contents/Resources/app/node_modules/appium/node_modules/appium-webdriveragent`)
+1. Start Appium Desktop
+1. Click `Start Server`
+1. On the new screen, click the magnifier image on the top-right `Start Inspector Session`
+1. On the new popup, add the following capabilities:
 
-```json
+    ```json
 {
     "automationName": "XCUITest",
     "deviceName": "desired device here, for instance 'iPhone 11'",
@@ -52,21 +52,21 @@ FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been mer
     "platformVersion": "desired platform version, for instance '14.3'",
     "app": "location of your .app iOS app file",
 }
-```
+    ```
 
-* Click `Start Session` and wait untill your app starts (this takes a while)
-* Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+1. Click `Start Session` and wait untill your app starts (this takes a while)
+1. Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
 
-## 5 Setup Appium Desktop to spy on a Mendix native Android app
+## 5 Set Up Appium Desktop to Spy on a Mendix Native Android App
 
-* Add the Espresso dependencies by following the setup instructions [here](https://developer.android.com/training/testing/espresso/setup)
-* Build a native Android app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
-* Start Appium Desktop
-* Click `Start Server`
-* On the new screen, click the magnifier logo on the top-right `Start Inspector Session`
-* On the new popup, add the following capabilities:
+1. Add the Espresso dependencies by following the setup instructions [here](https://developer.android.com/training/testing/espresso/setup)
+1. Build a native Android app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
+1. Start Appium Desktop
+1. Click `Start Server`
+1. On the new screen, click the magnifier logo on the top-right `Start Inspector Session`
+1. On the new popup, add the following capabilities:
 
-```json
+    ```json
 {
   "deviceName": "arbitrary name of your Android device",
   "avd": "snake-cased name of your Android emulator",
@@ -77,9 +77,10 @@ FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been mer
   "automationName": "Espresso",
   "app": "location of your .apk Android app file",
 }
-```
+    ```
 
 **NOTE 1**
+
 While using Espresson in combination with Mendix projects, we observed a `No static method lifecycleEventObserver` error. More information about this can be found [here](https://github.com/appium/appium-espresso-driver/issues/639). You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing:
 
 ```json
@@ -89,6 +90,7 @@ While using Espresson in combination with Mendix projects, we observed a `No sta
 ```
 
 **NOTE 2**
+
 While using Espresson in combination with Mendix projects, there have been the occoassional package conflicts. You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing your desired tools and versions:
 
 ```json

--- a/content/howto/testing/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/testing/testing-mendix-native-apps-using-appium.md
@@ -1,0 +1,114 @@
+---
+title: "Test Mendix Native apps using Appium"
+category: "Testing"
+menu_order: 50
+#description: "Set a description with a maximum of 140 characters; this should describe what the goal of the document is, and it can be different from the document introduction; this is optional, and it can be removed"
+tags: ["test", "testing", "appium", "mobile", "native"]
+---
+
+## 1 Introduction
+
+Mendix let's you create native mobile apps for both Android and iOS from a single project. To verify that these apps work as expected, you can test them using Appium. The benefits of using Appium:
+
+* It supports both the iOS and Android platform with a single API
+* The API resembles that of Selenium
+
+This allows you to write end-to-end tests once and run them on both platforms, all while using a familiar API.
+This description is for running and testing your apps on emulators.
+
+**This how-to will teach you how to do the following:**
+
+* Understand how Studio (pro) widgets relate to your native app
+* Setup Appium GUI to spy on a Mendix native iOS app
+* Setup Appium GUI to spy on a Mendix native Android app
+* Automatically testing your Mendix native app
+
+## 2 Prerequisites
+
+Before starting this how-to, make sure you have completed the following prerequisites:
+
+* Install [Appium Desktop](https://github.com/appium/appium-desktop)
+* Install, run and fix any issues found by [Appiun-doctor](https://github.com/appium/appium-doctor)
+
+## 3 Understand how Studio (pro) widgets relate to your native app
+
+TLDR: For each widget in the page editor of Studio (pro) the value of the name property will map to a property of the corresponding UI element in the native app. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property. `view-tag` properties can only be read with the Espresso Android driver.
+
+Under the hood, Mendix uses react-native to create your native apps. React-native's components have a property called `testID` that can be set. This `testID` is created specifically for end-to-end testing. For every component Mendix fills this with the value of the name property of the corresponding widget in the page editor. The `testID` is then mapped to a UI element's property in the native app by react-native. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property.
+
+However, the default Appium Android driver (UIAutomator2) is unable to read the `view-tag` property. For Appium to be able to read that property, you will need to configure it to use another driver; the Espresso driver.
+The Espresso driver requires you to install instrumentation in your app to work.
+
+FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been merged to the react-native codebase and will be available from version 0.6.4 on. This means that once Mendix starts using that version (or higher) of react-native to create your native apps, it should also expose the value of a widget's name property as the Android native `resource-id` property. This is readable by the UiAutomator2 driver, eliminating the need for using the Espresso driver. There are pro's and con's to each driver, but the UiAutomator2 driver is the easiest to setup and start with and supports the most functionality.
+
+## 4 Setup Appium Desktop to spy on a Mendix native iOS app
+
+* Build a native iOS app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
+* Build the WebDriverAgent project that is shipped with your Appium Desktop installation as described [here](http://appium.io/docs/en/advanced-concepts/wda-custom-server/) (For Appium Desktop, the WDA project can be found in: `/Applications/Appium.app/Contents/Resources/app/node_modules/appium/node_modules/appium-webdriveragent`)
+* Start Appium Desktop
+* Click `Start Server`
+* On the new screen, click the magnifier image on the top-right `Start Inspector Session`
+* On the new popup, add the following capabilities:
+
+```json
+{
+    "automationName": "XCUITest",
+    "deviceName": "desired device here, for instance 'iPhone 11'",
+    "platformName": "iOS",
+    "platformVersion": "desired platform version, for instance '14.3'",
+    "app": "location of your .app iOS app file",
+}
+```
+
+* Click `Start Session` and wait untill your app starts (this takes a while)
+* Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+
+## 5 Setup Appium Desktop to spy on a Mendix native Android app
+
+* Add the Espresso dependencies by following the setup instructions [here](https://developer.android.com/training/testing/espresso/setup)
+* Build a native Android app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
+* Start Appium Desktop
+* Click `Start Server`
+* On the new screen, click the magnifier logo on the top-right `Start Inspector Session`
+* On the new popup, add the following capabilities:
+
+```json
+{
+  "deviceName": "arbitrary name of your Android device",
+  "avd": "snake-cased name of your Android emulator",
+  "platformName": "Android",
+  "udid": "udid of your Android device",
+  "appPackage": "the package name of your app",
+  "appActivity": "the main activity name of your app",
+  "automationName": "Espresso",
+  "app": "location of your .apk Android app file",
+}
+```
+
+**NOTE 1**
+While using Espresson in combination with Mendix projects, we observed a `No static method lifecycleEventObserver` error. More information about this can be found [here](https://github.com/appium/appium-espresso-driver/issues/639). You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing:
+
+```json
+{
+    "additionalAndroidTestDependencies": ["androidx.lifecycle:lifecycle-common:2.2.0"]
+}
+```
+
+**NOTE 2**
+While using Espresson in combination with Mendix projects, there have been the occoassional package conflicts. You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing your desired tools and versions:
+
+```json
+{
+    "toolsVersions": {
+        "compileSdk": "30"
+        ...
+    }
+}
+```
+
+* Click `Start Session` and wait untill your app starts (this takes a while)
+* Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+
+## 6 Automatically testing your Mendix native app
+
+Once you have desired capabilities that work with `Appium Desktop` you can also use them with the `Appium CLI` to run automated tests. Everything you need to create your first automated test can be found [here](http://appium.io/docs/en/about-appium/getting-started/?lang=en). You can use the the `Appium Desktop Inspector` to find the right locators.

--- a/content/howto/testing/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/testing/testing-mendix-native-apps-using-appium.md
@@ -102,8 +102,8 @@ While using Espresson in combination with Mendix projects, there have been the o
 }
 ```
 
-* Click `Start Session` and wait untill your app starts (this takes a while)
-* Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+1. Click `Start Session` and wait untill your app starts (this takes a while)
+1. Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
 
 ## 6 Automatically testing your Mendix native app
 

--- a/content/howto/testing/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/testing/testing-mendix-native-apps-using-appium.md
@@ -1,5 +1,5 @@
 ---
-title: "Test Mendix Native apps using Appium"
+title: "Test Mendix Native Apps Using Appium"
 category: "Testing"
 menu_order: 50
 #description: "Set a description with a maximum of 140 characters; this should describe what the goal of the document is, and it can be different from the document introduction; this is optional, and it can be removed"
@@ -8,27 +8,21 @@ tags: ["test", "testing", "appium", "mobile", "native"]
 
 ## 1 Introduction
 
-Mendix let's you create native mobile apps for both Android and iOS from a single project. To verify that these apps work as expected, you can test them using Appium. The benefits of using Appium:
-
-* It supports both the iOS and Android platform with a single API
-* The API resembles that of Selenium
-
-This allows you to write end-to-end tests once and run them on both platforms, all while using a familiar API.
-This description is for running and testing your apps on emulators.
+Mendix lets you create native mobile apps for both Android and iOS from a single project. To verify that your apps work as expected, you can test them using Appium. Using Appium can help you because it supports both iOS and Android with a single API that resembles Selenium's. This how-to will teach you how to write end-to-end tests once and run them on both platforms, all while using a familiar API. You will also learn how to run and test your apps on emulators.
 
 **This how-to will teach you how to do the following:**
 
-* Understand how Studio (pro) widgets relate to your native app
-* Setup Appium GUI to spy on a Mendix native iOS app
-* Setup Appium GUI to spy on a Mendix native Android app
-* Automatically testing your Mendix native app
+* Understand how Mendix Studio and Studio Pro widgets relate to your native app
+* Set up Appium GUI to spy on a Mendix native iOS app
+* Set up Appium GUI to spy on a Mendix native Android app
+* Set up automatic testing for your Mendix native app
 
 ## 2 Prerequisites
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
 * Install [Appium Desktop](https://github.com/appium/appium-desktop)
-* Install, run and fix any issues found by [Appiun-doctor](https://github.com/appium/appium-doctor)
+* Install, run, and fix any issues found by [Appiun-doctor](https://github.com/appium/appium-doctor)
 
 ## 3 Understand how Studio (pro) widgets relate to your native app
 

--- a/content/howto/testing/testing-mendix-native-apps-using-appium.md
+++ b/content/howto/testing/testing-mendix-native-apps-using-appium.md
@@ -26,26 +26,23 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## 3 Understand How Widgets Relate to Your Native App
 
-TLDR: For each widget in the page editor of Studio (pro) the value of the name property will map to a property of the corresponding UI element in the native app. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property. `view-tag` properties can only be read with the Espresso Android driver.
+For each widget in the page editor of Studio and Studio Pro, the value of the named property will map to a property of the corresponding UI element in the native app. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property. `view-tag` properties can only be read with the Espresso Android driver.
 
-Under the hood, Mendix uses react-native to create your native apps. React-native's components have a property called `testID` that can be set. This `testID` is created specifically for end-to-end testing. For every component Mendix fills this with the value of the name property of the corresponding widget in the page editor. The `testID` is then mapped to a UI element's property in the native app by react-native. For iOS these UI elements will have an `accessibility id` property and for Android there will be a `view-tag` property.
+Under the hood, Mendix uses react-native to create your native apps. React-native's components have a property called `testID` that can be set. This `testID` is created specifically for end-to-end testing. For every component Mendix fills this with the value of the name property of the corresponding widget in the page editor. The `testID` is then mapped to a UI element's property in the native app by React Native. For iOS these UI elements will have an `accessibility id` property, and for Android there will be a `view-tag` property.
 
-However, the default Appium Android driver (UIAutomator2) is unable to read the `view-tag` property. For Appium to be able to read that property, you will need to configure it to use another driver; the Espresso driver.
-The Espresso driver requires you to install instrumentation in your app to work.
-
-FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been merged to the react-native codebase and will be available from version 0.6.4 on. This means that once Mendix starts using that version (or higher) of react-native to create your native apps, it should also expose the value of a widget's name property as the Android native `resource-id` property. This is readable by the UiAutomator2 driver, eliminating the need for using the Espresso driver. There are pro's and con's to each driver, but the UiAutomator2 driver is the easiest to setup and start with and supports the most functionality.
+However, the default Appium Android driver (UIAutomator2) is unable to read the `view-tag` property. For Appium to be able to read that property, you will need to configure it to use another driver: the Espresso driver. The Espresso driver requires you to install instrumentation in your app to work.
 
 ## 4 Set Up Appium Desktop to Spy on a Mendix Native iOS App
 
-1. Build a native iOS app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
-1. Build the WebDriverAgent project that is shipped with your Appium Desktop installation as described [here](http://appium.io/docs/en/advanced-concepts/wda-custom-server/) (For Appium Desktop, the WDA project can be found in: `/Applications/Appium.app/Contents/Resources/app/node_modules/appium/node_modules/appium-webdriveragent`)
+1. Build a native iOS app for your Mendix project (see [How to Build Native Apps](/howto/mobile/build-native-apps) for more information).
+1. Build the WebDriverAgent project that is shipped with your Appium Desktop installation as described [here](http://appium.io/docs/en/advanced-concepts/wda-custom-server/).For Appium Desktop, the WDA project can be found in */Applications/Appium.app/Contents/Resources/app/node_modules/appium/node_modules/appium-webdriveragent*.
 1. Start Appium Desktop
-1. Click `Start Server`
-1. On the new screen, click the magnifier image on the top-right `Start Inspector Session`
-1. On the new popup, add the following capabilities:
+1. Click **Start Server**.
+1. On the new screen, click the **Start Inspector Session** magnifier image in the top-right.
+1. In the new window, add the following capabilities:
 
     ```json
-{
+    {
     "automationName": "XCUITest",
     "deviceName": "desired device here, for instance 'iPhone 11'",
     "platformName": "iOS",
@@ -54,20 +51,20 @@ FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been mer
 }
     ```
 
-1. Click `Start Session` and wait untill your app starts (this takes a while)
-1. Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+1. Click **Start Session** and wait untill your app starts.
+1. Click on the blue **Select Elements** button, and then click on an element in the app preview to spy on that element.
 
 ## 5 Set Up Appium Desktop to Spy on a Mendix Native Android App
 
-1. Add the Espresso dependencies by following the setup instructions [here](https://developer.android.com/training/testing/espresso/setup)
-1. Build a native Android app for your Mendix project (See [here](https://docs.mendix.com/howto/mobile/build-native-apps) for more information)
-1. Start Appium Desktop
-1. Click `Start Server`
-1. On the new screen, click the magnifier logo on the top-right `Start Inspector Session`
-1. On the new popup, add the following capabilities:
+1. Add the Espresso dependencies by following the setup instructions [here](https://developer.android.com/training/testing/espresso/setup).
+1. Build a native Android app for your Mendix project (See [How to Build Native Apps](/howto/mobile/build-native-apps) for more information).
+1. Start Appium Desktop.
+1. Click **Start Server**.
+1. On the new screen, click the **Start Inspector Session** magnifier image in the top-right.
+1. In the new window, add the following capabilities:
 
     ```json
-{
+    {
   "deviceName": "arbitrary name of your Android device",
   "avd": "snake-cased name of your Android emulator",
   "platformName": "Android",
@@ -79,32 +76,32 @@ FYI: [This](https://github.com/facebook/react-native/pull/29610) PR has been mer
 }
     ```
 
-**NOTE 1**
-
+    {{% alert type="info" %}}
 While using Espresson in combination with Mendix projects, we observed a `No static method lifecycleEventObserver` error. More information about this can be found [here](https://github.com/appium/appium-espresso-driver/issues/639). You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing:
 
-```json
-{
+    ```json
+    {
     "additionalAndroidTestDependencies": ["androidx.lifecycle:lifecycle-common:2.2.0"]
 }
-```
+    ```
+    {{% /alert %}}
+    
+    {{% alert type="info" %}}
+While using Espresson in combination with Mendix projects, there have been occasional package conflicts. You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing your desired tools and versions:
 
-**NOTE 2**
-
-While using Espresson in combination with Mendix projects, there have been the occoassional package conflicts. You can fix this by adding the `espressoBuildConfig` property to the capabilities. It should point to a JSON file containing your desired tools and versions:
-
-```json
-{
+    ```json
+    {
     "toolsVersions": {
         "compileSdk": "30"
         ...
     }
 }
-```
+    ```
+    {{% /alert %}}
+    
+1. Click **Start Session** and wait untill your app starts.
+1. Click on the blue **Select Elements** button, and then click on an element in the app preview to spy on that element.
 
-1. Click `Start Session` and wait untill your app starts (this takes a while)
-1. Click on the blue `Select Elements` button and then click on an element in th app preview to spy on that element
+## 6 Automatically Testing Your Mendix Bative App
 
-## 6 Automatically testing your Mendix native app
-
-Once you have desired capabilities that work with `Appium Desktop` you can also use them with the `Appium CLI` to run automated tests. Everything you need to create your first automated test can be found [here](http://appium.io/docs/en/about-appium/getting-started/?lang=en). You can use the the `Appium Desktop Inspector` to find the right locators.
+Once you have the capabilities you want that work with Appium Desktop, you can also use them with Appium CLI to run automated tests. Everything you need to create your first automated test can be found [here](http://appium.io/docs/en/about-appium/getting-started/?lang=en). You can use the the Appium Desktop Inspector to find the right locators.


### PR DESCRIPTION
This change adds a how-to on using Appium to test Mendix native mobile apps. 