### PR TITLE
Remove unsupported databases

### DIFF
--- a/content/refguide/system-requirements.md
+++ b/content/refguide/system-requirements.md
@@ -159,8 +159,8 @@ Current support:
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2016, 2017, 2019
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 130 or higher
 * [MySQL](mysql) 8.0
-* [Oracle Database](oracle) 18, 19
-* PostgreSQL 9.5, 9.6, 10, 11, 12, 13
+* [Oracle Database](oracle) 19
+* PostgreSQL 9.6, 10, 11, 12, 13
 * [SAP HANA](saphana) 2.00.040.00.1545918182
 
 {{% alert type="warning" %}}


### PR DESCRIPTION
We don't support Oracle 18 and PostgreSQL 9.5 anymore.
