### PR TITLE
CAT-1795 Deletions and clean-up of Data Hub Catalog documents

### DIFF
--- a/content/apidocs-mxsdk/apidocs/data-hub-apis.md
+++ b/content/apidocs-mxsdk/apidocs/data-hub-apis.md
@@ -24,8 +24,7 @@ The interactive features of the OpenAPI interface are not operational, so the **
 
 ## 2 Search API {#search}
 
-The [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in Data Hub that satisfy the specified search criteria. For an example API call, see the [Search via the API](/data-hub/data-hub-catalog/search#search-api) section of *How to 
-Search in the Data Hub Catalog*.
+The [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in Data Hub that satisfy the specified search criteria. For an example API call, see the [Search via the API](/data-hub/data-hub-catalog/search#search-api) section of *How to Search in the Data Hub Catalog*.
 
 ## 3 Registration API {#registration}
 

--- a/content/apidocs-mxsdk/apidocs/data-hub-apis.md
+++ b/content/apidocs-mxsdk/apidocs/data-hub-apis.md
@@ -8,31 +8,31 @@ tags: ["data hub", "Data Hub API", "Warden", "authentication", "personal access 
 
 ## 1 Introduction
 
-The [Data Hub APIs](https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html) OpenAPI (formerly Swagger) specifications that can be accessed at: <https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html>.
-
-From this page the following APIs are available:
-
+The [Data Hub APIs](https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html) are OpenAPI (formerly Swagger) specifications with the following APIs available:
 
 * [Search API](#search) — search and retrieve information on regisered assets that can be used in your app development
-* [Register API](#registration) — register and update data sources to the organization's Mendix Data Hub
+* [Registration API](#registration) — register and update data sources to the organization's Mendix Data Hub
 * [Transform API](#transform) — for Mendix users deploying to a non-Mendix environment, generate the request bodies to register data sources published from your Mendix app
 
-{{% alert type="info" %}}
-The Data Hub API v2 is now deprecated and will be removed. Users should update their calls to this API and use the latest Registration and Search API URLs.
+{{% alert type="warning" %}}
+The Data Hub API v2 is now deprecated and will be removed. You should update your calls to this API and use the latest [Search](#search) and [Registration](#registration) API URLs.
 {{% /alert %}}
 
+{{% alert type="info" %}}
 The interactive features of the OpenAPI interface are not operational, so the **Try it out** feature does not work.
+{{% /alert %}}
 
 ## 2 Search API {#search}
 
-The [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in the Data Hub that satisfy specified search criteria. See an example API call at [Search via the API](https://docs.mendix.com/data-hub/data-hub-catalog/search#search-api).
+The [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in Data Hub that satisfy the specified search criteria. For an example API call, see the [Search via the API](/data-hub/data-hub-catalog/search#search-api) section of *How to 
+Search in the Data Hub Catalog*.
 
 ## 3 Registration API {#registration}
 
-The [Registration API](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html) can be used to register applications, environments and services or data sources. See an example API call at [Register an Application](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#register-application).
+The [Registration API](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html) can be used to register applications, environments, and services or data sources. See an example API call at [Register an Application](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#register-application).
 
-The API includes `POST` methods for registering new assets where a UUID is generated and returned for the asset in the response body. There are also `PUT` calls to *update* assets for existing UUIDs, or create new applications and environments for new UUIDs.
+The API includes `POST` methods for registering new assets where a UUID is generated and returned for the asset in the response body. There are also `PUT` calls to *update* assets for existing UUIDs or create new applications and environments for new UUIDs.
 
 ## 4 Transform API {#transform}
 
-Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the request body for the Registration API. The Transform API reconfigures information from the **dependencies.json** file into the correct fields. See an example API at [Preparing Your Service Details Using the Transform API](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#transform-api).
+Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the request body for the Registration API. The Transform API reconfigures information from the **dependencies.json** file into the correct fields. For an example API, see the [Preparing Your Service Details Using the Transform API](/data-hub/data-hub-catalog/register-data#transform-api) section of *How to Register OData Resources in the Data Hub Catalog*.

--- a/content/apidocs-mxsdk/apidocs/data-hub-apis.md
+++ b/content/apidocs-mxsdk/apidocs/data-hub-apis.md
@@ -8,164 +8,31 @@ tags: ["data hub", "Data Hub API", "Warden", "authentication", "personal access 
 
 ## 1 Introduction
 
-The [Data Hub APIs](#datahubapis) are OpenAPI 3.0 specs available at https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html.
+The [Data Hub APIs](https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html) OpenAPI (formerly Swagger) specifications that can be accessed at: <https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html>.
 
 From this page the following APIs are available:
 
-* **Register API** — register and update data sources to the organization's Mendix Data Hub
-* **Search API** — search and retrieve information on regisered assets that can be used in your app development
-* [Data Hub Transform API](#transform) — for Mendix users deploying to a non-Mendix environment, generate the request bodies to register data sources published from your Mendix app
+
+* [Search API](#search) — search and retrieve information on regisered assets that can be used in your app development
+* [Register API](#registration) — register and update data sources to the organization's Mendix Data Hub
+* [Transform API](#transform) — for Mendix users deploying to a non-Mendix environment, generate the request bodies to register data sources published from your Mendix app
 
 {{% alert type="info" %}}
-The Data Hub API v2 version of the API is now deprecated and will be removed. Users should update their calls to this API and use the latest Registration and Search API URLs.
+The Data Hub API v2 is now deprecated and will be removed. Users should update their calls to this API and use the latest Registration and Search API URLs.
 {{% /alert %}}
 
-When using any of the Data Hub APIs authorization must be included in the headers of the API calls as described in [Authentication and Authorization](#pat-token).
+The interactive features of the OpenAPI interface are not operational, so the **Try it out** feature does not work.
 
-{{% alert type="info" %}}
-To use the Mendix Data Hub a license is required.
-{{% /alert %}}
+## 2 Search API {#search}
 
-## 2 Authentication and Authorization {#pat-token}
+The [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in the Data Hub that satisfy specified search criteria. See an example API call at [Search via the API](https://docs.mendix.com/data-hub/data-hub-catalog/search#search-api).
 
-When making calls to the Data Hub APIs, authentication and authorization have to be included in the request headers. Users must send a Personal Access Token (PAT) that will enable access to the organization's Data Hub. Mendix users can obtain a PAT as described in [Generating your Personal Access Token](#generatepat).
+## 3 Registration API {#registration}
 
-### 2.1 Authorization Header
+The [Registration API](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html) can be used to register applications, environments and services or data sources. See an example API call at [Register an Application](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#register-application).
 
-For every request that is made to the Data Hub API, you must include the following key—value pair as part of the header:
+The API includes `POST` methods for registering new assets where a UUID is generated and returned for the asset in the response body. There are also `PUT` calls to *update* assets for existing UUIDs, or create new applications and environments for new UUIDs.
 
-`Authorization: MxToken <your_PAT_Token>`
+## 4 Transform API {#transform}
 
-where you insert the PAT in place of the <*your_PAT_Token*> string. This line will ensure that you have access your organization’s Data Hub.
-
-### 2.2 Generating Your Personal Access Token {#generatepat}
-
-Mendix users (with a registered account) can obtain a PAT using the Mendix **Warden** app by following these steps:
-
-1. To access the **Warden** app go to: https://warden.mendix.com/.
-
-2. At the prompt, sign-in using your username and password. The Warden Home page is displayed:
-
-    ![Warden Home Screen](attachments/dta-hub-apis/warden-home-screen.png)
-
-3. To create a new personal access token, click **Add**;  the **Create a Personal Access Token** screen is displayed.
-
-4. Enter a unique **Name** for the token. This name will be listed displayed in the generated tokens list on the Warden home screen.
-
-5. For the **Select scopes that can be used with this token:** under Data Hub, check both the **mx:datahub:services:read** and **mx:datahub:services:write**:
-
-    ![create token home](attachments/dta-hub-apis/create-pat-token.png)
-
-6. Click **Create**. The token will be generated and displayed in a pop-up window:
-
-    ![generated token](attachments/dta-hub-apis/generated-pat-token.png)
-
-7. Copy the **Token secret** to your clipboard by clicking the storage icon below the secret.
-
-    {{% alert type="info" %}}Make sure that you keep this token in a secure place. You will not get another chance to view this token once you **Close** this dialog box.  {{% /alert %}}
-
-    {{% alert type="info" %}}For every request that is made to the Data Hub API, you must include the following key—value pair as a header <br/> `Authorization: MxToken <your_PAT_Token>`. <br/> Insert the *Token secret* that was generated for the `<your_PAT_Token>` string. This provides access to your organization’s Data Hub.{{% /alert %}}
-
-8. Click **Close** to return to the **Personal Access Tokens** home screen.
-
-### 2.3 Operations from the Warden Home Screen
-
-The **Warden Home Screen** displays a list of all the tokens:
-
-![token list](attachments/dta-hub-apis/token-list.png)
-
-* **Last Used:** indicates when the token was last used
-* Delete unused tokens by clicking the "bin" icon for the token
-
-## 3 Data Hub OpenAPI Index Page {#datahubapis}
-
-The [Data Hub APIs](https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html) OpenAPI (formerly Swagger) specifications that can be accessed from the Data Hub PI Index Page at: <https://datahub-spec.s3.eu-central-1.amazonaws.com/index.html>.
-
-From this page the following APIs are currently available:
-
-* [Search API](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html)
-* [Registration API](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html)
-* [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html)
-
-The [Data Hub Transform OpenAPI Spec](#transform) describes how to generate the request bodies for registering Mendix Apps.
-
-{{% alert type="info" %}}
-The Data Hub API v2 version  is now deprecated and will be removed. Users should update their calls to the latest APIs and use the latest Registration and Search API URLs.
-{{% /alert %}}
-
-{{% alert type="info" %}}
-For the current release, the interactive features of the OpenAPI interface are not operational and therefore the **Try it out** feature does not work.
-{{% /alert %}}
-
-## 4 Data Hub Search API {#search-API}
-
-The [Search OpenAPI](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html) enables users to search and retrieve assets that are registered in the Data Hub that satisfy specified search criteria.
-
-The API also includes calls to retrieve all versions of a data source and full details of specific services.
-
-## 5 Data Hub Registration API {#registration-api}
-
-The [Registration API](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html) can be used to register applications, environments and services or data sources.
-
-The API includes POST methods for registering new assets where a UUID is generated and returned for the asset in the response body.
-There are also PUT calls to *update* assets that are already registered and also for registering new applications and environments where you provide the UUID.
-
-Apps that consume registered assets can also be registered to ensure that a complete network of shared assets can be maintained.
-
-## 6 Data Hub Transform OpenAPI Spec {#transform}
-
-Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the registration request body for the PUT published endpoints for the Data Hub API. The Transform API extracts the information from the **dependencies.json** file and the response can be used in the request bodies for the PUT calls to the Data Hub API.
-
-Information that is not returned by the Transform API and which should be specified separately is listed in [Optional Values not Obtained from **dependencies.json**](#not-in-depfile)
-
-### 6.1 Using the Transform API
-
-The Transform API is available at: https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html.
-
-The base URL for all calls to the API is: https://hub.mendix.com/rest/transform/v1/dependenciesjson.
-
-{{% alert type="info" %}}
-For the current release, the interactive features of the OpenAPI interface are not operational and therefore the **Try it out** feature does not work.
-{{% /alert %}}
-
-### 6.2 Location of the dependencies.json File of an App
-
-For a Mendix app, the **dependencies.json** file is usually located in the project folder of the app under the following directory: **Mendix\<YourApplicationName>\deployment\model**.
-
-This file has to be inserted in the call to the API in *escaped json format*.
-
-### 6.3 Making the API Call
-
-When making the call to the API the following two object have to be specified.
-
-#### 6.3.1 `DependenciesJsonString`
-
-Insert the `dependencies.json` file of the app *in escaped json format*.
-
-#### 6.3.2 `EndpointLocationConstants`
-
-This object must specify the location constants for the published endpoints that are referred to in the `dependencies.json` file.
-
-You can find the values in the **location constants** document in the **App Explorer** or in the **metadata.json** file.
-
-For the example given in the OpenAPI  spec in the `dependencies.json` file, the object `"constant":"MyFirstModule.EmployeeManagement_location"` is defined with the value of the location:
-
-     "EndpointLocationConstants": [
-    {
-      "Name": "MyFirstModule.EmployeeManagement_Location",
-      "Value": "https://hr.acmecorp.test/employeeservice/v2"
-    }
-
-### 6.4 Optional Values not Obtained from dependencies.json {#not-in-depfile}
-
-The `dependencies.json` file response body does not contain the values of the following objects that are specific to the Catalog registration of a data source:
-
-* `PublishedEndpointRequestDetails`
-  * `SecurityClassification`
-  * `Discoverable`
-  * `Validated`
-* `ServiceVersion`
-    *`Tags`
-
-They can be added to the generated response body.
-When the above attributes are not specified, the registration will be made using default values. The **Discoverable**, **Validated**, and **Tags** can also be added when the asset is curated in the Data Hub Catalog.
+Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the request body for the Registration API. The Transform API reconfigures information from the **dependencies.json** file into the correct fields. See an example API at [Preparing Your Service Details Using the Transform API](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#transform-api).

--- a/content/apidocs-mxsdk/apidocs/data-hub-apis.md
+++ b/content/apidocs-mxsdk/apidocs/data-hub-apis.md
@@ -34,4 +34,4 @@ The API includes `POST` methods for registering new assets where a UUID is gener
 
 ## 4 Transform API {#transform}
 
-Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the request body for the Registration API. The Transform API reconfigures information from the **dependencies.json** file into the correct fields. For an example API, see the [Preparing Your Service Details Using the Transform API](/data-hub/data-hub-catalog/register-data#transform-api) section of *How to Register OData Resources in the Data Hub Catalog*.
+Mendix users who deploy to *non-Mendix clouds* can make use of the [Transform API](https://datahub-spec.s3.eu-central-1.amazonaws.com/transform.html) to generate the request body for the Registration API. The Transform API reconfigures information from the *dependencies.json* file into the correct fields. For an example API, see the [Preparing Your Service Details Using the Transform API](/data-hub/data-hub-catalog/register-data#transform-api) section of *How to Register OData Resources in the Data Hub Catalog*.

--- a/content/data-hub/data-hub-catalog/register-data.md
+++ b/content/data-hub/data-hub-catalog/register-data.md
@@ -60,7 +60,7 @@ Once you have a Personal Access Token, follow this series of REST calls to regis
 
 The [Data Hub Registration API specification](https://datahub-spec.s3.eu-central-1.amazonaws.com/registration.html) describes all the optional fields, required formats, other operations on these same paths. You will only fill out the required fields and one operation per path in this how-to. 
 
-#### 4.1.1 Creating a Data Hub Catalog Registration API token {#create-token}
+#### 4.1.1 Creating a Data Hub Catalog API token {#create-token}
 
 You can create a Personal Access Token in the Mendix **Warden** application. Follow the steps below:
 

--- a/content/data-hub/data-hub-catalog/search.md
+++ b/content/data-hub/data-hub-catalog/search.md
@@ -12,10 +12,10 @@ Finding the right data to use in your app development is made easier using the s
 
 ## 2 Search via the API {#search-api}
 
-To use the Data Hub Catalog Search API, you need:
+To use the Data Hub Catalog Search API, you need the following:
 
-- a [Personal Access Token](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#create-token)
-- a search term
+* A [Personal Access Token](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#create-token)
+* A search term
 
 For more details on what can and cannot be provided in your search query, see the [API specification](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html#/Search/get_data).
 
@@ -26,8 +26,8 @@ curl --location --request GET 'https://hub.mendix.com/rest/search/v3/data?query=
 --header 'Content-Type: application/json' \
 --header 'Authorization: MxToken <your_Personal_Access_Token>'
 ```
-A successful `GET` call results in a `200` status code and a JSON response body that includes the details about the search results:
 
+A successful `GET` call results in a `200` status code and a JSON response body that includes the details about the search results:
 
 ```json
 {
@@ -299,7 +299,7 @@ In the **Filters** dialog box, check the **Environment Type** that you want to i
 
 #### 3.4.3 Search Results {#search-results}
 
-The number of items satisfying the search criteria (search string plus filters) are shown the search results list. The order of the items presented in the search results will be a combination of the following:
+The number of items satisfying the search criteria (search string plus filters) are shown in the search results list. The order of the items presented in the search results will be a combination of the following:
 
 * Closest match to the search string
 * Popularity of the service (the number of connections)
@@ -309,7 +309,7 @@ When an item in the search results is selected, the **Landscape** tab shows the 
 
 ### 3.5 Selected Asset Details {#search-details}
 
-When you click on a search result, the details are displayed in this panel.
+When you click a search result, the details are displayed in this panel.
 
 #### 3.5.1 Details of a Selected Data Source {#service-details}
 
@@ -380,8 +380,8 @@ You can perform the following actions from this screen:
  ![associations info](attachments/search/attributes-associations.png)
 
 * **Name** – the name of the association that is exposed in the OData service contract.
-
 * **Navigates to** – the dataset the association is made with. Click the link to see the details of the associated dataset in the Catalog.
+
 
 ### 3.6 Metadata Panel {#metadata}
 
@@ -391,11 +391,13 @@ The metadata panel at the right of the asset details screen displays details fro
 
 #### 3.6.1 Tags
 
-The tags that have been assigned to the data source in the Catalog, see more about this in [Curation.](curate#tags) Tags assigned at a data source level propagate down to the datasets and attributes exposed in the service.
+These are the tags that have been assigned to the data source in the Catalog (for more information, see the [Adding or Editing Tags to a Service](curate#tags) section of *How to 
+Curate Registered Assets*). Tags assigned at a data source-level propagate down to the datasets and attributes exposed in the service.
 
 #### 3.6.2 Business Owner
 
-A link to the business owner of the data exposed in the data source, see more about this in [changing owners](curate#changing-owners).
+This is a link to the business owner of the data exposed in the data source. For more information, see the [Changing Owners of an App](curate#changing-owners) section of *How to 
+Curate Registered Assets*.
 
 #### 3.6.3 Technical Owner
 
@@ -418,7 +420,7 @@ The following discoverability values can be set:
 
 #### 3.6.5 Validated
 
-Indicates if the data source has been **Validated**. See [Curate Bar](#curate-bar) for changing **Validated** as an owner or curator.
+This indicates if the data source has been **Validated**. For details on changing **Validated** as an owner or curator, see the [Curate Bar](#curate-bar) section below.
 
 #### 3.6.6 Application
 
@@ -452,21 +454,15 @@ The data source URI is the location of the service contract of the data source �
 
 ### 3.9 Download the Metadata Contract of a Data Source {#download-contract}
 
-For a selected data source, you can click **Download** to download the OData service contract that is located at the data source endpoint. A `.zip` file that includes the all the files that make up the full metadata contract is generated and downloaded.
+For a selected data source, you can click **Download** to download the OData service contract that is located at the data source endpoint. A ZIP file that includes the all the files that make up the full metadata contract is generated and downloaded.
 
-The resulting `.zip` file is named as follows:
+The resulting ZIP file is named *DataHub\_<service_name>\_<service_version>\_<technology>.zip* where the string *<technology>* identifies the OData version (*v3* or *v4*) in the file name.
 
-```DataHub_<service_name>_<service_version>_<technology>.zip```
-
-The string `<technology>` identifies the OData version (`v3` or `v4`) in the file name.
-
-For the following example:
+Here is an example:
 
 ![download example](attachments/search/download_example.png)
 
-When you click **Download** the following file is downloaded: `DataHub_SAP_Intelligence_1.0_OData4.zip`
-
-This zip file has the folder: `DataHub_SAP_Intelligence_1.0_OData4` which contains the all the metadata files that define the service.
+When you click **Download**, the following file is downloaded: *DataHub\_SAP\_Intelligence\_1.0_OData4.zip*. This ZIP file has the folder *DataHub\_SAP\_Intelligence\_1.0\_OData4*, which contains the all the metadata files that define the service.
 
 ### 3.10 Viewing Search Results in the Data Hub Landscape
 

--- a/content/data-hub/data-hub-catalog/search.md
+++ b/content/data-hub/data-hub-catalog/search.md
@@ -10,7 +10,7 @@ tags: ["data hub", "data hub catalog"]
 
 Finding the right data to use in your app development is made easier using the search functionality in the Data Hub Catalog. The details of registered data assets can be accessed via the [Data Hub Search API](/apidocs-mxsdk/apidocs/data-hub-apis), or viewed in the [Asset details](#search-details) screen of the Catalog or the [Data Hub pane](/refguide/data-hub-pane) in Studio Pro.  This document describes the functionality of the Data Hub Catalog.
 
-## 2 Search via the API
+## 2 Search via the API {#search-api}
 
 To use the Data Hub Catalog Search API, you need:
 
@@ -218,7 +218,7 @@ A successful `GET` call results in a `200` status code and a JSON response body 
 }
 ```
 
-## 3 Search in the Catalog
+## 3 Search in the Catalog {#search-catalog}
 
 ### 3.1 Details of Registered Assets
 

--- a/content/data-hub/data-hub-catalog/search.md
+++ b/content/data-hub/data-hub-catalog/search.md
@@ -29,15 +29,15 @@ The environment also provides an indication of the quality of the dataset that i
 Search results show the data source endpoints. If a version of a service is deployed on both a test and acceptance environment, two endpoints are shown in the search results.
 
 {{% alert type="info" %}}
-By default, search results in the Data Hub Catalog are filtered to show only hits in the **Production** environments. You can extend the search to **Non-production** or **Mendix Free App (Sandbox)** environments by checking them in the search pane **Add Filter** list. For more details, see the[Filters](#filter) section below.
+By default, search results in the Data Hub Catalog are filtered to show only hits in the **Production** environments. You can extend the search to **Non-production** or **Mendix Free App (Sandbox)** environments by checking them in the search pane **Add Filter** list. For more details, see the [Filters](#filter) section below.
 {{% /alert %}}
 
-### 2.3 Asset Descriptions
+### 2.3 Asset Description
 
-The description that is included as part of the published service metadata. This description can be further curated at the data source, dataset, and attribute level by owners and curators to provide further details of the exposed datasets and the associated data.
+The description that is included as part of the published service metadata. This description can be edited at the data source, dataset, and attribute level by owners and curators.
 
 {{% alert type="info" %}}
-In Studio Pro, when publishing an OData service, it is possible to specify a summary of the service and a description. Only the description is included in the OData service contract document and displayed in the Data Hub Catalog.
+In Studio Pro, when publishing an OData service, it is possible to specify a summary of the service and a description. Only the description is included in the OData service contract document and registered in the Data Hub Catalog.
 {{% /alert %}}
 
 ## 3 Search in the Data Hub Catalog {#data-hub-home}
@@ -56,88 +56,56 @@ From the **Data Hub Home** page, you can search the Catalog in the following way
 
 ![data hub home page](../share-data/attachments/share-data/data-hub-home.png)
 
-* Type a search term in the search box and click **Search** (search strings can be a minimum of three characters and consist of alphanumeric characters)
+* Type a search term in the search box and click **Search** (search strings must be at least 3 alphanumeric characters)
 * Click one of the *tags* given in the **Search suggestions**
-* Click one of the services under **Most Popular Services**
+* Click one of the services under **Popular Data Sources**
 * Click the **Catalog** tab
 
 Any of the above actions will take you to the **Search** screen.
 
 ### 3.2 Search Screen {#search-tab}
 
-The **Search** screen is divided into the [search](#search-pane) pane on the left, the [asset details](#search-details) of the selected asset in the centre panel, and the [asset metadata](#metadata) panel on the right.
+The **Search** screen is divided into the [search](#search-pane) pane on the left, the [asset details](#search-details) of the selected asset in the center panel, and the [asset metadata](#metadata) panel on the right.
 
 ![search details](attachments/search/search-details-page.png)
 
 ## 4 Search Pane {#search-pane}
 
-The collapsable **Search** pane is used to search for registered assets in the Data Hub Catalog:
+The collapsible **Search** pane is used to search for registered assets in the Data Hub Catalog:
 
  {{% image_container width="300" %}}![search pane](attachments/search/search-pane.png){{% /image_container %}}
 
 ### 4.1 Specifying the Search
 
-Enter a search string in the **Search** area comprising a minimum of 3 alpha-numeric characters.
-
-The wildcard `*` can also be used to imply an empty search but it is not necessary as search without specifying any search string will return all registered items.
-
-{{% alert type="info" %}}
-Punctuation cannot be used as part of the search term.
-{{% /alert %}}
-
-{{% alert type="info" %}}
-Search is case-insensitive.
-{{% /alert %}}
-
-The search is carried out asset metadata that includes the following:
-
-* all application names
-* data sources, datasets (or entity sets)
-* attribute
-* tags
-* descriptions
+Enter a search string in the **Search** area with a minimum of 3 alphanumeric characters. Searching for the wildcard `*` or the empty string `''` will return all registered items.
 
 ### 4.2 Filters {#filter}
 
-You can filter search results by environment type. By default, the **Production** environment filter is active and this restricts search to assets in the production environment.
+You can filter search results by environment type. The **Production** environment filter is active by default.
 
-To specify the environment type for the search, click **Filter**:
+To change the environment type filter, click **Filter**:
 
 ![filter box](attachments/search/dh-filter-box.png)
 
-In the **Filters** dialog box, check the **Environment Type** that you want to restrict your search to and click, **Apply Filters**. The search results will only display hits for the specified search string in the checked environments.
-
-{{% alert type="info" %}}
-The **Sandbox** filter refers to apps deployed to the Mendix Free App environment.
-{{% /alert %}}
-
-The number of filters that are active for the current search is displayed adjacent to the filter:
-
-{{% image_container width="200" %}}![filter active](attachments/search/filter-active.png){{% /image_container %}}
-
-Click **Clear Filters** to clear all the checked environments and click **Apply Filters** to see search results in all environments.
+In the **Filters** dialog box, check the **Environment Type** that you want to include in your search. Then click **Apply Filters**. The search results will only display results in the selected environments.
 
 ### 4.3 Search Results {#search-results}
 
-The number of items satisfying the search criteria (search string plus filters) are shown above the search results list. Search results include assets that match the search string and satisfy the active filters. The order of the items presented in the search results will be a combination of the following:
+The number of items satisfying the search criteria (search string plus filters) are shown the search results list. The order of the items presented in the search results will be a combination of the following:
 
 * Closest match to the search string
 * Popularity of the service (the number of connections)
-* **Validated** assets before non-validated items
+* **Validated** assets before non-validated ones
 
- {{% alert type="info" %}}The weighting in the search results is cumulative depending on the validate property being set for datasets in a data source. For example, if there is a dataset named **Customer** that is **Validated** in a **Validated** data source, this is listed higher in the search results list than a dataset of the same name that is not **Validated** in a **Validated** data source.{{% /alert %}}
-
-{{% alert type="info" %}}Assets that are set to [Non-discoverable](#discoverability-metadata) are not included in the search results unless you are a curator or owner of the asset.{{% /alert %}}
-
-When an item in the search results is selected, the **Catalog** tab displays the **Details** of the asset and the **Landscape** tab shows the network of connections and dependencies of the selected item in the [Data Hub Landscape](/data-hub/data-hub-landscape/).
+When an item in the search results is selected, the **Landscape** tab shows the network of connections and dependencies of the selected item in the [Data Hub Landscape](/data-hub/data-hub-landscape/).
 
 ## 5 Selected Asset Details {#search-details}
 
-When you click on an asset (data source or dataset) in the search results, the details are displayed in this panel.
+When you click on a search result, the details are displayed in this panel.
 
 ### 5.1 Details of a Selected Data Source {#service-details}
 
-The contract of the published OData service (the *$metadata* document) contains the definitions details of what is exposed in the service. This includes the metadata of the exposed datasets (or entity sets in Mendix Studio Pro) and their exposed attributes, associations, types, and accessibility. The contract metadata is displayed in the Data Source details along with any Catalog-curated metadata.
+The contract of the published OData service (the *$metadata* document) contains the details of what is exposed in the service. This includes the metadata of the exposed datasets (or entity sets in Mendix Studio Pro) and their exposed attributes, associations, and types. The contract metadata is displayed, along with any Catalog-curated metadata.
 
 When a data source is selected in the search results, the following details are displayed:
 
@@ -147,7 +115,7 @@ When a data source is selected in the search results, the following details are 
 
 * Name of the data source
 
-* **Non-discoverable** icon – if the data source has been set to non-discoverable (by default, no icon indicates that it can be seen by all users)
+* **Non-discoverable** icon – if the data source has been set to non-discoverable (by default, data sources are discoverable to all users in your company and no icon appears)
 
 * **Validated** icon – if it has been set for the asset
 
@@ -161,7 +129,7 @@ When a data source is selected in the search results, the following details are 
 
 * All **Datasets** that are exposed in the data source (you can expand each one to see details of the attributes and associations)
 
- {{% alert type="info" %}}In Mendix Studio Pro, the **Dataset** is the name of the **Entity set** of a published **Entity**, which by default, is the entity name with an "s" appended to it. For example, if an entity named `Customer` is published in an OData service, the **Dataset** name in the **Search Details** will be `Customers`.{{% /alert %}}
+ {{% alert type="info" %}}In Mendix Studio Pro, the **Dataset** is the name of the **Entity set** of a published **Entity**. This defaults to the entity name with an "s" appended to it. For example, if an entity named `Customer` is published in an OData service, the **Dataset** name in the **Search Details** will be `Customers`.{{% /alert %}}
 
 You can perform the following actions from this screen:
 
@@ -215,12 +183,11 @@ The metadata panel at the right of the asset details screen displays details fro
 
 ### 6.1 Tags
 
-The tags that have been assigned to the data source during [curation.](curate#tags)
-{{% alert type="info" %}}Tags assigned at a data source level propagate down to the datasets and attributes exposed in the service.{{% /alert %}}
+The tags that have been assigned to the data source in the Catalog, see more about this in [Curation.](curate#tags) Tags assigned at a data source level propagate down to the datasets and attributes exposed in the service.
 
 ### 6.2 Business Owner
 
-A link to the business owner of the data exposed in the data source. Business owners can be [added as a curation task](curate#changing-owners).
+A link to the business owner of the data exposed in the data source, see more about this in [changing owners](curate#changing-owners).
 
 ### 6.3 Technical Owner
 
@@ -228,37 +195,28 @@ The technical contact of the app; by default this is the owner who registered th
 
 For apps hosted in the Mendix Cloud, the **Technical Owner** is the app developer that deployed the app.
 
-Technical owners can be [changed as a curation task](curate#changing-owners).
+Technical owners can be [changed](curate#changing-owners).
 
 ### 6.4 Discoverability {#discoverability-metadata}
 
-When a data source is registered, by default, it is **Discoverable** in the Data Hub Catalog. When this is set, all users can find it, view the details, and consume it. The owners of an asset and curators can set a data source as **non-discoverable**, which means it is not visible to users unless they are the owner or a curator.
+When a data source is registered, by default, it is **Discoverable** in the Data Hub Catalog. When this is set, all users in your company can find it, view the details, and consume it. The owners of an asset and curators can set a data source as **Non-discoverable**, which means it is not visible to users unless they are the owner or a curator.
 
 See [Curate Bar](#curate-bar) for changing **Discoverability** as the owner of the data source or curator.
 
 The following discoverability values can be set:
 
-* **Discoverable** – all users of the Data Hub Catalog and Studio Pro can see and consume the asset provided they meet the requirements of the **Classification**
-* **Non-Discoverable** – the asset is not visible in the Catalog and only owners, Data Hub curators, and the Data Hub Admin can find, use, and curate the service.
-  {{% alert type="info" %}}A **Non-discoverable** asset is also not included in the search results in the **Data Hub** pane of Studio Pro, or any other client of the Data Hub API.{{% /alert %}}
+* **Discoverable** – all users in your company can see and consume the asset in the Data Hub Catalog and Studio Pro 
+* **Non-Discoverable** – the asset is only visible to owners, Data Hub curators, and the Data Hub Admin in the Catalog; it is not included in the search results in the **Data Hub** pane of Studio Pro, or any other client of the Data Hub API.
 
 ### 6.5 Validated
 
-Indicates if the data source has been **Validated**. See [Curate Bar](#curate-bar) for changing **Validated** as an owner of the data source or curator.
+Indicates if the data source has been **Validated**. See [Curate Bar](#curate-bar) for changing **Validated** as an owner or curator.
 
-### 6.6 Access Level
-
-Displays the access classification of the data exposed by the service: end-users of the app will only be able to see the information must have the appropriate [user role](/refguide/user-roles) to access the data:
-
-* **Public** – classified as public and available to all users, internal and external to the organization
-* **Internal** – restricted to the members of the organization
-  {{% alert type="info" %}}Classifications at a data source level propagate down to the datasets and attributes exposed in the OData service. {{% /alert %}}
-
-### 6.7 Application
+### 6.6 Application
 
 A link to the application from which the data source was published in the given environment.
 
-### 6.8 Environment Type
+### 6.7 Environment Type
 
 The environment type indicates the quality and the status of the data that the exposed datasets connect to. The following environment types can be specified:
 
@@ -277,24 +235,18 @@ The following actions can be carried out:
 * **Edit Metadata** – edit information that is displayed in the Catalog for the asset:
   * for a selected data source you can edit [Application Details](./curate#curate-application) and [Data Source Details](./curate#service-details)
   * for a selected dataset you can edit [Dataset Details](./curate#curate-datasets)
-* **Discoverable**/**Validated** – set the discoverability of the data source, and set a data source or dataset as validated
-  * **Discoverable** – all users of Data Hub and Studio Pro can see and consume the service in combination with the classification of the data
-  * **Not Discoverable** – the service is not visible; only owners of the service, Data Hub curators, and the Data Hub Admin can access the service
-  * **Validated** – indicates if the data source or dataset has been validated
-
-{{% alert type="info" %}}By default, newly registered services are set to **Discoverable** and visible to all users.{{% /alert %}}
 
 For further details, see [Curate Registered Assets](./curate).
 
 ## 8 Data Source and Dataset URIs
 
-The data source URI is the location of the service contract of the data source – also known as the service endpoint. The endpoints of all exposed datasets (entity sets) are defined in the contract. From the details screen of the data source and dataset, you can copy the URIs to the clipboard by clicking the **Copy Data Source URI** and **Copy Dataset URI**, respectively. These URIs can be used for directly accessing the contract and resource in other BI applications.
+The data source URI is the location of the service contract of the data source – also known as the service endpoint. The endpoints of all exposed datasets (entity sets) are defined in the contract. From the details screen of the data source and dataset, you can copy the URIs to the clipboard by clicking the **Copy Data Source URI** and **Copy Dataset URI** respectively. These URIs can be used for directly accessing the contract and resource in BI applications.
 
 ## 9 Download the Metadata Contract of a Data Source {#download-contract}
 
-For a selected data source, you can click **Download** to download the OData service contract that is located at the data source endpoint. A ***.zip*** file that includes the all the files that make up the full metadata contract is generated and downloaded.
+For a selected data source, you can click **Download** to download the OData service contract that is located at the data source endpoint. A `.zip` file that includes the all the files that make up the full metadata contract is generated and downloaded.
 
-The resulting ***.zip*** file is named as follows:
+The resulting `.zip` file is named as follows:
 
 ```DataHub_<service_name>_<service_version>_<technology>.zip```
 

--- a/content/data-hub/data-hub-catalog/search.md
+++ b/content/data-hub/data-hub-catalog/search.md
@@ -10,17 +10,227 @@ tags: ["data hub", "data hub catalog"]
 
 Finding the right data to use in your app development is made easier using the search functionality in the Data Hub Catalog. The details of registered data assets can be accessed via the [Data Hub Search API](/apidocs-mxsdk/apidocs/data-hub-apis), or viewed in the [Asset details](#search-details) screen of the Catalog or the [Data Hub pane](/refguide/data-hub-pane) in Studio Pro.  This document describes the functionality of the Data Hub Catalog.
 
-## 2 Details of Registered Assets
+## 2 Search via the API
+
+To use the Data Hub Catalog Search API, you need:
+
+- a [Personal Access Token](https://docs.mendix.com/data-hub/data-hub-catalog/register-data#create-token)
+- a search term
+
+For more details on what can and cannot be provided in your search query, see the [API specification](https://datahub-spec.s3.eu-central-1.amazonaws.com/search.html#/Search/get_data).
+
+You can see an example of a request below where the search term is `Customer`:
+
+```curl
+curl --location --request GET 'https://hub.mendix.com/rest/search/v3/data?query=Customer' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: MxToken <your_Personal_Access_Token>'
+```
+A successful `GET` call results in a `200` status code and a JSON response body that includes the details about the search results:
+
+
+```json
+{
+    "TotalResults": 145,
+    "Links": [
+        {
+            "Href": "https://hub.mendix.com/rest/search/v3/data?query=Customer",
+            "Rel": "First"
+        },
+        {
+            "Href": "https://hub.mendix.com/rest/search/v3/data?query=Customer",
+            "Rel": "Current"
+        },
+        {
+            "Href": "https://hub.mendix.com/rest/search/v3/data?query=Customer&afterId=18d7d608-723f-4f33-b247-a85271d5eefd",
+            "Rel": "Next"
+        }
+    ],
+    "Data": [
+        {
+            "Connections": 34,
+            "Validated": true,
+            "Description": "This is the primary data source for customer information.",
+            "SecurityClassification": "Internal",
+            "TotalItems": 3,
+            "Name": "CustomerApi",
+            "Version": "1.1.0",
+            "ContractType": "OData_3_0",
+            "Environment": {
+                "Type": "Production",
+                "UUID": "5f0e2439-cc8b-4b12-87a4-556437d9e4d1",
+                "Name": "Production",
+                "Location": "https://your-app-url.com"
+            },
+            "Links": [
+                {
+                    "Rel": "Self",
+                    "Href": "https://hub.mendix.com/rest/search/v3/endpoints/9756545b-9b36-4f51-8655-1102c36e9288"
+                },
+                {
+                    "Rel": "Catalog",
+                    "Href": "https://hub.mendix.com/link/endpoint?EndpointUUID=9756545b-9b36-4f51-8655-1102c36e9288"
+                }
+            ],
+            "Items": [
+                {
+                    "Type": "DataSource",
+                    "Validated": false,
+                    "EntitySetName": "Customers",
+                    "Updatable": false,
+                    "Links": [{
+                        "Rel": "Catalog",
+                        "Href": "https://hub.mendix.com/link/entity?EndpointUUID=9756545b-9b36-4f51-8655-1102c36e9288&EntityUUID=d27150f1-1ba3-41f0-965b-3ce3402412ef"
+                    }],
+                    "Deletable": false,
+                    "Items": [
+                        {
+                            "Type": "Attribute",
+                            "EdmxType": "Edm.Int64",
+                            "Updatable": false,
+                            "Insertable": false,
+                            "Name": "CustomerId"
+                        },
+                        {
+                            "Type": "Association",
+                            "ReferencedDataSource": "ContactHistory",
+                            "Multiplicity": "*",
+                            "EntitySetName": "ContactHistorys",
+                            "Updatable": false,
+                            "Insertable": false,
+                            "Namespace": "mx.customer.api",
+                            "Name": "ContactHistory_Customer",
+                            "EntityTypeName": "ContactHistory"
+                        },
+                        {
+                            "Type": "Association",
+                            "ReferencedDataSource": "ContactInfo",
+                            "Multiplicity": "0..1",
+                            "EntitySetName": "ContactInfos",
+                            "Updatable": false,
+                            "Insertable": false,
+                            "Namespace": "mx.customer.api",
+                            "Name": "ContactInfo_Customer",
+                            "EntityTypeName": "ContactInfo"
+                        }
+                    ],
+                    "TotalItems": 6,
+                    "Insertable": false,
+                    "Namespace": "mx.customer.api",
+                    "Name": "Customer",
+                    "EntityTypeName": "Customer"
+                },
+                {
+                    "Type": "DataSource",
+                    "Validated": false,
+                    "EntitySetName": "ContactHistorys",
+                    "Updatable": false,
+                    "Links": [{
+                        "Rel": "Catalog",
+                        "Href": "https://hub.mendix.com/link/entity?EndpointUUID=9756545b-9b36-4f51-8655-1102c36e9288&EntityUUID=3aeb0d6b-4205-4bc6-adef-67487e85e178"
+                    }],
+                    "Deletable": false,
+                    "Items": [{
+                        "Type": "Association",
+                        "ReferencedDataSource": "Customer",
+                        "Multiplicity": "0..1",
+                        "EntitySetName": "Customers",
+                        "Updatable": false,
+                        "Insertable": false,
+                        "Namespace": "mx.customer.api",
+                        "Name": "ContactHistory_Customer",
+                        "EntityTypeName": "Customer"
+                    }],
+                    "TotalItems": 6,
+                    "Insertable": false,
+                    "Namespace": "mx.customer.api",
+                    "Name": "ContactHistory",
+                    "EntityTypeName": "ContactHistory"
+                },
+                {
+                    "Type": "DataSource",
+                    "Validated": false,
+                    "EntitySetName": "ContactInfos",
+                    "Updatable": false,
+                    "Links": [{
+                        "Rel": "Catalog",
+                        "Href": "https://hub.mendix.com/link/entity?EndpointUUID=9756545b-9b36-4f51-8655-1102c36e9288&EntityUUID=6939a90c-c3bc-4eaf-a741-a484cf2248ad"
+                    }],
+                    "Deletable": false,
+                    "Items": [{
+                        "Type": "Association",
+                        "ReferencedDataSource": "Customer",
+                        "Multiplicity": "*",
+                        "EntitySetName": "Customers",
+                        "Updatable": false,
+                        "Insertable": false,
+                        "Namespace": "mx.customer.api",
+                        "Name": "ContactInfo_Customer",
+                        "EntityTypeName": "Customer"
+                    }],
+                    "TotalItems": 11,
+                    "Insertable": false,
+                    "Namespace": "mx.customer.api",
+                    "Name": "ContactInfo",
+                    "EntityTypeName": "ContactInfo"
+                }
+            ],
+            "LastUpdated": "2021-07-24T16:12:52.795Z",
+            "UUID": "9756545b-9b36-4f51-8655-1102c36e9288",
+            "SecurityScheme": {
+                "Types": [{"Name": "Anonymous"}],
+                "MxAllowedRoles": [
+                    {
+                        "UUID": "abc56ffb-75ab-44f6-9c04-87fbe419ce74",
+                        "Name": "Administrator"
+                    },
+                    {
+                        "UUID": "3f8cbb62-bbcc-4d9f-b583-27d4b50d5405",
+                        "Name": "User"
+                    }
+                ]
+            },
+            "Application": {
+                "Type": "Other",
+                "TechnicalOwner": {
+                    "Email": "roselien.opmeer@mendix.com",
+                    "OpenID": "https://mxid2.mendixcloud.com/mxid2/id?id=3abbc519-36cb-49e0-b158-120e9100e8be",
+                    "Name": "Roselien Opmeer"
+                },
+                "Icon": "https://hub.mendix.com/resources/logos/other_icon.png",
+                "UUID": "34aacfda-8a85-497c-bb21-74f1c6ee2b18",
+                "RepositoryLocation": "https://sprintr.home.mendix.com/link/project/a2e76491-bd8d-4284-b865-00c9ae8dde94",
+                "BusinessOwner": {
+                    "Email": "roselien.opmeer@mendix.com",
+                    "OpenID": "https://mxid2.mendixcloud.com/mxid2/id?id=3abbc519-36cb-49e0-b158-120e9100e8be",
+                    "Name": "Roselien Opmeer"
+                },
+                "Name": "CustomerApp"
+            },
+            "Tags": [
+                {"Name": "customer"},
+                {"Name": "contact"}
+            ]
+        }, {...}, {...}, {...},
+    ],
+    "Limit": 20,
+    "LastId": "18d7d608-723f-4f33-b247-a85271d5eefd"
+}
+```
+
+## 3 Search in the Catalog
+
+### 3.1 Details of Registered Assets
 
 You can start searching from the [Data Hub Home](#data-hub-home) page, or click the [Catalog](#search-tab) tab to go to the **Search** pane and **Asset Details** screen. This section describes important properties of registered assets: data sources, datasets, and attributes.
 
 {{% alert type="info" %}}The **Dataset** is the name of the **Entity set** of a published **Entity** in Mendix Studio Pro, which by default, is the entity name with an "s" appended to it. For example, if an entity named `Customer` is published in an OData service, the **Dataset** name in the **Search Details** will be `Customers`.{{% /alert %}}
 
-### 2.1 Versions
+#### 3.1.1 Versions
 
 Every published OData service (or data source) has a version number. Apps that consume a data source will consume from a specific version. Updates and changes to a service will be indicated by a change in the version number. Several versions of a registered data source may be available in the Catalog. The data source version is displayed in the [Asset Details](#search-details).
 
-### 2.2 Environments
+#### 3.1.2 Environments
 
 The Data Hub Catalog is a register of published OData services (or data sources) that are deployed to a particular environment. Each registered data source is a unique **endpoint** combination of service version and environment.
 
@@ -32,7 +242,7 @@ Search results show the data source endpoints. If a version of a service is depl
 By default, search results in the Data Hub Catalog are filtered to show only hits in the **Production** environments. You can extend the search to **Non-production** or **Mendix Free App (Sandbox)** environments by checking them in the search pane **Add Filter** list. For more details, see the [Filters](#filter) section below.
 {{% /alert %}}
 
-### 2.3 Asset Description
+#### 3.1.3 Asset Description
 
 The description that is included as part of the published service metadata. This description can be edited at the data source, dataset, and attribute level by owners and curators.
 
@@ -40,7 +250,7 @@ The description that is included as part of the published service metadata. This
 In Studio Pro, when publishing an OData service, it is possible to specify a summary of the service and a description. Only the description is included in the OData service contract document and registered in the Data Hub Catalog.
 {{% /alert %}}
 
-## 3 Search in the Data Hub Catalog {#data-hub-home}
+### 3.2 Searching for Assets from Data Hub Home {#data-hub-home}
 
 When searching in the Data Hub Catalog, the following fields are searched:
 
@@ -49,8 +259,6 @@ When searching in the Data Hub Catalog, the following fields are searched:
 * Dataset: Name, Description
 * Attribute: Name, Description
 * Association: Name
-
-### 3.1 Searching for Assets
 
 From the **Data Hub Home** page, you can search the Catalog in the following ways:
 
@@ -63,23 +271,23 @@ From the **Data Hub Home** page, you can search the Catalog in the following way
 
 Any of the above actions will take you to the **Search** screen.
 
-### 3.2 Search Screen {#search-tab}
+### 3.3 Search Screen {#search-tab}
 
 The **Search** screen is divided into the [search](#search-pane) pane on the left, the [asset details](#search-details) of the selected asset in the center panel, and the [asset metadata](#metadata) panel on the right.
 
 ![search details](attachments/search/search-details-page.png)
 
-## 4 Search Pane {#search-pane}
+### 3.4 Search Pane {#search-pane}
 
 The collapsible **Search** pane is used to search for registered assets in the Data Hub Catalog:
 
  {{% image_container width="300" %}}![search pane](attachments/search/search-pane.png){{% /image_container %}}
 
-### 4.1 Specifying the Search
+#### 3.4.1 Specifying the Search
 
 Enter a search string in the **Search** area with a minimum of 3 alphanumeric characters. Searching for the wildcard `*` or the empty string `''` will return all registered items.
 
-### 4.2 Filters {#filter}
+#### 3.4.2 Filters {#filter}
 
 You can filter search results by environment type. The **Production** environment filter is active by default.
 
@@ -89,7 +297,7 @@ To change the environment type filter, click **Filter**:
 
 In the **Filters** dialog box, check the **Environment Type** that you want to include in your search. Then click **Apply Filters**. The search results will only display results in the selected environments.
 
-### 4.3 Search Results {#search-results}
+#### 3.4.3 Search Results {#search-results}
 
 The number of items satisfying the search criteria (search string plus filters) are shown the search results list. The order of the items presented in the search results will be a combination of the following:
 
@@ -99,11 +307,11 @@ The number of items satisfying the search criteria (search string plus filters) 
 
 When an item in the search results is selected, the **Landscape** tab shows the network of connections and dependencies of the selected item in the [Data Hub Landscape](/data-hub/data-hub-landscape/).
 
-## 5 Selected Asset Details {#search-details}
+### 3.5 Selected Asset Details {#search-details}
 
 When you click on a search result, the details are displayed in this panel.
 
-### 5.1 Details of a Selected Data Source {#service-details}
+#### 3.5.1 Details of a Selected Data Source {#service-details}
 
 The contract of the published OData service (the *$metadata* document) contains the details of what is exposed in the service. This includes the metadata of the exposed datasets (or entity sets in Mendix Studio Pro) and their exposed attributes, associations, and types. The contract metadata is displayed, along with any Catalog-curated metadata.
 
@@ -138,13 +346,13 @@ You can perform the following actions from this screen:
 * [Download](#download-contract) – retrieve and save the OData contract from the data source endpoint to your computer.
 * **Copy Dataset URI** – click to copy the URI of the dataset to the clipboard for use in other business applications.
 
-### 5.2 Details for a Selected Dataset {#entity-details}
+#### 3.5.2 Details for a Selected Dataset {#entity-details}
 
 When a **Dataset** is selected in the search results, the following details are displayed in the **Search Details** panel.
 
 ![search details entity](attachments/search/search-details-entity.png)
 
-#### 5.2.1 General Information
+##### 3.5.2.1 General Information
 
 The source and endpoint details of the dataset are displayed:
 
@@ -163,7 +371,7 @@ You can perform the following actions from this screen:
 * **Copy Dataset URI** – click to copy the URI of the dataset to the clipboard for use in other business applications
 * **Share Dataset** – click to copy the link to this dataset detail page to the clipboard so that it can be shared with others
 
-#### 5.2.2 Dataset Information
+#### 3.5.2.2 Dataset Information
 
  The **Attributes** tab lists the attributes that are exposed for the dataset in the OData service.
 
@@ -175,21 +383,21 @@ You can perform the following actions from this screen:
 
 * **Navigates to** – the dataset the association is made with. Click the link to see the details of the associated dataset in the Catalog.
 
-## 6 Metadata Panel {#metadata}
+### 3.6 Metadata Panel {#metadata}
 
 The metadata panel at the right of the asset details screen displays details from the OData service metadata contract and values that have been curated in the Data Hub Catalog:
 
  {{% image_container width="300" %}}![metadata pane](attachments/search/metadata.png){{% /image_container %}}
 
-### 6.1 Tags
+#### 3.6.1 Tags
 
 The tags that have been assigned to the data source in the Catalog, see more about this in [Curation.](curate#tags) Tags assigned at a data source level propagate down to the datasets and attributes exposed in the service.
 
-### 6.2 Business Owner
+#### 3.6.2 Business Owner
 
 A link to the business owner of the data exposed in the data source, see more about this in [changing owners](curate#changing-owners).
 
-### 6.3 Technical Owner
+#### 3.6.3 Technical Owner
 
 The technical contact of the app; by default this is the owner who registered the OData service.
 
@@ -197,7 +405,7 @@ For apps hosted in the Mendix Cloud, the **Technical Owner** is the app develope
 
 Technical owners can be [changed](curate#changing-owners).
 
-### 6.4 Discoverability {#discoverability-metadata}
+#### 3.6.4 Discoverability {#discoverability-metadata}
 
 When a data source is registered, by default, it is **Discoverable** in the Data Hub Catalog. When this is set, all users in your company can find it, view the details, and consume it. The owners of an asset and curators can set a data source as **Non-discoverable**, which means it is not visible to users unless they are the owner or a curator.
 
@@ -208,15 +416,15 @@ The following discoverability values can be set:
 * **Discoverable** – all users in your company can see and consume the asset in the Data Hub Catalog and Studio Pro 
 * **Non-Discoverable** – the asset is only visible to owners, Data Hub curators, and the Data Hub Admin in the Catalog; it is not included in the search results in the **Data Hub** pane of Studio Pro, or any other client of the Data Hub API.
 
-### 6.5 Validated
+#### 3.6.5 Validated
 
 Indicates if the data source has been **Validated**. See [Curate Bar](#curate-bar) for changing **Validated** as an owner or curator.
 
-### 6.6 Application
+#### 3.6.6 Application
 
 A link to the application from which the data source was published in the given environment.
 
-### 6.7 Environment Type
+#### 3.6.7 Environment Type
 
 The environment type indicates the quality and the status of the data that the exposed datasets connect to. The following environment types can be specified:
 
@@ -224,7 +432,7 @@ The environment type indicates the quality and the status of the data that the e
 * **Non-Production**
 * **Sandbox** (the Mendix Free App environment)
 
-## 7 Curate Bar {#curate-bar}
+### 3.7 Curate Bar {#curate-bar}
 
 The **Curate Bar** is displayed in the asset detail screen if you are the owner of the selected asset or a curator:
 
@@ -238,11 +446,11 @@ The following actions can be carried out:
 
 For further details, see [Curate Registered Assets](./curate).
 
-## 8 Data Source and Dataset URIs
+### 3.8 Data Source and Dataset URIs
 
 The data source URI is the location of the service contract of the data source – also known as the service endpoint. The endpoints of all exposed datasets (entity sets) are defined in the contract. From the details screen of the data source and dataset, you can copy the URIs to the clipboard by clicking the **Copy Data Source URI** and **Copy Dataset URI** respectively. These URIs can be used for directly accessing the contract and resource in BI applications.
 
-## 9 Download the Metadata Contract of a Data Source {#download-contract}
+### 3.9 Download the Metadata Contract of a Data Source {#download-contract}
 
 For a selected data source, you can click **Download** to download the OData service contract that is located at the data source endpoint. A `.zip` file that includes the all the files that make up the full metadata contract is generated and downloaded.
 
@@ -260,6 +468,6 @@ When you click **Download** the following file is downloaded: `DataHub_SAP_Intel
 
 This zip file has the folder: `DataHub_SAP_Intelligence_1.0_OData4` which contains the all the metadata files that define the service.
 
-## 10 Viewing Search Results in the Data Hub Landscape
+### 3.10 Viewing Search Results in the Data Hub Landscape
 
 When an item is selected in the search results pane, you can click the [Landscape](/data-hub/data-hub-landscape/) tab to see the network of connections and dependencies for the selected asset. This provides a graphical representation to indicate the context and relevance of a selected item and the data for the exposed datasets.


### PR DESCRIPTION
Still to do:
- add search API details to search page
- edit registration page so it's clear the token can be used for any API
- remove sections 2 and 6 from the APIs page, maybe more