### PR TITLE
Add 8.18 also as preferred Studio Pro version in 8.12 release notes

### DIFF
--- a/content/releasenotes/studio-pro/8.12.md
+++ b/content/releasenotes/studio-pro/8.12.md
@@ -6,7 +6,7 @@ description: "The release notes for Mendix Studio Pro version 8.12 (including al
 ---
 
 {{% alert type="info" %}}
-The preferred Studio Pro version 8 releases for apps in production are [8.6](8.6) and 8.12. High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
+The preferred Studio Pro version 8 releases for apps in production are [8.6](8.6), 8.12 and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
 {{% /alert %}}
 
 ## 8.12.5 {#8125}

--- a/content/releasenotes/studio-pro/8.12.md
+++ b/content/releasenotes/studio-pro/8.12.md
@@ -6,7 +6,7 @@ description: "The release notes for Mendix Studio Pro version 8.12 (including al
 ---
 
 {{% alert type="info" %}}
-The preferred Studio Pro version 8 releases for apps in production are [8.6](8.6), 8.12 and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
+The preferred Studio Pro version 8 releases for apps in production are [8.6](8.6), 8.12, and [8.18](8.18). High-priority issues fixed in [7.23](7.23) patch releases will also be fixed in these version 8 patch releases if applicable.
 {{% /alert %}}
 
 ## 8.12.5 {#8125}


### PR DESCRIPTION
Updated the preferred Studio Pro version alert info message to include 8.18 as well.