### PR TITLE
Mention correct tab name for import/export table mappings

### DIFF
--- a/content/appstore/modules/database-replication.md
+++ b/content/appstore/modules/database-replication.md
@@ -271,7 +271,7 @@ Each import action is executed in a single transaction, which means it is able t
 
 ## 10 Importing & Exporting a File
 
-You can import and export table mappings to an XML file using the **Import/export file** tab.
+You can import and export table mappings to an XML file using the **Table mapping** tab.
 
 ## 11 Troubleshooting
 


### PR DESCRIPTION
Importing/Exporting a table mapping is now part of Table mapping tab.