### PR TITLE
Add extra XPath mathematical operations restriction to 8.18.6 RN

### DIFF
--- a/content/releasenotes/studio-pro/8.18.md
+++ b/content/releasenotes/studio-pro/8.18.md
@@ -26,6 +26,10 @@ There is an issue with installing Studio Pro for the first time due to inability
 
 * Starting with version 8.18.8, we will drop support for Microsoft SQL Server 2016, which will no longer be supported by its vendor.
 
+### Breaking Changes
+
+* It is no longer possible to add mathematical expressions in an XPath outside of tokens. Mathematical expressions should be calculated outside of the XPath expression.
+
 ### Known Issues
 
 * When you update a [consumed OData service](/refguide8/consumed-odata-service) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.

--- a/content/releasenotes/studio-pro/8.18.md
+++ b/content/releasenotes/studio-pro/8.18.md
@@ -28,7 +28,7 @@ There is an issue with installing Studio Pro for the first time due to inability
 
 ### Breaking Changes
 
-* It is no longer possible to add mathematical expressions in an XPath outside of tokens. Mathematical expressions should be calculated outside of the XPath expression.
+* It is no longer possible to add mathematical expressions in an XPath outside of [tokens](/refguide8/xpath-tokens). Mathematical expressions should be calculated outside of the XPath expression.
 
 ### Known Issues
 


### PR DESCRIPTION
Starting with this version we restrict mathematical operators just like with 9.0.