### PR TITLE
Add note for 8.18.10 regarding OQL IN condition fix

### DIFF
--- a/content/releasenotes/studio-pro/8.18.md
+++ b/content/releasenotes/studio-pro/8.18.md
@@ -30,6 +30,7 @@ There is an issue with installing Studio Pro for the first time due to inability
 * We fixed an issue where synchronization failed for the Oracle database if an unlimited attribute was changed to a limited attribute. (Ticket 120186)
 * We fixed an issue where NPEs were not returned from a microflow in certain cases. (Ticket 125909)
 * We fixed an issue in iOS where pickers did not respect the current device orientation but always defaulted to portrait mode. (Tickets 127454, 127687)
+* We fixed an issue that occurred when using single parameter values in OQL `IN` query conditions. (Ticket 126647)
 
 ### Known Issues
 


### PR DESCRIPTION
This was fixed and released with 8.18.10 with a backport, so was not added here.