### PR TITLE
Small Mx4PC documentation fix (no release date)

### DIFF
--- a/content/developerportal/deploy/private-cloud-monitor.md
+++ b/content/developerportal/deploy/private-cloud-monitor.md
@@ -38,8 +38,6 @@ to ensure that this logging/monitoring solution is compliant with your organizat
 
 ### 2.1 Prerequisites
 
-{{% alert type="warning" %}}The Grafana Helm chart doesn't yet support Kubernetes version 1.22 and above.{{% /alert %}}
-
 Before installing Grafana, make sure you have [installed Helm](https://grafana.com/docs/loki/latest/installation/helm/) and can access your Kubernetes cluster.
 
 Download the latest version of the Grafana Helm chart using the following commands:
@@ -75,7 +73,7 @@ Run the following commands in a Bash console, (replace `{namespace}` with the na
 
 ```shell
 NAMESPACE={namespace}
-helm upgrade --install loki grafana/loki-stack --version='^2.5.0' --namespace=${NAMESPACE} --set grafana.enabled=true,grafana.persistence.enabled=true,grafana.persistence.size=1Gi,grafana.initChownData.enabled=false,grafana.admin.existingSecret=grafana-admin \
+helm upgrade --install loki grafana/loki-stack --version='^2.5.1' --namespace=${NAMESPACE} --set grafana.enabled=true,grafana.persistence.enabled=true,grafana.persistence.size=1Gi,grafana.initChownData.enabled=false,grafana.admin.existingSecret=grafana-admin \
 --set prometheus.enabled=true,prometheus.server.persistentVolume.enabled=true,prometheus.server.persistentVolume.size=50Gi,prometheus.server.retention=7d \
 --set loki.persistence.enabled=true,loki.persistence.size=10Gi,loki.config.chunk_store_config.max_look_back_period=168h,loki.config.table_manager.retention_deletes_enabled=true,loki.config.table_manager.retention_period=168h \
 --set promtail.enabled=true,promtail.securityContext.privileged=true \
@@ -167,7 +165,7 @@ Run the following commands in a Bash console: replace `{uid}` with the UID chose
 ```shell
 PROJECT={project}
 GRAFANA_UID={uid}
-helm upgrade --install loki grafana/loki-stack --version='^2.5.0' --namespace=${PROJECT} --set grafana.enabled=true,grafana.persistence.enabled=true,grafana.persistence.size=1Gi,grafana.initChownData.enabled=false,grafana.admin.existingSecret=grafana-admin \
+helm upgrade --install loki grafana/loki-stack --version='^2.5.1' --namespace=${PROJECT} --set grafana.enabled=true,grafana.persistence.enabled=true,grafana.persistence.size=1Gi,grafana.initChownData.enabled=false,grafana.admin.existingSecret=grafana-admin \
 --set prometheus.enabled=true,prometheus.server.persistentVolume.enabled=true,prometheus.server.persistentVolume.size=50Gi,prometheus.server.retention=7d \
 --set loki.persistence.enabled=true,loki.persistence.size=10Gi,loki.config.chunk_store_config.max_look_back_period=168h,loki.config.table_manager.retention_deletes_enabled=true,loki.config.table_manager.retention_period=168h \
 --set promtail.enabled=true,promtail.securityContext.privileged=true \
@@ -363,9 +361,9 @@ The Mendix Runtime Prometheus metrics are not yet supported by Mendix for Privat
 The reference dashboard provided in this document will not be compatible with the native Mendix 9.6 metrics.
 {{% /alert %}}
 
-### 4.1 Import the Dashboard
+### 4.1 Import the Dashboard{#import-dashboard}
 
-To install the reference dashboard, download the [dashboard JSON](https://cdn.mendix.com/mendix-for-private-cloud/grafana-dashboard/mendix_app_dashboard-1.0.0.json) to a local file.
+To install the reference dashboard, download the [dashboard JSON](https://cdn.mendix.com/mendix-for-private-cloud/grafana-dashboard/mendix_app_dashboard_compatibility-1.1.0.json) to a local file.
 
 [Import](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) the downloaded JSON into Grafana:
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2022
 
-### January ???th, 2022
+### January 12th, 2022
 
 #### Prometheus Metrics
 

--- a/content/releasenotes/developer-portal/mendix-for-private-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-for-private-cloud.md
@@ -10,6 +10,14 @@ These release notes cover changes to deployment to [Mendix for Private Cloud](/d
 
 For information on the current status of deployment to Mendix for Private Cloud and any planned releases see [Mendix Status](https://status.mendix.com/).
 
+## 2022
+
+### January ???th, 2022
+
+#### Prometheus Metrics
+
+* We have updated the [Grafana dashboard](/developerportal/deploy/private-cloud-monitor#import-dashboard) to be compatible with version 2.5.1 of the `grafana/loki-stack` Helm chart. If you're planning to upgrade the `loki-stack` Helm chart in your cluster, you will need to use the updated dashboard.
+* The monitoring solution is now compatible with Kubernetes version 1.22.
 
 ## 2021
 


### PR DESCRIPTION
Grafana updated their Helm chart [on January 5](https://artifacthub.io/packages/helm/grafana/loki-stack/2.5.1), and the Mx4PC dashboard is no longer compatible with metrics generated by this new version.

We've created a new version of the dashboard to address this issue.