### PR TITLE
Add weights to spaces and categories

### DIFF
--- a/content/addons/apd-addon/index.md
+++ b/content/addons/apd-addon/index.md
@@ -1,5 +1,6 @@
 ---
 title: "APD"
+weight: 20
 aliases:
     - /addons/apm-addon/index.html
 ---

--- a/content/addons/aqm-addon/index.md
+++ b/content/addons/aqm-addon/index.md
@@ -1,5 +1,6 @@
 ---
 title: "AQM"
+weight: 30
 ---
 
 ## 1 Introduction

--- a/content/addons/ats-addon/index.md
+++ b/content/addons/ats-addon/index.md
@@ -1,5 +1,6 @@
 ---
 title: "ATS"
+weight: 10
 ---
 
 ## 1 Introduction

--- a/content/addons/index.md
+++ b/content/addons/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Quality Add-ons Guide"
 description: "Presents guides for APM, AQM, and ATS."
+weight: 55
 ---
 
 The *Quality Add-ons Guide* are divided into the following categories:

--- a/content/apidocs-mxsdk/apidocs/index.md
+++ b/content/apidocs-mxsdk/apidocs/index.md
@@ -1,6 +1,7 @@
 ---
 title: "API Documentation"
 description: "The Mendix Platform API documentation is divided into sections such as Runtime, Client, Feedback, and Deploy."
+weight: 10
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/apidocs-mxsdk/index.md
+++ b/content/apidocs-mxsdk/index.md
@@ -1,6 +1,7 @@
 ---
 title: "APIs & SDK"
 description: "Presents the Mendix API documentation as well as the documentation for the Mendix Platform SDK."
+weight: 50
 ---
 
 The *APIs & SDK* are divided into the following categories:

--- a/content/apidocs-mxsdk/mxsdk/index.md
+++ b/content/apidocs-mxsdk/mxsdk/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mendix Platform SDK"
+weight: 20
 ---
 
 ## 1 Introduction & FAQ

--- a/content/appstore/app-services/index.md
+++ b/content/appstore/app-services/index.md
@@ -2,6 +2,7 @@
 title: "App Services"
 description: "Presents details on the app services available in the Mendix Marketplace."
 tags: ["marketplace", "marketplace component", "app service"]
+weight: 30
 ---
 
 ## 1 Introduction

--- a/content/appstore/connectors/index.md
+++ b/content/appstore/connectors/index.md
@@ -2,6 +2,7 @@
 title: "Connectors"
 description: "Presents details on the connectors available in the Mendix Marketplace."
 tags: ["marketplace",  "marketplace component", "connector"]
+weight: 40
 ---
 
 ## 1 Introduction

--- a/content/appstore/creating-content/index.md
+++ b/content/appstore/creating-content/index.md
@@ -2,6 +2,7 @@
 title: "Creating Content"
 description: "How to create content for the Mendix Marketplace."
 tags: ["marketplace", "marketplace component", "app service", "solution"]
+weight: 20
 ---
 
 {{% alert type="info" %}}

--- a/content/appstore/general/index.md
+++ b/content/appstore/general/index.md
@@ -1,6 +1,7 @@
 ---
 title: "General Info"
 description: "Presents details on using, sharing, and getting support on Mendix Marketplace content."
+weight: 10
 aliases:
     - /community/app-store/index.html
 ---

--- a/content/appstore/index.md
+++ b/content/appstore/index.md
@@ -2,6 +2,7 @@
 title: "Marketplace Guide"
 description: "Presents documentation on configuring and using the latest versions of platform-supported components."
 tags: ["marketplace",  "component", "platform support"]
+weight: 35
 ---
 
 ## 1 Introduction

--- a/content/appstore/modules/index.md
+++ b/content/appstore/modules/index.md
@@ -2,6 +2,7 @@
 title: "Modules"
 description: "Presents details on the modules available in the Mendix Marketplace."
 tags: ["marketplace", "marketplace component", "module"]
+weight: 50
 ---
 
 ## 1 Introduction {#intro}

--- a/content/appstore/widgets/index.md
+++ b/content/appstore/widgets/index.md
@@ -2,6 +2,7 @@
 title: "Widgets"
 description: "Presents details on the widgets available in the Mendix Marketplace."
 tags: ["platform support"]
+weight: 60
 ---
 
 ## 1 Introduction

--- a/content/data-hub/data-hub-catalog/index.md
+++ b/content/data-hub/data-hub-catalog/index.md
@@ -2,6 +2,7 @@
 title: "Data Hub Catalog"
 description: "Introduces the processes and properties of Mendix Data Hub."
 tags: ["data hub", "data hub catalog"]
+weight: 30
 ---
 
 ## 1 Introduction

--- a/content/data-hub/data-hub-landscape/index.md
+++ b/content/data-hub/data-hub-landscape/index.md
@@ -2,6 +2,7 @@
 title: "Data Hub Landscape"
 description: "Using the Data Hub Landscape to explore the connections with registered assets"
 tags: ["data hub catalog", "data hub", "external entities", "landscape", "published odata service"]
+weight: 40
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
 

--- a/content/data-hub/index.md
+++ b/content/data-hub/index.md
@@ -2,6 +2,7 @@
 title: "Data Hub Guide"
 description: "This guide describes Mendix Data Hub for finding and sharing enterprise data assets."
 tags: ["data hub", "data hub catalog", "data hub landscape"]
+weight: 40
 aliases:
     - /data-hub/data-catalog/index.html
 ---

--- a/content/data-hub/share-data/index.md
+++ b/content/data-hub/share-data/index.md
@@ -2,6 +2,7 @@
 title: "Share Data Between Apps"
 description: "Describes how to publish and register a simple data asset to Mendix Data Hub from Studio Pro and create a new apps that consumes this asset."
 tags: ["data hub catalog", "data hub", "external entities", "landscape", "published OData service" ,"how to", "consume"]
+weight: 10
 aliases:
     - /data-hub/data-hub-catalog/use-data-catalog.html
     - /datahub/general/share-data/index.html

