### PR TITLE
Removed a release note

### DIFF
--- a/content/releasenotes/studio-pro/9.6.md
+++ b/content/releasenotes/studio-pro/9.6.md
@@ -41,7 +41,6 @@ Finally, we have redesigned the [App Explorer](/refguide/project-explorer) with 
 ### Improvements
 
 * We have improved the speed of garbage collection by up to 100x in some cases. (Ticket 125380)
-* We expanded the logging of published OData services on the debug and trace levels so that headers and content are logged as well.
 * You can now use the [tab container](/refguide/tab-container) widget inside a [containment or repeatable containment](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types#widgets) pluggable widget.
 * You can now drag a microflow from the **App Explorer** into the editor and it will create a new system task automatically.
 * We renamed the **Image** and **Image Viewer** core widgets to [Static Image](/refguide/image) and [Dynamic Image](/refguide/image-viewer), respectively.


### PR DESCRIPTION
Removed a release note from Studio Pro 9.6, because that feature was not part of that release. This entered the release notes by accident.