### PR TITLE
Document Offline-first and Access Rules with XPath Constraints

### DIFF
--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -267,3 +267,7 @@ Excel and CSV export are not available in offline applications.
 ### 4.9 Hashed String Attributes {#hashed-strings}
 
 Attributes with the hashed string [attribute type](attributes#type) will not be synchronized.
+
+### 4.10 Access Rules with XPath Constraints
+
+Offline-first apps can not apply access rules with XPath constraints while working offline. For example, you can change and commit an object in a nanoflow in a way that starts satisfying the XPath constraint of an access rule. In this case, the member accesses defined in the access rule will not be applied until you synchronize the object. 

--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -268,6 +268,6 @@ Excel and CSV export are not available in offline applications.
 
 Attributes with the hashed string [attribute type](attributes#type) will not be synchronized.
 
-### 4.10 Access Rules with XPath Constraints
+### 4.10 Access Rules with XPath Constraints {#access-rules}
 
-OOffline-first apps can not apply access rules with XPath constraints while working offline. For example, consider a Customer entity with Locked (boolean) and Name  (string) attributes. There is an access rule where the Name attribute of the customer is writable only when Locked attribute is false. Changing (and committing) the Locked attribute’s value in offline will not change the read-only status of the Name attribute. It will take effect after you synchronize the changed Customer object.
+While working offline, offline-first apps cannot apply access rules with XPath constraints. For example, consider a **Customer** entity with **Locked** (Boolean) and **Name** (string) attributes. There is an access rule where the **Name** attribute of the customer is writable only when the **Locked** attribute is false. Changing and committing the **Locked** attribute’s value while offline will not change the read-only status of the **Name** attribute. Instead, this change will take effect after you synchronize the changed **Customer** object.

--- a/content/refguide/offline-first.md
+++ b/content/refguide/offline-first.md
@@ -270,4 +270,4 @@ Attributes with the hashed string [attribute type](attributes#type) will not be 
 
 ### 4.10 Access Rules with XPath Constraints
 
-Offline-first apps can not apply access rules with XPath constraints while working offline. For example, you can change and commit an object in a nanoflow in a way that starts satisfying the XPath constraint of an access rule. In this case, the member accesses defined in the access rule will not be applied until you synchronize the object. 
+OOffline-first apps can not apply access rules with XPath constraints while working offline. For example, consider a Customer entity with Locked (boolean) and Name  (string) attributes. There is an access rule where the Name attribute of the customer is writable only when Locked attribute is false. Changing (and committing) the Locked attribute’s value in offline will not change the read-only status of the Name attribute. It will take effect after you synchronize the changed Customer object.


### PR DESCRIPTION
Added a section to explain that offline apps do not take access rules with XPath constraints into account while working offline.