--- a/content/data-hub/write-data/index.md
+++ b/content/data-hub/write-data/index.md
@@ -2,6 +2,7 @@
 title: "Write Data to Another App"
 description: "Describes add annotations to an OData service in Mendix Studio Pro, see external entities with these features in the Data Hub Catalog, and use them to build your app."
 tags: ["Data Hub", "external entities", "published OData service" ,"how to","OData", "Data Hub Catalog"]
+weight: 20
 ---
 
 ## 1 Introduction

--- a/content/developerportal/collaborate/index.md
+++ b/content/developerportal/collaborate/index.md
@@ -5,6 +5,7 @@ tags: ["Developer Portal", "Sprint", "story", "stories", "buzz"]
 aliases:
     - /developerportal/develop/
     - /developerportal/settings/
+weight: 5
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/developerportal/community-tools/index.md
+++ b/content/developerportal/community-tools/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Community Tools"
 description: "Describes the main tools that Mendix maintains to support the awesome Mendix community."
+weight: 25
 ---
 
 ## 1 Introduction

--- a/content/developerportal/control-center/index.md
+++ b/content/developerportal/control-center/index.md
@@ -2,6 +2,7 @@
 title: "Control Center"
 description: "Describes the Mendix Control Center, used for the governance of company members, apps, security, and cloud resources."
 tags: ["control center", "mendix admin", "developer portal", "role", "permissions", "fallback", "resource pack", "node", "offboard"]
+weight: 20
 aliases:
     - /developerportal/company-app-roles/users.html
 ---

--- a/content/developerportal/deploy/index.md
+++ b/content/developerportal/deploy/index.md
@@ -2,6 +2,7 @@
 title: "Deployment"
 description: "Deployment section of the Developer Portal Guide: How to deploy Mendix apps to different environments and how to manage those deployments."
 tags: ["Deploy","Manage", "Mendix Cloud", "IBM", "SAP", "Cloud Foundry", "Kubernetes", "On-premises", "Environment"]
+weight: 10
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/developerportal/index.md
+++ b/content/developerportal/index.md
@@ -2,6 +2,7 @@
 title: "Developer Portal Guide"
 description: "Describes the sections of the Mendix Developer Portal and links to more detailed documents in the guide."
 tags: ["mendix", "developer portal", "platform services", "buzz", "apps", "community", "marketplace", "academy", "forum", "docs", "documentation"]
+weight: 30
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/developerportal/operate/index.md
+++ b/content/developerportal/operate/index.md
@@ -2,6 +2,7 @@
 title: "Operations"
 description: "The day-to-day operation of an app from the the Developer Portal. This is mainly useful for apps running in the Mendix Cloud."
 tags: ["Operate", "App", "Developer Portal", "Metrics", "Alerts", "Logs", "Backups", "Mendix Cloud", "v3", "v4"]
+weight: 15
 ---
 
 ## 1 Introduction

--- a/content/developerportal/support/index.md
+++ b/content/developerportal/support/index.md
@@ -2,6 +2,7 @@
 title: "Mendix Support"
 description: ""
 tags: ["Support", "SLA", "Gold", "Platinum"]
+weight: 30
 aliases:
     - /howtogeneral/support/index.html
 ---

--- a/content/howto/collaboration-requirements-management/index.md
+++ b/content/howto/collaboration-requirements-management/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Collaboration"
+weight: 20
 tags: ["collaboration", "requirements", "management"]
 ---
 

--- a/content/howto/data-models/index.md
+++ b/content/howto/data-models/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Data Models"
+weight: 50
 tags: ["studio pro"]
 ---
 

--- a/content/howto/extensibility/index.md
+++ b/content/howto/extensibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Extensibility"
 description: "A selection of how to's that explain how to use connectors and adapters from the Marketplace."
+weight: 80
 tags: ["widget", "marketplace", "connectors", "adapters"]
 ---
 

--- a/content/howto/front-end/atlas-ui.md
+++ b/content/howto/front-end/atlas-ui.md
@@ -7,7 +7,7 @@ tags: ["Atlas", "UI", "UX", "user experience", "design"]
 
 ## 1 Introduction
 
