### PR TITLE
Add missing qr codes and links for legacy apps

### DIFF
--- a/content/refguide/getting-the-make-it-native-app.md
+++ b/content/refguide/getting-the-make-it-native-app.md
@@ -34,7 +34,17 @@ To acquire the archive you need, see the [Android Make It Native Archive](https:
 
 iOS archive versions for Make It Native are served via TestFlight links. To join a specific TestFlight version of the Make It Native app and install it, tap the appropriate link using the device with the account you would like to join TestFlight with. Use the TestFlight app to install the version of the app you already joined.
 
-## 3 Read More
+## 3 Direct Download Links {#direct-links}
+
+### 3.1 Make It Native for Studio Pro 8.8 and Below:
+
+|                                  Android                                  |                                iOS                                |
+| :-----------------------------------------------------------------------: | :---------------------------------------------------------------: |
+| ![Android QR Code](attachments/make-it-native-archive/qr-android-8.8.png) | ![iOS QR Code](attachments/make-it-native-archive/qr-ios-8.8.png) |
+|   [Link](https://www.dropbox.com/s/z0255q1gcxpvlwl/MiN%208.8.apk?dl=0)    |        [Link](https://testflight.apple.com/join/ra3QR6iG)         |
+
+
+## 4 Read More
 
 * [How to Deploy Your First Mendix Native Mobile App](/howto/mobile/deploying-native-app)
 * [How to Create a Custom Developer App](/howto/mobile/how-to-devapps)


### PR DESCRIPTION
When moving from 8 to 9 somehow the QR codes and links weren't included.