### PR TITLE
Removed unsupported databases.

### DIFF
--- a/content/refguide7/system-requirements.md
+++ b/content/refguide7/system-requirements.md
@@ -61,12 +61,12 @@ The browser you use needs to have JavaScript turned on.
 ### 5.3 Database Server
 
 * [IBM DB2](db2) 11.1, 11.5 for Linux, Unix, and Windows
-* [MariaDB](mysql) 10.1, 10.2, 10.3, 10.4, 10.5
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2016, 2017, 2019
+* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2017, 2019
 * Azure SQL v12 (support is not independently verified and is available only through compatible versions of SQL Server)
 * [MySQL](mysql) 5.7, 8.0
-* [Oracle Database](oracle) 12c Release 2, 18, 19
-* PostgreSQL 9.5, 9.6, 10, 11, 12, 13
+* [Oracle Database](oracle) 12c Release 2, 19
+* PostgreSQL 9.6, 10, 11, 12, 13
 * [SAP HANA](saphana) 2.00.040.00.1545918182
 
 ### 5.4 Java


### PR DESCRIPTION
We don't support Oracle 18, SqlServer 2016, PostgreSQL 9.5 and MariaDB 10.1 anymore.
