### PR TITLE
Custom HTTP header

### DIFF
--- a/content/refguide/call-rest-action.md
+++ b/content/refguide/call-rest-action.md
@@ -130,7 +130,7 @@ The **Password** property defines the password that will be used to authenticate
 
 ### 5.4 Custom HTTP Headers
 
-These headers are added to the HTTP request header. Each custom header is a pair with a key and a value (a microflow expression).
+These headers are added to the HTTP request header. Each custom header is a pair with a key and a value (a microflow expression). Do note that key values of custom HTTP headers may not contain an underscore (_). NGINX will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables as both dashes and underscores are mapped to underscores during that process.
 
 ## 6 Request Tab {#request}
 

--- a/content/refguide/call-rest-action.md
+++ b/content/refguide/call-rest-action.md
@@ -130,7 +130,11 @@ The **Password** property defines the password that will be used to authenticate
 
 ### 5.4 Custom HTTP Headers
 
-These headers are added to the HTTP request header. Each custom header is a pair with a key and a value (a microflow expression). Do note that key values of custom HTTP headers may not contain an underscore (_). NGINX will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables as both dashes and underscores are mapped to underscores during that process.
+These headers are added to the HTTP request header. Each custom header is a pair with a key and a value (a microflow expression).
+
+{{% alert type="warning" %}}
+REST endpoints which are using NGINX as a webserver will ['silently drop'](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#missing-disappearing-http-headers) HTTP headers which contain an underscore `_`.
+{{% /alert %}}
 
 ## 6 Request Tab {#request}
 


### PR DESCRIPTION
It tooks us quite a while to figur out why a custom header was missing while the other headers did show fine. Only then did we find out that HTTP headers may not contain an underscore. Would be nice if the Mendix modeler would already check this. Now at least it is in the documentation.
Regards,
Ronald