### PR TITLE
Add switch (web) 3.0.0 documentation

### DIFF
--- a/content/appstore/widgets/switch.md
+++ b/content/appstore/widgets/switch.md
@@ -22,6 +22,8 @@ The widget offers the following for configuration:
 * A **Style** design property for brand styling, influencing the Switch's colors
 * [Common properties](https://docs.mendix.com/refguide/common-widget-properties)
 
+This widget is compatible with [Atlas Core](https://marketplace.mendix.com/link/component/117187).
+
 ## 3 Previous Versions' Documentation
 
 ### Widgets Below v3.0.0

--- a/content/appstore/widgets/switch.md
+++ b/content/appstore/widgets/switch.md
@@ -16,9 +16,9 @@ To use this widget, place it in a [data container](https://docs.mendix.com/refgu
 
 The widget offers the following for configuration:
 
-* A boolean attribute to toggle on user-interaction
+* A Boolean attribute to toggle on user-interaction
 * An action (such as Microflow or Nanoflow) to trigger when the Switch is toggled
-* A **Device style** design property with two options, `iOS` and `Android`, influencing the Switch's appearance
+* A **Device style** design property with two options (`iOS` and `Android`) influencing the Switch's appearance
 * A **Style** design property for brand styling, influencing the Switch's colors
 * [Common properties](https://docs.mendix.com/refguide/common-widget-properties)
 

--- a/content/appstore/widgets/switch.md
+++ b/content/appstore/widgets/switch.md
@@ -10,7 +10,27 @@ tags: ["marketplace", "marketplace component", "widget", "switch", "platform sup
 
 The [Switch](https://appstore.home.mendix.com/link/app/50324/) widget enables toggling a Boolean attribute.
 
-### 1.1 Features
+## 2 Usage
+
+To use this widget, place it in a [data container](https://docs.mendix.com/refguide/data-sources) that has a Boolean attribute.
+
+The widget offers the following for configuration:
+
+* A boolean attribute to toggle on user-interaction
+* An action (such as Microflow or Nanoflow) to trigger when the Switch is toggled
+* A **Device style** design property with two options, `iOS` and `Android`, influencing the Switch's appearance
+* A **Style** design property for brand styling, influencing the Switch's colors
+* [Common properties](https://docs.mendix.com/refguide/common-widget-properties)
+
+## 3 Previous Versions' Documentation
+
+### Widgets Below v3.0.0
+
+#### 1 Introduction
+
+The [Switch](https://appstore.home.mendix.com/link/app/50324/) widget enables toggling a Boolean attribute.
+
+##### 1.1 Features
 
 * Deactivate when attribute or context is read-only
 * Execute a microflow when toggled
@@ -19,15 +39,15 @@ The [Switch](https://appstore.home.mendix.com/link/app/50324/) widget enables to
 * Display in either iOS style or android(material design)
 * Display in various bootstrap styles
 
-### 1.2 Demo App
+##### 1.2 Demo App
 
 For a demo app that has been deployed with this widget, see [here](http://booleansliderwidge.mxapps.io).
 
-## 2 Usage
+#### 2 Usage
 
 To use this widget, place it in the context of an object that has a Boolean attribute.
 
-## 3 Developing This Marketplace Component
+#### 3 Developing This Marketplace Component
 
 To contribute to the development of this widget, follow these steps:
 
@@ -47,6 +67,6 @@ To contribute to the development of this widget, follow these steps:
 
 We are actively maintaining this widget. Please report any issues or suggestions for improvement at [mendixlabs/boolean-slider](https://github.com/mendixlabs/boolean-slider/issues).
 
-## 4 Read More
+#### 4 Read More
 
 * [CAB.02 - Switch](https://docs.mendix.com/addons/ats-addon/ht-two-cab-02-switch)


### PR DESCRIPTION
The soon-to-be-released Switch widget is version 3.0.0. 

This PR updates the documentation for this widget under `Marketplace Guide` > `Widgets` section. 