### PR TITLE
[UFC-206] Added custom runtime setting for file document caching (mx9)

### DIFF
--- a/content/refguide/custom-settings.md
+++ b/content/refguide/custom-settings.md
@@ -57,6 +57,7 @@ The following custom settings can be configured:
 | **TempPath** | The location of the temporary files. | [deployment folder]\data\tmp |
 | **TrackWebServiceUserLastLogin** | Defines whether to update the web service user's `LastLogin` field on each login. When this happens a database update query has to be sent and this can have performance consequences on heavy load systems. When this setting is set to false, no database interaction is necessary. | true |
 | **UploadedFilesPath** | The location of the uploaded files. A valid path can be: `\\FileServer\CustomerPortalFiles`. | [deployment folder]\data\files |
+| **EnableFileDocumentCaching** | Defines whether file documents should be cached. Only enable this if you are sure that the file documents will not contain sensitive information. Images are always cached. | false |
 
 ## 3 Log File Settings
 


### PR DESCRIPTION
**From security team. This should be merged only after CVE has been published. Same for the other MRs**

Added the `EnableFileDocumentCaching` setting, which can be used to enable file document caching if desired. We are disabling this by default in the upcoming Mendix 9 version.