### PR TITLE
Remove the limitation of associated attributes in DB2 and SAP HANA

### DIFF
--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -53,9 +53,7 @@ According to the [order-by-clause](https://www.ibm.com/support/knowledgecenter/S
 Taking this limitation into account, ordering by the associated attribute is not supported when a Mendix application is backed by DB2. Therefore, any associated attribute that is used for ordering is filtered out from the query and the result set is returned as if ordering by the associated attribute had not been presented in the query.
 
 {{% alert type="info" %}}
-
-This limitation has been removed in Mendix versions 9.8.0 and above.
-
+This limitation has been removed in Studio Pro versions [9.8.0](/releasenotes/studio-pro/9.8) and above.
 {{% /alert %}}
 
 ### 5.4 Non-Blocking Read-Isolated Streaming with OData

--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -54,7 +54,7 @@ Taking this limitation into account, ordering by the associated attribute is not
 
 {{% alert type="info" %}}
 
-This limitation has been removed in Mendix versions 9.8.0 and above, and also from MTS version 9.6 patch version 3 (9.6.3) and above.
+This limitation has been removed in Mendix versions 9.8.0 and above.
 
 {{% /alert %}}
 

--- a/content/refguide/db2.md
+++ b/content/refguide/db2.md
@@ -52,6 +52,12 @@ According to the [order-by-clause](https://www.ibm.com/support/knowledgecenter/S
 
 Taking this limitation into account, ordering by the associated attribute is not supported when a Mendix application is backed by DB2. Therefore, any associated attribute that is used for ordering is filtered out from the query and the result set is returned as if ordering by the associated attribute had not been presented in the query.
 
+{{% alert type="info" %}}
+
+This limitation has been removed in Mendix versions 9.8.0 and above, and also from MTS version 9.6 patch version 3 (9.6.3) and above.
+
+{{% /alert %}}
+
 ### 5.4 Non-Blocking Read-Isolated Streaming with OData
 
 According to the [Isolation levels](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.admin.perf.doc/doc/c0004121.html) documentation in *IBM DB2 Application design*, non-blocking read-isolated queries are not supported by DB2. The default behavior of DB2 is that when one user is retrieving rows from a table and another user is making modifications on the same table at the same time, then those modifications will show up in the data in the retrieve query (which means database reads are not isolated). Configuring a stricter transaction isolation level to prevent this behavior puts locks on those same rows (which means concurrent database actions are blocking).

--- a/content/refguide/saphana.md
+++ b/content/refguide/saphana.md
@@ -17,7 +17,7 @@ For example, you have two associated entities — **Person** and **Address** —
 
 {{% alert type="info" %}}
 
-This limitation has been removed in Mendix versions 9.8.0 and above, and also from MTS version 9.6 patch version 3 (9.6.3) and above.
+This limitation has been removed in Mendix versions 9.8.0 and above.
 
 {{% /alert %}}
 

--- a/content/refguide/saphana.md
+++ b/content/refguide/saphana.md
@@ -15,6 +15,12 @@ Retrieving an entity that is sorted on an attribute of one of its associated ent
 
 For example, you have two associated entities — **Person** and **Address** — and they have the **name** and **street** attributes, respectively. You cannot retrieve `Person` objects sorted on `Person_Address/Address/street`. 
 
+{{% alert type="info" %}}
+
+This limitation has been removed in Mendix versions 9.8.0 and above, and also from MTS version 9.6 patch version 3 (9.6.3) and above.
+
+{{% /alert %}}
+
 ## 3 Behavior of Unlimited & Very Long Strings
 
 ### 3.1 Comparison Functions

--- a/content/refguide/saphana.md
+++ b/content/refguide/saphana.md
@@ -16,9 +16,7 @@ Retrieving an entity that is sorted on an attribute of one of its associated ent
 For example, you have two associated entities — **Person** and **Address** — and they have the **name** and **street** attributes, respectively. You cannot retrieve `Person` objects sorted on `Person_Address/Address/street`. 
 
 {{% alert type="info" %}}
-
-This limitation has been removed in Mendix versions 9.8.0 and above.
-
+This limitation has been removed in Studio Pro versions [9.8.0](/releasenotes/studio-pro/9.8) and above.
 {{% /alert %}}
 
 ## 3 Behavior of Unlimited & Very Long Strings


### PR DESCRIPTION
Reviving #3792 which was closed accidentally.