### PR TITLE
Updated sample-app-kubernetes tag

### DIFF
--- a/content/developerportal/deploy/run-mendix-on-kubernetes.md
+++ b/content/developerportal/deploy/run-mendix-on-kubernetes.md
@@ -277,7 +277,7 @@ spec:
           name: mendix-data
 ```
 
-Replace `<hub-user>/<repo-name>:<tag>` with the Docker image of your app, for example, `mendix/sample-app-kubernetes:v2`.
+Replace `<hub-user>/<repo-name>:<tag>` with the Docker image of your app, for example, `mendix/sample-app-kubernetes:v3`.
 
 Create a Docker image of your Mendix app using the instructions in the [Mendix Docker Buildpack](https://github.com/mendix/docker-mendix-buildpack) on GitHub.
 
@@ -287,7 +287,7 @@ Once you have created the Docker image, push it to the Docker hub using the foll
 docker push <hub-user>/<repo-name>:<tag>
 ```
 
-Where `<hub-user>/<repo-name>:<tag>` is the Docker image of your app identified in *mendix-app.yaml*. For the example above, this is again `mendix/sample-app-kubernetes:v2`.
+Where `<hub-user>/<repo-name>:<tag>` is the Docker image of your app identified in *mendix-app.yaml*. For the example above, this is again `mendix/sample-app-kubernetes:v3`.
 
 {{% alert type="info" %}}
 In this example, we use a local storage folder on the node to show how to externalize the data stored for your app from the Docker container. For production systems, we recommend using the storage provided on the selected cloud platform.


### PR DESCRIPTION
This change is not related to any release and can be reviewed and released at any convenient moment.

The current `mendix/sample-app-kubernetes:v2` example app is no longer compatible with the Docker Buildpack because it's still using port 80 (changed to 8080 some time ago).

We've prepared a new version of the example app, `mendix/sample-app-kubernetes:v3` that's built with the latest version of the Docker Buildpack and is using the right port, 8080. This will improve the experience of any users who follow the documentation to run Mendix Docker Buildpack apps in Kubernetes.