### PR TITLE
Private Cloud documentation improvements (no release date)

### DIFF
--- a/content/developerportal/deploy/private-cloud-operator.md
+++ b/content/developerportal/deploy/private-cloud-operator.md
@@ -57,7 +57,7 @@ spec:
   storage: # Specification of Storage CR
     servicePlan: dev
   mendixRuntimeVersion: 7.23.3.48173 # Mendix version to use for placeholder runtime image
-  sourceURL: https://example.com/example-app.mda # URL of App's source MDA or MPK
+  sourceURL: https://example.com/example-app.mda # URL of App's source MDA
   appURL: example-mendixapp.k8s-cluster.example.com # URL to access the app
   tls: # Optional, can be omitted : set a custom TLS configuration, overriding the default operator configuration
     # Enable or disable TLS for the app

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -248,7 +248,7 @@ Mendix for Private Cloud will use the existing ingress controller.
 We strongly recommend using the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/), even if other Ingress controllers or OpenShift Routes are available.
 
 NGINX Ingress can be used to deny access to sensitive URLs, add HTTP headers, enable compression, and cache static content.
-NGINX Ingress is fully compatible with [cert-manager](https://cert-manager.io/), removing the need to manually manage TLS certificates.
+NGINX Ingress is fully compatible with [cert-manager](https://cert-manager.io/), removing the need to manually manage TLS certificates. In addition, NGINX Ingress can use a [Linkerd](https://linkerd.io/) Service Mesh to encrypt network traffic between the Ingress Controller  and the Pod running a Mendix app.
 
 These features will likely be required once your application is ready for production.
 {{% /alert %}}
@@ -275,10 +275,10 @@ It is also possible to provide a custom TLS configuration for individual environ
 
 ### 6.2 Ingress
 
-We currently support the following ingress controllers:
+Mendix for Private Cloud is compatible with the following ingress controllers:
 
 * [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
-* [Traefik 1.7](https://containo.us/traefik/)
+* [Traefik](https://traefik.io/traefik/)
 
 For ingress, it is possible to do the following:
 


### PR DESCRIPTION
These changes are not associated with any release and can be merged at any convenient time.

* Fixed incorrect description of the `sourceURL` field (it only accepts MDA files, not *.MPK)
* Clarified some details about Ingresses and added yet another reason to use NGINX Ingress