### PR TITLE
New icon files in the pluggable widget package (PAG-1620)

### DIFF
--- a/content/apidocs-mxsdk/apidocs/pluggable-widgets.md
+++ b/content/apidocs-mxsdk/apidocs/pluggable-widgets.md
@@ -50,9 +50,12 @@ A widget package file is just a ZIP archive containing the following things:
 * A *package.xml* file describing the whole package
 * A widget definition XML file, preferably located in *{widgetName}.xml* where `widdgetName` is the last part of widget [ID](#widget-id)
 * A client component of a widget located, for example, in  `com/mendix/widget/MyProgressCircle.js` for a widget with the ID `com.mendix.widget.MyProgressCircle`
-* Optionally, a widget preview for Studio and Studio Pro’s Design mode located in *{widgetDefinitionXmlName}.editorPreview.js*
+* Optionally, a widget preview for Studio and Studio Pro’s Design mode located in *{widgetName}.editorPreview.js*
+* Optionally, widget icons (*Note: these need to be PNG format*):
+    * *{widgetName}.icon.png* sets the widget icon inside the Studio Pro toolbox in list view. The ideal image size is 64x64 pixels, but other sizes will be resized to fit.
+    * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view, as well as in Studio. The ideal image size is 256x192 pixels, but other sizes will be resized to fit.
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-	* Note that all CSS files you add, except the one located in the `lib` sub-directory, will automatically be loaded in an app via the widget
+	* Note that all CSS files you add, except the one located in the `lib` sub-directory, will automatically be loaded in an app via the widget.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 
 
@@ -81,8 +84,6 @@ A simple widget XML file might look like this:
     <?xml version="1.0" encoding="utf-8" ?>
     <widget [attibutes]>
         <name>{User friendly widget name}</name>
-        <icon>{base64 encoded icon}</icon>
-    
         <properties>
             [properties]
         </properties>
@@ -118,7 +119,6 @@ After widget attributes, you will see a description of a widget that will be pre
 
 ```xml
 	<name>My Progress Card</name>
-	<icon>[image base64]</icon>
 ```
 In Mendix Studio Pro, the widget described above would look like this:
 

--- a/content/apidocs-mxsdk/apidocs/pluggable-widgets.md
+++ b/content/apidocs-mxsdk/apidocs/pluggable-widgets.md
@@ -48,14 +48,14 @@ Manually building a widget package can be difficult, so Mendix recommends you us
 A widget package file is just a ZIP archive containing the following things:
 
 * A *package.xml* file describing the whole package
-* A widget definition XML file, preferably located in *{widgetName}.xml* where `widdgetName` is the last part of widget [ID](#widget-id)
-* A client component of a widget located, for example, in  `com/mendix/widget/MyProgressCircle.js` for a widget with the ID `com.mendix.widget.MyProgressCircle`
+* A widget definition XML file, preferably located in *{widgetName}.xml* where `widgetName` is the last part of widget [ID](#widget-id)
+* A client component of a widget located, for example, in  *com/mendix/widget/MyProgressCircle.js* for a widget with the ID `com.mendix.widget.MyProgressCircle`
 * Optionally, a widget preview for Studio and Studio Pro’s Design mode located in *{widgetName}.editorPreview.js*
-* Optionally, widget icons (*Note: these need to be PNG format*):
-    * *{widgetName}.icon.png* sets the widget icon inside the Studio Pro toolbox in list view. The ideal image size is 64x64 pixels, but other sizes will be resized to fit.
-    * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view, as well as in Studio. The ideal image size is 256x192 pixels, but other sizes will be resized to fit.
+* Optionally, widget icons (which must be the PNG format):
+    * *{widgetName}.icon.png* sets the widget icon inside the Studio Pro toolbox in list view (the ideal image size is 64x64 pixels, but other sizes will be resized to fit)
+    * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view, as well as in Studio (the ideal image size is 256x192 pixels, but other sizes will be resized to fit)
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-	* Note that all CSS files you add, except the one located in the `lib` sub-directory, will automatically be loaded in an app via the widget.
+	* Note that all CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 
 

--- a/content/howto/extensibility/build-native-widget.md
+++ b/content/howto/extensibility/build-native-widget.md
@@ -1090,83 +1090,9 @@ First change the widget property configuration:
 
 	![Group box icon](attachments/build-native-widget/group-box.png)
 
-	b. Generate a Base64 representation of the *.png* file:
+	b. Rename the file to GroupBox.icon.png
 
-	**— For Windows**:
-
-	i. Open command prompt.<br />
-	ii. Change your current working directory to the folder where *GroupBox.png* is stored.<br />
-	iii. Execute the following command to generate the Base64 representation:<br />
-	
-	```shell
-	$ certutil -encode GroupBox.png data.b64
-	```
-	
-	Upon success, you will see a **data.b64** file in the same location as your original image.
-	
-	**— For Unix**:
-	
-	i. Open a terminal.<br />
-	ii. Change the current working directory to the folder where the "GroupBox.png" is stored.<br />
-	iii. Execute the following command to generate the Base64 representation:<br />
-	
-	```shell
-	$ base64 -i GroupBox.png -o data.b64
-	```
-	
-	Upon success, you will see a **data.b64** file in the same location as your original image.
-	
-	c. Add **data.b64** to the icon element in the *.xml* file. For ease, the contents of the file you made is included below. You can simply copy and paste this snippet with its binary Base64 representation included into your *xml* file:
-
- 	```xml
- 	<?xml version="1.0" encoding="utf-8" ?>
- 	<widget id="com.mendix.widget.native.groupbox.GroupBox" pluginWidget="true" offlineCapable="true" supportedPlatform="Native"
- 		xmlns="http://www.mendix.com/widget/1.0/"
- 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
- 		<name>Group box</name>
- 		<description />
- 		<icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAAHdbkFIAAAAAXNSR0IArs4c6QAA ArVJREFUeAHtWk12gjAQBl4X9Q72PsVFnxufN+ihegOfG18XtfeRO9gVNBMZDPlx gIAQGDcxmczMN99MQohGkc9nt9sVCWVgChNiAAloKbBuOaU9hTBJDPGjKI7HYyyJ 2u/3aZ7nP24y7BIw8AIiUIZO+v2XFnlhGPrdrmqOYC4i80oVGJLY0JodqH0UdUgW 7er30fEN3LGM9c0njZlI45sEjilpEwXqyEpExffT1Vj7AmJ23q6kp1Lp7lko1gxg yaJBva0qTxFUBhCSImv+tYsy6oxfiYwgirw56KeQmpfcBGfetnUBDEv7WRhxYVc5 QMcowH7frR6oAQAdpqfrRWxua+xTrb6VCUcXoVPpuwJzAsBNlHLskguHt+3eNaEc NwDoFBH63mIDgIsqb0+lAT1A753EFxgDYAaYAXUfyMSSWuvr1HeZsf7kGVAPJLXH 55DIkyTZHA6HM/hQl2H17B7SOdhWrwXUVSD9Lu5paDCA9Lc5ksVJvDl/vMqcor56 JFNzjnJs1RrAMdm2OQ9GefFVU751qpoSObfJ5SwnA/oh0+Lg4VDTWnIy8NB6j0KD gWc/C6bHQNPcdc2CzvDoDDAAZoAZYAaYAWaAGVjsiSjreqBhPWZgbgxU9yMYmPpO i2Mzams/HUNctgdB9U49o8AxFCM24zmAM7Ed+j0R/QzV6u+huh9bBehzZt0nK0CP vs29ma5L9dW/e7jmEnuUscZddnC8fQUk8ScARQN9tdKmsE3ZE5eNMMfmPytllIma vHUFlDehjX4PrnnqqVPervfmv30F9BTIVMyQFUDtolMJpCsOrgCKOT4HUAwFLl/8 EmACAq9gb/hcAd4UBm6AKyDwBHrD5wrwpjBwA1wBgSfQGz5XgDeFgRtYfAXwjZBe wfAXTzFmu3XVp4bWh1tjiI0/zIDCwD+0qr6OmQMSvQAAAABJRU5ErkJggg==</icon>
- 		<properties>
- 			<propertyGroup caption="General">
- 				<propertyGroup caption="General">
- 					<property key="content" type="widgets" required="false">
- 						<caption>Content</caption>
- 						<description>Widgets to place inside.</description>
- 					</property>
- 					<property key="collapsible" type="enumeration" defaultValue="no">
- 						<caption>Collapsible</caption>
- 						<description />
- 						<enumerationValues>
- 							<enumerationValue key="no">No</enumerationValue>
- 							<enumerationValue key="yesStartExpanded">Yes (start expanded)</enumerationValue>
- 							<enumerationValue key="yesStartCollapsed">Yes (start collapsed)</enumerationValue>
- 						</enumerationValues>
- 					</property>
- 				</propertyGroup>
- 				<propertyGroup caption="Header">
- 					<property key="headerCaption" type="string" required="false">
- 						<caption>Caption</caption>
- 						<description />
- 					</property>
- 					<property key="expandIcon" type="icon" required="false">
- 						<caption>Expand icon</caption>
- 						<description>Icon used to indicate that the group box can be expanded.</description>
- 					</property>
- 					<property key="collapseIcon" type="icon" required="false">
- 						<caption>Collapse icon</caption>
- 						<description>Icon used to indicate that the group box can be collapsed.</description>
- 					</property>
- 				</propertyGroup>
- 				<propertyGroup caption="Common">
- 					<systemProperty key="Name" />
- 					<systemProperty key="Visibility" />
- 				</propertyGroup>
- 			</propertyGroup>
- 		</properties>
- 	</widget>
- 	```
-
-5. Save the *.xml* file.
+	c. Add the file to the *src* folder which contains the *xml* file
 
 Now support this section's two features with your display component:
 

--- a/content/howto/extensibility/build-native-widget.md
+++ b/content/howto/extensibility/build-native-widget.md
@@ -1094,6 +1094,9 @@ First change the widget property configuration:
 
 	c. Add the file to the *src* folder which contains the *xml* file
 
+	{{% alert type="info" %}}This functionality was introduced in Studio Pro 9.6. If the widget icon needs to be shown in Studio Pro 9.5 and below, the icon needs to be added to the xml file. To do this, please follow the steps from the [Mendix 8 documentation](/howto8/extensibility/build-native-widget#adding-a-collapsible-property).
+	{{% /alert %}}
+
 Now support this section's two features with your display component:
 
 1. Navigate to the display component **src/components/GroupBox.tsx**.

--- a/content/howto/extensibility/build-native-widget.md
+++ b/content/howto/extensibility/build-native-widget.md
@@ -1090,11 +1090,11 @@ First change the widget property configuration:
 
 	![Group box icon](attachments/build-native-widget/group-box.png)
 
-	b. Rename the file to GroupBox.icon.png
+	b. Rename the file to *GroupBox.icon.png*
 
 	c. Add the file to the *src* folder which contains the *xml* file
 
-	{{% alert type="info" %}}This functionality was introduced in Studio Pro 9.6. If the widget icon needs to be shown in Studio Pro 9.5 and below, the icon needs to be added to the xml file. To do this, please follow the steps from the [Mendix 8 documentation](/howto8/extensibility/build-native-widget#adding-a-collapsible-property).
+	{{% alert type="info" %}}This functionality was introduced in Studio Pro v9.6. To show a widget icon in Studio Pro v9.5 or below, the icon needs to be added to the *xml* file. To do this, follow the steps from the [Mendix 8](/howto8/extensibility/build-native-widget#adding-a-collapsible-property) version of this document.
 	{{% /alert %}}
 
 Now support this section's two features with your display component:

--- a/content/howto8/extensibility/build-native-widget.md
+++ b/content/howto8/extensibility/build-native-widget.md
@@ -981,7 +981,7 @@ Fix your icon issue by introducing a default style for your container component:
 	
 	![collapsed with euro](attachments/build-native-widget/8-collapsed-w-euro-sign.png)
 
-#### 3.3.7 Adding a Collapsible Property
+#### 3.3.7 Adding a Collapsible Property {#adding-a-collapsible-property}
 
 You are close to completing your group box widget. There are two more features essential for a Mendix developer: setting if the group box should be collapsible and setting the initial state of being collapsed or not.
 


### PR DESCRIPTION
This documents the Studio Pro 9.6 ability to simply add widget icons to the package, instead of having to convert them to base64 first and then adding them to the XML file. Also, we added the ability to add a tile image for the new tile view (also starting 9.6).