### PR TITLE
Clarify backup structure

### DIFF
--- a/content/developerportal/operate/restore-backup.md
+++ b/content/developerportal/operate/restore-backup.md
@@ -137,11 +137,17 @@ The dump must be created with pg_dump version 9.6.17 or below. If it is created 
 
 ### tree folder
 
-This contains the files which are stored in external file storage. The file has the name of the uuid used within Mendix to identify the resource.
+This contains the files which are stored in external file storage. Each file has the name of the uuid used within Mendix to identify the resource.
 
-#### Cloud v3
+#### Mendix Cloud V4
 
-The situation for Cloud v3 is slightly different. Each file is stored in a second level location:
+For Mendix Cloud V4 the files are stored in a flat structure.
+
+#### Mendix Cloud V3
+
+The situation for the deprecated Mendix Cloud v3 is slightly different. If you need to restore a backup to Mendix Cloud V3, you will need to implement the structure described below. The restore functionality in Mendix Cloud V4 will also recognize this structure if you are restoring a backup taken on V3 to a V4 environment.
+
+Each file is stored in a second level location:
 
 ```
 /tree

--- a/content/developerportal/operate/restore-backup.md
+++ b/content/developerportal/operate/restore-backup.md
@@ -137,7 +137,11 @@ The dump must be created with pg_dump version 9.6.17 or below. If it is created 
 
 ### tree folder
 
-This contains the files which are stored in external file storage. Each file is stored in a second level location:
+This contains the files which are stored in external file storage. The file has the name of the uuid used within Mendix to identify the resource.
+
+#### Cloud v3
+
+The situation for Cloud v3 is slightly different. Each file is stored in a second level location:
 
 ```
 /tree


### PR DESCRIPTION
We no longer require the use of subfolders for files in Cloud v4, though we still generate backups in that format to be compatible with Cloud v3. I don't know whether the phrasing I've used is clear enough, but at least this should make life a lot easier for customers migrating from on-prem / Mendix Private Cloud to Cloud v4. 