### PR TITLE
Add note about Native Mobile Resources version file

### DIFF
--- a/content/appstore/modules/native-mobile-resources.md
+++ b/content/appstore/modules/native-mobile-resources.md
@@ -31,7 +31,7 @@ For excellent deep-dive demonstrations of how to use these native mobile widgets
 />
 
 {{% alert type="info" %}}
-Native Mobile Resources releases v3.1.3 and above will indicate their version inside *themesource/nativemobileresources/.version* located in the project directory. Versions below v3.1.3 included a constant in the module indicating version.
+Native Mobile Resources v3.1.4 and above will indicate their version inside *themesource/nativemobileresources/.version* located in the project directory. Versions v3.1.3 and below included a constant in the module indicating version.
 {{% /alert %}}
 
 ## 2 Native Widgets

--- a/content/appstore/modules/native-mobile-resources.md
+++ b/content/appstore/modules/native-mobile-resources.md
@@ -31,7 +31,7 @@ For excellent deep-dive demonstrations of how to use these native mobile widgets
 />
 
 {{% alert type="info" %}}
-Native Mobile Resources releases v3.1.3 and above will indicate their version inside **themesource/nativemobileresources/.version** located in the project directory. Versions below v3.1.3 included a constant in the module indicating version.
+Native Mobile Resources releases v3.1.3 and above will indicate their version inside *themesource/nativemobileresources/.version* located in the project directory. Versions below v3.1.3 included a constant in the module indicating version.
 {{% /alert %}}
 
 ## 2 Native Widgets

--- a/content/appstore/modules/native-mobile-resources.md
+++ b/content/appstore/modules/native-mobile-resources.md
@@ -31,7 +31,7 @@ For excellent deep-dive demonstrations of how to use these native mobile widgets
 />
 
 {{% alert type="info" %}}
-Releases of Native Mobile Resources after v3.1.3 will indicate their version in a file located in **themesource/nativemobileresources/.version** in the project directory, whereas previous versions included a constant in the module.
+Native Mobile Resources releases v3.1.3 and above will indicate their version inside **themesource/nativemobileresources/.version** located in the project directory. Versions below v3.1.3 included a constant in the module indicating version.
 {{% /alert %}}
 
 ## 2 Native Widgets

--- a/content/appstore/modules/native-mobile-resources.md
+++ b/content/appstore/modules/native-mobile-resources.md
@@ -30,6 +30,10 @@ For excellent deep-dive demonstrations of how to use these native mobile widgets
   data-type="inline"
 />
 
+{{% alert type="info" %}}
+Releases of Native Mobile Resources after v3.1.3 will indicate their version in a file located in **themesource/nativemobileresources/.version** in the project directory, whereas previous versions included a constant in the module.
+{{% /alert %}}
+
 ## 2 Native Widgets
 
 These are the native widgets included in these resources along with links to the GitHub repositories where they are stored (with further documentation as necessary):


### PR DESCRIPTION
Due to our automation workflow, we decided to remove the constant from the module and use a file with a version string to indicate the module's version.

This MR adds an explicit note about this, as an info alert.