### PR TITLE
Update deploy-api.md

### DIFF
--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -323,7 +323,7 @@ An object with the following key-value pairs:
      "Url" :  "https://calc-accp.mendixcloud.com",
      "ModelVersion" :  "1.1.0.253",
      "MendixVersion" :  "6.10.10",
-     "Production" :  "false"
+     "Production" :  false
 }
 ```
 

--- a/content/apidocs-mxsdk/apidocs/deploy-api.md
+++ b/content/apidocs-mxsdk/apidocs/deploy-api.md
@@ -249,7 +249,7 @@ List of objects with the following key-value pairs:
         "Url" :  "https://calc-accp.mendixcloud.com",
         "ModelVersion" :  "1.1.0.253",
         "MendixVersion" :  "6.10.10",
-        "Production" :  "false"
+        "Production" :  false
 
     },
     {
@@ -259,7 +259,7 @@ List of objects with the following key-value pairs:
         "Url" :  "https://calc.mendixcloud.com",
         "ModelVersion" :  "175.0.0.3702",
         "MendixVersion" :  "6.10.12",
-        "Production" :  "false"
+        "Production" :  false
     }
 ]
 ```


### PR DESCRIPTION
JSON example was wrong. Booleans should be false and not "false" because then they become a string. Furthermore should the picture of the domain model be updated. Environment object is missing all kinds of attributes. Furthermore does it not reflect the Backup API V2. And the documentation should change again when V3 cloud gets depricated due to attribute name changes depending on V3 or V4 cloud.