### PR TITLE
Fix the missing braces in the module-level theme settings

### DIFF
--- a/content/howto/front-end/module-level-theme-settings.md
+++ b/content/howto/front-end/module-level-theme-settings.md
@@ -44,6 +44,7 @@ By excluding [layouts](/refguide/layout) and [page templates](/refguide/page-tem
             "layouts": true,
             "pageTemplates": true
         }
+    }
 }
 ```
 


### PR DESCRIPTION
Fixes the missing braces in section 2.1 of [Configure Module-Level Theme Settings](https://docs.mendix.com/howto/front-end/module-level-theme-settings).