### PR TITLE
Clarify backup API

### DIFF
--- a/content/apidocs-mxsdk/apidocs/backups-api.md
+++ b/content/apidocs-mxsdk/apidocs/backups-api.md
@@ -7,7 +7,21 @@ menu_order: 10
 
 ## 1 Introduction
 
-The Backups API V2 allows you to manage data snapshots of applications hosted in the Mendix Cloud V4. Data snapshots consist of a Postgresql database dump and file objects referenced from the database. You can create new snapshots and restore or download them. Uploading snapshots is currently only supported via the [Developer Portal](/developerportal/operate/backups). Unlike the [older V1 API](backups-api-v1), this new V2 API is focused on asynchronous operations of long-running tasks.
+The **Backups API V2** allows you to manage backups of the data in your app hosted in the Mendix Cloud V4.
+
+If you want to download a backup of your data, you need to perform three steps:
+
+1. Create a *snapshot*, or find the `snapshot-id` of an existing one
+2. Create an *archive* file from a snapshot
+3. Download the archive using the URL provided 
+
+Data **snapshots** consist of a PostgreSQL database dump and all the file objects referenced from the database.
+
+Database **archives** are a zip file which contains all the data in the snapshot, or the database and files separately if you prefer. 
+
+You cannot currently upload an archive through this API. This function is currently only supported via the [Developer Portal](/developerportal/operate/backups). However, you can use this API to restore data from an existing environment snapshot.
+
+V2 of this API is focused on working with snapshots and archives asynchronously, as these can be very long-running tasks for large quantities of data. The [older V1 API](backups-api-v1), in contrast, works synchronously. 
 
 {{% alert type="info" %}}
 This article is only applicable to applications deployed in **Mendix Cloud V4**. You can check which version of the Mendix Cloud you are using in the [Developer Portal](/developerportal/deploy/environments-details).
