### PR TITLE
Remove PostgreSQL deprecation as we will announce it later

### DIFF
--- a/content/releasenotes/studio-pro/8.18.md
+++ b/content/releasenotes/studio-pro/8.18.md
@@ -31,10 +31,6 @@ There is an issue with installing Studio Pro for the first time due to inability
 * We fixed the MxAssist Logic Bot context menu for the second flow in the [decision](/refguide8/decisions) object.
 * We optimized the MxAssist Logic Bot to predict a request to the server.
 
-### Deprecations
-
-* Starting with Studio Pro 8.18.11, we will no longer support PostgreSQL 9.6 due to it no longer being supported by the vendor.
-
 ### Known Issues
 
 * When you update a [consumed OData service](/refguide8/consumed-odata-service) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.


### PR DESCRIPTION
Removing the deprecation message for now, the EOL of 9.6 from PostgreSQL is Nov 11 2021, so this might be too soon.