### PR TITLE
Private Cloud - announcing support for new Kubernetes and Postgres versions [no release date]

### DIFF
--- a/content/developerportal/deploy/private-cloud-cli-non-interactive.md
+++ b/content/developerportal/deploy/private-cloud-cli-non-interactive.md
@@ -18,6 +18,7 @@ Please see [Download the Configuration Tool](private-cloud-cluster#download-conf
 {{% alert type="info" %}} Use "./mxpc-cli <command> --help" for more information about a given command. {{% /alert %}}
 
 The following parameters may be used in the commands:
+  
 * `--namespace` – a cluster namespace.
 * `--clusterType` – a cluster type *openshift* or *generic*.
 * `--clusterMode` – a cluster mode *standalone* or *connected*.

--- a/content/developerportal/deploy/private-cloud-data-transfer.md
+++ b/content/developerportal/deploy/private-cloud-data-transfer.md
@@ -42,7 +42,7 @@ The following file storage options are supported:
 
 The data transfer tool needs the following:
 
-* [pg_dump](https://www.postgresql.org/docs/9.6/app-pgdump.html) and [pg_restore](https://www.postgresql.org/docs/9.6/app-pgrestore.html) binaries in a location listed in the system path
+* [pg_dump](https://www.postgresql.org/docs/12/app-pgdump.html) and [pg_restore](https://www.postgresql.org/docs/12/app-pgrestore.html) binaries in a location listed in the system path
 * Network access to the PostgreSQL server and S3/Minio storage
   * If the database is running inside the cluster or on a Virtual Private Cloud (VPC), it might not be reachable from outside the cluster
 * Permissions to call the Kubernetes API
@@ -143,7 +143,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
   - name: pgtools
-    image: docker.io/bitnami/postgresql:9.6
+    image: docker.io/bitnami/postgresql:12
     command: ["sleep", "infinity"]
     lifecycle:
       preStop:
@@ -152,10 +152,15 @@ spec:
 ```
 
 This configuration creates a pod which includes `pgtools` (PostgreSQL tools such as `pg_dump` and `pg_restore`), and a Service Account that can get the database credentials from an environment.
+If your database is using another PostgreSQL version (for example, PostgreSQL 13), change the `image: docker.io/bitnami/postgresql:12` to match the targer PostgreSQL version.
 
 {{% alert type="warning" %}}
 Before importing a backup file into an environment, the environment should be stopped (scaled down to 0 replicas).
 Importing data into a running environment might cause the environment to stop working.
+{{% /alert %}}
+
+{{% alert type="warning" %}}
+These instructions have been validated in Windows Subsystem for Linux and macOS and might not work in the Windows commandline terminal, Git Bash or Powershell. 
 {{% /alert %}}
 
 To export data from an environment into a backup file, run the following commands (replace `{namespace}` with the environment's namespace, and `{environment}` with the environment's internal name):

--- a/content/developerportal/deploy/private-cloud-data-transfer.md
+++ b/content/developerportal/deploy/private-cloud-data-transfer.md
@@ -152,7 +152,7 @@ spec:
 ```
 
 This configuration creates a pod which includes `pgtools` (PostgreSQL tools such as `pg_dump` and `pg_restore`), and a Service Account that can get the database credentials from an environment.
-If your database is using another PostgreSQL version (for example, PostgreSQL 13), change the `image: docker.io/bitnami/postgresql:12` to match the targer PostgreSQL version.
+If your database is using another PostgreSQL version (for example, PostgreSQL 13), change the `image: docker.io/bitnami/postgresql:12` to match the target PostgreSQL version (for example, `docker.io/bitnami/postgresql:13`).
 
 {{% alert type="warning" %}}
 Before importing a backup file into an environment, the environment should be stopped (scaled down to 0 replicas).

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -34,15 +34,15 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.21
-* OpenShift 4.6 through 4.7
+* Kubernetes versions 1.19 through 1.22
+* OpenShift 4.6 through 4.8
 
 {{% alert type="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
-This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
+This version of Kubernetes is not yet offered or fully supported by most distributions and providers.
 
-Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we have fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
+Mendix for Private Cloud Operator v2.\*.\* is compatible with Kubernetes 1.22.
 
 Existing clusters running Mendix for Private Cloud Operator v1.\*.\* will need to be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
 {{% /alert %}}

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -38,11 +38,13 @@ Mendix for Private Cloud Operator `v2.*.*` is the latest version which officiall
 * OpenShift 4.6 through 4.7
 
 {{% alert type="warning" %}}
-Mendix for Private Cloud has not yet been fully validated to support Kubernetes 1.22, a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
+Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
 
 This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
 
-Upgrading an existing cluster to Kubernetes 1.22 might cause issues with Mendix for Private Cloud.
+Mendix for Private Cloud Operator v2.\*.\* is expected to be compatible with Kubernetes 1.22 - but until we have fully validated this, running Mendix for Private Cloud in Kubernetes 1.22 is not officially supported.
+
+Existing clusters running Mendix for Private Cloud Operator v1.\*.\* will need to be upgraded to Kubernetes 1.21 and Mendix for Private Cloud Operator v2.\*.\* **before** upgrading to Kubernetes 1.22.
 {{% /alert %}}
 
 Mendix for Private Cloud Operator `v1.12.*` is an LTS release which officially supports older Kubernetes versions:

--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -159,6 +159,15 @@ The following standard PostgreSQL databases are supported:
 
 * PostgreSQL 9.6
 * PostgreSQL 10
+* PostgreSQL 11
+* PostgreSQL 12
+* PostgreSQL 13
+
+{{% alert type="info" %}}
+While Mendix for Private Cloud supports all Postgres versions listed above, the Mendix Runtime might require a more specific Postgres version.
+
+For best compatibility, use Postgres 12 - it's supported by the latest supported LTS versions of the Mendix Runtime.
+{{% /alert %}}
 
 A standard PostgreSQL database is an unmodified PostgreSQL database installed from a Helm chart or from an installation package.
 

--- a/content/developerportal/deploy/private-cloud-upgrade-guide.md
+++ b/content/developerportal/deploy/private-cloud-upgrade-guide.md
@@ -25,11 +25,14 @@ If you are using your own private registry, follow the [Migrating to Your Own Re
 to migrate new component versions of Mendix for Private Cloud into your private registry.
 
 {{% alert type="warning" %}}
-Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
+If you're using Mendix for Private Cloud Operator v1.\*.\* and are planning to upgrade to Kubernetes 1.22, follow these steps first:
 
-This version of Kubernetes was released recently and is not yet offered or fully supported by most distributions and providers.
+1. Upgrade your cluster to Kubernetes 1.21
+2. Upgrade all namespaces in your cluster to Mendix for Private Cloud Operator v2.\*.\*
+3. Validate that Mendix for Private Cloud is working correctly in all namespaces
 
-Mendix for Private Cloud has not been fully validated to support Kubernetes 1.22.
+Kubernetes 1.22 [deprecated](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) multiple APIs;
+upgrading to Kubernetes 1.21 and Mendix Operator v2.\*.\* will prepare resources such as Ingresses to be compatible with APIs available in Kubernetes 1.22.
 {{% /alert %}}
 
 ## 2 Prerequisites

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,6 +13,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
+### November ???, 2021
+
+#### Supported platforms
+
+* We have completed validation of Kubernetes 1.22 and Postgres versions 11, 12 and 13.
+
+To see more details about supported databases and Kubernetes versions, see the [Supported Providers](/developerportal/deploy/private-cloud-supported-environments) document.
+
 ### October 27th, 2021
 
 #### Prometheus Metrics


### PR DESCRIPTION
We have completed Mx4PC compatibility testing with the latest Kubernetes and Postgres versions, and can now officially announce that they are supported by the latest version of Mx4PC.

This PR updates documentation to include all supported Postgres and Kubernetes versions and is not linked with any upcoming release - any customers already running [the latest Operator version](https://docs.mendix.com/releasenotes/developer-portal/mendix-for-private-cloud#mendix-operator-v2-1-0-and-mendix-gateway-agent-v2-1-0) can directly proceed to upgrade their Postgres database and Kubernetes.