### PR TITLE
Re-add limitation on file documents

### DIFF
--- a/content/refguide8/synchronize-to-device.md
+++ b/content/refguide8/synchronize-to-device.md
@@ -55,6 +55,7 @@ they will not be synchronized to a device. If the offline database already conta
 * If the object to synchronize to a device is deleted in the same microflow,
 **Synchronize to device** activity will remove it from the offline database, if found.
 * Autocommited and new objects get skipped.
+* Synchronizing files is not allowed.
 * It will only synchronize objects in a microflow that are called from a nanoflow, not from an event microflow.
 
 ## 6 Remarks


### PR DESCRIPTION
The limitation syncing file documents got removed from the Mendix 8 documentation by accident in https://github.com/mendix/docs/pull/3216. See also this Slack thread: https://mendix.slack.com/archives/CJZ85RLTA/p1619619949303400 TL;DR: the limitation is not there in Mendix 9, but it is still there in Mendix 8. As we don't add new features to LTS versions, the improvement will not be backported.