### PR TITLE
Add better sync failure messages to 9.7 changelog

### DIFF
--- a/content/releasenotes/studio-pro/9.7.md
+++ b/content/releasenotes/studio-pro/9.7.md
@@ -97,6 +97,7 @@ Since user tasks will most likely be re-captioned after addition.The generated e
 * We fixed the text color of folders in the tree view that displays when you are performing dragging-and-dropping actions.
 * We fixed an issue with the selected item in App Explorer that occurred when you start an app.
 * When [consuming an OData service](/refguide/consumed-odata-services) that has updatable entities with key attributes, these key attributes are no longer updatable. It was already recommended not to change the values of these attributes, and now it is no longer possible.
+* We fixed the log message that incorrectly stated that database changes were rolled back, even if that was not possible. We now log correctly when the changes are rolled back and when that was not possible.  (Ticket 129661)
 
 ### Known Issues
 


### PR DESCRIPTION
Minor, but still customer facing, improvement regarding how we let them know that the synchronization failure did not lead to a rollback.

Does not affect most of our customers running in our cloud since postgres works correctly in this regard.