### PR TITLE
Update expressions.md

### DIFF
--- a/content/studio/expressions.md
+++ b/content/studio/expressions.md
@@ -45,7 +45,7 @@ Attributes and associations of objects are accessed using a slash (for example, 
 You can use brackets to determine the priority and associativity of calculations. For example, the **SellingPrice** is being calculated based on the default **Price** and **Discount** attributes:
 
 ```
-$CurrentPrice/Price - (($CurrentPrice/Price **div** 100) * $OrderLine/Discount)
+$CurrentPrice/Price - (($CurrentPrice/Price div 100) * $OrderLine/Discount)
 ```
 
 Arithmetic functions (subtraction, dividing, and multiplying) are being combined here.


### PR DESCRIPTION
example in paragraph 2.1 contained markdown inside the code part. 
Which rendered the example incorrect.