### PR TITLE
Write release notes for Datahub Catalog 1.42 release

### DIFF
--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -9,6 +9,20 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 ## 2021
 
+###  August 12th, 2021
+
+#### New Features
+
+* Write capabilities: 
+  * Added parsing of Updatable, Insertable and Deletable capabilities from Annotations in OData V4 contracts
+  * Write capabilities are returned on the Search API 
+  * Write capabilities are displayed on the UI
+
+
+#### Fixes
+
+* Improvements to security
+
 ### August 5th, 2021
 
 #### Fixes

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -13,15 +13,14 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 #### New Features
 
-* Write capabilities: 
-  * Added parsing of Updatable, Insertable and Deletable capabilities from Annotations in OData V4 contracts
-  * Write capabilities are returned on the Search API 
-  * Write capabilities are displayed on the UI
-
+* We added the following write capabilities: 
+ * Parsing updatable, insertable, and deletable capabilities from annotations is now available in OData v4 contracts
+ * Write capabilities are returned on the [Data Hub Search API ](/apidocs-mxsdk/apidocs/data-hub-apis)
+ * Write capabilities are displayed on the Data Hub UI
 
 #### Fixes
 
-* Improvements to security
+* We made improvements to Data Hub security.
 
 ### August 5th, 2021
 

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -9,7 +9,7 @@
 	<li><a href="/releasenotes/mobile/native-template">Native Template 6.2.0</a> – Jul 20th, 2021</li>	
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Jul 27th, 2021</li>
 	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Aug 6th, 2021</li>
-	<li><a href="/releasenotes/data-hub">Data Hub</a> – Aug 5th, 2021</li>
+	<li><a href="/releasenotes/data-hub">Data Hub</a> – Aug 12th, 2021</li>
 	<li><a href="/releasenotes/app-store">Marketplace</a> – Jul 29th, 2021</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.52.0</a> – Jun 16th, 2021</li>
 	<li><a href="/releasenotes/sdk/metamodel-9.4">Metamodel 9.4.0</a> – Jul 20th, 2021</li>


### PR DESCRIPTION
Added release notes for Datahub Catalog 1.42 release on Thursday 12th of August