### PR TITLE
Remove feature flag section from Mx9 Git how-to

### DIFF
--- a/content/howto/collaboration-requirements-management/on-premises-git-howto.md
+++ b/content/howto/collaboration-requirements-management/on-premises-git-howto.md
@@ -109,11 +109,9 @@ For more information on PAT, see the [Supported Git Service Providers](#supporte
 
 ### 4.2 Preparing Studio Pro for Git {#preparing-git-support}
 
-To use Git, you need to activate the Git support in Studio Pro.
-    1. Start Studio Pro.        
-    2. Once Studio Pro is opened, go to **Edit > Preferences > Version Control** and make sure to activate private version control for Git. The name and email values will be used to identify your commit:
+To use Git, you need to activate the Git support in Studio Pro by navigating to **Edit** > **Preferences** > **Version Control** and selecting **Enable private version control with Git**. The name and email values will be used to identify your commit:
 
-        ![Preferences dialog](attachments/on-premises-git-howto/preferences-git.png)
+![Preferences dialog](attachments/on-premises-git-howto/preferences-git.png)
 
 Studio Pro now is set up to support Git.
 

--- a/content/howto/collaboration-requirements-management/on-premises-git-howto.md
+++ b/content/howto/collaboration-requirements-management/on-premises-git-howto.md
@@ -28,7 +28,6 @@ You will not be able to use Mendix Studio for collaborative development if you u
 Before starting this how-to, make sure you have completed the following prerequisites:
 
 * Make sure you have the right server provider. We currently only support Git Private Server. For more information, see the [Preparing Your Repository](#preparing-your-repo) section. 
-* You have a feature flag enabled. For more information, see the [Enabling a Feature Flag](#enable-feature-flag) section.
 * You have an unversioned Mendix app. For more information, see the [Creating an App](#create-app) section.
 
 ## 3 Supported Authentication Mechanisms
@@ -108,24 +107,11 @@ To interact with this private repository from Studio Pro, you need a link to the
 
 For more information on PAT, see the [Supported Git Service Providers](#supported-providers) section above.
 
-### 4.2 Enabling a Feature Flag {#enable-feature-flag}
+### 4.2 Preparing Studio Pro for Git {#preparing-git-support}
 
-To use Git, you need to start Studio Pro with a specific feature flag. Navigate to the directory where Studio Pro is located, specifically where the **studiopro.exe** file is. There are two ways to enable the feature flag: 
-
-1. **The command-line method** – Open the command line at that location (or navigate to it from the command line) and type the following command: `studiopro.exe --enable-git-support`.
-
-2. **The shortcut method** – do the following:
-
-    1. Right-click the file and click **Create shortcut**. If you are asked to save it on the Desktop, click **Yes**. 
-
-    2. Once the shortcut is created, right-click it and select **Properties**.
-    3. At the end of the **Target** field, add the feature flag `--enable-git-support` after a space:
-
-        ![Shortcut Properties dialog](attachments/on-premises-git-howto/shortcut-properties.png)
-
-    1. Click **OK**.
-    2. Start Studio Pro by double-clicking the shortcut.        
-    3. Once Studio Pro is opened, go to **Edit > Preferences > Version Control** and make sure to activate private version control for Git. The name and email values will be used to identify your commit:
+To use Git, you need to activate the Git support in Studio Pro.
+    1. Start Studio Pro.        
+    2. Once Studio Pro is opened, go to **Edit > Preferences > Version Control** and make sure to activate private version control for Git. The name and email values will be used to identify your commit:
 
         ![Preferences dialog](attachments/on-premises-git-howto/preferences-git.png)
 
@@ -163,7 +149,7 @@ The app is downloaded and ready to be used with version control.
 
 ### 4.5 Opening the Existing Git App
 
-There are a few ways to open a Git Mendix app, as long as you have Studio Pro started up with the [git feature flag](#enable-feature-flag).
+There are a few ways to open a Git Mendix app, as long as you have Studio Pro [Git support activated](#preparing-git-support).
 
 #### 4.5.1 Recent Apps List
 


### PR DESCRIPTION
As `--enable-git-support` feature flag is not available for Mx9 anymore we have to remove the section 4.2 from the Git how-to document.