### PR TITLE
MX8 and 9 Pluggable Widgets API parent page corrections

### DIFF
--- a/content/apidocs-mxsdk/apidocs/pluggable-parent-8.md
+++ b/content/apidocs-mxsdk/apidocs/pluggable-parent-8.md
@@ -10,5 +10,5 @@ The following Mendix 8 pluggable widget API documents are available here:
 
 * [Client APIs Available to Pluggable Widgets](client-apis-for-pluggable-widgets-8) for Mendix 8
 * [Pluggable Widget Property Types](property-types-pluggable-widgets-8) for Mendix 8
-* [How to Build Pluggable Widgets](studio-apis-for-pluggable-widgets-8) for Mendix 8
+* [Preview Appearance APIs for Pluggable Widgets](studio-apis-for-pluggable-widgets-8) for Mendix 8
 * [Differences Between Pluggable and Custom Widgets](differences-between-pluggable-and-custom-widgets)

--- a/content/apidocs-mxsdk/apidocs/pluggable-parent-9.md
+++ b/content/apidocs-mxsdk/apidocs/pluggable-parent-9.md
@@ -9,5 +9,6 @@ tags: ["API", "pluggable","widget"]
 The following Mendix 9 pluggable widget API documents are available here:
 
 * [Client APIs Available to Pluggable Widgets](client-apis-for-pluggable-widgets) for Mendix 9
+* [Declaring Native Dependencies for Pluggable Widgets](native-dependencies) for Mendix 9
 * [Pluggable Widget Property Types](property-types-pluggable-widgets) for Mendix 9
 * [Preview Appearance APIs for Pluggable Widgets](studio-apis-for-pluggable-widgets) for Mendix 9

--- a/content/apidocs-mxsdk/apidocs/pluggable-parent-9.md
+++ b/content/apidocs-mxsdk/apidocs/pluggable-parent-9.md
@@ -10,4 +10,4 @@ The following Mendix 9 pluggable widget API documents are available here:
 
 * [Client APIs Available to Pluggable Widgets](client-apis-for-pluggable-widgets) for Mendix 9
 * [Pluggable Widget Property Types](property-types-pluggable-widgets) for Mendix 9
-* [How to Build Pluggable Widgets](studio-apis-for-pluggable-widgets) for Mendix 9
+* [Preview Appearance APIs for Pluggable Widgets](studio-apis-for-pluggable-widgets) for Mendix 9


### PR DESCRIPTION
- clarify link name in MX8 and 9 parent page
- add missing native dependency link to MX9 parent page