### PR TITLE
Fix broken links

### DIFF
--- a/content/partners/siemens/mindsphere-asset-management-connector.md
+++ b/content/partners/siemens/mindsphere-asset-management-connector.md
@@ -39,7 +39,7 @@ This domain model mirrors the asset manager data model, which is described in de
 
 A **GetQueryParams** object is used to control which objects which are returned. This object needs to be populated and passed to the microflow action. If no GetQueryParams object is passed, then the defaults are used.
 
-GetQueryParams has the following attributes, which match the parameters of the APIs described on the MindSphere developer site here: [Asset Management Service – API Specification Europe 1](https://developer.mindsphere.io/apis/advanced-assetmanagement/api-assetmanagement-api-swagger-3-9-0.html).
+GetQueryParams has the following attributes, which match the parameters of the APIs described on the MindSphere developer site here: [Asset Management Service – API Specification Europe 1](https://developer.mindsphere.io/apis/advanced-assetmanagement/api-assetmanagement-api.html).
 
 | **Attribute** | **Description**                                                                                                    | **Default** | **Example**          |
 | ------------- | ------------------------------------------------------------------------------------------------------------------ | ----------- | -------------------- |
@@ -96,7 +96,7 @@ This populates the following entities in the domain model:
 * AspectType
 * Variable
 
-For more information about these entities, and what is returned by the *GET /assets* API call, see the *Models* and *GET /assets* sections of the [Asset Management Service – API Specification Europe 1](https://developer.mindsphere.io/apis/advanced-assetmanagement/api-assetmanagement-api-swagger-3-9-0.html).
+For more information about these entities, and what is returned by the *GET /assets* API call, see the *Models* and *GET /assets* sections of the [Asset Management Service – API Specification Europe 1](https://developer.mindsphere.io/apis/advanced-assetmanagement/api-assetmanagement-api.html).
 
 {{% alert type="warning" %}}
 By default, MindSphere limits the data returned to the first ten assets. This behavior can be modified through a GetQueryParams object.


### PR DESCRIPTION
The previous URL (https://developer.mindsphere.io/apis/advanced-assetmanagement/api-assetmanagement-api-swagger-3-9-0.html) contains the version of the API. The version now is 3.15.0, so the URL is also changed accordingly. To prevent the links from becoming outdated again in the future, it is better to direct the user to the **Available API Versions**, and then user can just choose the available API version for **Europe 1**.