### PR TITLE
Private Cloud Operator release February 18

### DIFF
--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -299,7 +299,11 @@ To use TLS, specify the MinIO URL with an `https` schema, for example `https://m
 If the MinIO URL is specified with an `http` schema, TLS will not be used.
 {{% /alert %}}
 
-**S3 (create on-demand)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account which only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+**S3 (create bucket and user with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account with an inline policy only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key.
+
+To enable this mode, select the following options: **Create Bucket**, **Create User**, **Create inline policy**.
+
+The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
 ```json
 {
@@ -337,7 +341,243 @@ If the MinIO URL is specified with an `http` schema, TLS will not be used.
 If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
 {{% /alert %}}
 
-**S3 (existing bucket)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
+{{% /alert %}}
+
+**S3 (create bucket and user with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account. The specified existing policy will be attached to the account. You will need to provide all the information about your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
+
+To enable this mode, select the following options: **Create Bucket**, **Create User**.
+
+Create an IAM policy that will be attached to app users and write down its Policy ARN (specify this value in the **Attach Policy ARN** field):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowListingOfUserFolder",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::${aws:username}"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": [
+                        "${aws:username}/*",
+                        "${aws:username}"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "AllowAllS3ActionsInUserFolder",
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::${aws:username}/${aws:username}/*"
+            ],
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject"
+            ]
+        }
+    ]
+}
+```
+
+The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "LimitedAttachmentPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "iam:AttachUserPolicy",
+                "iam:DetachUserPolicy"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "ArnEquals": {
+                    "iam:PolicyArn": [
+                        "<policy_arn>"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "iamPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "iam:DeleteAccessKey",
+                "iam:DeleteUser",
+                "iam:CreateUser",
+                "iam:CreateAccessKey"
+            ],
+            "Resource": [
+                "arn:aws:iam::<account_id>:user/mendix-*"
+            ]
+        },
+        {
+            "Sid": "bucketPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket"
+            ],
+            "Resource": "arn:aws:s3:::mendix-*"
+        }
+    ]
+}
+```
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
+{{% /alert %}}
+
+**S3 (create user with inline policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account with an inline policy only has access to a subdirectory in the existing S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
+
+To enable this mode, select the following options: **Create User**, **Create Inline Policy**.
+
+The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "iamPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "iam:DeleteAccessKey",
+                "iam:PutUserPolicy",
+                "iam:DeleteUserPolicy",
+                "iam:DeleteUser",
+                "iam:CreateUser",
+                "iam:CreateAccessKey"
+            ],
+            "Resource": [
+                "arn:aws:iam::<account_id>:user/mendix-*"
+            ]
+        }
+    ]
+}
+```
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
+{{% /alert %}}
+
+**S3 (create user with existing policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account. The specified existing policy will be attached to the account and should restrict the user to only have access to a subdirectory in the S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
+
+To enable this mode, select the following options: **Create User**.
+
+Create an IAM policy that will be attached to app users (replacing `<bucket_name>` with the name of the existing bucket) and write down its Policy ARN (specify this value in the **Attach Policy ARN** field):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowListingOfUserFolder",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::<bucket_name>"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": [
+                        "${aws:username}/*",
+                        "${aws:username}"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "AllowAllS3ActionsInUserFolder",
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::<bucket_name>/${aws:username}/*"
+            ],
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject"
+            ]
+        }
+    ]
+}
+```
+
+The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "LimitedAttachmentPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "iam:AttachUserPolicy",
+                "iam:DetachUserPolicy"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "ArnEquals": {
+                    "iam:PolicyArn": [
+                        "<policy_arn>"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "iamPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "iam:DeleteAccessKey",
+                "iam:DeleteUser",
+                "iam:CreateUser",
+                "iam:CreateAccessKey"
+            ],
+            "Resource": [
+                "arn:aws:iam::<account_id>:user/mendix-*"
+            ]
+        }
+    ]
+}
+```
+
+{{% alert type="info" %}}
+If the plan name already exists you will receive an error that it cannot be created. This is not a problem, you can continue to use the plan, and it will now have the new configuration.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
+{{% /alert %}}
+
+**S3 (existing bucket and user)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
 
 ```json
 {

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -299,11 +299,11 @@ To use TLS, specify the MinIO URL with an `https` schema, for example `https://m
 If the MinIO URL is specified with an `http` schema, TLS will not be used.
 {{% /alert %}}
 
-**S3 (create bucket and account with inline policy)** will connect to an AWS account to create S3 buckets and associated accounts (IAM users). Each app environment will receive a dedicated S3 bucket and an account (IAM user) with an inline policy which only has access to that specific S3 bucket. The Mendix Operator will use a **management account** (IAM user) to create and delete S3 buckets and accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
+**S3 (create bucket and account with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM user accounts. Each app environment will receive a dedicated S3 bucket and an IAM user account with an inline policy which only has access to that specific S3 bucket. The Mendix Operator will use a **management IAM user account** to create and delete S3 buckets and IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**, **Create inline policy**.
 
-The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
 ```json
 {
@@ -345,7 +345,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create bucket and account with existing policy)** will connect to an AWS account to create S3 buckets and associated accounts (IAM users). Each app environment will receive a dedicated S3 bucket and an account (IAM user). An existing policy, which you specify, will be attached to the account. The Mendix Operator will use a **management account** (IAM user) to create and delete S3 buckets and accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
+**S3 (create bucket and account with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM user accounts. Each app environment will receive a dedicated S3 bucket and an IAM user account. An existing policy, which you specify, will be attached to the account. The Mendix Operator will use a **management IAM user account** to create and delete S3 buckets and IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**.
 
@@ -391,7 +391,7 @@ Create an IAM policy that will be attached to app users and copy its Policy ARN 
 }
 ```
 
-The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
 
 ```json
 {
@@ -447,11 +447,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create account with inline policy)** will connect to an AWS account to create accounts (IAM users). Each app environment will receive a dedicated account (IAM user) with an inline policy. This inline policy only allows access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management account** (IAM user) to create and delete accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
+**S3 (create account with inline policy)** will connect to an AWS account to IAM user accounts. Each app environment will receive a dedicated IAM user account with an inline policy. This inline policy only allows access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management IAM user account** to create and delete IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**, **Create Inline Policy**.
 
-The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
 ```json
 {
@@ -484,11 +484,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create account with existing policy)** will connect to an AWS account to create accounts (IAM users). Each app environment will receive a dedicated account (IAM user). The specified existing policy will be attached to the account and should only allow access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management account** (IAM user) to create and delete accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
+**S3 (create account with existing policy)** will connect to an AWS account to IAM user accounts. Each app environment will receive a dedicated IAM user account. The specified existing policy will be attached to the account and should only allow access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management IAM user account** to create and delete IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**.
 
-Create an IAM policy that will be attached to app accounts (IAM users) (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
+Create an IAM policy that will be attached to app environment IAM user accounts (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
 ```json
 {
@@ -530,7 +530,7 @@ Create an IAM policy that will be attached to app accounts (IAM users) (replacin
 }
 ```
 
-The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
 
 ```json
 {
@@ -577,7 +577,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (existing bucket and account)** will connect to an existing S3 bucket with the provided IAM user access key and secret keys. All apps (environments) will use the same S3 bucket and an IAM user. You will need to provide all the information relating to your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated account (IAM user) needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+**S3 (existing bucket and account)** will connect to an existing S3 bucket with the provided IAM user access key and secret keys. All apps (environments) will use the same S3 bucket and an IAM user account. You will need to provide all the information relating to your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM user account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
 
 ```json
 {

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -299,7 +299,7 @@ To use TLS, specify the MinIO URL with an `https` schema, for example `https://m
 If the MinIO URL is specified with an `http` schema, TLS will not be used.
 {{% /alert %}}
 
-**S3 (create bucket and user with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account with an inline policy only has access to that specific S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, region, access key, and secret key.
+**S3 (create bucket and user with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account with an inline policy which only has access to that specific S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**, **Create inline policy**.
 
@@ -345,11 +345,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create bucket and user with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account. The specified existing policy will be attached to the account. You will need to provide all the information about your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
+**S3 (create bucket and user with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account. An existing policy, which you specify, will be attached to the account. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**.
 
-Create an IAM policy that will be attached to app users and write down its Policy ARN (specify this value in the **Attach Policy ARN** field):
+Create an IAM policy that will be attached to app users and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
 ```json
 {
@@ -447,7 +447,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create user with inline policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account with an inline policy only has access to a subdirectory in the existing S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
+**S3 (create user with inline policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account with an inline policy which only has access to a subdirectory in the existing S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**, **Create Inline Policy**.
 
@@ -484,11 +484,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create user with existing policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account. The specified existing policy will be attached to the account and should restrict the user to only have access to a subdirectory in the S3 bucket. You will need to provide all the information about your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
+**S3 (create user with existing policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account. The specified existing policy will be attached to the account and should restrict the user to only have access to a subdirectory in the S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**.
 
-Create an IAM policy that will be attached to app users (replacing `<bucket_name>` with the name of the existing bucket) and write down its Policy ARN (specify this value in the **Attach Policy ARN** field):
+Create an IAM policy that will be attached to app users (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
 ```json
 {
@@ -577,7 +577,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (existing bucket and user)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information about your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+**S3 (existing bucket and user)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information relating to your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
 
 ```json
 {

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -301,7 +301,7 @@ If the MinIO URL is specified with an `http` schema, TLS will not be used.
 
 **S3 (create bucket and account with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM user accounts. Each app environment will receive a dedicated S3 bucket and an IAM user account with an inline policy which only has access to that specific S3 bucket. The Mendix Operator will use a **management IAM user account** to create and delete S3 buckets and IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
 
-To enable this mode, select the following options: **Create Bucket**, **Create User**, **Create inline policy**.
+To enable this mode, select the following options: **Create S3 Bucket per environment**, **Create account (IAM user) per environment**, **Create inline policy**.
 
 The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
@@ -347,7 +347,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 **S3 (create bucket and account with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM user accounts. Each app environment will receive a dedicated S3 bucket and an IAM user account. An existing policy, which you specify, will be attached to the account. The Mendix Operator will use a **management IAM user account** to create and delete S3 buckets and IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
 
-To enable this mode, select the following options: **Create Bucket**, **Create User**.
+To enable this mode, select the following options: **Create S3 Bucket per environment**, **Create account (IAM user) per environment**.
 
 Create an IAM policy that will be attached to app users and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
@@ -449,7 +449,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 **S3 (create account with inline policy)** will connect to an AWS account to IAM user accounts. Each app environment will receive a dedicated IAM user account with an inline policy. This inline policy only allows access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management IAM user account** to create and delete IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
 
-To enable this mode, select the following options: **Create User**, **Create Inline Policy**.
+To enable this mode, select the following options: **Create account (IAM user) per environment**, **Create Inline Policy**.
 
 The **management IAM user account** needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
@@ -486,7 +486,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 **S3 (create account with existing policy)** will connect to an AWS account to IAM user accounts. Each app environment will receive a dedicated IAM user account. The specified existing policy will be attached to the account and should only allow access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management IAM user account** to create and delete IAM user accounts. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
 
-To enable this mode, select the following options: **Create User**.
+To enable this mode, select the following options: **Create account (IAM user) per environment**.
 
 Create an IAM policy that will be attached to app environment IAM user accounts (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -349,7 +349,7 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 To enable this mode, select the following options: **Create S3 Bucket per environment**, **Create account (IAM user) per environment**.
 
-Create an IAM policy that will be attached to app users and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
+Create an IAM policy that will be attached to IAM user accounts and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
 ```json
 {

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -299,11 +299,11 @@ To use TLS, specify the MinIO URL with an `https` schema, for example `https://m
 If the MinIO URL is specified with an `http` schema, TLS will not be used.
 {{% /alert %}}
 
-**S3 (create bucket and user with inline policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account with an inline policy which only has access to that specific S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
+**S3 (create bucket and account with inline policy)** will connect to an AWS account to create S3 buckets and associated accounts (IAM users). Each app environment will receive a dedicated S3 bucket and an account (IAM user) with an inline policy which only has access to that specific S3 bucket. The Mendix Operator will use a **management account** (IAM user) to create and delete S3 buckets and accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**, **Create inline policy**.
 
-The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
 ```json
 {
@@ -345,7 +345,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create bucket and user with existing policy)** will connect to an AWS account to create S3 buckets and associated IAM accounts. Each app will receive a dedicated S3 bucket and an IAM account. An existing policy, which you specify, will be attached to the account. You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
+**S3 (create bucket and account with existing policy)** will connect to an AWS account to create S3 buckets and associated accounts (IAM users). Each app environment will receive a dedicated S3 bucket and an account (IAM user). An existing policy, which you specify, will be attached to the account. The Mendix Operator will use a **management account** (IAM user) to create and delete S3 buckets and accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create Bucket**, **Create User**.
 
@@ -391,7 +391,7 @@ Create an IAM policy that will be attached to app users and copy its Policy ARN 
 }
 ```
 
-The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
 
 ```json
 {
@@ -447,11 +447,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create user with inline policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account with an inline policy which only has access to a subdirectory in the existing S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
+**S3 (create account with inline policy)** will connect to an AWS account to create accounts (IAM users). Each app environment will receive a dedicated account (IAM user) with an inline policy. This inline policy only allows access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management account** (IAM user) to create and delete accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**, **Create Inline Policy**.
 
-The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
+The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number):
 
 ```json
 {
@@ -484,11 +484,11 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (create user with existing policy)** will connect to an AWS account to create IAM accounts. Each app will receive a dedicated IAM account. The specified existing policy will be attached to the account and should restrict the user to only have access to a subdirectory in the S3 bucket. You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
+**S3 (create account with existing policy)** will connect to an AWS account to create accounts (IAM users). Each app environment will receive a dedicated account (IAM user). The specified existing policy will be attached to the account and should only allow access to objects in the existing S3 bucket if the object name prefix matches the environment's account name (IAM user name). The Mendix Operator will use a **management account** (IAM user) to create and delete accounts (IAM users). You will need to provide all the information relating to your Amazon S3 storage such as plan name, bucket name, region, policy ARN, access key, and secret key.
 
 To enable this mode, select the following options: **Create User**.
 
-Create an IAM policy that will be attached to app users (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
+Create an IAM policy that will be attached to app accounts (IAM users) (replacing `<bucket_name>` with the name of the existing bucket) and copy its Policy ARN (specify this value in the **Attach Policy ARN** field):
 
 ```json
 {
@@ -530,7 +530,7 @@ Create an IAM policy that will be attached to app users (replacing `<bucket_name
 }
 ```
 
-The management IAM account needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
+The management account (IAM user) needs to have the following IAM policy (replace `<account_id>` with your AWS account number, and `<policy_arn>` with the Policy ARN):
 
 ```json
 {
@@ -577,7 +577,7 @@ If the plan name already exists you will receive an error that it cannot be crea
 To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide) the Mendix Operator to version 1.8.0 or later.
 {{% /alert %}}
 
-**S3 (existing bucket and user)** will connect to an existing S3 bucket with the provided IAM account access key and secret keys. All apps will use the same S3 bucket and an IAM account. You will need to provide all the information relating to your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated IAM account needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
+**S3 (existing bucket and account)** will connect to an existing S3 bucket with the provided IAM user access key and secret keys. All apps (environments) will use the same S3 bucket and an IAM user. You will need to provide all the information relating to your Amazon S3 storage such as plan name, endpoint, access key, and secret key. The associated account (IAM user) needs to have the following IAM policy (replace `<bucket_name>` with the your S3 bucket name):
 
 ```json
 {

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -39,7 +39,7 @@ For example, if the image name is `quay.io/digital_ecosystems/mendix-operator:1.
 This process will take:
 
 * about 15 to 30 minutes when upgrading from Mendix Operator 1.0.\*
-* about 15 minutes when upgrading from Mendix Operator 1.1.\*-1.7.\*.
+* about 15 minutes when upgrading from Mendix Operator 1.1.\* to 1.7.\*.
 
 Some upgrade steps are only required when upgrading from older versions of the Mendix Operator. There is a notice on these steps indicating which upgrade paths they apply to and for which paths the step should be skipped.
 
@@ -57,7 +57,7 @@ kubectl -n $OPERATOR_NAMESPACE scale deployment mendix-operator --replicas=0
 #### 2.2.2 Upgrading the Custom Resource Definitions
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator versions 1.0.\*-1.7.\*  only.
+Follow this step when upgrading from Mendix Operator versions 1.0.\* to 1.7.\*  only.
 {{% /alert %}}
 
 Run the following command to upgrade to the latest version of the Custom Resource Definitions for the Mendix Operator:
@@ -71,7 +71,7 @@ kubectl apply -f https://installergen.private-cloud.api.mendix.com/privatecloud/
 #### 2.2.3 Upgrading the dependency versions
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator versions 1.0.\*-1.7.\*  only.
+Follow this step when upgrading from Mendix Operator versions 1.0.\* to 1.7.\*  only.
 {{% /alert %}}
 
 Run the following command to upgrade to the latest version of the Custom Resource Definitions for the Mendix Operator:
@@ -96,7 +96,7 @@ kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-operator -p \
 ##### 2.2.5.1 Updating the Mendix Operator Configuration (from version 1.0.\*)
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator 1.0.\* only.
+Follow this step when upgrading from Mendix Operator version 1.0.\* only.
 If you're running a later version of the Mendix Operator, proceed [to the next step](#update-configuration-1.1.0).
 {{% /alert %}}
 
@@ -163,12 +163,12 @@ kubectl -n $OPERATOR_NAMESPACE patch operatorconfiguration mendix-operator-confi
 #### 2.2.6.1 Update the Kubernetes Role for OpenShift routes
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator 1.0.\*, 1.1.\* and 1.2.\*.
+Follow this step when upgrading from Mendix Operator versions 1.0.\*, 1.1.\*, and 1.2.\*.
 
 It can be skipped if the Mendix Operator is not configured to use OpenShift Routes for incoming network traffic.
 {{% /alert %}}
 
-To enable changing the App URL in OpenShift Routes, you need to perform this step to add the `update` permission to the `mendix-operator` role.
+To allow you to change the App URL in OpenShift Routes, you need to perform this step to add the `update` permission to the `mendix-operator` role.
 
 Search for the `mendix-operator` Role in the OpenShift web console and open if for editing, or run the following command to start editing the `mendix-operator` Role:
 
@@ -209,12 +209,12 @@ Save the role to apply the changes.
 #### 2.2.6.2 Update the Kubernetes Role for OperatorVersions CRD
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator 1.0.\*-1.7.\*.
+Follow this step when upgrading from Mendix Operator versions 1.0.\* to 1.7.\*.
 {{% /alert %}}
 
 To allow the Operator to manage its dependency versions, add the `operatorversions` resource to the `mendix-operator` role.
 
-Search for the `mendix-operator` Role in the OpenShift web console and open if for editing, or run the following command to start editing the `mendix-operator` Role:
+Search for the `mendix-operator` Role in the OpenShift web console and open it for editing, or run the following command to start editing the `mendix-operator` Role:
 
 ```shell
 kubectl -n $OPERATOR_NAMESPACE edit role mendix-operator
@@ -261,7 +261,7 @@ Save the role to apply the changes.
 #### 2.2.7 Update the Storage Plan provisioners
 
 {{% alert type="info" %}}
-Only follow this step when upgrading from Mendix Operator 1.0.\*-1.7.\*.
+Only follow this step when upgrading from Mendix Operator versions 1.0.\* to 1.7.\*.
 {{% /alert %}}
 
 Run the following command:
@@ -308,7 +308,7 @@ The StatefulSets should be cleaned up manually as documented in the [Cleanup pha
 #### 2.2.9 Cleanup Phase{#cleanup-phase}
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator 1.0.\* only.
+Follow this step when upgrading from Mendix Operator version 1.0.\* only.
 {{% /alert %}}
 
 Delete StatefulSets from the Namespace where the Operator was installed:
@@ -331,7 +331,7 @@ Upgrading the Mendix Gateway Agent is only possible if the cluster was originall
 
 ### 3.1 Preparation
 
-Before upgrading to the Mendix Gateway Agent 1.7.0, first [upgrade](#operator-latest) the Mendix Operator to the latest version
+Before upgrading to Mendix Gateway Agent version 1.7.0, first [upgrade](#operator-latest) the Mendix Operator to the latest version
 and set the `OPERATOR_NAMESPACE` variable in your Bash terminal as described above.
 
 Check the current version of the Agent by running the following command:
@@ -354,7 +354,7 @@ There is a notice on these steps indicating which upgrade paths they apply to an
 #### 3.2.1 Update the Kubernetes Role for OperatorVersions CRD
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Gateway Agent versions 1.0.\*-1.6.\* only.
+Follow this step when upgrading from Mendix Gateway Agent versions 1.0.\* to 1.6.\* only.
 {{% /alert %}}
 
 To allow the Mendix Gateway Agent to report and manage dependency versions for the Mendix Operator, add the `operatorversions` resource to the `mendix-agent` role.

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -12,7 +12,7 @@ This document describes how an existing installation of Mendix for Private Cloud
 
 Both the Mendix Operator and Mendix Agent should be upgraded at the same time.
 
-## 2 Upgrading to Mendix Operator 1.7.0{#operator-latest}
+## 2 Upgrading to Mendix Operator 1.8.0{#operator-latest}
 
 ### 2.1 Preparation
 
@@ -39,7 +39,7 @@ For example, if the image name is `quay.io/digital_ecosystems/mendix-operator:1.
 This process will take:
 
 * about 15 to 30 minutes when upgrading from Mendix Operator 1.0.\*
-* about 10 minutes when upgrading from Mendix Operator 1.1.\*, 1.2.\* , 1.3.\*, 1.4.\*, 1.5.\*, and 1.6.\*
+* about 10 minutes when upgrading from Mendix Operator 1.1.\*, 1.2.\* , 1.3.\*, 1.4.\*, 1.5.\*, 1.6.\* and 1.7.\*.
 
 Some upgrade steps are only required when upgrading from older versions of the Mendix Operator. There is a notice on these steps indicating which upgrade paths they apply to and for which paths the step should be skipped.
 
@@ -57,7 +57,7 @@ kubectl -n $OPERATOR_NAMESPACE scale deployment mendix-operator --replicas=0
 #### 2.2.2 Upgrading the Custom Resource Definitions
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator versions 1.0.\*, 1.1.\*, 1.2.\*, 1.3.\*, 1.4.\*, 1.5.\*, and 1.6.\*
+Follow this step when upgrading from Mendix Operator versions 1.0.\*, 1.1.\*, 1.2.\*, 1.3.\*, 1.4.\*, 1.5.\*, 1.6.\* and 1.7.\*.
 {{% /alert %}}
 
 Run the following command to upgrade to the latest version of the Custom Resource Definitions for the Mendix Operator:
@@ -68,18 +68,32 @@ kubectl apply -f https://installergen.private-cloud.api.mendix.com/privatecloud/
 
 [Custom Resource Definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) allow Mendix applications to be managed with Kubernetes APIs and tools such as `kubectl` and `oc`.
 
-#### 2.2.3 Upgrading the Mendix Operator Deployment
+#### 2.2.3 Upgrading the dependency versions
 
-Run the following command to switch to Mendix Operator version 1.7.0:
+{{% alert type="info" %}}
+Follow this step when upgrading from Mendix Operator versions 1.0.\*, 1.1.\*, 1.2.\*, 1.3.\*, 1.4.\*, 1.5.\*, 1.6.\* and 1.7.\*.
+{{% /alert %}}
+
+Run the following command to upgrade to the latest version of the Custom Resource Definitions for the Mendix Operator:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE apply -f https://installergen.private-cloud.api.mendix.com/privatecloud/ocf/v1/versions
+```
+
+[Custom Resource Definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) allow Mendix applications to be managed with Kubernetes APIs and tools such as `kubectl` and `oc`.
+
+#### 2.2.4 Upgrading the Mendix Operator Deployment
+
+Run the following command to switch to Mendix Operator version 1.8.0:
 
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-operator -p \
-  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-operator","image":"private-cloud.registry.mendix.com/mendix-operator:1.7.0"}]}}}}'
+  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-operator","image":"private-cloud.registry.mendix.com/mendix-operator:1.8.0"}]}}}}'
 ```
 
-#### 2.2.4 Updating the Mendix Operator Configuration
+#### 2.2.5 Updating the Mendix Operator Configuration
 
-##### 2.2.4.1 Updating the Mendix Operator Configuration (from version 1.0.\*)
+##### 2.2.5.1 Updating the Mendix Operator Configuration (from version 1.0.\*)
 
 {{% alert type="info" %}}
 Follow this step when upgrading from Mendix Operator 1.0.\* only.
@@ -91,9 +105,9 @@ Run the following commands to switch to the latest component versions:
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch operatorconfiguration mendix-operator-configuration --type merge -p \
 '{"spec":{
-    "sidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-sidecar:1.5.0",
-    "metricsSidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-metrics:1.1.1",
-    "builderImage":"private-cloud.registry.mendix.com/image-builder:ingvar-rhel",
+    "sidecarImage":null,
+    "metricsSidecarImage":null,
+    "builderImage":null,
     "buildRuntimeBaseImage":"private-cloud.registry.mendix.com/runtime-base:{{.MxRuntimeVersion}}-rhel",
     "dockerfile":null
 }}'
@@ -125,7 +139,7 @@ kubectl -n $OPERATOR_NAMESPACE get storageplan --no-headers=true -o name | sed -
   xargs -I {} kubectl -n $OPERATOR_NAMESPACE patch storageplan {} --type=merge -p '{"spec":{"type":"on-demand"}}'
 ```
 
-##### 2.2.4.2 Updating the Mendix Operator Configuration (from versions 1.1.\*, 1.2.\*, 1.3.\*, and 1.4.\*){#update-configuration-1.1.0}
+##### 2.2.5.2 Updating the Mendix Operator Configuration (from versions 1.1.\*, 1.2.\*, 1.3.\*, and 1.4.\*){#update-configuration-1.1.0}
 
 {{% alert type="info" %}}
 Follow this step only when upgrading from Mendix Operator 1.1.\*, 1.2.\*, 1.3.\*, and 1.4.\*.
@@ -138,17 +152,17 @@ Run the following commands to switch to the latest component versions:
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch operatorconfiguration mendix-operator-configuration --type merge -p \
 '{"spec":{
-    "sidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-sidecar:1.5.0",
-    "metricsSidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-metrics:1.1.1",
-    "builderImage":"private-cloud.registry.mendix.com/image-builder:ingvar-rhel",
+    "sidecarImage":null,
+    "metricsSidecarImage":null,
+    "builderImage":null,
     "buildRuntimeBaseImage":"private-cloud.registry.mendix.com/runtime-base:{{.MxRuntimeVersion}}-rhel"
 }}'
 ```
 
-##### 2.2.4.3 Updating the Mendix Operator Configuration (from versions 1.5.\* and 1.6.\*){#update-configuration-1.5.0}
+##### 2.2.5.3 Updating the Mendix Operator Configuration (from versions 1.5.\*, 1.6.\* and 1.7.\*){#update-configuration-1.5.0}
 
 {{% alert type="info" %}}
-Follow this step only when upgrading from Mendix Operator 1.5.\* and 1.6.\*.
+Follow this step only when upgrading from Mendix Operator 1.5.\*, 1.6.\* and 1.7.\*.
 {{% /alert %}}
 
 Run the following commands to switch to the latest component versions:
@@ -156,15 +170,18 @@ Run the following commands to switch to the latest component versions:
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch operatorconfiguration mendix-operator-configuration --type merge -p \
 '{"spec":{
-    "sidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-sidecar:1.5.0",
-    "metricsSidecarImage":"private-cloud.registry.mendix.com/mx-m2ee-metrics:1.1.1"
+    "sidecarImage":null,
+    "metricsSidecarImage":null,
+    "builderImage":null
 }}'
 ```
 
-#### 2.2.5 Update the Kubernetes Role
+#### 2.2.6 Update the Kubernetes Role
+
+#### 2.2.6.1 Update the Kubernetes Role for OpenShift routes
 
 {{% alert type="info" %}}
-Follow this step when upgrading from Mendix Operator 1.2.\*, 1.1.\*, and 1.0.\*.
+Follow this step when upgrading from Mendix Operator 1.0.\*, 1.1.\* and 1.2.\*.
 
 It can be skipped if the Mendix Operator is not configured to use OpenShift Routes for incoming network traffic.
 {{% /alert %}}
@@ -207,7 +224,59 @@ and add an `update` verb to the list of verbs:
 
 Save the role to apply the changes.
 
-#### 2.2.6 Update the Storage Plan image repository
+#### 2.2.6.2 Update the Kubernetes Role for OperatorVersions CRD
+
+{{% alert type="info" %}}
+Follow this step when upgrading from Mendix Operator 1.0.\*, 1.1.\*, 1.2.\*, 1.3.\*, 1.4.\*, 1.5.\*, 1.6.\* and 1.7.\*.
+{{% /alert %}}
+
+To allow the Operator to manage its dependency versions, add the `operatorversions` resource to the `mendix-operator` role.
+
+Search for the `mendix-operator` Role in the OpenShift web console and open if for editing, or run the following command to start editing the `mendix-operator` Role:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE edit role mendix-operator
+```
+
+Find the following resource (containing `apiGroups`: `privatecloud.mendix.com`):
+```yaml
+- apiGroups:
+  - privatecloud.mendix.com
+  resources:
+  - '*'
+  - builds
+  - runtimes
+  - mendixapps
+  - operatorconfigurations
+  - endpoints
+  - storageplans
+  - storageinstances
+  verbs:
+  - '*'
+```
+
+and add an `operatorversions` resource to the list of resources:
+
+```yaml
+- apiGroups:
+  - privatecloud.mendix.com
+  resources:
+  - '*'
+  - builds
+  - runtimes
+  - mendixapps
+  - operatorconfigurations
+  - endpoints
+  - storageplans
+  - storageinstances
+  - operatorversions # add this line
+  verbs:
+  - '*'
+```
+
+Save the role to apply the changes.
+
+#### 2.2.7 Update the Storage Plan image repository
 
 {{% alert type="info" %}}
 Only follow this step when upgrading from Mendix Operator 1.1.\*, 1.2.\*, 1.3.\*, and 1.4.\*.
@@ -229,7 +298,7 @@ kubectl -n $OPERATOR_NAMESPACE edit storageplan
 
 and replacing `quay.io/digital_ecosystems` with `private-cloud.registry.mendix.com`.
 
-#### 2.2.7 Start the Mendix Operator
+#### 2.2.8 Start the Mendix Operator
 
 To start the updated version of the Mendix Operator, run:
 
@@ -253,7 +322,7 @@ The StatefulSets should be cleaned up manually as documented in the [Cleanup pha
 
 {{% /alert %}}
 
-#### 2.2.8 Cleanup Phase{#cleanup-phase}
+#### 2.2.9 Cleanup Phase{#cleanup-phase}
 
 {{% alert type="info" %}}
 Follow this step when upgrading from Mendix Operator 1.0.\* only.
@@ -267,7 +336,7 @@ kubectl -n $OPERATOR_NAMESPACE delete --all statefulsets
 
 These StatefulSets were replaced with deployments when the new version of the Operator was started.
 
-## 3 Upgrading to Mendix Gateway Agent 1.6.0{#agent-latest}
+## 3 Upgrading to Mendix Gateway Agent 1.7.0{#agent-latest}
 
 {{% alert type="info" %}}
 
@@ -277,11 +346,70 @@ Upgrading the Mendix Gateway Agent is only possible if the cluster was originall
 
 {{% /alert %}}
 
-Before upgrading to the Mendix Gateway Agent 1.6.0, first [upgrade](#operator-latest) the Mendix Operator to the latest version
+### 3.1 Preparation
+
+Before upgrading to the Mendix Gateway Agent 1.7.0, first [upgrade](#operator-latest) the Mendix Operator to the latest version
 and set the `OPERATOR_NAMESPACE` variable in your Bash terminal as described above.
 
-Run the following command to switch to the Mendix Agent version 1.6.0:
+Check the current version of the Agent by running the following command:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE get deployment mendix-agent -o=jsonpath='{.spec.template.spec.containers[].image}' 
+```
+
+The image name will look similar to `private-cloud.registry.mendix.com/mendix-agent:{VERSION}` or `quay.io/digital_ecosystems/mendix-agent:{VERSION}`.
+
+Only follow the steps applicable to your currently installed version of the Mendix Agent.
+
+For example, if the image name is `quay.io/digital_ecosystems/mendix-agent:1.6.0`, follow only the steps for upgrading from Mendix Agent 1.6.\*.
+
+Some upgrade steps are only required when upgrading from older versions of the Mendix Gateway Agent.
+There is a notice on these steps indicating which upgrade paths they apply to and for which paths the step should be skipped.
+
+#### 3.2 Update the Kubernetes Role
+
+#### 3.2.1 Update the Kubernetes Role for OperatorVersions CRD
+
+{{% alert type="info" %}}
+Follow this step when upgrading from Mendix Gateway Agent 1.0.\*, 1.1.\*, 1.2.\*, 1.3.\*, 1.4.\*, 1.5.\* and 1.6.\*.
+{{% /alert %}}
+
+To allow the Mendix Gateway Agent to report and manage dependency versions for the Mendix Operator, add the `operatorversions` resource to the `mendix-agent` role.
+
+Search for the `mendix-agent` Role in the OpenShift web console and open if for editing, or run the following command to start editing the `mendix-agent` Role:
+
+```shell
+kubectl -n $OPERATOR_NAMESPACE edit role mendix-agent
+```
+
+Find the following resource (containing `apiGroups`: `privatecloud.mendix.com`):
+```yaml
+- apiGroups:
+  - privatecloud.mendix.com
+  resources:
+  - mendixapps
+  verbs:
+  - '*'
+```
+
+and add an `operatorversions` resource to the list of resources:
+
+```yaml
+- apiGroups:
+  - privatecloud.mendix.com
+  resources:
+  - mendixapps
+  - operatorversions # add this line
+  verbs:
+  - '*'
+```
+
+Save the role to apply the changes.
+
+#### 3.3 Upgrading the Mendix Gateway Agent Deployment
+
+Run the following command to switch to the Mendix Agent version 1.7.0:
 ```shell
 kubectl -n $OPERATOR_NAMESPACE patch deployment mendix-agent -p \
-  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-agent","image":"private-cloud.registry.mendix.com/kubernetes-agent:1.6.0"}]}}}}'
+  '{"spec":{"template":{"spec":{"containers":[{"name":"mendix-agent","image":"private-cloud.registry.mendix.com/kubernetes-agent:1.7.0"}]}}}}'
 ```

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -139,11 +139,10 @@ kubectl -n $OPERATOR_NAMESPACE get storageplan --no-headers=true -o name | sed -
   xargs -I {} kubectl -n $OPERATOR_NAMESPACE patch storageplan {} --type=merge -p '{"spec":{"type":"on-demand"}}'
 ```
 
-##### 2.2.5.2 Updating the Mendix Operator Configuration (from versions 1.1.\*, 1.2.\*, 1.3.\*, and 1.4.\*){#update-configuration-1.1.0}
+##### 2.2.5.2 Updating the Mendix Operator Configuration (from versions 1.1.\* to 1.7.\*){#update-configuration-1.1.0}
 
 {{% alert type="info" %}}
-Follow this step only when upgrading from Mendix Operator 1.1.\*-1.7.\* only.
-If you're running a later version of the Mendix Operator, proceed [to the next step](#update-configuration-1.5.0).
+Follow this step only when upgrading from Mendix Operator 1.1.\* to 1.7.\* only.
 {{% /alert %}}
 
 Run the following commands to switch to the latest component versions:

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,6 +13,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
+### January 25th, 2021
+
+#### Mendix for Private Cloud — Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
+
+* We have improved dependency version management, so upgrading to future versions of the Mendix Operator would be easier.
+* We have added a feature to report installed component versions to the Private Cloud Portal. In the future, this will be used to indicate which Mendix for Private Cloud Operator version is installed and which features it supports.
+
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
+
 ### January 6th, 2021
 
 #### Improvements

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,7 +13,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
-### January 25th, 2021
+### February 11th, 2021
 
 #### Mendix for Private Cloud — Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -20,7 +20,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have improved dependency version management, so upgrading to future versions of the Mendix Operator will be easier.
 * We have introduced versioning for all components, instead of using the "latest" version. All components are now tested for compatibility, and once the Mendix Operator is installed, its behavior will remain unchanged. Components can only be updated through a manual update process.
 * We have added a feature to report installed component versions to the Private Cloud Portal. In the future, this will be used to indicate which Mendix for Private Cloud Operator version is installed and which features it supports.
-* We have added a new S3 option, allowing the use of an existing IAM policy and S3 bucket. Each environment will still get its own user and will not have access to files from other environments.
+* We have added a new S3 option, allowing the use of an existing IAM policy and S3 bucket. Each environment will still get its own account (AWS IAM user) and will not have access to files from other environments.
 * We have improved the S3 storage configuration UI in the Configuration Tool.
 * We have updated the Configuration Tool to run in fullscreen, so that it adapts better to smaller and larger screens.
 
@@ -281,4 +281,3 @@ To upgrade an existing installation of Private Cloud to the latest version, foll
 #### Improvements
 
 * On the **General** page of [App Buzz](/developerportal/collaborate/buzz#app-buzz), we added a **Private Cloud** target. This will currently take you to a closed beta test that allows you to connect your private cluster to Mendix. You can ask to join the beta program, but places are currently limited.
-

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -18,9 +18,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Mendix for Private Cloud — Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
 
 * We have improved dependency version management, so upgrading to future versions of the Mendix Operator would be easier.
+* We have introduced versioning for all components, instead of using the "latest" version. All components are now tested for compatibility, and once the Mendix Operator is installed, its behavior will remain unchanged. Components will only be updated through a manual update process.
 * We have added a feature to report installed component versions to the Private Cloud Portal. In the future, this will be used to indicate which Mendix for Private Cloud Operator version is installed and which features it supports.
+* We have added a new S3 option, allowing to use an existing IAM policy and S3 bucket. Each environment would still get its own user and will not have access to files from other environments.
+* We have improved the S3 storage configuration UI in the Configuration Tool.
+* We have updated the Configuration Tool to run in fullscreen, so that it adapts better to smaller and larger screens.
 
 To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
+After updrading the Mendix Operator, we recommend downloading the latest version of the Configuration Tool.
 
 ### January 6th, 2021
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -17,15 +17,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix for Private Cloud — Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
 
-* We have improved dependency version management, so upgrading to future versions of the Mendix Operator would be easier.
-* We have introduced versioning for all components, instead of using the "latest" version. All components are now tested for compatibility, and once the Mendix Operator is installed, its behavior will remain unchanged. Components will only be updated through a manual update process.
+* We have improved dependency version management, so upgrading to future versions of the Mendix Operator will be easier.
+* We have introduced versioning for all components, instead of using the "latest" version. All components are now tested for compatibility, and once the Mendix Operator is installed, its behavior will remain unchanged. Components can only be updated through a manual update process.
 * We have added a feature to report installed component versions to the Private Cloud Portal. In the future, this will be used to indicate which Mendix for Private Cloud Operator version is installed and which features it supports.
-* We have added a new S3 option, allowing to use an existing IAM policy and S3 bucket. Each environment would still get its own user and will not have access to files from other environments.
+* We have added a new S3 option, allowing the use of an existing IAM policy and S3 bucket. Each environment will still get its own user and will not have access to files from other environments.
 * We have improved the S3 storage configuration UI in the Configuration Tool.
 * We have updated the Configuration Tool to run in fullscreen, so that it adapts better to smaller and larger screens.
 
 To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
-After updrading the Mendix Operator, we recommend downloading the latest version of the Configuration Tool.
+After upgrading the Mendix Operator, we recommend downloading the latest version of the Configuration Tool.
 
 ### January 6th, 2021
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,9 +13,17 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
-### February 11th, 2021
+### February 18th, 2021
 
-#### Mendix for Private Cloud — Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
+#### Portal Improvements
+
+* We have improved instructions how to install Mendix for Private Cloud components from a Windows system.
+* For Mendix Operator v1.8.0 and later versions, the Private Cloud Portal will display versions of components currently running in a cluster.
+* The Private Cloud Portal now allows to download a version of the Configuration Tool that's compatible with the Mendix Operator installed in a cluster.
+* We have fixed a UI layout issues that were sometimes visible when an environment failed to build a container image. (Ticket 114548)
+* We have fixed an issue with the feedback widget duplicating itself.
+
+#### Mendix Operator v1.8.0 and Mendix Gateway Agent v1.7.0
 
 * We have improved dependency version management, so upgrading to future versions of the Mendix Operator will be easier.
 * We have introduced versioning for all components, instead of using the "latest" version. All components are now tested for compatibility, and once the Mendix Operator is installed, its behavior will remain unchanged. Components can only be updated through a manual update process.
@@ -23,6 +31,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have added a new S3 option, allowing the use of an existing IAM policy and S3 bucket. Each environment will still get its own account (AWS IAM user) and will not have access to files from other environments.
 * We have improved the S3 storage configuration UI in the Configuration Tool.
 * We have updated the Configuration Tool to run in fullscreen, so that it adapts better to smaller and larger screens.
+* We have fixed an issue with misleading error messages in the container logs if Mendix Runtime is failing to start. If the MxAdmin user has an insecure password, a correct error message will be displayed.
 
 To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide#operator-latest).
 After upgrading the Mendix Operator, we recommend downloading the latest version of the Configuration Tool.


### PR DESCRIPTION
Updated documentation, release notes and upgrade instructions for the new Mendix Operator version.

We're planning to release this new version on Thursday, ~~February 11~~ February 18.