### PR TITLE
Add naming constraint on metrics (Mendix 9.10)

### DIFF
--- a/content/developerportal/operate/datadog-metrics.md
+++ b/content/developerportal/operate/datadog-metrics.md
@@ -425,7 +425,7 @@ If you have any issues related to accessing Datadog, please contact their suppor
 
 | Metric | Description |
 | --- | --- |
-| jmx.com.mendix.* | Core runtime metrics |
+| jmx.com.mendix.* | JMX metrics for the `com.mendix` domain (core runtime). |
 | mx.database.diskstorage_size | Disk storage available to the application database (this is a fixed value) |
 | mx.activity.time | How long a microflow activity takes to run |
 | mx.client.time | The time to handle a request to a request handler that is used by the web ui |

--- a/content/refguide/metrics-counter.md
+++ b/content/refguide/metrics-counter.md
@@ -39,7 +39,16 @@ You can also open the dialog box by double-clicking the activity in the microflo
 
 ### 3.1 Name
 
-The name of the counter whose value you want to increment.
+The name of the counter whose value you want to increment, which must adhere to the following rules:
+
+* The name can only contain alpha-numeric characters, dots or underscores.
+* The name must start with a letter.
+* The name cannot start with `mx`, because this prefix is reserved for Mendix internal metrics.
+* The name is case-insensitive.
+
+{{% alert type="info" %}}
+It is recommended to use a common prefix that uniquely defines your organisation and application.
+{{% /alert %}}
 
 ### 3.2 Value
 

--- a/content/refguide/metrics-gauge.md
+++ b/content/refguide/metrics-gauge.md
@@ -39,7 +39,16 @@ You can also open the dialog box by double-clicking the activity in the microflo
 
 ### 3.1 Name
 
-The name of the gauge for which you want to set a value.
+The name of the gauge for which you want to set a value, which must adhere to the following rules:.
+
+* The name can only contain alpha-numeric characters, dots or underscores.
+* The name must start with a letter.
+* The name cannot start with `mx`, because this prefix is reserved for Mendix internal metrics.
+* The name is case-insensitive.
+
+{{% alert type="info" %}}
+It is recommended to use a common prefix that uniquely defines your organisation and application.
+{{% /alert %}}
 
 ### 3.2 Value
 

--- a/content/refguide/metrics-increment-counter.md
+++ b/content/refguide/metrics-increment-counter.md
@@ -39,7 +39,16 @@ You can also open the dialog box by double-clicking the activity in the microflo
 
 ### 3.1 Name
 
-The name of the counter whose value you want to increment by 1.
+The name of the counter whose value you want to increment by 1, which must adhere to the following rules:
+
+* The name can only contain alpha-numeric characters, dots or underscores.
+* The name must start with a letter.
+* The name cannot start with `mx`, because this prefix is reserved for Mendix internal metrics.
+* The name is case-insensitive.
+
+{{% alert type="info" %}}
+It is recommended to use a common prefix that uniquely defines your organisation and application.
+{{% /alert %}}
 
 ### 3.2 Tags
 

--- a/content/refguide/metrics.md
+++ b/content/refguide/metrics.md
@@ -279,7 +279,7 @@ The above filter discards metrics which starts with **"Unnamed."**, **"Invalid."
 The following should be taken into account when configuring the metrics registries.
 {{% /alert %}}
 
-1. There are also some internal metrics used by Mendix. Filters will also have an effect on them. For example metrics emitted by Mendix which starts with "com.mendix." or "mx.".
+1. There are also some internal metrics used by Mendix. Filters will also have an effect on them. For example metrics emitted by Mendix which start with "mx.".
 
 2. If you have a metric and another metric with the same name but with additional tags, these will be considered as different metrics. Example, Metric ("app.counter1") and ("app.counter1" with tag ("version" -> "1")) are different.
 
@@ -358,6 +358,17 @@ Counter counter2 = Core.metrics().createCounter("app.count").build();
 ```
 
 In the same way, we can also create a `gauge` and a `timer` using the `createGauge` and `createTimer` methods respectively.
+
+The name must adhere to the following rules:
+
+* The name can only contain alpha-numeric characters, dots or underscores.
+* The name must start with a letter.
+* The name cannot start with `mx`, because this prefix is reserved for Mendix internal metrics.
+* The name is case-insensitive.
+
+{{% alert type="info" %}}
+It is recommended to use a common prefix that uniquely defines your organisation and application.
+{{% /alert %}}
 
 ### 5.2 Deprecated usages
 


### PR DESCRIPTION
Names of customer metrics cannot start with 'mx'.