### PR TITLE
Add SQL Server 2016 deprecation warning to RN of 8.18.6

### DIFF
--- a/content/releasenotes/studio-pro/8.18.md
+++ b/content/releasenotes/studio-pro/8.18.md
@@ -22,7 +22,9 @@ There is an issue with installing Studio Pro for the first time due to inability
 ### Fixes
 
 
+### Deprecations
 
+* Starting with version 8.18.8, we will drop support for Microsoft SQL Server 2016, which will no longer be supported by its vendor.
 
 ### Known Issues
 


### PR DESCRIPTION
This follows from https://docs.microsoft.com/en-us/lifecycle/products/sql-server-2016.