### PR TITLE
Remove unsupported databases

### DIFF
--- a/content/refguide8/system-requirements.md
+++ b/content/refguide8/system-requirements.md
@@ -107,11 +107,11 @@ Current support:
 
 * [IBM DB2](db2) 11.1 and 11.5 for Linux, Unix, and Windows
 * [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2016, 2017, 2019
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2017, 2019
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 130 or higher
 * [MySQL](mysql) 8.0
-* [Oracle Database](oracle) 18, 19
-* PostgreSQL 9.5, 9.6, 10, 11, 12, 13
+* [Oracle Database](oracle) 19
+* PostgreSQL 9.6, 10, 11, 12, 13
 * [SAP HANA](saphana) 2.00.040.00.1545918182
 
 {{% alert type="warning" %}}


### PR DESCRIPTION
We don't support Oracle 18, SqlServer 2016 and PostgreSQL 9.5 anymore.
