### PR TITLE
Private Cloud release notes (for August 12)

### DIFF
--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -132,7 +132,7 @@ Now you can download the Configuration Tool by doing the following:
 
 3. Choose the **Mendix Operator Version** that you would like to install. If you have already installed the Mendix Operator, your currently installed version will be highlighted.
 
-	{{% alert type="info" %}}Mendix Operator version 2.\*.\* supports Kubernetes versions 1.19 and later. Mendix Operator version 1.12.\* supports Kubernetes versions 1.12 through 1.21. Choose the latest version that's supported by your Kubernetes cluster.{{% /alert %}}
+	{{% alert type="info" %}}Mendix Operator version 2.\*.\* supports Kubernetes versions 1.19 and later. Mendix Operator version 1.12.\* supports Kubernetes versions 1.12 through 1.21. Choose the latest version that is supported by your Kubernetes cluster.{{% /alert %}}
 
 	{{% alert type="info" %}}Versions earlier than 1.9.0 are only available to allow _configuration_ of previously installed Mendix Operator versions.{{% /alert %}}
 
@@ -698,15 +698,15 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 ##### 4.3.2.3 Ingress{#ingress}
 
-**openshift-route** will configure an OpenShift Route. This can only be used for OpenShift clusters. This option allows to enable or disable TLS.
+**openshift-route** will configure an OpenShift Route. This can only be used for OpenShift clusters. This option allows you to enable or disable TLS.
 
-**kubernetes-ingress** will configure ingress according to the additional domain name you supply. This option allows to configure the ingress path and custom ingress class (depends on the Ingress controller) and enable or disable TLS.
+**kubernetes-ingress** will configure ingress according to the additional domain name you supply. This option allows you to configure the ingress path and custom ingress class (dependent on the Ingress controller) and enable or disable TLS.
 
 **service-only** will create just a Kubernetes Service, without an Ingress or OpenShift route.
-This option can be used to use a Load Balancer without an Ingress, or to manually create and manage the Ingress object (an Ingress that's not managed by Mendix for Private Cloud).
+This option enables you to use a Load Balancer without an Ingress, or to manually create and manage the Ingress object (an Ingress that is not managed by Mendix for Private Cloud).
 
 {{% alert type="info" %}}
-When switching between Ingress, OpenShift Routes and Service Only, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
+When switching between Ingress, OpenShift Routes, and Service Only, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
 
 Only objects that are supported by the current option are managed by the Mendix Operator.
 For example, switching from OpenShift Routes to Ingress will not delete already existing OpenShift Routes - the Mendix Operator will be managing only Service and Ingress objects.

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -707,9 +707,6 @@ This option enables you to use a Load Balancer without an Ingress, or to manuall
 
 {{% alert type="info" %}}
 When switching between Ingress, OpenShift Routes, and Service Only, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
-
-Only objects that are supported by the current option are managed by the Mendix Operator.
-For example, switching from OpenShift Routes to Ingress will not delete already existing OpenShift Routes - the Mendix Operator will be managing only Service and Ingress objects.
 {{% /alert %}}
 
 {{% alert type="info" %}}

--- a/content/developerportal/deploy/private-cloud-cluster.md
+++ b/content/developerportal/deploy/private-cloud-cluster.md
@@ -132,7 +132,9 @@ Now you can download the Configuration Tool by doing the following:
 
 3. Choose the **Mendix Operator Version** that you would like to install. If you have already installed the Mendix Operator, your currently installed version will be highlighted.
 
-	{{% alert type="info" %}}Choose the latest version, or at least version 1.9.0. Versions earlier than 1.9.0 are only available to allow _configuration_ of previously installed Mendix Operator versions.{{% /alert %}}
+	{{% alert type="info" %}}Mendix Operator version 2.\*.\* supports Kubernetes versions 1.19 and later. Mendix Operator version 1.12.\* supports Kubernetes versions 1.12 through 1.21. Choose the latest version that's supported by your Kubernetes cluster.{{% /alert %}}
+
+	{{% alert type="info" %}}Versions earlier than 1.9.0 are only available to allow _configuration_ of previously installed Mendix Operator versions.{{% /alert %}}
 
     {{% alert type="warning" %}}Once you've installed a certain version of the Mendix Operator into any namespace in the cluster, you should not install older versions of the Mendix Operator into the same cluster, including other namespaces.{{% /alert %}}
 
@@ -696,14 +698,22 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide)
 
 ##### 4.3.2.3 Ingress{#ingress}
 