@@ -17,14 +31,13 @@ This article is only applicable to applications deployed in **Mendix Cloud V4**.
 
 The Backups API requires authentication via API keys that are bound to your Mendix account (for more information, see [Deploy Authentication](deploy-api#authentication)). In addition to the **API Access** permission, the **Backups** permission is also required to manage backups.
 
-
 ## 3 API Calls
 
-### 3.1 List Environment Backups
+### 3.1 List Environment Snapshots
 
 #### 3.1.1 Description
 
-Lists the backups of an environments. By setting the `offset` parameter you can page through the list of backups belonging to an environment.
+Lists the snapshots of an environments. By setting the `offset` parameter, you can page through the list of snapshots created for an environment.
 
 ```bash
 HTTP Method: GET
@@ -59,7 +72,7 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 An object with the following key-value pairs:
 
 *   _snapshots_ (List): List of snapshot objects.
-*   _total_ (Long): There are in total this amount of snapshots for the requested environment.
+*   _total_ (Long): The total number of snapshots for the requested environment.
 *   _offset_ (Long): The offset value of the current request.
 *   _limit_ (Long): The limit value of the current request.
 
@@ -107,15 +120,15 @@ An object with the following key-value pairs:
 }
 ```
 
-### 3.2 Submit request to download a Backup for an Environment
+### 3.2 Request Creation of an Environment Snapshot
 
 #### 3.2.1 Description
 
-Requests download the backup for an environment. The response contains an archive job object with `archive_id` attribute. You can use this `archive_id` to periodically check the status of this job.
+Request the creation of a snapshot of an environment. The response is a JSON object containing the `snapshot_id` attribute which identifies a snapshot. Use the `snapshot_id` in an API request to check the progress of the creation this snapshot.
 
 ```bash
 HTTP Method: POST
-URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots/<SnapshotId>/archives
+URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots
 ```
 
 #### 3.2.2 Request
@@ -124,7 +137,160 @@ URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<Environment
 
 *   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
 *   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
-*   _SnapshotId_ (String): Identifier of the backup.
+
+**Request Body**
+
+A JSON object with the following attributes:
+
+*   _comment_ (String): Optional comment for this snapshot.
+
+
+**Example Request**
+
+```bash
+POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
+Host: deploy.mendix.com
+
+Content-Type: application/json
+Mendix-Username: richard.ford51@example.com
+Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
+
+{
+     "comment" :  "My snapshot"
+}
+```
+
+#### 3.2.3 Output
+
+A JSON object with the following key-value pairs:
+
+*   _snapshot\_id_ (String): Unique identification of the snapshot job.
+*   _status\_message_ (String): Human readable status message of this job.
+*   _finished\_at_ (String): ISO 8601 date and time when this job reached the end state.
+*   _updated\_at_ (String): ISO 8601 date and time when this job was updated.
+*   _created\_at_ (String): ISO 8601 date and time when this job was created.
+*   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
+*   _model\_version_ (String): Model version that was running when the snapshot was created.
+*   _expires\_at_ (String): ISO 8601 date and time when this snapshot will be expired.
+*   _comment_ (String): A comment describing this snapshot. Can be set by users for easier future reference.
+
+**Error Codes**
+
+| HTTP Status | Error code | Description |
+| --- | --- | --- |
+| 400 | INVALID_PARAMETERS | Not enough parameters given. Please set project_id and environment_id parameters. |
+| 400 | NOT_SUPPORTED | This endpoint can only be used with Mendix Cloud V4 |
+| 400 | ENVIRONMENT_BUSY | Environment is busy, please try again later or contact support for assistance.|
+| 400 | INVALID_STATE | Failed to create a backup. There is currently a maintenance action in progress. Please wait until that is finished. |
+| 403 | NO_ACCESS | The user does not have access to the backups of this environment. |
+| 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
+| 404 | NOT_FOUND | Snapshot not found. |
+| 500 | SERVICE_UNAVAILABLE | Operation failed. Please try again later or contact support if the problem persists. |
+
+**Example Output**
+
+```json
+{
+   "status_message":null,
+   "model_version":null,
+   "expires_at":"2020-05-18T16:00:18.000Z",
+   "finished_at":null,
+   "updated_at":null,
+   "snapshot_id":"51dc7872-771e-4c3e-853b-352359444db6",
+   "created_at":"2020-02-18T16:00:18.000Z",
+   "comment":"My snapshot",
+   "state":"queued"
+}
+```
+
+### 3.3 Request Status of Creation of a Snapshot
+
+#### 3.3.1 Description
+
+Check the current status of an ongoing snapshot creation.
+
+```bash
+HTTP Method: GET
+URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots/<SnapshotId>
+```
+
+#### 3.3.2 Request
+
+**Request Parameters**
+
+*   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
+*   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
+*   _SnapshotId_ (String): Identifier of the snapshot being created.
+
+**Example Request**
+
+```bash
+GET /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots/51dc7872-771e-4c3e-853b-352359444db6
+Host: deploy.mendix.com
+
+Content-Type: application/json
+Mendix-Username: richard.ford51@example.com
+Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
+```
+
+#### 3.3.3 Output
+
+An object with the following key-value pairs:
+
+*   _snapshot\_id_ (String): Unique identification of the snapshot job.
+*   _status\_message_ (String): Human readable status message of this job.
+*   _finished\_at_ (String): ISO 8601 date and time when this job reached the end state.
+*   _updated\_at_ (String): ISO 8601 date and time when this job was updated.
+*   _created\_at_ (String): ISO 8601 date and time when this job was created.
+*   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
+*   _model\_version_ (String): Model version that was running when the snapshot was created.
+*   _expires\_at_ (String): ISO 8601 date and time when this snapshot will be expired.
+*   _comment_ (String): A comment describing this snapshot. Can be set by users for easier future reference.
+
+**Error Codes**
+
+| HTTP Status | Error code | Description |
+| --- | --- | --- |
+| 400 | INVALID_PARAMETERS | Not enough parameters given. Please set project_id and environment_id parameters. |
+| 400 | NOT_SUPPORTED | This endpoint can only be used with Mendix Cloud V4 |
+| 403 | NO_ACCESS | The user does not have access to the backups of this environment. |
+| 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
+| 404 | NOT_FOUND | Snapshot not found. |
+| 500 | SERVICE_UNAVAILABLE | Operation failed. Please try again later or contact support if the problem persists. |
+**Example Output**
+
+```json
+{
+   "status_message":"Completed backup creation",
+   "model_version":"1.0.0.7",
+   "expires_at":"2020-05-18T16:00:18.000Z",
+   "finished_at":"2020-02-18T16:00:19.000Z",
+   "updated_at":"2020-02-18T16:00:19.000Z",
+   "snapshot_id":"51dc7872-771e-4c3e-853b-352359444db6",
+   "created_at":"2020-02-18T16:00:18.000Z",
+   "comment":"Manually created snapshot",
+   "state":"completed"
+}
+```
+
+### 3.4 Request Creation of a Snapshot Archive
+
+#### 3.4.1 Description
+
+Requests the creation of an archive of a backup snapshot. The response is a JSON object containing the `archive_id` attribute which identifies an archive. use this `archive_id` in an API request to check the progress of the creation of this archive, and obtain a URL to allow you to download it.
+
+```bash
+HTTP Method: POST
+URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots/<SnapshotId>/archives
+```
+
+#### 3.4.2 Request
+
+**Request Parameters**
+
+*   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
+*   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
+*   _SnapshotId_ (String): Identifier of the snapshot for which you want to create an archive.
 
 **Query Parameters**
 
@@ -143,7 +309,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-#### 3.2.3 Output
+#### 3.4.3 Output
 
 An object with the following key-value pairs:
 
@@ -185,26 +351,25 @@ An object with the following key-value pairs:
 }
 ```
 
+### 3.5 Request Status of Creation of an Archive
 
-### 3.3 Check download job of a Backup for an Environment
+#### 3.5.1 Description
 
-#### 3.3.1 Description
-
-After a request to download the backup is submitted, you can check the progress this job using the `archive_id`. This job will eventually reach one of the following end states: *completed* or *failed*. When it is completed, the `url` attribute is populated with direct link to your requested backup. This link is valid for eight hours after completion.
+After a request to create an archive is submitted, you can check the progress of the archive creation using the `archive_id`. The archive creation will eventually reach one of the following end states: *completed* or *failed*. When it is completed, the `url` attribute is populated with a direct link to your requested backup. This link is valid for eight hours after completion.
 
 ```bash
 HTTP Method: GET
 URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots/<SnapshotId>/archives/<ArchiveId>
 ```
 
-#### 3.3.2 Request
+#### 3.5.2 Request
 
 **Request Parameters**
 
 *   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
 *   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
 *   _SnapshotId_ (String): Identifier of the backup.
-*   _ArchiveId_ (String): Identifier of the archiving request.
+*   _ArchiveId_ (String): Identifier of the archive being created.
 
 **Example Request**
 
@@ -218,7 +383,7 @@ Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 ```
 
-#### 3.3.3 Output
+#### 3.5.3 Output
 
 An object with the following key-value pairs:
 
@@ -230,7 +395,7 @@ An object with the following key-value pairs:
 *   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
 *   _data\_type_ (String): Type of data of the requested archive.
 *   _snapshot\_id_ (String): Snapshot identifier of which this archive belongs to.
-*   _url_ (String): Direct URL to the backup archive. This URL can be used with download managers.
+*   _url_ (String): Direct URL to the backup archive. This URL can be used to download your backup archive file.
 
 **Error Codes**
 
@@ -256,169 +421,15 @@ An object with the following key-value pairs:
    "created_at":"2020-02-18T17:01:56.000Z",
    "state":"completed",
    "archive_id":"a6f519aa-a68e-4054-9341-2cfec72ea184",
-   "url":"https://..."
+   "url":"https://…"
 }
 ```
 
-### 3.4 Submit request to create a Backup of an Environment
-
-#### 3.4.1 Description
-
-Request to create a backup of an environment. The response is an unfinished snapshot object with `snapshot_id` attribute. Use `snapshot_id` to check the status of this snapshot job.
-
-```bash
-HTTP Method: POST
-URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots
-```
-
-#### 3.4.2 Request
-
-**Request Parameters**
-
-*   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
-*   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
-
-**Request Body**
-
-A JSON object with the following attributes:
-
-*   _comment_ (String): Optional comment for this snapshot.
-
-
-**Example Request**
-
-```bash
-POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
-Host: deploy.mendix.com
-
-Content-Type: application/json
-Mendix-Username: richard.ford51@example.com
-Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
-
-{
-     "comment" :  "My snapshot"
-}
-```
-
-#### 3.4.3 Output
-
-An object with the following key-value pairs:
-
-*   _snapshot\_id_ (String): Unique identification of the snapshot job.
-*   _status\_message_ (String): Human readable status message of this job.
-*   _finished\_at_ (String): ISO 8601 date and time when this job reached the end state.
-*   _updated\_at_ (String): ISO 8601 date and time when this job was updated.
-*   _created\_at_ (String): ISO 8601 date and time when this job was created.
-*   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
-*   _model\_version_ (String): Model version that was running when the snapshot was created.
-*   _expires\_at_ (String): ISO 8601 date and time when this snapshot will be expired.
-*   _comment_ (String): A comment describing this snapshot. Can be set by users for easier future reference.
-
-**Error Codes**
-
-| HTTP Status | Error code | Description |
-| --- | --- | --- |
-| 400 | INVALID_PARAMETERS | Not enough parameters given. Please set project_id and environment_id parameters. |
-| 400 | NOT_SUPPORTED | This endpoint can only be used with Mendix Cloud V4 |
-| 400 | ENVIRONMENT_BUSY | Environment is busy, please try again later or contact support for assistance.|
-| 400 | INVALID_STATE | Failed to create a backup. There is currently a maintenance action in progress. Please wait until that is finished. |
-| 403 | NO_ACCESS | The user does not have access to the backups of this environment. |
-| 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
-| 404 | NOT_FOUND | Snapshot not found. |
-| 500 | SERVICE_UNAVAILABLE | Operation failed. Please try again later or contact support if the problem persists. |
-
-**Example Output**
-
-```json
-{
-   "status_message":null,
-   "model_version":null,
-   "expires_at":"2020-05-18T16:00:18.000Z",
-   "finished_at":null,
-   "updated_at":null,
-   "snapshot_id":"51dc7872-771e-4c3e-853b-352359444db6",
-   "created_at":"2020-02-18T16:00:18.000Z",
-   "comment":"My snapshot",
-   "state":"queued"
-}
-```
-
-
-### 3.5 Check request to create a Backup of an Environment
-
-#### 3.5.1 Description
-
-Check the current status of an ongoing backup creation.
-
-```bash
-HTTP Method: GET
-URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/snapshots/<SnapshotId>
-```
-
-#### 3.5.2 Request
-
-**Request Parameters**
-
-*   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
-*   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
-*   _SnapshotId_ (String): Identifier of the backup.
-
-**Example Request**
-
-```bash
-GET /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots/51dc7872-771e-4c3e-853b-352359444db6
-Host: deploy.mendix.com
-
-Content-Type: application/json
-Mendix-Username: richard.ford51@example.com
-Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
-```
-
-#### 3.5.3 Output
-
-An object with the following key-value pairs:
-
-*   _snapshot\_id_ (String): Unique identification of the snapshot job.
-*   _status\_message_ (String): Human readable status message of this job.
-*   _finished\_at_ (String): ISO 8601 date and time when this job reached the end state.
-*   _updated\_at_ (String): ISO 8601 date and time when this job was updated.
-*   _created\_at_ (String): ISO 8601 date and time when this job was created.
-*   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
-*   _model\_version_ (String): Model version that was running when the snapshot was created.
-*   _expires\_at_ (String): ISO 8601 date and time when this snapshot will be expired.
-*   _comment_ (String): A comment describing this snapshot. Can be set by users for easier future reference.
-
-**Error Codes**
-
-| HTTP Status | Error code | Description |
-| --- | --- | --- |
-| 400 | INVALID_PARAMETERS | Not enough parameters given. Please set project_id and environment_id parameters. |
-| 400 | NOT_SUPPORTED | This endpoint can only be used with Mendix Cloud V4 |
-| 403 | NO_ACCESS | The user does not have access to the backups of this environment. |
-| 404 | ENVIRONMENT_NOT_FOUND | Environment not found. |
-| 404 | NOT_FOUND | Snapshot not found. |
-| 500 | SERVICE_UNAVAILABLE | Operation failed. Please try again later or contact support if the problem persists. |
-**Example Output**
-
-```json
-{
-   "status_message":"Completed backup creation",
-   "model_version":"1.0.0.7",
-   "expires_at":"2020-05-18T16:00:18.000Z",
-   "finished_at":"2020-02-18T16:00:19.000Z",
-   "updated_at":"2020-02-18T16:00:19.000Z",
-   "snapshot_id":"51dc7872-771e-4c3e-853b-352359444db6",
-   "created_at":"2020-02-18T16:00:18.000Z",
-   "comment":"Manually created snapshot",
-   "state":"completed"
-}
-```
-
-### 3.6 Update an existing backup
+### 3.6 Update an Existing Snapshot
 
 #### 3.6.1 Description
 
-Set a new comment for an existing backup. The _updated\_at_ attribute remains unchanged after this operation.
+Set a new comment for an existing snapshot. The _updated\_at_ attribute remains unchanged after this operation.
 
 ```bash
 HTTP Method: PUT
