### PR TITLE
Specifics on licensing limit error messages

### DIFF
--- a/content/refguide/consumed-odata-service-requirements.md
+++ b/content/refguide/consumed-odata-service-requirements.md
@@ -105,3 +105,13 @@ With a Data Hub license, apps are not limited.
 {{% alert type="info" %}}Apps running in development environments (and also when running from the Studios) do not have this limitation. This means that you can run your app from the Studios without Data Hub license limitations.{{% /alert %}}
 
 Contact your [Mendix Admin](/developerportal/control-center/#company) or Data Hub Admin to find out what type of Data Hub license your organization has.
+
+### 4.1 Licence Limitation Errors
+The app instance logs for each call how many objects it has retrieved, and how many are left within the license limitation. Once the limit of a 1000 objects has been reached we'll log two different statements:
+
+1. On `info` level we log the following statement when the limit is reached:
+`"Exceeded the daily limit. Retrieved $delta objects, which would increase the counter to $newCount (of max $max per day)."`
+2. On `error` level we log the following statement when the limit is reached:
+`"The limit of $max objects has been reached."`
+
+    ***Note:** It’s up to the application to communicate to its end-users that the daily limit has been reached, if this is not done, the end-user will get a message that an error occurred.*

--- a/content/refguide/consumed-odata-service-requirements.md
+++ b/content/refguide/consumed-odata-service-requirements.md
@@ -94,24 +94,29 @@ An OData v3 association can only be used if it has two ends.
 
 An OData v4 navigation property can only be used as an association if it has a partner.
 
-## 4 Data Hub License Limitations {#license-limitations}
+## 4 Data Hub License
 
-Mendix Data Hub is a separately licensed product.
+### 4.1 Limitations {#license-limitations}
 
-Without a license, an app can retrieve a total of 1000 OData objects per day for each runtime instance. After that limit is exceeded, an error will occur when users try to retrieve more data. The number of consumed objects per day is reset at midnight in the timezone of the Mendix Runtime scheduler (which can be defined in the app [Project Settings](project-settings#scheduled)).
+Mendix Data Hub is a separately licensed product. 
 
-With a Data Hub license, apps are not limited.
+Without a license, an app can retrieve a total of 1000 OData objects per day for each runtime instance. After that limit is exceeded, an error occurs when users try to retrieve more data. The number of consumed objects per day is reset at midnight in the time zone of the Mendix Runtime scheduler (which can be defined in the [Scheduled Event Time Zone](project-settings#scheduled) of the **App Settings**).
 
-{{% alert type="info" %}}Apps running in development environments (and also when running from the Studios) do not have this limitation. This means that you can run your app from the Studios without Data Hub license limitations.{{% /alert %}}
+With a Data Hub license, apps are not limited in retrieving OData objects.
 
-Contact your [Mendix Admin](/developerportal/control-center/#company) or Data Hub Admin to find out what type of Data Hub license your organization has.
+{{% alert type="info" %}}
+Apps running in development environments (and also when running from the Studios) do not have this limitation. This means that you can run your app from the Studios without Data Hub license limitations.
+{{% /alert %}}
 
-### 4.1 Licence Limitation Errors
-The app instance logs for each call how many objects it has retrieved, and how many are left within the license limitation. Once the limit of a 1000 objects has been reached we'll log two different statements:
+Contact your [Mendix Admin](/developerportal/control-center/#company) to find out what type of Data Hub license your organization has.
 
-1. On `info` level we log the following statement when the limit is reached:
-`"Exceeded the daily limit. Retrieved $delta objects, which would increase the counter to $newCount (of max $max per day)."`
-2. On `error` level we log the following statement when the limit is reached:
-`"The limit of $max objects has been reached."`
+### 4.1 Limitation Errors
 
-    ***Note:** It’s up to the application to communicate to its end-users that the daily limit has been reached, if this is not done, the end-user will get a message that an error occurred.*
+For each call, the app instance logs how many objects it has retrieved and how many are left within the license limitation. Once the limit of a 1000 objects has been reached, two different statements are logged.
+
+* On the `info` level, the following statement is logged when the limit is reached: `"Exceeded the daily limit. Retrieved $delta objects, which would increase the counter to $newCount (of max $max per day)."`
+* On the `error` level, the following statement is logged when the limit is reached: `"The limit of $max objects has been reached."`
+
+{{% alert type="warning" %}}
+It is up to the application to communicate to its end-users that the daily limit has been reached. If this is not done, the end-user gets a message that an error occurred.
+{{% /alert %}}


### PR DESCRIPTION
Added a section that describes how to notice that an application has exceeded the Free licence limit.