### PR TITLE
Attribution stored in different location

### DIFF
--- a/content/refguide/third-party-licenses.md
+++ b/content/refguide/third-party-licenses.md
@@ -11,7 +11,7 @@ Mendix uses various third-party libraries that have their own licenses. All the 
 
 | Libraries and Licenses   | Location                                                     |
 | ------------------------ | ------------------------------------------------------------ |
-| Runtime Server libraries | **runtime\lib**                                              |
+| Runtime Server libraries | **runtime\bundles**                                          |
 | Studio Pro libraries     | **modeler\Licenses**                                         |
 | Client licenses          | Client licenses can be found in the following locations: <ul><li>**modeler\deployment.mxz** – this is a ZIP file where you can navigate to **web\lib\bootstrap\css\bootstrap.css** and to **web\lib\rbootstrap\css\rbootstrap.css** for Bootstrap licenses (when you deploy an app, you can also find all these files in your deployment folder)</li><li>**runtime\mxclientsystem\mxui.mxui.js** for the Dojo license</li></ul> |
 

--- a/content/refguide8/third-party-licenses.md
+++ b/content/refguide8/third-party-licenses.md
@@ -11,7 +11,7 @@ Mendix uses various third-party libraries that have their own licenses. All the 
 
 | Libraries and Licenses   | Location                                                     |
 | ------------------------ | ------------------------------------------------------------ |
-| Runtime Server libraries | **runtime\lib**                                              |
+| Runtime Server libraries | **runtime\bundles**                                          |
 | Studio Pro libraries     | **modeler\Licenses**                                         |
 | Client licenses          | Client licenses can be found in the following locations: <ul><li>**modeler\deployment.mxz** – this is a ZIP file where you can navigate to **web\lib\bootstrap\css\bootstrap.css** and to **web\lib\rbootstrap\css\rbootstrap.css** for Bootstrap licenses (when you deploy an app, you can also find all these files in your deployment folder)</li><li>**runtime\mxclientsystem\mxui.mxui.js** for the Dojo license</li></ul> |
 


### PR DESCRIPTION
This changed around mid Mendix-8, and does not affect versions before