### PR TITLE
Add restriction of mathematical operators in XPath starting with 7.23.21

### DIFF
--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -37,6 +37,10 @@ There is an issue with installing Studio Pro for the first time due to inability
 * We will drop support for Oracle 18 before June 30th. We will announce this again when the support is dropped.
 * Starting with version 7.23.23, we will drop support for Microsoft SQL Server 2016, which will no longer be supported by its vendor.
 
+### Breaking Changes
+
+* It is no longer possible to add mathematical expressions in an XPath outside of tokens. Mathematical expressions should be calculated outside of the XPath expression.
+
 ## 7.23.20 {#72320}
 
 **Release date: March 8th, 2021**

--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -39,7 +39,7 @@ There is an issue with installing Studio Pro for the first time due to inability
 
 ### Breaking Changes
 
-* It is no longer possible to add mathematical expressions in an XPath outside of tokens. Mathematical expressions should be calculated outside of the XPath expression.
+* It is no longer possible to add mathematical expressions in an XPath outside of [tokens](/refguide7/xpath-tokens). Mathematical expressions should be calculated outside of the XPath expression.
 
 ## 7.23.20 {#72320}
 


### PR DESCRIPTION
Starting with this version we restrict mathematical operators just like with 9.0.