### PR TITLE
Removed project setting about web service calls

### DIFF
--- a/content/refguide8/project-settings.md
+++ b/content/refguide8/project-settings.md
@@ -201,10 +201,6 @@ For more details on migration, see [Uniqueness Constraint Migration](uniqueness-
 
 Falling back to the **Runtime** option will remove the unique constraints from the database, and uniqueness rules will not be checked at the database level anymore. Hence, data accuracy cannot be guaranteed at the highest level, especially in the case of high concurrency transactions.
 
-### 3.13 Web Service Calls {#web-service-calls}
-
-The way web services are called has been optimized, which means you can use custom proxy settings for each web service call. However, this implementation does not support complex schemas that use a policy reference with an algorithm suite. This configuration option allows you to use the old implementation, in case you need this feature.
-
 ## 4 Languages Tab
 
 For more information about using different languages in your app, see [Language Menu](translatable-texts).


### PR DESCRIPTION
The web service calls project setting was removed in 8.0.0, see release note "We removed support for the deprecated old implementation of web service calls."