### PR TITLE
More complete description by example

### DIFF
--- a/content/refguide/parse-and-format-decimal-function-calls.md
+++ b/content/refguide/parse-and-format-decimal-function-calls.md
@@ -43,8 +43,8 @@ The following examples demonstrate which output you get depending on input param
 Given a variable that is empty:
 
 * `parseDecimal($StingVariable)` will throw an error
-* `parseDecimal($StingVariable, empty)` returns an empty. Resulting variable may throw an error when used as decimal (like in an expression '$var > 0') 
-* `parseDecimal($StingVariable, 0)` returns `0`. Resulting vairable will always be a decimal and never throw an exception.
+* `parseDecimal($StingVariable, empty)` returns an empty; the resulting variable may throw an error when used as a decimal (like in the expression `'$var > 0'`) 
+* `parseDecimal($StingVariable, 0)` returns `0`; the resulting variable will always be a decimal and never throw an exception
 
 ## 3 formatDecimal
 

--- a/content/refguide/parse-and-format-decimal-function-calls.md
+++ b/content/refguide/parse-and-format-decimal-function-calls.md
@@ -43,7 +43,8 @@ The following examples demonstrate which output you get depending on input param
 Given a variable that is empty:
 
 * `parseDecimal($StingVariable)` will throw an error
-* `parseDecimal($StingVariable, 5.05)` returns `5.05`
+* `parseDecimal($StingVariable, empty)` returns an empty. Resulting variable may throw an error when used as decimal (like in an expression '$var > 0') 
+* `parseDecimal($StingVariable, 0)` returns `0`. Resulting vairable will always be a decimal and never throw an exception.
 
 ## 3 formatDecimal
 


### PR DESCRIPTION
Another finding in real live programming where a parseDecimal  got followed by a Decision '$var > 0' which started throwing an exception once we set parseDecimal's default to 'empty' instead of '0'.