### PR TITLE
[WC-170] Add docs for renaming dropdown option to toggle in Mendix 9 [9.0.5]

### DIFF
--- a/content/apidocs-mxsdk/apidocs/design-properties.md
+++ b/content/apidocs-mxsdk/apidocs/design-properties.md
@@ -207,6 +207,28 @@ Example of a property and options that were renamed:
 
 The design property above was renamed from **my Dropdown Propery** to **My Dropdown Property**. Also **Styling option two** was renamed twice from the old names **Stling option 2** and **Styling option 2**.
 
+### 6.1 Renaming a Dropdown option to a Toggle Property
+
+{{% alert type="info" %}}
+This feature was introduced in Mendix 9.
+{{% /alert %}}
+
+It is also possible to rename an option of a **Dropdown** property to a separate **Toggle** property. In this case, the old name of the **Toggle** property consists of the name of the **Dropdown** property and the name of the option separated by two colons (`::`). It is not required for the  **Dropdown** property to still exist, it may have been removed entirely.
+
+Example of a **Toggle** property that was renamed from a **Dropdown** option:
+
+```js
+{
+	"name": "Styling 3",
+	"oldNames": "My Dropdown Property::Styling option 3",
+	"type: "Toggle",
+	"description": "Description of Styling 3 toggle property",
+	"class": "stylingClassThree"
+}
+```
+
+The design property above is a replacement for the removed option **Styling option 3** of **My Dropdown Property** and will be set to **Yes** if that option was selected.
+
 ## 7 Read More
 
 * [How to Style Your Mendix App](/howto/mobile/how-to-use-native-styling)

--- a/content/apidocs-mxsdk/apidocs/design-properties.md
+++ b/content/apidocs-mxsdk/apidocs/design-properties.md
@@ -207,15 +207,15 @@ Example of a property and options that were renamed:
 
 The design property above was renamed from **my Dropdown Propery** to **My Dropdown Property**. Also **Styling option two** was renamed twice from the old names **Stling option 2** and **Styling option 2**.
 
-### 6.1 Renaming a Dropdown option to a Toggle Property
+### 6.1 Renaming a Dropdown Option to a Toggle Property
 
 {{% alert type="info" %}}
 This feature was introduced in Mendix 9.
 {{% /alert %}}
 
-It is also possible to rename an option of a **Dropdown** property to a separate **Toggle** property. In this case, the old name of the **Toggle** property consists of the name of the **Dropdown** property and the name of the option separated by two colons (`::`). It is not required for the  **Dropdown** property to still exist, it may have been removed entirely.
+It is also possible to rename an option of a **Dropdown** property to a separate **Toggle** property. In this case, the old name of the **Toggle** property consists of the **Dropdown** property's name and the option's name separated by two colons. It is not required for the  **Dropdown** property to still exist — it may have been removed entirely.
 
-Example of a **Toggle** property that was renamed from a **Dropdown** option:
+Here is an example of a **Toggle** property that was renamed from a **Dropdown** option:
 
 ```js
 {
@@ -227,7 +227,7 @@ Example of a **Toggle** property that was renamed from a **Dropdown** option:
 }
 ```
 
-The design property above is a replacement for the removed option **Styling option 3** of **My Dropdown Property** and will be set to **Yes** if that option was selected. The value of **My Dropdown Property** will then be set to empty (if that design property still exists).
+The design property above is a replacement for the removed option **Styling option 3** of **My Dropdown Property** and will be set to **Yes** if that option was selected. The value of **My Dropdown Property** will then be set to empty if that design property still exists.
 
 ## 7 Read More
 

--- a/content/apidocs-mxsdk/apidocs/design-properties.md
+++ b/content/apidocs-mxsdk/apidocs/design-properties.md
@@ -227,7 +227,7 @@ Example of a **Toggle** property that was renamed from a **Dropdown** option:
 }
 ```
 
-The design property above is a replacement for the removed option **Styling option 3** of **My Dropdown Property** and will be set to **Yes** if that option was selected.
+The design property above is a replacement for the removed option **Styling option 3** of **My Dropdown Property** and will be set to **Yes** if that option was selected. The value of **My Dropdown Property** will then be set to empty (if that design property still exists).
 
 ## 7 Read More
 

--- a/content/apidocs-mxsdk/apidocs/design-properties.md
+++ b/content/apidocs-mxsdk/apidocs/design-properties.md
@@ -220,7 +220,7 @@ Example of a **Toggle** property that was renamed from a **Dropdown** option:
 ```js
 {
 	"name": "Styling 3",
-	"oldNames": "My Dropdown Property::Styling option 3",
+	"oldNames": ["My Dropdown Property::Styling option 3"],
 	"type: "Toggle",
 	"description": "Description of Styling 3 toggle property",
 	"class": "stylingClassThree"


### PR DESCRIPTION
Added a section to the existing documentation about renaming design properties to include the new possibility to rename a dropdown option to a separate toggle property.