@@ -496,11 +507,11 @@ An object with the following key-value pairs:
 }
 ```
 
-### 3.7 Delete an existing backup
+### 3.7 Delete an Existing Snapshot
 
 #### 3.7.1 Description
 
-Delete an existing backup. Use this to keep your backups list tidy.
+Delete an existing snapshot.
 
 ```bash
 HTTP Method: DELETE
@@ -545,11 +556,11 @@ Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 No content is returned when a backup has been successfully removed.
 
 
-### 3.8 Submit request to restore a Backup to an Environment
+### 3.8 Request a Restore of a Snapshot to an Environment
 
 #### 3.8.1 Description
 
-Restore a previously created backup to an environment. The environment to which the data will be restored must be stopped before using this call. The response of a successful call contains the details of the restored backup. This call is only available for Mendix Cloud v4 applications. Please note that the Snapshot ID can be a snapshot created for a different environment, similar to the "restore into" functionality in the Developer Portal.
+Restore a previously created backup snapshot to an environment. The environment to which the data will be restored must be stopped before using this call. The response of a successful call contains the details of the request. This call is only available for Mendix Cloud v4 applications. Please note that the `source_snapshot_id` can be a snapshot created for a different environment, similar to the "restore into" functionality in the Developer Portal.
 
 ```bash
 HTTP Method: POST
@@ -565,7 +576,7 @@ URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<Environment
 
 **Query Parameters**
 
-*   _source\_snapshot\_id_ (String): Snapshot identifier of which will be restored. This value is required and must belong to a snapshot within the same application but could be different environment.
+*   _source\_snapshot\_id_ (String): Identifier of the snapshot which will be restored. This value is required and must belong to a snapshot within the same application, although it could be a different environment.
 
 **Example Request**
 
@@ -589,8 +600,8 @@ An object with the following key-value pairs:
 *   _created\_at_ (String): ISO 8601 date and time when this job was created.
 *   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
 *   _source\_snapshot\_id_ (String): Identifier of the snapshot being restored.
-*   _source\_environment\_id_ (String): Identifier of the environment of the source snapshot being restored from.
-*   _target\_environment\_id_ (String): Identifier of the target environment to which is being restored.
+*   _source\_environment\_id_ (String): Identifier of the environment from which the source snapshot was created.
+*   _target\_environment\_id_ (String): Identifier of the target environment to which the snapshot is being restored.
 
 **Error Codes**
 
@@ -625,11 +636,12 @@ An object with the following key-value pairs:
 }
 ```
 
