### PR TITLE
Add 8.18 also as preferred Studio Pro version to 8.6 release notes

### DIFF
--- a/content/releasenotes/studio-pro/8.6.md
+++ b/content/releasenotes/studio-pro/8.6.md
@@ -5,7 +5,7 @@ description: "The release notes for Mendix Studio Pro version 8.6 (including all
 ---
 
 {{% alert type="info" %}}
-The preferred Studio Pro version 8 releases for apps in production are 8.6 and [8.12](8.12). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
+The preferred Studio Pro version 8 releases for apps in production are 8.6, [8.12](8.12) and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
 {{% /alert %}}
 
 ## 8.6.9 {#869}

--- a/content/releasenotes/studio-pro/8.6.md
+++ b/content/releasenotes/studio-pro/8.6.md
@@ -5,7 +5,7 @@ description: "The release notes for Mendix Studio Pro version 8.6 (including all
 ---
 
 {{% alert type="info" %}}
-The preferred Studio Pro version 8 releases for apps in production are 8.6, [8.12](8.12) and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
+The preferred Studio Pro version 8 releases for apps in production are 8.6, [8.12](8.12), and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
 {{% /alert %}}
 
 ## 8.6.9 {#869}


### PR DESCRIPTION
Updated the preferred Studio Pro version alert info message to include 8.18 as well.