### PR TITLE
Update check-box-set-selector.md

### DIFF
--- a/content/appstore/widgets/check-box-set-selector.md
+++ b/content/appstore/widgets/check-box-set-selector.md
@@ -42,6 +42,7 @@ The [Check Box Set Selector](https://appstore.home.mendix.com/link/app/121/) wid
 * **Attribute** – the attribute that is to be shown
 * **Width** – the width of the column for this display attribute in pixels or percentage
 * **Currency type** – lets you display the attribute as a currency (leave on **None** if not applicable)
+* Note: At least one _Display Attribute_ (with Header text, Attribute etc.) must be designated, otherwise the widget might block the page or popup from loading.
 
 ## 3 Read More
 

--- a/content/appstore/widgets/check-box-set-selector.md
+++ b/content/appstore/widgets/check-box-set-selector.md
@@ -43,7 +43,7 @@ The [Check Box Set Selector](https://appstore.home.mendix.com/link/app/121/) wid
 * **Width** – the width of the column for this display attribute in pixels or percentage
 * **Currency type** – lets you display the attribute as a currency (leave on **None** if not applicable)
 
-You must designate at least one **Display Attribute** (with **Header text**, **Attribute**, or otherwise), or else the widget might block the page or pop-up window from loading.
+You must designate at least one **Display Attribute** (with **Header text** and **Attribute** included), or else the widget might block the page or pop-up window from loading.
 
 ## 3 Read More
 

--- a/content/appstore/widgets/check-box-set-selector.md
+++ b/content/appstore/widgets/check-box-set-selector.md
@@ -42,7 +42,8 @@ The [Check Box Set Selector](https://appstore.home.mendix.com/link/app/121/) wid
 * **Attribute** – the attribute that is to be shown
 * **Width** – the width of the column for this display attribute in pixels or percentage
 * **Currency type** – lets you display the attribute as a currency (leave on **None** if not applicable)
-* Note: At least one _Display Attribute_ (with Header text, Attribute etc.) must be designated, otherwise the widget might block the page or popup from loading.
+
+You must designate at least one **Display Attribute** (with **Header text**, **Attribute**, or otherwise), or else the widget might block the page or pop-up window from loading.
 
 ## 3 Read More
 


### PR DESCRIPTION
Added the following note to 2.2:
At least one _Display Attribute_ (with Header text, Attribute etc.) must be designated, otherwise the widget might block the page or popup from loading.