### PR TITLE
Revert "Form-data headers"

### DIFF
--- a/content/refguide/call-rest-action.md
+++ b/content/refguide/call-rest-action.md
@@ -176,8 +176,6 @@ This option allows you to generate a multipart/form-data request for multiple pa
 
 FileDocuments and images are are also supported for this option when used as variables in microflow expressions.
 
-For each part, you can specify the HTTP headers. For each part, by default, the **Content-Disposition**  (for file documents and images) and **Content-Type** (for all parts) headers are added. You can specify different values for these headers, or add other headers.
-
 #### 6.3.1 Content Type
 
 Setting up a **Content-Type header** for a form-data request will result in a consistency error, as it will automatically be set to **multipart/form-data**. 


### PR DESCRIPTION
Reverts mendix/docs#3313 - intended for 9.2 which was overlooked when mergd