### PR TITLE
[WC-207] Write docs for new Maps widget

### DIFF
--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -6,9 +6,9 @@ tags: ["marketplace", "marketplace component", "widget", "maps", "google maps", 
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
-## 1 Introduction
+## 1 Introduction {#introduction}
 
-The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. It supports the following different map providers:
+The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. It supports the following map providers:
 
 * [Google Maps](https://www.google.com/maps/)
 * [OpenStreetMap](https://www.openstreetmap.org)
@@ -18,33 +18,32 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 ## 2 Basic Usage
 
 For the easiest way to get started with a basic map in your application, follow these steps:
-1. Drag a **Maps** widget onto your page.
-2. Go to the widget properties and add a Google Maps access token under **General > Configurations > Google maps API Key**
-3. Under the **General > Markers** properties section, select **New** for **Markers**.
-4. Create a new location marker based on either **latitude and longitude** or an **address**.
 
-If you want to configure more of your map, like how users can interact, the styling, or use a different map provider, please refer to next section for a detailed overview of all the settings and their possibilities.
+1. Drag the **Maps** widget onto your page.
+2. Open the widget properties and add a Google Maps access token under **General** > **Configurations** > **Google Maps API Key**.
+3. Under the **General** > **Markers** properties section, select **New** for **Markers**.
+4. Create a new location marker based on either **Latitude and longitude** or an **Address**.
 
-## 3 Settings
+If you want to configure more of your map (for example, user interactions and styling) or use a different map provider, see the [Settings](#settings) section below.
+
+## 3 Settings {#settings}
 
 ### 3.1 Map Provider
 
-By default, the Maps widget will use Google Maps.
-To change the map provider, go to the **General** properties of the map and enable the **Advanced > Show advanced** setting.
-This will introduce a new **Advanced** tab in the setting window.
-In there, all the above mentioned map providers are available to pick from.
+By default, the Maps widget will use Google Maps. 
+
+To change the map provider, go to the **General** properties of the map and enable the **Advanced** > **Show advanced** setting. This will introduce a new **Advanced** tab in the setting window. You can now select one of the map providers listed in the [Introduction](#introduction).
 
 ### 3.2 Access Token
 
-For all map types except OpenStreetMap, you need to have a token in order to view the map.
-The appropriate tokens can be retrieved via the links to the map types listed in the [Introduction](#intro) section above.
-After obtaining the access token, it can be provided to the widget in the **General > Configurations** widget settings section.
-For Google Maps the **Google maps API Key** property should be used, while for the other map providers the **API key** property should be used.
+For all the map providers except OpenStreetMap, you need to have a token in order to view the map. The appropriate tokens can be retrieved via the links to the map types listed in the [Introduction](#introduction).
 
-_Please note that placing markers based on addresses does not work without an access token set for **General > Configurations > Google maps API key**.
-This is especially relevant if you're opting into one of the non-Google maps providers, since you should still provide a Google maps API access token if you want to specify markers through their address.
-The token is necessary for converting addresses to their corresponding latitude and longitude values, which in turn are used to place the markers.
-If no Google maps API token is provided, the map is still usable but markers based on addresses will not be shown._
+After obtaining the access token, provide it to the widget in the **General** > **Configurations** widget settings. For Google Maps, the **Google Maps API Key** property should be used, while for the other map providers the **API key** property should be used.
+
+{{% alert type="info" %}}
+Placing markers based on addresses does not work without an access token set for **General** > **Configurations** > **Google Maps API key**. This is especially relevant if you are opting into one of the non-Google Maps providers, since you should still provide a Google Maps API access token if you want to specify markers through their address.
+The token is necessary for converting addresses to their corresponding latitude and longitude values, which in turn are used to place the markers. If no Google Maps API token is provided, the map is still usable, but markers based on addresses will not be shown.
+{{% /alert %}}
 
 ### 3.3 Current Location
 
@@ -145,6 +144,6 @@ To add a basic map to your application, follow these steps:
 	* For **Mapbox** and **Google Maps**, add an access token
 	* For **HERE maps**, add an app ID and app code
 
-### 5 Developing This Marketplace Component
+## 5 Developing This Marketplace Component
 
 We are actively maintaining this widget. Please report any issues or suggestions for improvement at [mendix/maps](https://github.com/mendix/maps/issues).

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -73,7 +73,7 @@ All the usual Mendix data source settings apply here, as well as the same marker
 Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
 * **Drag**: When enabled, the map will move along when dragging the map.
 * **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling.*
-* **Zoom**: When enabled, additional control buttons will be showed on the map
+* **Zoom**: When enabled, additional control buttons will be shown on the map
 * **Attribution**: When enabled, attributions will be shown at the bottom of the map (credits).
 
 If you're using Google Maps provider, there will be some additional controls available:

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -15,7 +15,9 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 * [Mapbox](https://www.mapbox.com)
 * [HERE maps](https://www.here.com/)
 
-## 2 Usage
+## 2 Basic Usage
+
+## 3 Settings
 
 ### Map Provider
 
@@ -37,6 +39,21 @@ If you want to show the user's location on the map, this can be enabled under **
 
 ### Markers
 
+To enhance the map widget, locations can be marked on the map by providing them in the widget through **General > Markers**.
+If exactly one location is provided, the map will center to that location.
+If multiple locations are provided, the map will center to a position in which all markers are visible.
+If no location is provided, a default center location of the Mendix offices is provided.
+
+There are two ways to specify locations to be marked, either **based on latitude and longitude** or **based on address**. 
+Providing either of them is also the only requirement for creating a marker.
+Each individual marker can be customized in the following way:
+* Each marker can be provided a title that will be displayed when clicking on the marker as a popup through the **Location > Title** setting.
+* The icon of the location marker is also customizable through the individual marker's setting **Visualization > Marker style**. Setting it to _Image_ allows you to customize it with either a static resource or dynamic entity.
+* An event handler can be attached to the marker to trigger when an user clicks on it through the **Events > On click** setting.
+
+To make the process of marking batches of locations easier, there's also the possibility to specify entire lists of markers at once.
+This can be done through the **General > Markers > Marker list** setting and requires a data source.
+All the usual Mendix data source settings apply here, as well as the same marker requirements and customizability as the individual markers. 
 
 ### Controls
 

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -6,7 +6,7 @@ tags: ["marketplace", "marketplace component", "widget", "maps", "google maps", 
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
-## 1 Introduction {#intro}
+## 1 Introduction
 
 The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. It supports the following different map providers:
 
@@ -16,6 +16,14 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 * [HERE maps](https://www.here.com/)
 
 ## 2 Basic Usage
+
+For the easiest way to get started with a basic map in your application, follow these steps:
+1. Drag a **Maps** widget onto your page.
+2. Go to the widget properties and add a Google Maps access token under **General > Configurations > Google maps API Key**
+3. Under the **General > Markers** properties section, select **New** for **Markers**.
+4. Create a new location marker based on either **latitude and longitude** or an **address**.
+
+If you want to configure more of your map, like how users can interact, the styling, or use a different map provider, please refer to next section for a detailed overview of all the settings and their possibilities.
 
 ## 3 Settings
 
@@ -32,6 +40,11 @@ For all map types except OpenStreetMap, you need to have a token in order to vie
 The appropriate tokens can be retrieved via the links to the map types listed in the [Introduction](#intro) section above.
 After obtaining the access token, it can be provided to the widget in the **General > Configurations** widget settings section.
 For Google Maps the **Google maps API Key** property should be used, while for the other map providers the **API key** property should be used.
+
+_Please note that placing markers based on addresses does not work without an access token set for **General > Configurations > Google maps API key**.
+This is especially relevant if you're opting into one of the non-Google maps providers, since you should still provide a Google maps API access token if you want to specify markers through their address.
+The token is necessary for converting addresses to their corresponding latitude and longitude values, which in turn are used to place the markers.
+If no Google maps API token is provided, the map is still usable but markers based on addresses will not be shown._
 
 ### Current Location
 

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -42,11 +42,23 @@ If you want to show the user's location on the map, this can be enabled under **
 
 Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
 * **Drag**: When enabled, the map will move along when dragging the map.
-* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling.
+* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling.*
 * **Zoom**: When enabled, additional control buttons will be showed on the map
 * **Attribution**: When enabled, attributions will be shown at the bottom of the map (credits).
 
+If you're using Google Maps provider, there will be some additional controls available:
+* **Street view**: When enabled, the user will have an icon button available in the bottom right corner to view the map in Google's street view mode.
+* **Map type**: When enabled, the user will be provided control buttons in the top left corner to change the type of the map. Options available are **Map**, with or without a **Terrain** layer, and **Satellite**, with or without a **Labels** layer. By default this is set to **Map** without the **Terrain** layer.
+* **Full screen**: When enabled, the user will have an icon button available in the top right corner to view the map in full screen.
+
+_\* - When using the Google Maps provider, the **scroll to zoom** setting requires the **drag** setting to be enabled in order to work._
+
 ### Dimensions
+
+Under the **Dimensions** properties tab, the following settings can be adjusted that are related to dimensional aspects of the map widgets:
+* **Width unit** and **Width**: The width of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage_ and _Pixels_. The width can then be set as an appropriate CSS value. These two properties need to be used together to work.
+* **Height unit** and **Height**: The height of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage of width_, _Pixels_, and _Percentage of parent_. The height can then be set as an appropriate CSS value. These two properties need to be used together to work.
+* **Zoom level**: The starting zoom level of the map. Options are: Automatic, World, Continent, City, Street, and Buildings.
 
 ## 3 Previous Versions' Documentation
 

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -8,6 +8,52 @@ tags: ["marketplace", "marketplace component", "widget", "maps", "google maps", 
 
 ## 1 Introduction {#intro}
 
+The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. It supports the following different map providers:
+
+* [Google Maps](https://www.google.com/maps/)
+* [OpenStreetMap](https://www.openstreetmap.org)
+* [Mapbox](https://www.mapbox.com)
+* [HERE maps](https://www.here.com/)
+
+## 2 Usage
+
+### Map Provider
+
+By default, the Maps widget will use Google Maps.
+To change the map provider, go to the **General** properties of the map and enable the **Advanced > Show advanced** setting.
+This will introduce a new **Advanced** tab in the setting window.
+In there, all the above mentioned map providers are available to pick from.
+
+### Access Token
+
+For all map types except OpenStreetMap, you need to have a token in order to view the map.
+The appropriate tokens can be retrieved via the links to the map types listed in the [Introduction](#intro) section above.
+After obtaining the access token, it can be provided to the widget in the **General > Configurations** widget settings section.
+For Google Maps the **Google maps API Key** property should be used, while for the other map providers the **API key** property should be used.
+
+### Current Location
+
+If you want to show the user's location on the map, this can be enabled under **General > Configurations > Show current location marker**.
+
+### Markers
+
+
+### Controls
+
+Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
+* **Drag**: When enabled, the map will move along when dragging the map.
+* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling.
+* **Zoom**: When enabled, additional control buttons will be showed on the map
+* **Attribution**: When enabled, attributions will be shown at the bottom of the map (credits).
+
+### Dimensions
+
+## 3 Previous Versions' Documentation
+
+### Widgets below v2.0.0
+
+#### 1 Introduction {#intro}
+
 The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. These are the available map types:
 
 * [Google Maps](https://www.google.com/maps/)
@@ -15,7 +61,7 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 * [Mapbox](https://www.mapbox.com)
 * [HERE maps](https://www.here.com/)
 
-### 1.1 Features
+##### 1.1 Features
 
 * Show a location on a map based on coordinates
 * Show a list of coordinates on the map
@@ -25,24 +71,24 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 	* Call a microflow or nanoflow
 * Customize the display of the marker – if the marker cannot be found from the custom markers, the widget uses the specified custom markers; otherwise, it uses the widget-bundled marker
 
-### 1.2 Limitations
+##### 1.2 Limitations
 
 * Addresses are not supported
 * Context and static data sources are offline-capable with Mendix data, but you still need to be online to view the map
 * For all map types except OpenStreetMap, you need to have a token in order to view the map – you can get the tokens via the links to the map types listed in the [Introduction](#intro) section above
 * Google maps uses [Google Maps API v3](https://cloud.google.com/maps-platform/), so the limitations from Google [Premium Plan Usage Rates and Limits](https://developers.google.com/maps/premium/usage-limits) apply
 
-### 1.3 Demo App
+##### 1.3 Demo App
 
 For a demo app that has been deployed with this widget, see [here](https://leafletmaps.mxapps.io/).
 
-## 2 How the Widget Works
+#### 2 How the Widget Works
 
 Locations are displayed based on coordinates. If there is one location, the map will center to that location. If there are multiple locations, the map will center to a position in which all markers are visible. If no location is available, a default center location of the Mendix offices is provided (in case default center coordinates are not specified).
 
 If auto-zoom is enabled, the map uses bounds zoom; otherwise, it uses the custom zoom level specified. The minimum zoom level is 2, and the maximum is 20.
 
-## 3 Usage
+#### 3 Usage
 
 To add a basic map to your application, follow these steps:
 
@@ -59,6 +105,6 @@ To add a basic map to your application, follow these steps:
 	* For **Mapbox** and **Google Maps**, add an access token
 	* For **HERE maps**, add an app ID and app code
 
-## 4 Developing This Marketplace Component
+#### 4 Developing This Marketplace Component
 
 We are actively maintaining this widget. Please report any issues or suggestions for improvement at [mendix/maps](https://github.com/mendix/maps/issues).

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -88,7 +88,7 @@ _\* - When using the Google Maps provider, the **scroll to zoom** setting requir
 Under the **Dimensions** properties tab, the following settings can be adjusted that are related to dimensional aspects of the map widgets:
 * **Width unit** and **Width**: The width of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage_ and _Pixels_. The width can then be set as an appropriate CSS value. These two properties need to be used together to work.
 * **Height unit** and **Height**: The height of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage of width_, _Pixels_, and _Percentage of parent_. The height can then be set as an appropriate CSS value. These two properties need to be used together to work.
-* **Zoom level**: The starting zoom level of the map. Options are: Automatic, World, Continent, City, Street, and Buildings.
+* **Zoom level**: The starting zoom level of the map. Options are: Automatic, World, Continent, City, Street, and Buildings. Please keep in mind when using this feature with multiple marked locations, the level of zoom chosen here will be applied after the map has centered to a position in which all markers are visible. 
 
 ## 3 Previous Versions' Documentation
 

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -27,14 +27,14 @@ If you want to configure more of your map, like how users can interact, the styl
 
 ## 3 Settings
 
-### Map Provider
+### 3.1 Map Provider
 
 By default, the Maps widget will use Google Maps.
 To change the map provider, go to the **General** properties of the map and enable the **Advanced > Show advanced** setting.
 This will introduce a new **Advanced** tab in the setting window.
 In there, all the above mentioned map providers are available to pick from.
 
-### Access Token
+### 3.2 Access Token
 
 For all map types except OpenStreetMap, you need to have a token in order to view the map.
 The appropriate tokens can be retrieved via the links to the map types listed in the [Introduction](#intro) section above.
@@ -46,11 +46,11 @@ This is especially relevant if you're opting into one of the non-Google maps pro
 The token is necessary for converting addresses to their corresponding latitude and longitude values, which in turn are used to place the markers.
 If no Google maps API token is provided, the map is still usable but markers based on addresses will not be shown._
 
-### Current Location
+### 3.3 Current Location
 
 If you want to show the user's location on the map, this can be enabled under **General > Configurations > Show current location marker**.
 
-### Markers
+### 3.4 Markers
 
 To enhance the map widget, locations can be marked on the map by providing them in the widget through **General > Markers**.
 If exactly one location is provided, the map will center to that location.
@@ -68,7 +68,7 @@ To make the process of marking batches of locations easier, there's also the pos
 This can be done through the **General > Markers > Marker list** setting and requires a data source.
 All the usual Mendix data source settings apply here, as well as the same marker requirements and customizability as the individual markers. 
 
-### Controls
+### 3.5 Controls
 
 Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
 * **Drag**: When enabled, the map will move along when dragging the map.
@@ -83,18 +83,16 @@ If you're using Google Maps provider, there will be some additional controls ava
 
 _\* - When using the Google Maps provider, the **scroll to zoom** setting requires the **drag** setting to be enabled in order to work._
 
-### Dimensions
+### 3.6 Dimensions
 
 Under the **Dimensions** properties tab, the following settings can be adjusted that are related to dimensional aspects of the map widgets:
 * **Width unit** and **Width**: The width of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage_ and _Pixels_. The width can then be set as an appropriate CSS value. These two properties need to be used together to work.
 * **Height unit** and **Height**: The height of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage of width_, _Pixels_, and _Percentage of parent_. The height can then be set as an appropriate CSS value. These two properties need to be used together to work.
 * **Zoom level**: The starting zoom level of the map. Options are: Automatic, World, Continent, City, Street, and Buildings. Please keep in mind when using this feature with multiple marked locations, the level of zoom chosen here will be applied after the map has centered to a position in which all markers are visible. 
 
-## 3 Previous Versions' Documentation
+## 4 Widgets Below Version 2.0.0
 
-### Widgets below v2.0.0
-
-#### 1 Introduction {#intro}
+### 4.1 Introduction {#intro}
 
 The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables showing locations on maps. These are the available map types:
 
@@ -103,7 +101,7 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 * [Mapbox](https://www.mapbox.com)
 * [HERE maps](https://www.here.com/)
 
-##### 1.1 Features
+#### 4.1.1 Features
 
 * Show a location on a map based on coordinates
 * Show a list of coordinates on the map
@@ -113,24 +111,24 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 	* Call a microflow or nanoflow
 * Customize the display of the marker – if the marker cannot be found from the custom markers, the widget uses the specified custom markers; otherwise, it uses the widget-bundled marker
 
-##### 1.2 Limitations
+#### 4.1.2 Limitations
 
 * Addresses are not supported
 * Context and static data sources are offline-capable with Mendix data, but you still need to be online to view the map
 * For all map types except OpenStreetMap, you need to have a token in order to view the map – you can get the tokens via the links to the map types listed in the [Introduction](#intro) section above
 * Google maps uses [Google Maps API v3](https://cloud.google.com/maps-platform/), so the limitations from Google [Premium Plan Usage Rates and Limits](https://developers.google.com/maps/premium/usage-limits) apply
 
-##### 1.3 Demo App
+#### 4.1.3 Demo App
 
 For a demo app that has been deployed with this widget, see [here](https://leafletmaps.mxapps.io/).
 
-#### 2 How the Widget Works
+### 4.2 How the Widget Works
 
 Locations are displayed based on coordinates. If there is one location, the map will center to that location. If there are multiple locations, the map will center to a position in which all markers are visible. If no location is available, a default center location of the Mendix offices is provided (in case default center coordinates are not specified).
 
 If auto-zoom is enabled, the map uses bounds zoom; otherwise, it uses the custom zoom level specified. The minimum zoom level is 2, and the maximum is 20.
 
-#### 3 Usage
+### 4.3 Usage
 
 To add a basic map to your application, follow these steps:
 
@@ -147,6 +145,6 @@ To add a basic map to your application, follow these steps:
 	* For **Mapbox** and **Google Maps**, add an access token
 	* For **HERE maps**, add an app ID and app code
 
-#### 4 Developing This Marketplace Component
+### 5 Developing This Marketplace Component
 
 We are actively maintaining this widget. Please report any issues or suggestions for improvement at [mendix/maps](https://github.com/mendix/maps/issues).

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -20,11 +20,11 @@ The [Maps](https://appstore.home.mendix.com/link/app/108261/) widget enables sho
 For the easiest way to get started with a basic map in your application, follow these steps:
 
 1. Drag the **Maps** widget onto your page.
-2. Open the widget properties and add a Google Maps access token under **General** > **Configurations** > **Google Maps API Key**.
-3. Under the **General** > **Markers** properties section, select **New** for **Markers**.
+2. Open the widget properties and add a Google Maps access token in **General** > **Configurations** > **Google Maps API Key**.
+3. In the **General** > **Markers** properties section, select **New** for **Markers**.
 4. Create a new location marker based on either **Latitude and longitude** or an **Address**.
 
-If you want to configure more of your map (for example, user interactions and styling) or use a different map provider, see the [Settings](#settings) section below.
+If you want to configure more of your map (for example, end-user interactions and styling) or use a different map provider, see the [Settings](#settings) section below.
 
 ## 3 Settings {#settings}
 
@@ -47,47 +47,59 @@ The token is necessary for converting addresses to their corresponding latitude 
 
 ### 3.3 Current Location
 
-If you want to show the user's location on the map, this can be enabled under **General > Configurations > Show current location marker**.
+To show the user's location on the map, enable this in **General** > **Configurations** > **Show current location marker**.
 
 ### 3.4 Markers
 
-To enhance the map widget, locations can be marked on the map by providing them in the widget through **General > Markers**.
-If exactly one location is provided, the map will center to that location.
-If multiple locations are provided, the map will center to a position in which all markers are visible.
-If no location is provided, a default center location of the Mendix offices is provided.
+To enhance the map widget, you can mark locations on the map by providing them in the widget through **General** > **Markers**. The following conditions apply:
 
-There are two ways to specify locations to be marked, either **based on latitude and longitude** or **based on address**. 
-Providing either of them is also the only requirement for creating a marker.
-Each individual marker can be customized in the following way:
-* Each marker can be provided a title that will be displayed when clicking on the marker as a popup through the **Location > Title** setting.
-* The icon of the location marker is also customizable through the individual marker's setting **Visualization > Marker style**. Setting it to _Image_ allows you to customize it with either a static resource or dynamic entity.
-* An event handler can be attached to the marker to trigger when an user clicks on it through the **Events > On click** setting.
+* If exactly one location is provided, the map will center to that location
+* If multiple locations are provided, the map will center to a position in which all markers are visible
+* If no location is provided, a default center location of the Mendix offices is provided
 
-To make the process of marking batches of locations easier, there's also the possibility to specify entire lists of markers at once.
-This can be done through the **General > Markers > Marker list** setting and requires a data source.
-All the usual Mendix data source settings apply here, as well as the same marker requirements and customizability as the individual markers. 
+There are two ways to specify locations to be marked, either **Based on latitude and longitude** or **Based on address**. Providing either of these is also the only requirement for creating a marker.
+
+You can customize each individual marker in the following ways:
+
+* You can provide each marker with a title that will be displayed in a pop-up window when the marker is clicked via the **Location** > **Title** setting
+* You can customize the icon of the location marker via the individual marker's setting in **Visualization** > **Marker style** (setting it to *Image* allows you to customize it with either a static resource or dynamic entity)
+* You can attach an event handler to the marker to trigger when an end-user clicks it via the **Events** > **On click** setting
+
+To make the process of marking batches of locations easier, it is also possible to specify entire lists of markers at once. You can do this through the **General** > **Markers** > **Marker list** setting, which requires a data source. All the usual Mendix data-source settings apply here, as well as the same marker requirements and customizability as the individual markers. 
 
 ### 3.5 Controls
 
-Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
-* **Drag**: When enabled, the map will move along when dragging the map.
-* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling on desktop or using pinch gestures on mobile.*
-* **Zoom**: When enabled, additional control buttons will be shown on the map
-* **Attribution**: When enabled, attributions will be shown at the bottom of the map (credits).
+Under the **Controls** properties tab, you can adjust the following settings related to how an end-user interacts with the map:
 
-If you're using Google Maps provider, there will be some additional controls available:
-* **Street view**: When enabled, the user will have an icon button available in the bottom right corner to view the map in Google's street view mode.
-* **Map type**: When enabled, the user will be provided control buttons in the top left corner to change the type of the map. Options available are **Map**, with or without a **Terrain** layer, and **Satellite**, with or without a **Labels** layer. By default this is set to **Map** without the **Terrain** layer.
-* **Full screen**: When enabled, the user will have an icon button available in the top right corner to view the map in full screen.
+* **Drag** – when enabled, the map will move along when dragging the map
+* **Scroll to zoom** – when enabled, the end-user can change the zoom level of the map by mouse-scrolling on a desktop machine or using pinch gestures on mobile
+	* Note that when using the Google Maps provider, this setting requires the **Drag** setting to be enabled in order to work
+* **Zoom** – when enabled, additional control buttons are shown on the map
+* **Attribution** – when enabled, attributions (credits) are shown at the bottom of the map 
 
-_\* - When using the Google Maps provider, the **scroll to zoom** setting requires the **drag** setting to be enabled in order to work._
+If you are using the Google Maps provider, these additional controls are available:
+
+* **Street view** – when enabled, there is a button available in the bottom-right corner of the map to view the map in Google's Street View mode
+* **Map type** – when enabled, there are control buttons in the top-left corner of the map to change the type of the map
+	* The available options are **Map**, with or without a **Terrain** layer, and **Satellite**, with or without a **Labels** layer
+	* By default, this is set to **Map** without the **Terrain** layer
+* **Full screen** – when enabled, there is a button available in the top-right corner of the map to view the map in full screen
 
 ### 3.6 Dimensions
 
-Under the **Dimensions** properties tab, the following settings can be adjusted that are related to dimensional aspects of the map widgets:
-* **Width unit** and **Width**: The width of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage_ and _Pixels_. The width can then be set as an appropriate CSS value. These two properties need to be used together to work.
-* **Height unit** and **Height**: The height of the widget in relation to the rest of the elements on the page. The available options for unit are _Percentage of width_, _Pixels_, and _Percentage of parent_. The height can then be set as an appropriate CSS value. These two properties need to be used together to work.
-* **Zoom level**: The starting zoom level of the map. Options are: Automatic, World, Continent, City, Street, and Buildings. Please keep in mind when using this feature with multiple marked locations, the level of zoom chosen here will be applied after the map has centered to a position in which all markers are visible. 
+Under the **Dimensions** properties tab, you can adjust the following settings that are related to dimensional aspects:
+
+* **Width unit** and **Width** – the width of the widget in relation to the rest of the elements on the page
+	* The available **Width unit** options are **Percentage** and **Pixels**
+	* The **Width** can be set as an appropriate CSS value
+	* These two properties need to be used together to work
+* **Height unit** and **Height** – the height of the widget in relation to the rest of the elements on the page
+	* The available **Height unit** options **Percentage of width**, **Pixels**, and **Percentage of parent**
+	* The **Height** can be set as an appropriate CSS value
+	* These two properties need to be used together to work
+* **Zoom level** – the starting zoom level of the map
+	* The available options are: **Automatic**, **World**, **Continent**, **City**, **Street**, and **Buildings**
+	* Note that when using this setting with multiple marked locations, the level of zoom chosen here will be applied after the map has centered to a position in which all markers are visible
 
 ## 4 Widgets Below Version 2.0.0
 

--- a/content/appstore/widgets/maps.md
+++ b/content/appstore/widgets/maps.md
@@ -72,7 +72,7 @@ All the usual Mendix data source settings apply here, as well as the same marker
 
 Under the **Controls** properties tab, the following settings can be adjusted that are related to how the users interacts with the map:
 * **Drag**: When enabled, the map will move along when dragging the map.
-* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling.*
+* **Scroll to zoom**: When enabled, the user can change the zoom level of the map by mouse scrolling on desktop or using pinch gestures on mobile.*
 * **Zoom**: When enabled, additional control buttons will be shown on the map
 * **Attribution**: When enabled, attributions will be shown at the bottom of the map (credits).
 


### PR DESCRIPTION
Similar to #3100:

This updates the Maps pluggable widget documentation that will only be supported on MX 9 and above. I kept the old widget documentation as well, since mx developers can still use these widgets with mx 7 or 8.

This needs to go through a technical review. So for you guys it might be best to delay proofread until after that has happened