### PR TITLE
Update style-google-maps.md

### DIFF
--- a/content/howto/front-end/style-google-maps.md
+++ b/content/howto/front-end/style-google-maps.md
@@ -76,7 +76,7 @@ Supporting communities is cool. Therefore I will also show you how to upload you
 
 1.  Go-to Snazzymaps and click **Create.**
     **![](attachments/19202780/19398964.png)** 
-2.  Now you will see the same sort of handy quick style method that Mendix provides at [https://ux.mendix.com/theme-creator.html](https://ux.mendix.com/theme-creator.html).
+2.  Now you will see the same sort of handy quick style method that Mendix provides at [https://atlas.mendix.com](https://atlas.mendix.com/).
     ![](attachments/19202780/19398965.png) 
 
     Happy modeling!

--- a/content/howto/front-end/style-google-maps.md
+++ b/content/howto/front-end/style-google-maps.md
@@ -76,7 +76,7 @@ Supporting communities is cool. Therefore I will also show you how to upload you
 
 1.  Go-to Snazzymaps and click **Create.**
     **![](attachments/19202780/19398964.png)** 
-2.  Now you will see the same sort of handy quick style method that Mendix provides at [https://atlas.mendix.com](https://atlas.mendix.com/).
+2.  Now you will see the same sort of handy quick style method that Mendix provides at the [Atlas 3](https://atlas.mendix.com/) site.
     ![](attachments/19202780/19398965.png) 
 
     Happy modeling!


### PR DESCRIPTION
Hi guys! In https://docs.mendix.com/howto/front-end/style-google-maps we refer to https://ux.mendix.com/theme-creator.html; from https://mendix.slack.com/archives/C09UW557B/p1615969415000400 I understand that this website is taken down and the new site is atlas.mendix.com.
Not 100% sure if the redirect should go to https://www.mendix.com/atlas/ or https://atlasdesignsystem.mendixcloud.com/p/dashboard though :).