### PR TITLE
Fix alignment of list of deprecated database versions in 7.23.13

### DIFF
--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -197,6 +197,7 @@ We added experimental support for queuing tasks as a part of a closed Beta test.
 	* MariaDB 5.5, 10.0
 	* PostgreSQL 9.2, 9.3, 9.4
 	* SQL Server 2008, 2008r2, 2012, 2014
+
 ### Known Issues
 
 * Users with non-administrative [user roles](/refguide/user-roles) with the permission to manage users are able to escalate their privileges. For more information on this vulnerability, see [SSA-875726 Privilege Escalation Vulnerability in Mendix](https://new.siemens.com/global/en/products/services/cert.html#SecurityPublications).

--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -143,6 +143,7 @@ There is an issue with installing Studio Pro for the first time due to inability
 	* MariaDB 5.5, 10.0
 	* PostgreSQL 9.2, 9.3, 9.4
 	* SQL Server 2008, 2008r2, 2012, 2014
+	
 ### Known Issues
 
 * Users with non-administrative [user roles](/refguide/user-roles) with the permission to manage users are able to escalate their privileges. For more information on this vulnerability, see [SSA-875726 Privilege Escalation Vulnerability in Mendix](https://new.siemens.com/global/en/products/services/cert.html#SecurityPublications).

--- a/content/releasenotes/studio-pro/7.23.md
+++ b/content/releasenotes/studio-pro/7.23.md
@@ -192,10 +192,10 @@ We added experimental support for queuing tasks as a part of a closed Beta test.
 
 * Starting with Mendix 7.23.15, we will drop support for the following database versions that are no longer supported by vendors:
 	* Oracle 11, 12.1
-	 	* MySQL 5.5, 5.6
-	 	* MariaDB 5.5, 10.0
-	 	* PostgreSQL 9.2, 9.3, 9.4
-	  * SQL Server 2008, 2008r2, 2012, 2014
+	* MySQL 5.5, 5.6
+	* MariaDB 5.5, 10.0
+	* PostgreSQL 9.2, 9.3, 9.4
+	* SQL Server 2008, 2008r2, 2012, 2014
 ### Known Issues
 
 * Users with non-administrative [user roles](/refguide/user-roles) with the permission to manage users are able to escalate their privileges. For more information on this vulnerability, see [SSA-875726 Privilege Escalation Vulnerability in Mendix](https://new.siemens.com/global/en/products/services/cert.html#SecurityPublications).


### PR DESCRIPTION
The list should have a single level, with each DB vendor occupying a single entry.