### PR TITLE
Remove deprecation warning in barcode scanner docs

### DIFF
--- a/content/appstore/widgets/barcode-scanner.md
+++ b/content/appstore/widgets/barcode-scanner.md
@@ -8,7 +8,7 @@ tags: ["marketplace", "marketplace component", "widget", "barcode scanner", "pla
 
 ## 1 Introduction
 
-The [Barcode Scanner](https://appstore.home.mendix.com/link/app/1469/) widget enables a barcode scanning functionality within your Mendix web application.
+The [Barcode Scanner](https://marketplace.mendix.com/link/component/117627) widget enables a barcode scanning functionality within your Mendix web application.
 
 The widget does the following:
 

--- a/content/appstore/widgets/barcode-scanner.md
+++ b/content/appstore/widgets/barcode-scanner.md
@@ -6,10 +6,6 @@ tags: ["marketplace", "marketplace component", "widget", "barcode scanner", "pla
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
-{{% alert type="warning" %}}
-This widget is deprecated.
-{{% /alert %}}
-
 ## 1 Introduction
 
 The [Barcode Scanner](https://appstore.home.mendix.com/link/app/1469/) widget enables a barcode scanning functionality within your Mendix web application.


### PR DESCRIPTION
A deprecation warning was added to the barcode scanner docs in https://github.com/mendix/docs/pull/3458, but this widget is a newly implemented one and definitely not deprecated 😄 

cc @Adam-Dupaski @Luyao-Zhang-1 