### PR TITLE
Release notes for DataHub Catalog 2.1 release.

### DIFF
--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -13,7 +13,7 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 #### Fixes
 
-* We fixed an issue where searching in the Data Hub pane in Studio Pro would cause an error in some cases.
+* We fixed an issue where searching in the [Data Hub pane](/refguide/data-hub-pane) in Studio Pro caused an error.
 
 ### September 23rd, 2021
 

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -9,6 +9,12 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 ## 2021
 
+### September 30th, 2021
+
+#### Fixes
+
+* We fixed an issue where searching in the Data Hub pane in Studio Pro would cause an error in some cases.
+
 ### September 23rd, 2021
 
 #### Data Hub Free Edition

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -9,7 +9,7 @@
 	<li><a href="/releasenotes/mobile/nt-6-rn">Native Template 6.2.2</a> – Aug 9th, 2021</li>	
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Sep 23rd, 2021</li>
 	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Sep 27th, 2021</li>
-	<li><a href="/releasenotes/data-hub">Data Hub</a> – Sep 23rd, 2021</li>
+	<li><a href="/releasenotes/data-hub">Data Hub</a> – Sep 30th, 2021</li>
 	<li><a href="/releasenotes/app-store">Marketplace</a> – Sep 7th, 2021</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.54.0</a> – Aug 23rd, 2021</li>
 	<li><a href="/releasenotes/sdk/metamodel-9.5">Metamodel 9.5.0</a> – Aug 23rd, 2021</li>


### PR DESCRIPTION
To be released on Thursday, Sep 30, 8:00 CEST