-**OpenShift Route** will configure an OpenShift Route. This can only be used for OpenShift clusters.
+**openshift-route** will configure an OpenShift Route. This can only be used for OpenShift clusters. This option allows to enable or disable TLS.
 
-**Ingress** will configure ingress according to the additional domain name you supply.
+**kubernetes-ingress** will configure ingress according to the additional domain name you supply. This option allows to configure the ingress path and custom ingress class (depends on the Ingress controller) and enable or disable TLS.
 
-Both forms of ingress can have TLS enabled or disabled.
+**service-only** will create just a Kubernetes Service, without an Ingress or OpenShift route.
+This option can be used to use a Load Balancer without an Ingress, or to manually create and manage the Ingress object (an Ingress that's not managed by Mendix for Private Cloud).
 
 {{% alert type="info" %}}
-When switching between Ingress and OpenShift Routes, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
+When switching between Ingress, OpenShift Routes and Service Only, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
+
+Only objects that are supported by the current option are managed by the Mendix Operator.
+For example, switching from OpenShift Routes to Ingress will not delete already existing OpenShift Routes - the Mendix Operator will be managing only Service and Ingress objects.
+{{% /alert %}}
+
+{{% alert type="info" %}}
+Additional network options such as Ingress/Service annotations and Service ports are available in [advanced network settings](#advanced-network-settings).
 {{% /alert %}}
 
 ##### 4.3.2.4 Registry{#registry}
@@ -845,7 +855,7 @@ When using a connected cluster, its status will be shown as **Connected** in the
 
 ## 5 Advanced Operator Configuration
 
-Some advanced configuration options of the Mendix Operator are not yet available in the reconfiguration script.
+Some advanced configuration options of the Mendix Operator are not yet available in the **Configuration Tool**.
 These options can be changed by editing the `OperatorConfiguration` custom resource directly in Kubernetes.
 
 Look at [Supported Providers](private-cloud-supported-environments) to ensure that your planned configuration is supported by Mendix for Private Cloud.
@@ -976,7 +986,7 @@ You can change the following options:
 * **ingressClassName**: - optional, can be used to specify the Ingress Class name
 * **path**: - optional, can be used to specify the Ingress path; default value is `/`
 * **pathType**: - optional, can be used to specify the Ingress pathType; if not set, no pathType will be specified in Ingress objects
-* **domain**: - optional for `openshiftRoute`, required for `ingress`, used to generate the app domain in case no app URL is specified; if left empty when using OpenShift Routes, the default OpenShift `apps` domain will be used; this parameter is also configured through the **Reconfiguration Script**
+* **domain**: - optional for `openshiftRoute`, required for `ingress`, used to generate the app domain in case no app URL is specified; if left empty when using OpenShift Routes, the default OpenShift `apps` domain will be used; this parameter is also configured through the **Configuration Tool**
 * **enableTLS**: - allows you to enable or disable TLS for the Mendix App's Ingress or OpenShift Route
 * **tlsSecretName**: - optional name of a `kubernetes.io/tls` secret containing the TLS certificate, can be a template: `{{.Name}}` will be replaced with the name of the CR for the Mendix app; if left empty, the default TLS certificate from the Ingress Controller or OpenShift Router will be used
 * **serviceType**: - can be used to specify the Service type, possible options are `ClusterIP` and `LoadBalancer`; if not specified, Services will be created with the `ClusterIP` type

--- a/content/developerportal/deploy/private-cloud-migrating.md
+++ b/content/developerportal/deploy/private-cloud-migrating.md
@@ -18,6 +18,7 @@ This document explains how to export the components from the Mendix registry and
 ## 2 Prerequisites for Migrating to Your Registry
 
 To export components from the Mendix registry, you will need the following:
+
 * Access to the internet
 * A local or managed image registry
 * All the other prerequisites for creating a Mendix for Private Cloud cluster, as documented in the [Prerequisites for Creating a Cluster](private-cloud-cluster#prerequisites) section of *Creating a Private Cloud Cluster*.

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -42,10 +42,8 @@ Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kuberne
 This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
 Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we have fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
-{{% /alert %}}
 
-{{% alert type="warning" %}}
-Existing clusters running Mendix for Private Cloud Operator v1.\*.\* should be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
+Existing clusters running Mendix for Private Cloud Operator v1.\*.\* will need to be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
 {{% /alert %}}
 
 Mendix for Private Cloud Operator **v1.12.\*** is an LTS release which officially supports older Kubernetes versions:

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -41,9 +41,8 @@ Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kuberne
 
 This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
-Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we have fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
-
-Existing clusters running Mendix for Private Cloud Operator v1.\*.\* will need to be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
+Mendix for Private Cloud has not been fully validated to support Kubernetes 1.22.
+Upgrading an existing cluster to Kubernetes 1.22 might cause issues with Mendix for Private Cloud.
 {{% /alert %}}
 
 Mendix for Private Cloud Operator **v1.12.\*** is an LTS release which officially supports older Kubernetes versions:

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -25,31 +25,33 @@ We currently support deploying to the following Kubernetes cluster types:
 * [k3s](https://k3s.io/)
 * [minikube](https://minikube.sigs.k8s.io/docs/)
 
-Mendix for Private Cloud Operator v2.\*.\* is the latest version which officially supports:
-
-* Kubernetes versions 1.19 through 1.21
-* OpenShift 4.6 through 4.7
-
-Mendix for Private Cloud Operator v1.12.\* is an LTS release which officially supports older Kubernetes versions:
-
-* Kubernetes versions 1.13 through 1.21
-* OpenShift 3.11 through 4.7
-
 {{% alert type="warning" %}}
 If deploying to Red Hat OpenShift, you need to specify that specifically when creating your deployment. All other cluster types use generic Kubernetes operations.
 {{% /alert %}}
+
+#### 2.1.1 Supported Versions
+
+Mendix for Private Cloud Operator **v2.\*.\*** is the latest version which officially supports:
+
+* Kubernetes versions 1.19 through 1.21
+* OpenShift 4.6 through 4.7
 
 {{% alert type="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
 This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
-Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we've fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
+Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we have fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
 {{% /alert %}}
 
 {{% alert type="warning" %}}
 Existing clusters running Mendix for Private Cloud Operator v1.\*.\* should be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
 {{% /alert %}}
+
+Mendix for Private Cloud Operator **v1.12.\*** is an LTS release which officially supports older Kubernetes versions:
+
+* Kubernetes versions 1.13 through 1.21
+* OpenShift 3.11 through 4.7
 
 ### 2.2 Cluster Requirements
 

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -37,11 +37,10 @@ Mendix for Private Cloud Operator **v2.\*.\*** is the latest version which offic
 * OpenShift 4.6 through 4.7
 
 {{% alert type="warning" %}}
-Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
+Mendix for Private Cloud has not yet been fully validated to support Kubernetes 1.22, a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
 This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
-Mendix for Private Cloud has not been fully validated to support Kubernetes 1.22.
 Upgrading an existing cluster to Kubernetes 1.22 might cause issues with Mendix for Private Cloud.
 {{% /alert %}}
 

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -20,17 +20,35 @@ We currently support deploying to the following Kubernetes cluster types:
 
 * [Amazon Elastic Kubernetes Service](https://aws.amazon.com/eks/) (EKS)
 * [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/)
-* [Red Hat OpenShift Container Platform](https://www.openshift.com/) (versions 4 and 3.11)
+* [Red Hat OpenShift Container Platform](https://www.openshift.com/)
 * [MicroK8s](https://microk8s.io/)
 * [k3s](https://k3s.io/)
 * [minikube](https://minikube.sigs.k8s.io/docs/)
 
+Mendix for Private Cloud Operator v2.\*.\* is the latest version which officially supports:
+
+* Kubernetes versions 1.19 through 1.21
+* OpenShift 4.6 through 4.7
+
+Mendix for Private Cloud Operator v1.12.\* is an LTS release which officially supports older Kubernetes versions:
+
+* Kubernetes versions 1.13 through 1.21
+* OpenShift 3.11 through 4.7
+
 {{% alert type="warning" %}}
 If deploying to Red Hat OpenShift, you need to specify that specifically when creating your deployment. All other cluster types use generic Kubernetes operations.
+{{% /alert %}}
 
-Only Kubernetes versions 1.13 through 1.20 are officially supported.
+{{% alert type="warning" %}}
+Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
-Mendix for Private Cloud has not been evaluated against Kubernetes 1.21 and later versions.
+This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
+
+Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we've fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
+{{% /alert %}}
+
+{{% alert type="warning" %}}
+Existing clusters running Mendix for Private Cloud Operator v1.\*.\* should be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
 {{% /alert %}}
 
 ### 2.2 Cluster Requirements
@@ -41,13 +59,15 @@ To install the Mendix Operator, the cluster administrator will need permissions 
 * Create roles in the target namespace or project
 * Create role bindings in the target namespace or project
 
-The cluster should have at least 2 CPUs and 2 GB memory available. This is enough to run one simple app.
+The cluster should have at least 2 CPU cores and 2 GB memory *available*. This is enough to run one simple app - but does not include additional resources required by Kubernetes core components .
 
 In OpenShift, the cluster administrator must have a `system:admin` role.
 
 ### 2.3 Unsupported Cluster Types
 
-It is not possible to use Mendix for Private Cloud in [OpenShift Online](https://www.openshift.com/products/online/) or *OpenShift Online Pro* because they don't allow the installation of Custom Resource Definitions.
+It is not possible to use Mendix for Private Cloud in [OpenShift Online](https://www.openshift.com/products/online/) (all editions, including Starter and Pro) or [OpenShift Developer Sandbox](https://developers.redhat.com/developer-sandbox) because they don't allow the installation of Custom Resource Definitions.
+
+Kubernetes included with [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) is not officially supported. 
 
 ## 3 Container Registries
 
@@ -105,7 +125,7 @@ The EKS cluster should be configured so that it can [pull images from ECR](https
 The following databases are supported, and provide the features listed.
 
 | Database | Data Persists | Provisioned by Operator |
-| === | === | === |
+| --- | --- | --- |
 | Ephemeral | No | Yes |
 | Standard PostgreSQL | Yes | Yes |
 | Microsoft SQL Server | Yes | Yes |

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -24,12 +24,23 @@ Once you have installed a particular version of the Mendix Operator into any nam
 If you are using your own private registry, follow the [Migrating to Your Own Registry](private-cloud-migrating) guide first
 to migrate new component versions of Mendix for Private Cloud into your private registry.
 
+{{% alert type="warning" %}}
+If you're using Mendix for Private Cloud Operator v1.\*.\* and are planning to upgrade to Kubernetes 1.22, follow these steps first:
+
+1. Upgrade your cluster to Kubernetes 1.21
+2. Upgrade all namespaces in your cluster to Mendix for Private Cloud Operator v2.\*.\*
+3. Validate that Mendix for Private Cloud is working correctly in all namespaces
+
+Kubernetes 1.22 [deprecated](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) multiple APIs;
+upgrading to Kubernetes 1.21 and Mendix Operator v2.\*.\* will prepare resources such as Ingresses to be compatible with APIs available in Kubernetes 1.22.
+{{% /alert %}}
+
 ## 2 Prerequisites
 
 ### 2.1 Download the Configuration Tool{#download-configuration-tool}
 
 Follow the instructions to [Download the Configuration Tool](private-cloud-cluster#download-configuration-tool).
-Before downloading the Configuration Tool, choose the version you would like to upgrade to (1.9.0 or a later version) in the **Mendix Operator Version** dropdown.
+When downloading the Configuration Tool, choose the version you would like to upgrade to (1.9.0 or a later version) - not the version that's currently installed.
 
 If you're using an OpenShift cluster, follow the [Signing in to OpenShift](private-cloud-cluster#openshift-signin) instructions.
 

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -40,7 +40,7 @@ upgrading to Kubernetes 1.21 and Mendix Operator v2.\*.\* will prepare resources
 ### 2.1 Download the Configuration Tool{#download-configuration-tool}
 
 Follow the instructions to [Download the Configuration Tool](private-cloud-cluster#download-configuration-tool).
-When downloading the Configuration Tool, choose the version you would like to upgrade to (1.9.0 or a later version) - not the version that's currently installed.
+When downloading the Configuration Tool, choose the version you would like to upgrade to (1.9.0 or a later version) - not the version that is currently installed.
 
 If you're using an OpenShift cluster, follow the [Signing in to OpenShift](private-cloud-cluster#openshift-signin) instructions.
 

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -25,14 +25,11 @@ If you are using your own private registry, follow the [Migrating to Your Own Re
 to migrate new component versions of Mendix for Private Cloud into your private registry.
 
 {{% alert type="warning" %}}
-If you're using Mendix for Private Cloud Operator v1.\*.\* and are planning to upgrade to Kubernetes 1.22, follow these steps first:
+Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
-1. Upgrade your cluster to Kubernetes 1.21
-2. Upgrade all namespaces in your cluster to Mendix for Private Cloud Operator v2.\*.\*
-3. Validate that Mendix for Private Cloud is working correctly in all namespaces
+This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
-Kubernetes 1.22 [deprecated](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) multiple APIs;
-upgrading to Kubernetes 1.21 and Mendix Operator v2.\*.\* will prepare resources such as Ingresses to be compatible with APIs available in Kubernetes 1.22.
+Mendix for Private Cloud has not been fully validated to support Kubernetes 1.22.
 {{% /alert %}}
 
 ## 2 Prerequisites

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,6 +13,20 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
+### August ???th, 2021
+
+#### Mendix Operator v2.0.0 and Mendix Gateway Agent v2.0.0
+
+* We have switched all components to use the modern Kubernetes APIs: `networking.k8s.io/v1` and `apiextensions.k8s.io/v1`.
+  This change allows us to continue supporting future versions of Kubernetes.
+* This version of Mendix Operator and Gateway Agent only supports Kubernetes 1.19 and later versions.
+* Mendix Operator v1.12.\* and Mendix Gateway Agent v1.11.\* will continue to be supported as an LTS branch for clusters running older versions of Kubernetes.
+
+{{% alert type="warning" %}}Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
+Mendix for Private Cloud has not been fully validated to support this Kubernetes version.{{% /alert %}}
+
+To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
+
 ### July 6th, 2021
 
 #### Portal Improvements

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -24,7 +24,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 To upgrade an existing installation of Mendix for Private Cloud to Mendix Operator v2.0.0 and Mendix Gateway Agent v2.0.0, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
 
-{{% alert type="warning" %}}Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
+{{% alert type="warning" %}}Mendix for Private Cloud has not yet been fully validated to support Kubernetes 1.22, a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 Mendix for Private Cloud has not been fully validated to support this Kubernetes version.{{% /alert %}}
 
 ### July 6th, 2021

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,7 +13,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
-### August ???th, 2021
+### August 12th, 2021
 
 #### Mendix Operator v2.0.0 and Mendix Gateway Agent v2.0.0
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -25,7 +25,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 To upgrade an existing installation of Mendix for Private Cloud to Mendix Operator v2.0.0 and Mendix Gateway Agent v2.0.0, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
 
 {{% alert type="warning" %}}Mendix for Private Cloud has not yet been fully validated to support Kubernetes 1.22, a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
-Mendix for Private Cloud has not been fully validated to support this Kubernetes version.{{% /alert %}}
+{{% /alert %}}
 
 ### July 6th, 2021
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -20,12 +20,12 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have switched all components to use the modern Kubernetes APIs: `networking.k8s.io/v1` and `apiextensions.k8s.io/v1`.
   This change allows us to continue supporting future versions of Kubernetes.
 * This version of Mendix Operator and Gateway Agent only supports Kubernetes 1.19 and later versions.
-* Mendix Operator v1.12.\* and Mendix Gateway Agent v1.11.\* will continue to be supported as an LTS branch for clusters running older versions of Kubernetes.
+* Mendix Operator v1.12.\* and Mendix Gateway Agent v1.11.\* will continue in Long Term Support (LTS) to support clusters running older versions of Kubernetes.
 
 {{% alert type="warning" %}}Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 Mendix for Private Cloud has not been fully validated to support this Kubernetes version.{{% /alert %}}
 
-To upgrade an existing installation of Private Cloud to this version, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
+To upgrade an existing installation of the Mendix Operator and Mendix Gateway Agent to version 2.0.0, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
 
 ### July 6th, 2021
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -22,10 +22,10 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * This version of Mendix Operator and Gateway Agent only supports Kubernetes 1.19 and later versions.
 * Mendix Operator v1.12.\* and Mendix Gateway Agent v1.11.\* will continue in Long Term Support (LTS) to support clusters running older versions of Kubernetes.
 
+To upgrade an existing installation of Mendix for Private Cloud to Mendix Operator v2.0.0 and Mendix Gateway Agent v2.0.0, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
+
 {{% alert type="warning" %}}Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 Mendix for Private Cloud has not been fully validated to support this Kubernetes version.{{% /alert %}}
-
-To upgrade an existing installation of the Mendix Operator and Mendix Gateway Agent to version 2.0.0, follow the [Upgrade instructions](/developerportal/deploy/private-cloud-upgrade-guide).
 
 ### July 6th, 2021
 


### PR DESCRIPTION
We've prepared a new major version of Mendix Operator - 2.0.0, which supports adds support for future versions of Kubernetes.

Updated documentation and release notes - so that users can make a decision to keep using the 1.12.\* branch (LTS) or upgrade to the latest 2.0.0 version.