### PR TITLE
[RTO-3016] Document new behavior of member changes in 9.5.0

### DIFF
--- a/content/releasenotes/studio-pro/9.5.md
+++ b/content/releasenotes/studio-pro/9.5.md
@@ -90,7 +90,7 @@ description: "The release notes for Mendix Studio Pro version 9.5 (including all
 
 ### Breaking Changes
 
-* <a name="bc-2678"></a>When changing an object member, the member’s state will now always become 'CHANGED', even if the old value and the new value are the same. For example, suppose we have a committed object `$User` with `$User/Name = 'Alice'`. Applying a change to set `$User/Name` to `'Alice'` results in the member becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member remaining 'UNCHANGED'.
+* <a name="bc-2678"></a>When changing an object member, the member’s state will now always become 'CHANGED', even if the old value and the new value are the same.<br/>For example, suppose we have a committed object `$User` with `$User/Name = 'Alice'`. Applying a change to set `$User/Name` to `'Alice'` results in the member becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member remaining 'UNCHANGED'.
 * We changed the format of the `mx-name-` class of links inside [menu widget](/refguide/menu-widgets) items. Previously, it was `mx-name-GUID-NUMBER`, but now it is `mx-name-WIDGETNAME-NUMBER`. This removes an inconsistency in this class format and should make it easier to use. However, this might require you to change the locators in your tests.
 * [Native Mobile Resources](/appstore/modules/native-mobile-resources) versions 2.0.1 and below have been black-listed due to changes required to support Android 11.
 * In line with the [mobile operating system support policy](/refguide/system-requirements#mobileos), we are removing support for iOS and Safari 12.

--- a/content/releasenotes/studio-pro/9.5.md
+++ b/content/releasenotes/studio-pro/9.5.md
@@ -54,7 +54,7 @@ description: "The release notes for Mendix Studio Pro version 9.5 (including all
 ### Fixes
 
 * XPath constraints are now allowed with entity name like `[MyFirstModule.AssociatedEntity_Entity/MyFirstModule.Entity = '[%CurrentObject%]']`, which means the same as `[MyFirstModule.AssociatedEntity_Entity = '[%CurrentObject%]']`. (Ticket 44168)
-* We fixed an issue that occurred when committing objects referencing auto-committed objects. In rare scenarios, changes were not committed to the database. (Tickets 86901, 117336, 117350)
+* We fixed an issue that occurred when committing objects referencing auto-committed objects. In rare scenarios, changes were not committed to the database. [This caused the breaking change described below](#bc-2678). (Tickets 86901, 117336, 117350)
 * We fixed an error that occurred when using import mapping with a large amount of objects. (Ticket 111544)
 * We fixed an issue that occurred when calling sub-microflows with parameters that went over associations. (Tickets 114521, 126033, 125908)
 * We fixed an issue where a retrieve in a microflow returned empty, although the value of the association was not empty. (Ticket 116967)
@@ -90,6 +90,7 @@ description: "The release notes for Mendix Studio Pro version 9.5 (including all
 
 ### Breaking Changes
 
+* <a name="bc-2678"></a>When changing an object member, the member’s state will now always become 'CHANGED', even if the old value and the new value are the same. For example, suppose we have a committed object `$User` with `$User/Name = 'Alice'`. Applying a change to set `$User/Name` to `'Alice'` results in the member becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member remaining 'UNCHANGED'.
 * We changed the format of the `mx-name-` class of links inside [menu widget](/refguide/menu-widgets) items. Previously, it was `mx-name-GUID-NUMBER`, but now it is `mx-name-WIDGETNAME-NUMBER`. This removes an inconsistency in this class format and should make it easier to use. However, this might require you to change the locators in your tests.
 * [Native Mobile Resources](/appstore/modules/native-mobile-resources) versions 2.0.1 and below have been black-listed due to changes required to support Android 11.
 * In line with the [mobile operating system support policy](/refguide/system-requirements#mobileos), we are removing support for iOS and Safari 12.


### PR DESCRIPTION
## Brief Overview

 > Release Target: **9.5.0**

A bug regarding state handling was fixed (also known as RTO-2678) in the **Mx9.5.0** release. This resulted in behavioral changes since the 9.5.0 release. However, these changes were not documented in the release notes.

This pull request aims to add these missing release notes, describing how the behavior changed.