### PR TITLE
Add SQL Server 2016 deprecation warning to 9.2 RN

### DIFF
--- a/content/releasenotes/studio-pro/9.2.md
+++ b/content/releasenotes/studio-pro/9.2.md
@@ -80,6 +80,10 @@ description: "The release notes for Mendix Studio Pro version 9.2 (including all
 * We fixed an issue where exporting a module without the **themesource** folder resulted in an exception.
 * We fixed an issue where the Buddhist calendar did not work properly in Android mobile browsers. Now, Android mobile browsers will show the Mendix app calendar instead of the native calendar.
 
+### Deprecations
+
+* Starting with version 9.4, we will drop support for Microsoft SQL Server 2016, which will no longer be supported by its vendor.
+
 ### Known Issues
 
 * When you update a [consumed OData service](/refguide/consumed-odata-service) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.


### PR DESCRIPTION
We will stop supporting this database version soon.