### PR TITLE
Add SQL Server 2016 deprecation warning to RN of 7.23.21

### DIFF
--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -35,6 +35,7 @@ There is an issue with installing Studio Pro for the first time due to inability
 ### Deprecations
 
 * We will drop support for Oracle 18 before June 30th. We will announce this again when the support is dropped.
+* Starting with version 7.23.23, we will drop support for Microsoft SQL Server 2016, which will no longer be supported by its vendor.
 
 ## 7.23.20 {#72320}
 


### PR DESCRIPTION
This follows from https://docs.microsoft.com/en-us/lifecycle/products/sql-server-2016.