### PR TITLE
Release notes for Appstore Release

### DIFF
--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -14,7 +14,8 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
 #### Fixes
 
-* We fixed the issue with downloading the Windows Service. We also fixed a minor bug for anonymous users.
+* <a name="windows-service"></a>We fixed the issue with downloading the Windows Service. 
+* We fixed a minor bug for anonymous users.
 
 ### April 7th, 2021
 
@@ -30,8 +31,8 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
 #### Known Issues
 
-* There is an issue with users having trouble downloading Windows Service. This is planned to be fixed soon.
-	* Workaround: First go to [My Marketplace](https://appstore.home.mendix.com/link/myappstore), then go back to the [Get Studio Pro](https://marketplace.mendix.com/link/studiopro/) and download the Windows Service again. 
+* There is an issue with users having trouble downloading Windows Service.
+	* Fixed on [May 4th, 2021](#windows-service).
 
 ### March 23rd, 2021
 

--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -10,6 +10,12 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
 ## 2021
 
+### May 4th, 2021
+
+#### Fixes
+
+* We fixed the issue with downloading the Windows Service. We also fixed a minor bug for anonymous users.
+
 ### April 7th, 2021
 
 #### Improvements

--- a/content/releasenotes/studio-pro/windows-service.md
+++ b/content/releasenotes/studio-pro/windows-service.md
@@ -3,15 +3,9 @@ title: "Windows Service"
 category: "Studio Pro"
 aliases:
     - /releasenotes/desktop-modeler/windows-service.html
-#ki: "If you face trouble" - AS-1760 (also Marketplace RN)
 ---
 
 To download the Windows Service, go to the [Get Studio Pro](https://marketplace.mendix.com/link/studiopro/) page in the Mendix Marketplace and click the **Related Downloads** button.
-
-{{% alert type="warning" %}}
-If you face trouble downloading the Windows Service, try first going to [My Marketplace](https://appstore.home.mendix.com/link/myappstore), then go back to the [Get Studio Pro](https://marketplace.mendix.com/link/studiopro/) and download the Windows Service again. The underlying cause of this error is planned to be fixed soon.
-{{% /alert %}}
-
 
 ## 4.6
 

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -10,7 +10,7 @@
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Apr 26th, 2021</li>
 	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – May 4th, 2021</li>
 	<li><a href="/releasenotes/data-hub">Data Hub</a> – Apr 29th, 2021</li>
-	<li><a href="/releasenotes/app-store">Marketplace</a> – Apr 7th, 2021</li>
+	<li><a href="/releasenotes/app-store">Marketplace</a> – May 4th, 2021</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.50.0</a> – Apr 21st, 2021</li>
 	<li><a href="/releasenotes/sdk/metamodel-9.1">Metamodel 9.1.0</a> – Apr 21st, 2021</li>
   </ul>


### PR DESCRIPTION
Added release notes for 8.11.0 Release.

This was already released on Tuesday, so these changes can be merged in at the earliest convenience.