### PR TITLE
Release notes for Appstore 8.9.0 Release

### DIFF
--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -11,10 +11,10 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
 ### April 7th, 2021
 
-* We added a section for Studio Pro versions that have Long-Term Support (LTS) and Medium-Term Support (MTS) in the Studio Pro download page. [Read here](/releasenotes/studio-pro/lts-mts#1-introduction) for more information of LTS and MTS versions.
+* We added a section to **Get Studio Pro** for downloading versions that have [long-term support (LTS)](/releasenotes/studio-pro/lts-mts#lts) and (medium-term support (MTS)](/releasenotes/studio-pro/lts-mts#mts).
 	{{% alert type="info" %}}This is based on an [upvoted idea from Alexander Keßler](https://forum.mendixcloud.com/link/ideas/2212) submitted to the [Mendix Idea Forum](https://forum.mendixcloud.com/link/ideas). Thanks, Alexander!
 	{{% /alert %}}
-* We fixed some performance issues, where certain sections were not loading properly. This also includes connection issues to App Store/Marketplace within Studio Pro.
+* We fixed some performance issues where certain Marketplace sections were not loading properly. This also includes connection issues to the App Store/Marketplace within Studio Pro.
 
 ### March 23rd, 2021
 

--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -14,7 +14,7 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 * We added a section for Studio Pro versions that have Long-Term Support (LTS) and Medium-Term Support (MTS) in the Studio Pro download page. [Read here](/releasenotes/studio-pro/lts-mts#1-introduction) for more information of LTS and MTS versions.
 	{{% alert type="info" %}}This is based on an [upvoted idea from Alexander Keßler](https://forum.mendixcloud.com/link/ideas/2212) submitted to the [Mendix Idea Forum](https://forum.mendixcloud.com/link/ideas). Thanks, Alexander!
 	{{% /alert %}}
-* We fixed some performance issues, where certain sections were not loading properly. This also includes connection issues to Appstore within Studio Pro.
+* We fixed some performance issues, where certain sections were not loading properly. This also includes connection issues to App Store/Marketplace within Studio Pro.
 
 ### March 23rd, 2021
 

--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -9,6 +9,13 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
 ## 2021
 
+### April 7th, 2021
+
+* We added a section for Studio Pro versions that have Long-Term Support (LTS) and Medium-Term Support (MTS) in the Studio Pro download page. [Read here](/releasenotes/studio-pro/lts-mts#1-introduction) for more information of LTS and MTS versions.
+	{{% alert type="info" %}}This is based on an [upvoted idea from Alexander Keßler](https://forum.mendixcloud.com/link/ideas/2212) submitted to the [Mendix Idea Forum](https://forum.mendixcloud.com/link/ideas). Thanks, Alexander!
+	{{% /alert %}}
+* We fixed some performance issues, where certain sections were not loading properly. This also includes connection issues to Appstore within Studio Pro.
+
 ### March 23rd, 2021
 
 * We added email notifications for several actions in the Marketplace. You can now receive emails if one of your components has changed, when a published component has received a review, and when you receive a reply to one of your reviews. You can unsubscribe from any of notifications in the [My App Store](/appstore/general/app-store-overview#my-app-store) section of the of Marketplace.

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -10,7 +10,7 @@
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Mar 30th, 2021</li>
 	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Mar 31st, 2021</li>
 	<li><a href="/releasenotes/data-hub">Data Hub</a> – Apr 1st, 2021</li>
-	<li><a href="/releasenotes/app-store">Marketplace</a> – Mar 23rd, 2021</li>
+	<li><a href="/releasenotes/app-store">Marketplace</a> – Apr 7th, 2021</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.49.0</a> – Mar 26th, 2021</li>
 	<li><a href="/releasenotes/sdk/metamodel-9.0">Metamodel 9.0.5</a> – Mar 26th, 2021</li>
   </ul>


### PR DESCRIPTION
These are for changes in the upcoming Appstore/Marketplace release, scheduled for morning of Wednesday, April 7th.