### PR TITLE
Clarify difference between Free Apps and Unlicensed Apps

### DIFF
--- a/content/developerportal/deploy/licensing-apps-outside-mxcloud.md
+++ b/content/developerportal/deploy/licensing-apps-outside-mxcloud.md
@@ -14,9 +14,11 @@ tags: ["App", "Developer Portal", "License", "Subscription Secret", "Upgrade", "
 
 ## 1 Introduction
 
-Mendix allows you to build **Free Apps** which give you the opportunity to try things out and to build and test apps using all the functionality of Mendix. You can deploy these to the Mendix Cloud, or to another public or private cloud of your choice, for example SAP Business Technology Platform (SAP BTP).
+On the Mendix Cloud, you can build **Free Apps** which give you the opportunity to try things out and to build and test apps using all the functionality of Mendix.
 
-However, Free Apps are restricted in how long they run; they will stop running after around 2 hours. If they are run outside the Mendix Cloud, they cannot have more than ten users. There are also restrictions on how they can be configured. A full list of restrictions is available in [Mendix Cloud](mendix-cloud-deploy) – note that some of these restrictions are specific to Free Apps running on Mendix Cloud.
+You can also deploy apps without a license to another public or private cloud of your choice, for example SAP Business Technology Platform (SAP BTP).
+
+However, Free Apps are restricted in how long they run; they will stop running after around 2 hours. Unlicensed apps, running outside the Mendix Cloud, also have these restrictions and, in addition, can only support six concurrent users. There are also restrictions on how Free Apps and unlicensed apps can be configured. A full list of restrictions is available in [Mendix Cloud](mendix-cloud-deploy) – note that some of these restrictions are specific to Free Apps running on Mendix Cloud.
 
 To use your app in a production environment, you need to license it. The method for doing this differs depending on the environment to which you are deploying your app.
 

--- a/content/developerportal/deploy/licensing-apps-outside-mxcloud.md
+++ b/content/developerportal/deploy/licensing-apps-outside-mxcloud.md
@@ -14,11 +14,20 @@ tags: ["App", "Developer Portal", "License", "Subscription Secret", "Upgrade", "
 
 ## 1 Introduction
 
-On the Mendix Cloud, you can build **Free Apps** which give you the opportunity to try things out and to build and test apps using all the functionality of Mendix.
+On the Mendix Cloud, you can build [Free Apps](mendix-cloud-deploy#free-app) which give you the opportunity to try things out and to build and test apps using all the functionality of Mendix.
 
-You can also deploy apps without a license to another public or private cloud of your choice, for example SAP Business Technology Platform (SAP BTP).
+You can also deploy apps without a license to another public or private cloud of your choice, for example SAP Business Technology Platform (SAP BTP). This gives you the opportunity to try things out and to build and test apps using both the functionality of Mendix and your target cloud.
 
-However, Free Apps are restricted in how long they run; they will stop running after around 2 hours. Unlicensed apps, running outside the Mendix Cloud, also have these restrictions and, in addition, can only support six concurrent users. There are also restrictions on how Free Apps and unlicensed apps can be configured. A full list of restrictions is available in [Mendix Cloud](mendix-cloud-deploy) – note that some of these restrictions are specific to Free Apps running on Mendix Cloud.
+Unlicensed apps, running outside the Mendix Cloud, have a number of restrictions which are listed in the table below:
+
+| Feature | Unlicensed App | Licensed App |
+| --- | --- | --- |
+| **Number of Concurrent Users** | 6 | Depends on your pricing plan.¹ |
+| **Sleep Mode** | Goes into Sleep Mode after two hours or so of inactivity and automatically resumes when a user accesses it. All your data is retained while the app is in Sleep Mode. | Does not have a Sleep Mode. |
+| **Number of Named Users** | No Limit | Depends on your pricing plan.¹ |
+| **Data Hub** | No Limit | Depends on your pricing plan.¹ |
+
+¹ The Mendix pricing plans are listed in [Mendix Pricing Plans](#plans), below. More information on the capabilities of different license options is available on [Mendix Platform Pricing](http://www.mendix.com/pricing).
 
 To use your app in a production environment, you need to license it. The method for doing this differs depending on the environment to which you are deploying your app.
 

--- a/content/developerportal/deploy/mendix-cloud-deploy.md
+++ b/content/developerportal/deploy/mendix-cloud-deploy.md
@@ -24,7 +24,7 @@ A Free App has a number of limitations compared to a licensed app. The main limi
 
 | Feature | Free App | Licensed App |
 | --- | --- | --- |
-| **Number of Users** | Unlimited users. | Depends on your pricing plan.¹ |
+| **Number of Users** | Unlimited users.¹ | Depends on your pricing plan.² |
 | **Sleep Mode** | Goes into Sleep Mode after an hour or so of inactivity and automatically resumes when a user accesses it. All your data is retained while the app is in Sleep Mode. | Does not have a Sleep Mode. |
 | **Disk Storage** | 0.5Gb Database and 1Gb Files. | Depends on your pricing plan.¹ |
 | **App vCPU**s | 0.5 | Depends on your pricing plan.¹ |
@@ -43,7 +43,9 @@ A Free App has a number of limitations compared to a licensed app. The main limi
 | **Backups** | Performed daily, cannot be triggered manually. Stored up to two weeks. |Performed daily, can also be created manually. Kept for up to one year, depending on your plan. |
 | **Support** | No Support. | Depending on license option. |
 
-¹The Mendix pricing plans are listed in [Mendix Pricing Plans](#plans), below. More information on the capabilities of different license options is available on [Mendix Platform Pricing](http://www.mendix.com/pricing).
+¹ Unlicensed apps running on a different cloud platform (for example SAP BTP) have similar restrictions to Free Apps. They have additional restrictions, including only allowing six concurrent users.
+
+² The Mendix pricing plans are listed in [Mendix Pricing Plans](#plans), below. More information on the capabilities of different license options is available on [Mendix Platform Pricing](http://www.mendix.com/pricing).
 
 {{% alert type="info" %}}
 Free Apps are part of our Free Edition.

--- a/content/developerportal/deploy/mendix-cloud-deploy.md
+++ b/content/developerportal/deploy/mendix-cloud-deploy.md
@@ -26,8 +26,8 @@ A Free App has a number of limitations compared to a licensed app. The main limi
 | --- | --- | --- |
 | **Number of Users** | Unlimited users.¹ | Depends on your pricing plan.² |
 | **Sleep Mode** | Goes into Sleep Mode after an hour or so of inactivity and automatically resumes when a user accesses it. All your data is retained while the app is in Sleep Mode. | Does not have a Sleep Mode. |
-| **Disk Storage** | 0.5Gb Database and 1Gb Files. | Depends on your pricing plan.¹ |
-| **App vCPU**s | 0.5 | Depends on your pricing plan.¹ |
+| **Disk Storage** | 0.5Gb Database and 1Gb Files. | Depends on your pricing plan.² |
+| **App vCPU**s | 0.5 | Depends on your pricing plan.² |
 | **Scheduled Events** | Are not run. | Are run and can be configured from the Developer Portal. |
 | **Environments** | Single environment in the Mendix Cloud. | A node in the cloud which has one or more environments, for example, production, acceptance, and test. |
 | **Deployment** | Can only be deployed to the cloud from Mendix Studio or Studio Pro. | Can be deployed from the Studios, or from the Developer Portal. |

--- a/content/developerportal/deploy/private-cloud-deploy.md
+++ b/content/developerportal/deploy/private-cloud-deploy.md
@@ -73,7 +73,7 @@ First you need to create an environment:
 5. Select the **Purpose**.
    
   1. For development of the app, for example acceptance testing, choose **Development**.
-  2. For production deployment, select **Production**. If you select **Production**, then you will be asked for the **Subscription Secret** which ensures that your app runs as a licensed app. See [Free Apps](mendix-cloud-deploy#free-app) in *Mendix Cloud* for the differences between free/test apps and licensed apps.
+  2. For production deployment, select **Production**. If you select **Production**, then you will be asked for the **Subscription Secret** which ensures that your app runs as a licensed app. These restrictions on unlicensed/test apps are very similar to those listed in the [Free Apps](mendix-cloud-deploy#free-app) section of *Mendix Cloud*.
 
     {{% alert type="warning" %}}Your app can only be deployed to a production environment if [security in the app is set on](/refguide/project-security). You will not receive an error if security is set off, but the deployment will appear to hang with a spinner being displayed.{{% /alert %}}
 
@@ -435,9 +435,9 @@ If any of these garbage collection steps fail, you will no longer see the enviro
 
 ##### 5.1.3.7 Change Purpose
 
-This enables you to change the purpose of your app environment. You can label an environment as one used for development of the app, for example acceptance testing. In this case choose **Development** and the app will be deployed as a Free App.
+This enables you to change the purpose of your app environment. You can label an environment as one used for development of the app, for example acceptance testing. In this case choose **Development** and the app will be deployed as an unlicensed.
 
-For production deployment, select **Production**. If you select **Production**, then you will be asked for the Subscription Secret which ensures that your app runs as a licensed app. For the differences between free/test apps and licensed apps, see the [Free App](mendix-cloud-deploy#free-app) section in *Mendix Cloud*.
+For production deployment, select **Production**. If you select **Production**, then you will be asked for the Subscription Secret which ensures that your app runs as a licensed app. For the differences between unlicensed/test apps and licensed apps, see the [Free App](mendix-cloud-deploy#free-app) section in *Mendix Cloud*.
 
 {{% alert type="warning" %}}
 Your app can only be deployed to a production environment if [security in the app is set on](/refguide/project-security). You will not receive an error if security is set off, but the deployment will appear to hang with a spinner being displayed.

--- a/content/developerportal/deploy/private-cloud-operator.md
+++ b/content/developerportal/deploy/private-cloud-operator.md
@@ -168,7 +168,7 @@ You need to make the following changes:
 * **debuggerPassword** – here you can provide the password for the debugger — this is optional. Setting an empty `debuggerPassword` will disable the debugging features. In order to connect to the debugger in Studio Pro, enter the debugger URL as `<AppURL>/debugger/`. You can find further information in [How to Debug Microflows Remotely](/howto/monitoring-troubleshooting/debug-microflows-remotely)
 * **dtapmode** – for development of the app, for example acceptance testing, choose **D**, for production deployment, select **P**
 
-    If you select production, then you will need to provide a **Subscription Secret** to ensure that your app runs as a licensed app — see [Free Apps](mendix-cloud-deploy#free-app) in *Mendix Cloud* for the differences between free/test apps and licensed apps
+    If you select production, then you will need to provide a **Subscription Secret** to ensure that your app runs as a licensed app — see [Free Apps](mendix-cloud-deploy#free-app) in *Mendix Cloud* for the differences between unlicensed/test apps and licensed apps
     the subscription secret needs to be supplied via the **customConfiguration** using the following values:
 
     * `"License.SubscriptionSecret":"{subscription secret}"`

--- a/content/developerportal/deploy/tencent-deploy.md
+++ b/content/developerportal/deploy/tencent-deploy.md
@@ -577,9 +577,9 @@ If the environment cannot be deleted, you will receive a warning, but can go ahe
 
 ##### 6.1.3.7 Change Purpose
 
-This enables you to change the purpose of your app environment. You can label an environment as one used for development of the app, for example acceptance testing. In this case choose **Development** and the app will be deployed as a Free App.
+This enables you to change the purpose of your app environment. You can label an environment as one used for development of the app, for example acceptance testing. In this case choose **Development** and the app will be deployed as an unlicensed App.
 
-For production deployment, select **Production**. If you select **Production**, then you will be asked for the Subscription Secret which ensures that your app runs as a licensed app. For the differences between free/test apps and licensed apps, see the [Free App](mendix-cloud-deploy#free-app) section in *Mendix Cloud*.
+For production deployment, select **Production**. If you select **Production**, then you will be asked for the Subscription Secret which ensures that your app runs as a licensed app. For the differences between unlicensed/test apps and licensed apps, see the [Free App](mendix-cloud-deploy#free-app) section in *Mendix Cloud*.
 
 {{% alert type="warning" %}}
 Your app can only be deployed to a production environment if security is set on. You will not receive an error if security is set off, but the deployment will appear to hang with a spinner being displayed.

--- a/content/product-naming/other-terms.md
+++ b/content/product-naming/other-terms.md
@@ -134,7 +134,9 @@ Do not use "insta-deploy" or "instant redeploy."
 
 ### Free App {#free-app}
 
-A [Free App](/developerportal/deploy/mendix-cloud-deploy#free-app) is an app that can be deployed without a license and is therefore free. There are restrictions on the resources available to a Free App. A Free App environment is a cloud environment, but it does not support complex or large applications. Free Apps are part of the [Free Edition](#free-edition).
+A [Free App](/developerportal/deploy/mendix-cloud-deploy#free-app) is an app that can be deployed to the Mendix Cloud without purchasing a specific license and is therefore free. There are restrictions on the resources available to a Free App. A Free App environment is a cloud environment, but it does not support complex or large applications. Free Apps are part of the [Free Edition](#free-edition).
+
+This is different from an *Unlicensed App* which is an app deployed to an unlicensed environment on another cloud platform, such as SAP or Private Cloud.
 
 {{% alert type="info" %}}
 Capitalize in all instances.<br />


### PR DESCRIPTION
Free App was used in cases where the apps were actually _unlicensed_ apps.
The main difference is a limitation on the number of concurrent users in the unlicensed apps.