### PR TITLE
[RTO-3016] Add changed behavior to migration guide

### DIFF
--- a/content/refguide/moving-from-8-to-9.md
+++ b/content/refguide/moving-from-8-to-9.md
@@ -101,6 +101,14 @@ If your app is still using Mendix runtime for uniqueness validation, then you sh
 
 If any are found, an error like **An error occured while initializing the Runtime: Detected unique constraing violation...** will be logged. To solve this, your app will have to be prepared before moving to Mendix 9. You can obtain the tools you need by [submitting a support request](/developerportal/support/submit-support-request).
 
+### 4.2 Mendix Object Changed Flag
+
+Starting with Mendix 9.5, when changing an object member, the member's state will now always become 'CHANGED', even if the old value and the new value are the same.
+
+This change also affects the `objectHasChanged` and the `memberHasChanged` Java Actions of the Community Commons module.
+
+For example, suppose we have a committed object `$User` with `$User/Name = 'Alice'`. Applying a change to set `$User/Name` to `'Alice'` results in the member becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member remaining 'UNCHANGED'.
+
 ## 5 Testing Native Mobile Apps
 
 To test and preview native mobile apps in Mendix 9, you must download the Mendix 9 version of the Make It Native app:

--- a/content/refguide/moving-from-8-to-9.md
+++ b/content/refguide/moving-from-8-to-9.md
@@ -103,11 +103,9 @@ If any are found, an error like **An error occured while initializing the Runtim
 
 ### 4.2 Mendix Object Changed Flag
 
-Starting with Mendix 9.5, when changing an object member, the member's state will now always become 'CHANGED', even if the old value and the new value are the same.
+In Mendix 9.5 and above, when an object member changes, the member state becomes 'CHANGED' even if the old value and the new value are the same.This also affects `objectHasChanged` and `memberHasChanged` Java actions of the Community Commons module.
 
-This change also affects the `objectHasChanged` and the `memberHasChanged` Java Actions of the Community Commons module.
-
-For example, suppose we have a committed object `$User` with `$User/Name = 'Alice'`. Applying a change to set `$User/Name` to `'Alice'` results in the member becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member remaining 'UNCHANGED'.
+For example, you have a committed object `$User` with `$User/Name = 'Alice'`. Setting `$User/Name` to `'Alice'` results in the member state becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member state remaining 'UNCHANGED'.
 
 ## 5 Testing Native Mobile Apps
 

--- a/content/refguide/moving-from-8-to-9.md
+++ b/content/refguide/moving-from-8-to-9.md
@@ -103,7 +103,7 @@ If any are found, an error like **An error occured while initializing the Runtim
 
 ### 4.2 Mendix Object Changed Flag
 
-In Mendix 9.5 and above, when an object member changes, the member state becomes 'CHANGED' even if the old value and the new value are the same.This also affects `objectHasChanged` and `memberHasChanged` Java actions of the Community Commons module.
+In Mendix 9.5 and above, when you change an object member, the member state becomes 'CHANGED' even if the old value and the new value are the same. This also affects `objectHasChanged` and `memberHasChanged` Java actions of the Community Commons module.
 
 For example, you have a committed object `$User` with `$User/Name = 'Alice'`. Setting `$User/Name` to `'Alice'` results in the member state becoming 'CHANGED' even though the name is the same. Previously, this would have resulted in the member state remaining 'UNCHANGED'.
 


### PR DESCRIPTION
## Quick Overview

This pull request adds the breaking change described in **Mendix 9.5.0** (see also https://github.com/mendix/docs/pull/4050), to the migration guide from Mendix 8 to 9.