-### 3.9 Check restore status of a Backup to an Environment
+### 3.9 Request Status of a Snapshot Restore
 
 #### 3.9.1 Description
 
 Check the status of a restore request.
+
 ```bash
 HTTP Method: GET
 URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<EnvironmentId>/restores/<RestoreId>
@@ -641,7 +653,7 @@ URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<Environment
 
 *   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
 *   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
-*   _SnapshotId_ (String): Identifier of the backup.
+*   _RestoreId_ (String): Identifier the request to restore the data.
 
 **Example Request**
 
@@ -665,8 +677,8 @@ An object with the following key-value pairs:
 *   _created\_at_ (String): ISO 8601 date and time when this job was created.
 *   _state_ (String): Current state of this job. It always starts with `queued` followed by `running` and eventually reaches either `failed` or `completed` end states.
 *   _source\_snapshot\_id_ (String): Identifier of the snapshot being restored.
-*   _source\_environment\_id_ (String): Identifier of the environment of the source snapshot being restored from.
-*   _target\_environment\_id_ (String): Identifier of the target environment to which is being restored.
+*   _source\_environment\_id_ (String): Identifier of the environment from which the source snapshot was created.
+*   _target\_environment\_id_ (String): Identifier of the target environment to which the snapshot is being restored.
 
 **Error Codes**
 

--- a/content/apidocs-mxsdk/apidocs/backups-api.md
+++ b/content/apidocs-mxsdk/apidocs/backups-api.md
@@ -653,7 +653,7 @@ URL: https://deploy.mendix.com/api/v2/apps/<ProjectId>/environments/<Environment
 
 *   _ProjectId_ (String): Unique project identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [apps API](deploy-api#list-apps).
 *   _EnvironmentId_ (String): Unique environment identifier. Can be looked up via the [developer portal](/developerportal/deploy/environments-details) or [environments API](deploy-api#list-environments).
-*   _RestoreId_ (String): Identifier the request to restore the data.
+*   _RestoreId_ (String): Identifier of the request to restore the data.
 
 **Example Request**
 

--- a/content/developerportal/operate/backups.md
+++ b/content/developerportal/operate/backups.md
@@ -92,7 +92,7 @@ You can download a backup archive containing one of the following:
 See [Download a Backup](download-backup) for more information.
 
 {{% alert type="info" %}}
-As the download archive is generated "on the fly" (meaning, while in progress), it is not possible to estimate the file size before downloading. Your browser will not show a progress bar.
+As the download archive is generated on request, it is not possible to estimate the file size before requesting a download.
 {{% /alert %}}
 
 ### 3.4 Restore Backup

--- a/content/developerportal/operate/backups.md
+++ b/content/developerportal/operate/backups.md
@@ -9,9 +9,9 @@ tags: ["Operate", "App", "Developer Portal", "Backup"]
 
 ## 1 Introduction
 
-Backups are created every night or on-demand, as described in the [Backups](#backups) section, below.
+Backup snapshots are created every night or on-demand, as described in the [Backups](#backups) section, below.
 
-Backups in the Mendix Cloud have two parts: the database and file documents. A full backup of the database is made each time, while file documents are backed up incrementally.
+Backup snapshots contain both the database and file documents referred to in the database.
 
 ## 2 Creation and Retention Schedules
 
@@ -42,7 +42,7 @@ The **Backups** page presents options for managing your backups. These are descr
 
 ### 3.1 Create Backup
 
-This will automatically generate a backup from your application data. See [Create a Backup](create-backup).
+This will automatically generate a backup snapshot from your application data. See [Create a Backup](create-backup).
 
 ### 3.2 Upload Backup
 
@@ -52,7 +52,7 @@ The sections below present details on uploading data in recent Mendix Cloud vers
 
 In **Mendix Cloud v4**, the upload will create a new backup item in your backup list, which you can then restore via the regular restore process. This will ensure less downtime for your application. 
 
-Anything you can download you can also upload again, which means you can upload the following:
+Anything you can download you can also upload again, which means you can upload archives containing the following:
 
 * **Full Snapshot**
 * **Database Only**
@@ -83,7 +83,7 @@ You can upload two types of data:
 
 ### 3.3 Download Backup
 
-You can download one of the following: 
+You can download a backup archive containing one of the following: 
 
 * **Full Snapshot**
 * **Database Only**
@@ -92,14 +92,14 @@ You can download one of the following:
 See [Download a Backup](download-backup) for more information.
 
 {{% alert type="info" %}}
-As the download files are generated "on the fly" (meaning, while in progress), it is not possible to estimate the file size before downloading. Your browser will not show a progress bar.
+As the download archive is generated "on the fly" (meaning, while in progress), it is not possible to estimate the file size before downloading. Your browser will not show a progress bar.
 {{% /alert %}}
 
 ### 3.4 Restore Backup
 
-You can choose the **destination** environment to which you want to restore the backup. This allows you to, for example, restore a production environment backup to an acceptance environment.
+You can choose the **destination** environment to which you want to restore the backup snapshot. This allows you to, for example, restore a production environment backup to an acceptance environment.
 
-If you restore a backup that was originally deployed with an older Mendix version, you will get a warning. You can still restore the backup, but you will have to deploy the older model later on. 
+If you restore a backup snapshot that was originally deployed with an older Mendix version, you will get a warning. You can still restore the data, but you will have to deploy the older model later on. 
 
 {{% alert type="info" %}}
 In Mendix Cloud v4, if the restore takes too long, the system will show a timeout message. The restore will continue behind the scenes, and you can track the progress of the restore by inspecting your database free disk space graphs. While the database free disk space keeps decreasing, the restore is still in progress. If the database free disk space is constant, the restore has stopped and you can try to start your application. If this happens regularly, consider upgrading to a database plan with more CPU cores, so that the restore can be executed faster.

--- a/content/developerportal/operate/create-backup.md
+++ b/content/developerportal/operate/create-backup.md
@@ -25,19 +25,21 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## 3 Create a Backup
 
-Follow these steps to create a backup of a licensed app:
+Follow these steps to create a backup archive of a licensed app:
 
 1. Go to the [Developer Portal](http://sprintr.home.mendix.com) and click **Apps** in the top navigation panel.
 2. Click **My Apps** and select **Nodes**.
-3. Select the node from which you want to download the backup.
+3. Select the node for which you want to create a backup snapshot.
 4. Click **Backups**.
-5. Select the environment from which you want to download the backup.
+5. Select the environment for which you want to create a backup snapshot.
 
     ![](attachments/create-backup/environment.png)
 
 6. Click **Create Backup**.
 
     ![](attachments/create-backup/backupoptions.jpg)
+
+You can now download a backup archive by clicking [Download Backup](download-backup).
 
 
 ## 4 Read More

--- a/content/developerportal/operate/download-backup.md
+++ b/content/developerportal/operate/download-backup.md
@@ -54,7 +54,14 @@ To download a backup of a licensed app, follow these steps:
     ![](attachments/download-a-backup/backupoptions.jpg)
 
 7. Select a backup and click **Download Backup**.
-8. Select the backup type **Full Snapshot**, **Database Only**, or **Files Only**
+8. Select the backup type **Full Snapshot**, **Database Only**, or **Files Only** and click **Start**.
+
+    {{% alert type="info" %}}If a backup archive has been prepared recently, the **Show URL** and **Download** buttons will be active and you can download it immediately.{{% /alert %}}
+    
+9. Once the download archive has been prepared, you can do one of the following:
+
+    * Click **Show URL** to see the URL of the backup
+    * Click **Download** to immediately initiate the download of the archive using your browser.
 
 ## 5 Read More
 


### PR DESCRIPTION
Customers were confused about the use of V2 of the backup API.
Updating terminology to match the API, and introducing the process to help the customer.