### PR TITLE
Specified the Windows JDK Version

### DIFF
--- a/content/refguide/managing-app-signing-keys.md
+++ b/content/refguide/managing-app-signing-keys.md
@@ -74,7 +74,7 @@ Android apps can be developed and deployed to Android devices without signing th
 
 To generate a keystore for Android, follow these steps:
 
-1. Install Java JDK either for Mac or Windows. Remember where you installed your JDK, as the JDK bin folder will be used later.
+1. Install Java JDK either for Mac or Windows (for Windows 10 use JDK 1.8.0_144). Remember where you installed your JDK, as the JDK bin folder will be used later.
 2. Open your **Command Prompt** and run your new *keytool.exe* located in your JDK’s bin folder.
 3.  The *keytool.exe* program can be found in the bin directory of your Java installation (for example: *C:\Program Files\Java\jre1.8.0_20\bin*):
 


### PR DESCRIPTION
Specified the Windows JDK version that should be used when signing android applications. It is small details like this that can save a lot of time.