### PR TITLE
Private Cloud Portal Release Notes (November 18)

### DIFF
--- a/content/developerportal/deploy/private-cloud-deploy.md
+++ b/content/developerportal/deploy/private-cloud-deploy.md
@@ -547,7 +547,7 @@ Delete all environments before you delete an app. If you delete an app which has
 
 ### 6.3 Deployment Package Size
 
-Mendix for Private Cloud has a limit of 200MB on the size of a deployment package.
+Mendix for Private Cloud has a limit of 512MB on the size of a deployment package.
 
 ## 7 Troubleshooting
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -13,6 +13,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2021
 
+### November 18th, 2021
+
+#### Portal Improvements
+
+* We have increased the Deployment Package limit from 200MB to 512MB.
+* We have fixed an issue when the Runtime version was not visible in the Transport package screen.
+* We have removed the restriction to use the `kubernetes.io/ingress.class` Ingress annotation.
+
 ### November 15th, 2021
 
 #### Supported Providers

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -20,6 +20,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have increased the Deployment Package limit from 200MB to 512MB.
 * We have fixed an issue when the Runtime version was not visible in the Transport package screen.
 * We have removed the restriction to use the `kubernetes.io/ingress.class` Ingress annotation.
+* We've removed some entries from the left navigation panel to match the Developer Portal.
 
 ### November 15th, 2021
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -17,10 +17,10 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Portal Improvements
 
-* We have increased the Deployment Package limit from 200MB to 512MB.
-* We have fixed an issue when the Runtime version was not visible in the Transport package screen.
-* We have removed the restriction to use the `kubernetes.io/ingress.class` Ingress annotation.
-* We've removed some entries from the left navigation panel to match the Developer Portal.
+* We have increased the deployment package size limit from 200MB to 512MB.
+* We have fixed an issue when the Runtime version was not visible on the transport package screen.
+* We have removed the restriction on the use of the `kubernetes.io/ingress.class` ingress annotation.
+* We have changed the left navigation panel to match the rest of the Developer Portal.
 
 ### November 15th, 2021
 


### PR DESCRIPTION
I apologize for not preparing the Release Notes earlier - we've released a new version of the Private Cloud Portal today and it includes a few bugfixes/improvements.