### PR TITLE
Add note about local notification event limitation

### DIFF
--- a/content/howto/mobile/local-notif-action.md
+++ b/content/howto/mobile/local-notif-action.md
@@ -26,6 +26,12 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 In this section you will learn to show a page when a user taps a notification.
 
+{{% alert type="info" %}}
+Local notifications do not support **On recieve** events.
+{{% /alert %}}
+
+To get started, do the following:
+
 1.  Drag and drop a **Notifications** widget onto your native home page. 
 
 	{{% image_container width="400" %}}![notifications widget](attachments/native-push/notif-widget.png){{% /image_container %}}
@@ -33,7 +39,7 @@ In this section you will learn to show a page when a user taps a notification.
 2. Double-click the widget.
 3. Click **Actions** > **New**. 
 4. Name your action *show_page*.
-5. Select **On open to** > **Show a Page**. Note: local notifications do not support **On receive** events.
+5. Select **On open to** > **Show a Page** (see the note above concerning **On receive** events).
 6. Click **New** to make a new page.
 7. Type *NotifPage* into **Page Name**.
 8. Click **Blank** pane on the left and select the **Blank** page template. 

--- a/content/howto/mobile/local-notif-action.md
+++ b/content/howto/mobile/local-notif-action.md
@@ -33,7 +33,7 @@ In this section you will learn to show a page when a user taps a notification.
 2. Double-click the widget.
 3. Click **Actions** > **New**. 
 4. Name your action *show_page*.
-5. Select **On open to** > **Show a Page**.
+5. Select **On open to** > **Show a Page**. Note: local notifications do not support **On receive** events.
 6. Click **New** to make a new page.
 7. Type *NotifPage* into **Page Name**.
 8. Click **Blank** pane on the left and select the **Blank** page template. 

--- a/content/howto/mobile/local-notif-data.md
+++ b/content/howto/mobile/local-notif-data.md
@@ -221,6 +221,12 @@ Next you are going to create a show page action for **ON_tapNotification**.
 
 Now you will set up a data view on your home page.
 
+{{% alert type="info" %}}
+Local notifications do not support **On recieve** events.
+{{% /alert %}}
+
+Do the following:
+
 1. Drag and drop a **Data View** widget on your **Home_Native** page.
 2. Double-click your data view.
 3. Select **Data source** > **Type** > **Nanoflow**.
@@ -238,7 +244,7 @@ Now you will set up a data view on your home page.
 	{{% image_container width="500" %}}![guid string](attachments/native-push/set-guid-string.png){{% /image_container %}}
 
 9. Click **Actions** > **New**.
-10. Create a **New Action** named *OpenPageWithParams*, set **On open** to **Call a nanoflow**, and select **ON_tapNotification**. Note: local notifications do not support **On receive** events.
+10. Create a **New Action** named *OpenPageWithParams*, set **On open** to **Call a nanoflow**, and select **ON_tapNotification** (see the note above concerning **On receive** events).
 
 	{{% image_container width="500" %}}![notification action](attachments/native-push/notif-action-2.png){{% /image_container %}}
 

--- a/content/howto/mobile/local-notif-data.md
+++ b/content/howto/mobile/local-notif-data.md
@@ -238,7 +238,7 @@ Now you will set up a data view on your home page.
 	{{% image_container width="500" %}}![guid string](attachments/native-push/set-guid-string.png){{% /image_container %}}
 
 9. Click **Actions** > **New**.
-10. Create a **New Action** named *OpenPageWithParams*, set **On open** to **Call a nanoflow**, and select **ON_tapNotification**.
+10. Create a **New Action** named *OpenPageWithParams*, set **On open** to **Call a nanoflow**, and select **ON_tapNotification**. Note: local notifications do not support **On receive** events.
 
 	{{% image_container width="500" %}}![notification action](attachments/native-push/notif-action-2.png){{% /image_container %}}
 


### PR DESCRIPTION
Based on [this ticket](https://mendix.atlassian.net/browse/NC-377), the Notifications widget (available in [Native Mobile Resources 3.1.0](https://marketplace.mendix.com/link/component/109513)) was updated to handle local notification events. However, based on the dependency used in code, "On receive" events are not supported in the local notification context.

This MR updates certain howto's to make this clear.