-Mendix offers Atlas UI, a cross-platform UI framework that gives teams the foundation they need to build engaging, high-quality experiences and brings UX, IT, and business together. See the [Atlas 3](https://atlas.mendix.com) site for more information about Atlas.
+Mendix offers Atlas UI, a cross-platform UI framework that gives teams the foundation they need to build engaging, high-quality experiences and brings UX, IT, and business together. See the [Atlas 3](https://atlas.mendix.com) site additional information on Atlas.
 
 If you use an older version of Mendix Studio Pro, see [atlas2.mendix.com](https://atlas2.mendix.com/) for information on Atlas 2.
 

--- a/content/howto/front-end/index.md
+++ b/content/howto/front-end/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Front End"
+weight: 30
 tags: ["studio pro"]
 ---
 

--- a/content/howto/general/index.md
+++ b/content/howto/general/index.md
@@ -1,6 +1,7 @@
 ---
 title: "General Info"
 description: "These introductory how-to's describe Mendix Studio Pro basics and best practices."
+weight: 10
 tags: ["studio pro", "how-to", "general"]
 ---
 

--- a/content/howto/index.md
+++ b/content/howto/index.md
@@ -2,6 +2,7 @@
 title: "Studio Pro 9 How-to's"
 description: "Step-by-step guides on various Mendix topics that will teach you how to build and customize apps."
 tags: ["studio pro"]
+weight: 15
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/howto/integration/index.md
+++ b/content/howto/integration/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Integration"
+weight: 70
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto/logic-business-rules/index.md
+++ b/content/howto/logic-business-rules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Logic & Business Rules"
+weight: 60
 tags: ["studio pro", "how-to"]
 ---
 

--- a/content/howto/mobile/index.md
+++ b/content/howto/mobile/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile"
+weight: 40
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto/monitoring-troubleshooting/index.md
+++ b/content/howto/monitoring-troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring & Troubleshooting"
+weight: 110
 tags: ["monitoring", "troubleshooting"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto/security/index.md
+++ b/content/howto/security/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Security"
+weight: 90
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto/testing/index.md
+++ b/content/howto/testing/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Testing"
+weight: 100
 tags: ["test", "testing"]
 ---
 

--- a/content/howto7/collaboration-requirements-management/index.md
+++ b/content/howto7/collaboration-requirements-management/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Collaboration & Requirements Management"
+weight: 120
 tags: ["collaboration", "requirements", "management"]
 ---
 

--- a/content/howto7/data-models/index.md
+++ b/content/howto7/data-models/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Data Models"
+weight: 30
 ---
 
 ## 1 Introduction

--- a/content/howto7/extensibility/index.md
+++ b/content/howto7/extensibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Extensibility"
 description: "A selection of how to's that explain how to use connectors and adapters from the Marketplace."
+weight: 80
 tags: ["widget", "marketplace", "connectors", "adapters", "charts"]
 ---
 

--- a/content/howto7/front-end/index.md
+++ b/content/howto7/front-end/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Front End"
+weight: 20
 ---
 
 ## 1 Introduction 

--- a/content/howto7/general/index.md
+++ b/content/howto7/general/index.md
@@ -1,6 +1,7 @@
 ---
 title: "General"
 description: "These introductory how-to's describe Mendix Modeler basics and best practices."
+weight: 10
 ---
 
 ## 1 Introduction

--- a/content/howto7/index.md
+++ b/content/howto7/index.md
@@ -2,6 +2,7 @@
 title: "Mendix 7 How-to's"
 notoc: true
 description: "Step-by-step guides on various Mendix topics that will teach you how to build and customize apps."
+weight: 85
 ---
 
 Browse the Mendix how-to's to find step-by-step guides that will teach you how to build and customize apps with Mendix.

--- a/content/howto7/integration/index.md
+++ b/content/howto7/integration/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Integration"
+weight: 70
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/howto7/logic-business-rules/index.md
+++ b/content/howto7/logic-business-rules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Logic & Business Rules"
+weight: 40
 ---
 
 ## 1 Introduction 

--- a/content/howto7/mobile/index.md
+++ b/content/howto7/mobile/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile Development"
+weight: 50
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/howto7/monitoring-troubleshooting/index.md
+++ b/content/howto7/monitoring-troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring & Troubleshooting"
+weight: 110
 tags: ["monitoring", "troubleshooting"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto7/security/index.md
+++ b/content/howto7/security/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Security"
+weight: 60
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/howto7/testing/index.md
+++ b/content/howto7/testing/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Testing"
+weight: 100
 tags: ["test", "testing"]
 ---
 

--- a/content/howto7/widget-development/index.md
+++ b/content/howto7/widget-development/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Widget Development"
+weight: 90
 tags: ["widget", "develop widget", "customize"]
 ---
 

--- a/content/howto8/collaboration-requirements-management/index.md
+++ b/content/howto8/collaboration-requirements-management/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Collaboration"
+weight: 20
 tags: ["collaboration", "requirements", "management"]
 ---
 

--- a/content/howto8/data-models/index.md
+++ b/content/howto8/data-models/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Data Models"
+weight: 50
 tags: ["studio pro"]
 ---
 

--- a/content/howto8/extensibility/index.md
+++ b/content/howto8/extensibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Extensibility"
 description: "A selection of how to's that explain how to use connectors and adapters from the Marketplace."
+weight: 80
 tags: ["widget", "marketplace", "connectors", "adapters"]
 ---
 

--- a/content/howto8/front-end/index.md
+++ b/content/howto8/front-end/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Front End"
+weight: 30
 tags: ["studio pro"]
 ---
 

--- a/content/howto8/general/install.md
+++ b/content/howto8/general/install.md
@@ -1,7 +1,7 @@
 ---
 title: "Install Mendix Studio Pro"
 category: "General Info"
-menu_order: 1
+weight: 10
 description: "Follow this how-to to learn how to install Mendix Studio Pro."
 toc-level: "2"
 tags: ["studio pro", "install", "install studio pro", "download"]

--- a/content/howto8/index.md
+++ b/content/howto8/index.md
@@ -2,6 +2,7 @@
 title: "Studio Pro 8 How-to's"
 description: "Step-by-step guides on various Mendix topics that will teach you how to build and customize apps."
 tags: ["studio pro"]
+weight: 65
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/howto8/integration/index.md
+++ b/content/howto8/integration/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Integration"
+weight: 70
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto8/logic-business-rules/index.md
+++ b/content/howto8/logic-business-rules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Logic & Business Rules"
+weight: 60
 tags: ["studio pro", "how-to"]
 ---
 

--- a/content/howto8/mobile/index.md
+++ b/content/howto8/mobile/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile"
+weight: 40
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto8/monitoring-troubleshooting/index.md
+++ b/content/howto8/monitoring-troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring & Troubleshooting"
+weight: 110
 tags: ["monitoring", "troubleshooting"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto8/security/index.md
+++ b/content/howto8/security/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Security"
+weight: 90
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/howto8/testing/index.md
+++ b/content/howto8/testing/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Testing"
+weight: 100
 tags: ["test", "testing"]
 ---
 

--- a/content/partners/index.md
+++ b/content/partners/index.md
@@ -2,6 +2,7 @@
 title: "Strategic Partners Guide"
 description: "Documentation for IBM, SAP, and Siemens widgets written and maintained by Mendix"
 tags: ["strategic partners", "ibm", "sap", "siemens"]
+weight: 45
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/partners/sap/index.md
+++ b/content/partners/sap/index.md
@@ -2,6 +2,7 @@
 title: "SAP"
 description: "Documentation for users who need material on consuming SAP services."
 tags: ["SAP", "OData", "XSUAA", "Destination Services", "Fiori"]
+weight: 20
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/partners/siemens/index.md
+++ b/content/partners/siemens/index.md
@@ -3,6 +3,7 @@ title: "Siemens"
 description: "Reference content for Siemens integrations."
 tags: ["Siemens", "MindSphere"]
 notoc: true
+weight: 10
 #layout: wide
 ---
 

--- a/content/product-naming/index.md
+++ b/content/product-naming/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Mendix Product Naming Guide"
 draft: true
+weight: 5
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
 

--- a/content/product-naming/main-product-names.md
+++ b/content/product-naming/main-product-names.md
@@ -1,6 +1,6 @@
 ---
 title: "Main Product Names"
-menu_order: 1
+weight: 10
 draft: true
 ---
 

--- a/content/product-naming/other-terms.md
+++ b/content/product-naming/other-terms.md
@@ -1,6 +1,6 @@
 ---
 title: "Other Mendix Terms"
-menu_order: 2
+weight: 20
 draft: true
 ---
 

--- a/content/product-naming/strategic-partner-terms.md
+++ b/content/product-naming/strategic-partner-terms.md
@@ -1,6 +1,6 @@
 ---
 title: "Strategic Partner Terms"
-menu_order: 3
+weight: 30
 draft: true
 ---
 

--- a/content/product-naming/terminology-history.md
+++ b/content/product-naming/terminology-history.md
@@ -1,6 +1,6 @@
 ---
 title: "Terminology History"
-menu_order: 4
+weight: 40
 draft: true
 ---
 

--- a/content/refguide/general.md
+++ b/content/refguide/general.md
@@ -1,5 +1,6 @@
 ---
 title: "General Info"
+weight: 10
 tags: ["studio pro"]
 ---
 

--- a/content/refguide/index.md
+++ b/content/refguide/index.md
@@ -2,6 +2,7 @@
 title: "Studio Pro 9 Guide"
 description: "The various sections of the Mendix Studio Pro Guide provide details on the features and functionality of the Mendix Platform."
 tags: ["studio pro"]
+weight: 10
 ---
 
 ## 1 Introduction

--- a/content/refguide/java-programming.md
+++ b/content/refguide/java-programming.md
@@ -1,6 +1,7 @@
 ---
 title: "Java Programming"
 description: "Describes how to use the Mendix Java library and use Eclipse as an environment to write your Mendix Java Actions."
+weight: 60
 tags: ["studio pro"]
 ---
 

--- a/content/refguide/mobile.md
+++ b/content/refguide/mobile.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile"
+weight: 50
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/refguide/modeling.md
+++ b/content/refguide/modeling.md
@@ -1,6 +1,7 @@
 ---
 title: "App Modeling"
 description: "Describes the various features used for modeling in Mendix Studio Pro, including document templates, the domain model, microflows, modules, pages, and security."
+weight: 20
 tags: ["Mendix", "Studio Pro", "Documents"]
 aliases:
     - /refguide/desktop-modeler.html

--- a/content/refguide/runtime.md
+++ b/content/refguide/runtime.md
@@ -1,5 +1,6 @@
 ---
 title: "Mendix Runtime"
+weight: 40
 tags: ["runtime", "runtime server", "mendix client", "cluster leader"]
 ---
 

--- a/content/refguide/version-control.md
+++ b/content/refguide/version-control.md
@@ -1,6 +1,7 @@
 ---
 title: "Version Control"
 description: "This document gives definitions and explains the version control  process"
+weight: 30
 tags: ["Version Control", "Application Lifecycle Management", "Commit", "Collaborate"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/refguide7/desktop-modeler.md
+++ b/content/refguide7/desktop-modeler.md
@@ -1,6 +1,7 @@
 ---
 title: "Desktop Modeler"
 description: "Describes the various features of the Mendix Modeler, including document templates, the domain model, microflows, modules, pages, and security."
+weight: 20
 tags: ["Mendix", "Desktop Modeler", "Documents"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.1 Introduction
 ---

--- a/content/refguide7/general.md
+++ b/content/refguide7/general.md
@@ -1,5 +1,6 @@
 ---
 title: "General"
+weight: 10
 ---
 
 ## 1 Introduction

--- a/content/refguide7/index.md
+++ b/content/refguide7/index.md
@@ -2,6 +2,7 @@
 title: "Mendix 7 Reference Guide"
 notoc: true
 description: "The various sections of the reference guide provide details on the features and functionality of the Mendix Platform."
+weight: 80
 ---
 
 The *Mendix Reference Guide* covers important topics on the  [Desktop Modeler](desktop-modeler), [Mendix Runtime](runtime), and other components of the Mendix Platform.

--- a/content/refguide7/java-programming.md
+++ b/content/refguide7/java-programming.md
@@ -1,6 +1,7 @@
 ---
 title: "Java Programming"
 description: "Describes how to use the Mendix Java library and use Eclipse as an environment to write your Mendix Java Actions."
+weight: 50
 ---
 
 ## 1 Introduction

--- a/content/refguide7/mobile.md
+++ b/content/refguide7/mobile.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile Development"
+weight: 60
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/refguide7/runtime.md
+++ b/content/refguide7/runtime.md
@@ -1,5 +1,6 @@
 ---
 title: "Mendix Runtime"
+weight: 40
 ---
 
 ## 1 Introduction

--- a/content/refguide7/version-control.md
+++ b/content/refguide7/version-control.md
@@ -1,6 +1,7 @@
 ---
 title: "Version Control"
 #description: "Set a description with a maximum of 140 characters; this should describe what the goal of the document is, and it can be different from the document introduction; this is optional, and it can be removed"
+weight: 30
 tags: ["Version Control", "Application Lifecycle Management", "Commit", "Collaborate"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/refguide8/general.md
+++ b/content/refguide8/general.md
@@ -1,5 +1,6 @@
 ---
 title: "General Info"
+weight: 10
 tags: ["studio pro"]
 ---
 

--- a/content/refguide8/index.md
+++ b/content/refguide8/index.md
@@ -2,6 +2,7 @@
 title: "Studio Pro 8 Guide"
 description: "The various sections of the Mendix Studio Pro Guide provide details on the features and functionality of the Mendix Platform."
 tags: ["studio pro"]
+weight: 60
 ---
 
 ## 1 Introduction

--- a/content/refguide8/java-programming.md
+++ b/content/refguide8/java-programming.md
@@ -1,6 +1,7 @@
 ---
 title: "Java Programming"
 description: "Describes how to use the Mendix Java library and use Eclipse as an environment to write your Mendix Java Actions."
+weight: 60
 tags: ["studio pro"]
 ---
 

--- a/content/refguide8/mobile.md
+++ b/content/refguide8/mobile.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile"
+weight: 50
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/refguide8/modeling.md
+++ b/content/refguide8/modeling.md
@@ -1,6 +1,7 @@
 ---
 title: "App Modeling"
 description: "Describes the various features used for modeling in Mendix Studio Pro, including document templates, the domain model, microflows, modules, pages, and security."
+weight: 20
 tags: ["Mendix", "Studio Pro", "Documents"]
 aliases:
     - /refguide8/desktop-modeler.html

--- a/content/refguide8/runtime.md
+++ b/content/refguide8/runtime.md
@@ -1,5 +1,6 @@
 ---
 title: "Mendix Runtime"
+weight: 40
 tags: ["runtime", "runtime server", "mendix client", "cluster leader"]
 ---
 

--- a/content/refguide8/version-control.md
+++ b/content/refguide8/version-control.md
@@ -1,6 +1,7 @@
 ---
 title: "Version Control"
 description: "This document gives definitions and explains the version control  process"
+weight: 30
 tags: ["Version Control", "Application Lifecycle Management", "Commit", "Collaborate"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/releasenotes/add-ons/index.md
+++ b/content/releasenotes/add-ons/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Quality Add-ons"
+weight: 45
 ---
 
 This category includes release notes for [Application Test Suite (ATS)](ats), [Application Performance Diagnostics (APD)](apd), and [Application Quality Monitor (AQM)](aqm).

--- a/content/releasenotes/app-store/index.md
+++ b/content/releasenotes/app-store/index.md
@@ -2,6 +2,7 @@
 title: "Marketplace"
 description: "Release notes for updates to the Mendix Marketplace"
 tags: ["marketplace", "connector", "module", "add on", "widget"]
+weight: 35
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/releasenotes/beta-features/index.md
+++ b/content/releasenotes/beta-features/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Beta Releases"
 tags: ["Beta", "Private Beta", "Public Beta", "GA", "General Availability", "feature", "feature flag", "product"]
+weight: 55
 #notoc: true
 #layout: wide
 #toc-level: "3"

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -2,6 +2,7 @@
 title: "Data Hub"
 description: "Release notes for updates to the Mendix Data Hub"
 tags: ["data hub", "data hub catalog", "data hub Landscape"]
+weight: 30
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -2,6 +2,7 @@
 title: "Deployment"
 description: "Release notes for deployment capabilities managed in the Mendix Developer Portal"
 tags: ["release notes", "deployment", "cloud environment", "Mendix Cloud", "SAP", "SAP BTP", "IBM", "on-premises", "free app", "Business Technology Platform"]
+weight: 25
 #This document is mapped to the landing page, featured.html. Update the link there if renaming or moving the doc file.
 ---
 

--- a/content/releasenotes/developer-portal/index.md
+++ b/content/releasenotes/developer-portal/index.md
@@ -2,6 +2,7 @@
 title: "Developer Portal"
 description: "Release notes for all project management parts of the Mendix Developer Portal"
 tags: ["developer portal", "buzz", "mendix profile"]
+weight: 20
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/releasenotes/index.md
+++ b/content/releasenotes/index.md
@@ -2,6 +2,7 @@
 title: "Release Notes"
 notoc: true
 description: "The release notes for the Mendix Platform are divided into various product categories and versions."
+weight: 5
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/releasenotes/mobile/index.md
+++ b/content/releasenotes/mobile/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Mobile"
 frontpage_featured: true
+weight: 15
 ---
 
 This category includes the following release notes: 

--- a/content/releasenotes/mx-world-2021/index.md
+++ b/content/releasenotes/mx-world-2021/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Feature Release Calendar"
 tags: ["mendix world", "announcements", "features", "feature release", "products", "features and products", "calendar"]
+weight: 60
 #notoc: true
 #layout: wide
 #toc-level: "3"

--- a/content/releasenotes/sdk/index.md
+++ b/content/releasenotes/sdk/index.md
@@ -1,5 +1,6 @@
 ---
 title: "SDKs"
+weight: 40
 ---
 
 This category includes release notes for both the Mendix [Model SDK](model-sdk) and [Platform SDK](platform-sdk) as well as the [Mendix Metamodel](metamodel).

--- a/content/releasenotes/security-advisories/index.md
+++ b/content/releasenotes/security-advisories/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Security Advisories"
 tags: ["security", "security advisories", "cve", "cvss", "ssa", "siemens security advisory"]
+weight: 50
 #notoc: true
 #layout: wide
 #toc-level: "3"

--- a/content/releasenotes/studio-pro/index.md
+++ b/content/releasenotes/studio-pro/index.md
@@ -3,6 +3,7 @@ title: "Studio Pro"
 toc-level: 1
 description: "Presents all of the available release notes for Mendix Studio Pro."
 frontpage_featured: true
+weight: 5
 aliases:
     - /releasenotes/desktop-modeler/index.html
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.

--- a/content/releasenotes/studio/index.md
+++ b/content/releasenotes/studio/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Studio"
 frontpage_featured: true
+weight: 10
 ---
 
 The release notes for [Mendix Studio](/studio/) are correlated with the version ranges of [Mendix Studio Pro](/releasenotes/studio-pro/): 

--- a/content/studio-how-to/domain-model-how-to-configure.md
+++ b/content/studio-how-to/domain-model-how-to-configure.md
@@ -1,7 +1,7 @@
 ---
 title: "Configure a Domain Model"
 description: "This how-to describes the process of configuring the domain model in Mendix Studio."
-menu_order: 30
+weight: 30
 tags: ["studio", "domain model", "decision", "domain model"]
 ---
 

--- a/content/studio-how-to/index.md
+++ b/content/studio-how-to/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Studio 9 How-to's"
 tags: ["studio", "how to"]
+weight: 25
 ---
 
 {{% alert type="warning" %}}

--- a/content/studio-how-to/microflows.md
+++ b/content/studio-how-to/microflows.md
@@ -1,6 +1,7 @@
 ---
 title: "Microflows"
 description: "A landing page for Studio how-to's on microflows."
+weight: 50
 tags: ["studio", "microflow", "how-to"]
 ---
 

--- a/content/studio-how-to/navigation-how-to-configure.md
+++ b/content/studio-how-to/navigation-how-to-configure.md
@@ -1,7 +1,7 @@
 ---
 title: "Configure a Navigation Bar"
 description: "This how-to describes the process of configuring a navigation bar in Mendix Studio."
-menu_order: 15
+weight: 15
 tags: ["studio", "navigation", "how to", "navigation bar"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio-how-to/pages.md
+++ b/content/studio-how-to/pages.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages"
 description: "A landing page for Studio how-to's on pages."
-menu_order: 10
+weight: 10
 tags: ["studio", "pages", "how-to"]
 ---
 

--- a/content/studio-how-to/security-how-to-configure-roles.md
+++ b/content/studio-how-to/security-how-to-configure-roles.md
@@ -1,7 +1,7 @@
 ---
 title: "Secure Your App and Configure Access to Its Functionality"
 description: "Describes how to configure security in Mendix Studio."
-menu_order: 40
+weight: 40
 tags: ["studio", "security", "user roles", "secure your app", "conditional visibility"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio-how-to/theme-customizer-how-to-customize-design.md
+++ b/content/studio-how-to/theme-customizer-how-to-customize-design.md
@@ -1,6 +1,7 @@
 ---
 title: "Customize the Design of Your App"
 description: "This how-to describes how to change and customize design in Mendix Studio."
+weight: 60
 tags: ["studio", "theme customizer", "how to", "customize", "design"]
 ---
 

--- a/content/studio-how-to/workflow-how-to-configure.md
+++ b/content/studio-how-to/workflow-how-to-configure.md
@@ -1,7 +1,7 @@
 ---
 title: "Configure a Workflow in Studio for the Employee Onboarding Process"
 description: "Describes how to configure a workflow in Mendix Studio."
-menu_order: 05
+weight: 05
 tags: ["studio", "workflow", "how to", task", "onboarding"]
 ---
 

--- a/content/studio-how-to8/domain-model-how-to-configure.md
+++ b/content/studio-how-to8/domain-model-how-to-configure.md
@@ -1,7 +1,7 @@
 ---
 title: "Configure a Domain Model"
 description: "This how-to describes the process of configuring the domain model in Mendix Studio."
-menu_order: 30
+weight: 30
 tags: ["studio", "domain model", "decision", "domain model"]
 ---
 

--- a/content/studio-how-to8/index.md
+++ b/content/studio-how-to8/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Studio 8 How-to's"
 tags: ["studio", "how to"]
+weight: 75
 ---
 
 {{% alert type="warning" %}}

--- a/content/studio-how-to8/microflows.md
+++ b/content/studio-how-to8/microflows.md
@@ -1,6 +1,7 @@
 ---
 title: "Microflows"
 description: "A landing page for Studio how-to's on microflows."
+weight: 50
 tags: ["studio", "microflow", "how-to"]
 ---
 

--- a/content/studio-how-to8/navigation-how-to-configure.md
+++ b/content/studio-how-to8/navigation-how-to-configure.md
@@ -1,7 +1,7 @@
 ---
 title: "Configure a Navigation Bar"
 description: "This how-to describes the process of configuring a navigation bar in Mendix Studio."
-menu_order: 15
+weight: 15
 tags: ["studio", "navigation", "how to", "navigation bar"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio-how-to8/pages.md
+++ b/content/studio-how-to8/pages.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages"
 description: "A landing page for Studio how-to's on pages."
-menu_order: 10
+weight: 10
 tags: ["studio", "pages", "how-to"]
 ---
 

--- a/content/studio-how-to8/security-how-to-configure-roles.md
+++ b/content/studio-how-to8/security-how-to-configure-roles.md
@@ -1,7 +1,7 @@
 ---
 title: "Secure Your App and Configure Access to Its Functionality"
 description: "Describes how to configure security in Mendix Studio."
-menu_order: 40
+weight: 40
 tags: ["studio", "security", "user roles", "secure your app", "conditional visibility"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio-how-to8/theme-customizer-how-to-customize-design.md
+++ b/content/studio-how-to8/theme-customizer-how-to-customize-design.md
@@ -1,6 +1,7 @@
 ---
 title: "Customize the Design of Your App"
 description: "This how-to describes how to change and customize design in Mendix Studio."
+weight: 60
 tags: ["studio", "theme customizer", "how to", "customize", "design"]
 ---
 

--- a/content/studio/checks.md
+++ b/content/studio/checks.md
@@ -1,7 +1,7 @@
 ---
 title: "Checks"
 description: "Describes checks during publishing process in Mendix Studio."
-menu_order: 70
+weight: 70
 tags: ["studio", "app viewing", "checks", "errors", "consistency errors"]
 ---
 

--- a/content/studio/collaboration.md
+++ b/content/studio/collaboration.md
@@ -1,6 +1,6 @@
 ---
 title: "Collaboration"
-weight: 110
+weight: 100
 description: "Describes collaborative development and Buzz in Mendix Studio."
 tags: ["studio", "data", "working with data", "work with data"]
 ---

--- a/content/studio/collaboration.md
+++ b/content/studio/collaboration.md
@@ -1,6 +1,6 @@
 ---
 title: "Collaboration"
-menu_order: 110
+weight: 110
 description: "Describes collaborative development and Buzz in Mendix Studio."
 tags: ["studio", "data", "working with data", "work with data"]
 ---

--- a/content/studio/expressions.md
+++ b/content/studio/expressions.md
@@ -1,6 +1,6 @@
 ---
 title: "Expressions"
-menu_order: 55
+weight: 55
 description: "Describes the microflow expressions available in Mendix Studio."
 tags: ["studio", "microflow", "expressions", "expression", "set value", "variable"]
 aliases:

--- a/content/studio/general.md
+++ b/content/studio/general.md
@@ -1,7 +1,7 @@
 ---
 title: "General Info"
 description: "Describes various features of Mendix Studio."
-menu_order: 10
+weight: 10
 tags: ["studio", "studio pro"]
 aliases:
     - /howto/tutorials/index.html

--- a/content/studio/index.md
+++ b/content/studio/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Studio 9 Guide"
 tags: ["studio", "web modeler"]
+weight: 20
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---

--- a/content/studio/microflows.md
+++ b/content/studio/microflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Microflows"
 description: "Describes the microflows in Mendix Studio."
-menu_order: 50
+weight: 50
 tags: ["studio", "microflow"]
 #If moving or renaming this doc file or section 5 Toolbox, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor <microflows-toolbox> below is mapped, so it should not be removed or changed.

--- a/content/studio/navigation.md
+++ b/content/studio/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation Document"
 description: "Describes the navigation menu in Mendix Studio."
-menu_order: 40
+weight: 40
 tags: ["studio", "navigation", "menu item", "navigation item", "app menu"]
 ---
 

--- a/content/studio/page-editor.md
+++ b/content/studio/page-editor.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages"
 description: "Describes the page editor in Mendix Studio."
-menu_order: 20
+weight: 20
 tags: ["studio", "page editor", "pages"]
 ---
 

--- a/content/studio/publishing-app.md
+++ b/content/studio/publishing-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Previewing & Publishing Your App"
 description: "Describes previewing and publishing processes in the Mendix Studio."
-menu_order: 60
+weight: 60
 tags: ["studio", "deployment", "publishing", "app publishing", "deploy", "deploying", "publish", "preview"]
 ---
 

--- a/content/studio/settings.md
+++ b/content/studio/settings.md
@@ -1,7 +1,7 @@
 ---
 title: "Settings"
 description: "Describes the Settings menu in Mendix Studio."
-menu_order: 90
+weight: 90
 tags: ["studio", "settings", "widgets"]
 ---
 

--- a/content/studio/theme-customizer.md
+++ b/content/studio/theme-customizer.md
@@ -1,7 +1,7 @@
 ---
 title: "Theme Customizer"
 description: "Describes the Theme Customizer in Mendix Studio."
-menu_order: 80
+weight: 80
 tags: ["studio", "theme customizer", "atlas ui"]
 ---
 

--- a/content/studio/work-with-data.md
+++ b/content/studio/work-with-data.md
@@ -1,6 +1,6 @@
 ---
 title: "Working with Data"
-menu_order: 30
+weight: 30
 description: "Describes how to work with data in Mendix Studio."
 tags: ["studio", "data", "working with data", "work with data"]
 ---

--- a/content/studio/workflows.md
+++ b/content/studio/workflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Workflows"
 description: "Describes the workflows in Mendix Studio."
-menu_order: 15
+weight: 15
 tags: ["workflow", "workflows", "Studio"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio7/checks.md
+++ b/content/studio7/checks.md
@@ -1,7 +1,7 @@
 ---
 title: "Checks"
 description: "Describes checks during publishing process in Mendix Studio."
-menu_order: 60
+weight: 80
 tags: ["studio", "app viewing", "checks", "errors", "consistency errors"]
 ---
 

--- a/content/studio7/consistency-errors.md
+++ b/content/studio7/consistency-errors.md
@@ -1,6 +1,6 @@
 ---
 title: "Consistency Errors"
-menu_order: 70
+weight: 90
 description: "Describes consistency errors in Mendix Studio and the way to fix them."
 tags: ["studio", "consistency errors", "checks", "errors"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.

--- a/content/studio7/domain-models.md
+++ b/content/studio7/domain-models.md
@@ -1,7 +1,7 @@
 ---
 title: "Domain Model"
 description: "Describes the domain models in Mendix Studio."
-menu_order: 20
+weight: 20
 tags: ["studio", "domain model"]
 ---
 

--- a/content/studio7/filters.md
+++ b/content/studio7/filters.md
@@ -1,6 +1,6 @@
 ---
 title: "Data Filters"
-menu_order: 52
+weight: 60
 description: "Describes data filtering in page and microflow editors in Mendix Studio."
 tags: ["studio", "microflow", "filter", "filters", "filtering", "data", "data filtering", "retrieve", "page", "xpath", "constraints"]
 ---

--- a/content/studio7/general.md
+++ b/content/studio7/general.md
@@ -1,7 +1,7 @@
 ---
 title: "General Info"
 description: "Describes various features of Mendix Studio."
-menu_order: 10
+weight: 10
 tags: ["studio", "studio pro"]
 ---
 

--- a/content/studio7/index.md
+++ b/content/studio7/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Mendix 7 Studio Guide"
 tags: ["studio", "web modeler"]
+weight: 5
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/studio7/microflows.md
+++ b/content/studio7/microflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Microflows"
 description: "Describes the microflows in Mendix Studio."
-menu_order: 50
+weight: 50
 tags: ["studio", "microflow"]
 #If moving or renaming this doc file or section 5 Toolbox, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio7/navigation.md
+++ b/content/studio7/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation Document"
 description: "Describes the navigation menu in Mendix Studio."
-menu_order: 40
+weight: 40
 tags: ["studio", "navigation", "app menu"]
 ---
 

--- a/content/studio7/page-editor.md
+++ b/content/studio7/page-editor.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages"
 description: "Describes the page editor in Mendix Studio."
-menu_order: 30
+weight: 30
 tags: ["studio", "page editor", "pages"]
 ---
 

--- a/content/studio7/publishing-app.md
+++ b/content/studio7/publishing-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Previewing & Publishing Your App"
 description: "Describes previewing and publishing processes in the Mendix Studio."
-menu_order: 55
+weight: 70
 tags: ["studio", "deployment", "publishing", "app publishing", "deploy", "deploying", "publish", "preview"]
 ---
 

--- a/content/studio7/settings.md
+++ b/content/studio7/settings.md
@@ -1,7 +1,7 @@
 ---
 title: "Settings"
 description: "Describes the Settings menu in Mendix Studio."
-menu_order: 90
+weight: 110
 tags: ["studio", "settings", "widgets"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio7/start-with-data.md
+++ b/content/studio7/start-with-data.md
@@ -1,6 +1,7 @@
 ---
 title: "Starting With Your Own Data"
 description: "Describes how to import an Excel spreadsheet to your domain model in Mendix Studio."
+weight: 120
 tags: ["studio", "domain model", "excel import", "start with data", "data model"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio7/theme-customizer.md
+++ b/content/studio7/theme-customizer.md
@@ -1,7 +1,7 @@
 ---
 title: "Theme Customizer"
 description: "Describes the Theme Customizer in Mendix Studio."
-menu_order: 80
+weight: 100
 tags: ["studio", "theme customizer", "atlas ui"]
 ---
 

--- a/content/studio8/checks.md
+++ b/content/studio8/checks.md
@@ -1,7 +1,7 @@
 ---
 title: "Checks"
 description: "Describes checks during publishing process in Mendix Studio."
-menu_order: 70
+weight: 70
 tags: ["studio", "app viewing", "checks", "errors", "consistency errors"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor viewing-checks below is mapped, so it should not be removed or changed.

--- a/content/studio8/collaboration.md
+++ b/content/studio8/collaboration.md
@@ -1,6 +1,6 @@
 ---
 title: "Collaboration"
-menu_order: 110
+weight: 100
 description: "Describes collaborative development and Buzz in Mendix Studio."
 tags: ["studio", "data", "working with data", "work with data"]
 ---

--- a/content/studio8/general.md
+++ b/content/studio8/general.md
@@ -1,7 +1,7 @@
 ---
 title: "General Info"
 description: "Describes various features of Mendix Studio."
-menu_order: 10
+weight: 10
 tags: ["studio", "studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/studio8/index.md
+++ b/content/studio8/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Studio 8 Guide"
 tags: ["studio", "web modeler"]
+weight: 70
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---

--- a/content/studio8/microflows.md
+++ b/content/studio8/microflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Microflows"
 description: "Describes the microflows in Mendix Studio."
-menu_order: 50
+weight: 50
 tags: ["studio", "microflow"]
 #If moving or renaming this doc file or section 5 Toolbox, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor <microflows-toolbox> below is mapped, so it should not be removed or changed.

--- a/content/studio8/navigation.md
+++ b/content/studio8/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation Document"
 description: "Describes the navigation menu in Mendix Studio."
-menu_order: 40
+weight: 40
 tags: ["studio", "navigation", "menu item", "navigation item", "app menu"]
 ---
 

--- a/content/studio8/page-editor.md
+++ b/content/studio8/page-editor.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages"
 description: "Describes the page editor in Mendix Studio."
-menu_order: 20
+weight: 20
 tags: ["studio", "page editor", "pages"]
 ---
 

--- a/content/studio8/publishing-app.md
+++ b/content/studio8/publishing-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Previewing & Publishing Your App"
 description: "Describes previewing and publishing processes in the Mendix Studio."
-menu_order: 60
+weight: 60
 tags: ["studio", "deployment", "publishing", "app publishing", "deploy", "deploying", "publish", "preview"]
 ---
 

--- a/content/studio8/settings.md
+++ b/content/studio8/settings.md
@@ -1,7 +1,7 @@
 ---
 title: "Settings"
 description: "Describes the Settings menu in Mendix Studio."
-menu_order: 90
+weight: 90
 tags: ["studio", "settings", "widgets"]
 ---
 

--- a/content/studio8/theme-customizer.md
+++ b/content/studio8/theme-customizer.md
@@ -1,7 +1,7 @@
 ---
 title: "Theme Customizer"
 description: "Describes the Theme Customizer in Mendix Studio."
-menu_order: 80
+weight: 80
 tags: ["studio", "theme customizer", "atlas ui"]
 ---
 

--- a/content/studio8/work-with-data.md
+++ b/content/studio8/work-with-data.md
@@ -1,6 +1,6 @@
 ---
 title: "Working with Data"
-menu_order: 30
+weight: 30
 description: "Describes how to work with data in Mendix Studio."
 tags: ["studio", "data", "working with data", "work with data"]
 ---

--- a/data/spaces.yml
+++ b/data/spaces.yml
@@ -218,7 +218,6 @@ data-hub:
   menu_categories:
     - "Share Data Between Apps"
     - "Write Data to Another App"
-    - "General Info"
     - "Data Hub Catalog"
     - "Data Hub Landscape"
 product-naming:

--- a/data/spaces.yml
+++ b/data/spaces.yml
@@ -202,7 +202,6 @@ partners:
   menu_categories:
     - "Siemens"
     - "SAP"
-    - "IBM"
 appstore:
   space: "Marketplace Guide"
   priority: false
@@ -231,4 +230,3 @@ product-naming:
     - "Other Mendix Terms"
     - "Strategic Partner Terms"
     - "Terminology History"
-    - "Maintaining Documentation Links"


### PR DESCRIPTION
Prior to upgrading HUGO version we need to make sure the navigation stays in the right order.
For most pages this is already done through *menu_order*, which equates to *weight* in the upgraded version.
For **Spaces** and **Categories**, this needs to be added to the Front matter as *weight:*, and can be added to the current site without affecting the build.
This PR adds weight to all the Space and Category index files.
The following is a list of spaces where the category indexes need to have the correct weights added:

- [x] All **Spaces**

**Categories**
- [x] apidocs-mxsdk: Connor
- [x] addons: Connor
- [x] howto7: Connor
- [x] howto8: Connor
- [x] howto: Connor
- [x] refguide7: Maria
- [x] refguide8: Maria
- [x] refguide: Maria
- [x] releasenotes: Mark
- [x] developerportal: Mark
- [x] studio: Maria
- [x] studio8: Maria
- [x] studio7: Maria
- [x] studio-how-to: Maria
- [x] studio-how-to8: Maria
- [x] partners: Mark
- [x] appstore: Luyao
- [x] data-hub: Mark
- [x] product-naming: Mark