### PR TITLE
Deprecation notice Release Pan & Burndown Chart

### DIFF
--- a/content/developerportal/collaborate/development.md
+++ b/content/developerportal/collaborate/development.md
@@ -35,7 +35,9 @@ All the changes made on this page are directly passed on to the **Stories** page
 
 ## 3 Burndown Chart
 
-{{% alert type="info" %}} Burndown chart tab will be removed on the 31st of August 2021. {{% /alert %}}
+{{% alert type="info" %}}
+This tab will be removed on the August 31st, 2021.
+{{% /alert %}}
 
 This tab graphically presents the progress of the current Sprint:
 
@@ -49,7 +51,9 @@ Under **Sprint History**, you can view burndown charts for completed sprints.
 
 ## 4 Release Plan Tab
 
-{{% alert type="info" %}} Release plan tab will be removed on the 31st of August 2021. Make sure that you save your data before it gets removed by using the "Export to Excel" button. {{% /alert %}}
+{{% alert type="info" %}}
+This tab will be removed on the August 31st, 2021. Make sure that you save your data before it is removed by using the **Export to Excel** button.
+{{% /alert %}}
 
 Under this tab, you will get an overview of all the springs.
 

--- a/content/developerportal/collaborate/development.md
+++ b/content/developerportal/collaborate/development.md
@@ -35,6 +35,8 @@ All the changes made on this page are directly passed on to the **Stories** page
 
 ## 3 Burndown Chart
 
+{{% alert type="info" %}} Burndown chart tab will be removed on the 31st of August 2021. {{% /alert %}}
+
 This tab graphically presents the progress of the current Sprint:
 
 * **Ideal Burndown** – the expected progress if the Sprint is completed at a consistent rate
@@ -46,6 +48,8 @@ This tab graphically presents the progress of the current Sprint:
 Under **Sprint History**, you can view burndown charts for completed sprints.
 
 ## 4 Release Plan Tab
+
+{{% alert type="info" %}} Release plan tab will be removed on the 31st of August 2021. Make sure that you save your data before it gets removed by using the "Export to Excel" button. {{% /alert %}}
 
 Under this tab, you will get an overview of all the springs.
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -24,6 +24,7 @@ To see the current status of the Mendix Developer Portal and Control Center, see
 * We removed the **Team** read-only overview page and send you straight to the [Manage Team](/developerportal/collaborate/team#managing) page.
 * We moved the [API Keys](/developerportal/collaborate/api-key) page to the [General Settings](/developerportal/collaborate/general-settings) page.
 * We implemented a new responsive search panel.
+* We will be removing the [Burndown Chart](/developerportal/collaborate/development#3-burndown-chart) and [Release Plan](/developerportal/collaborate/development#4-release-plan-tab) from the Developer Portal on 31 August 2021
 
 ### June 15th, 2021
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -24,7 +24,7 @@ To see the current status of the Mendix Developer Portal and Control Center, see
 * We removed the **Team** read-only overview page and send you straight to the [Manage Team](/developerportal/collaborate/team#managing) page.
 * We moved the [API Keys](/developerportal/collaborate/api-key) page to the [General Settings](/developerportal/collaborate/general-settings) page.
 * We implemented a new responsive search panel.
-* We will be removing the [Burndown Chart](/developerportal/collaborate/development#3-burndown-chart) and [Release Plan](/developerportal/collaborate/development#4-release-plan-tab) from the Developer Portal on 31 August 2021
+* We will remove the [Burndown Chart](/developerportal/collaborate/development#burndown) and [Release Plan](/developerportal/collaborate/development##release-plan) tabs from the Developer Portal on August 31st, 2021.
 
 ### June 15th, 2021
 


### PR DESCRIPTION
Part of Sprintr's release 11.3.0, which was deployed on Wednesday 30 June.