### PR TITLE
Fixes external links to PostgreSQL, MySQL and MariaDB documentation pages

### DIFF
--- a/content/howto/data-models/migrating-your-mendix-database.md
+++ b/content/howto/data-models/migrating-your-mendix-database.md
@@ -103,7 +103,7 @@ Having configured the Mendix app, just run the application locally and it will a
 
 ### 4.1 Exporting a PostgreSQL Database
 
-To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
+To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
 
 ### 4.2 Uploading an Exported PostgreSQL Database to a Mendix Cloud Database
 
@@ -125,7 +125,7 @@ Export the Mendix cloud database via the Developer Portal. This can be accessed 
 
 ### 5.1 Importing into an On-premises PostgreSQL Database
 
-To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to restore your downloaded database file.
+To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to restore your downloaded database file.
 
 ### 5.2 Migrating a PostgreSQL Database To a Non-PostgreSQL Database
 

--- a/content/howto7/data-models/migrating-your-mendix-database.md
+++ b/content/howto7/data-models/migrating-your-mendix-database.md
@@ -68,7 +68,7 @@ Having configured the Mendix project, just run the application locally and it wi
 
 ### 3.1 Exporting a PostgreSQL Database
 
-To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/1.22/backup.html) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
+To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/1.22/backup.html) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
 
 ### 3.2 Uploading an Exported PostgreSQL Database to the Mendix Cloud Database
 
@@ -82,7 +82,7 @@ Export the Mendix cloud database via the Developer Portal. This can be accessed 
 
 ### 4.1 Importing into an On-premises PostgreSQL Database
 
-To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/1.22/restore.html) visual tool documentation to understand how to restore your downloaded database file.
+To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/1.22/restore.html) visual tool documentation to understand how to restore your downloaded database file.
 
 ### 4.2 Migrating a PostgreSQL Database To a Non-PostgreSQL Database
 

--- a/content/howto8/data-models/migrating-your-mendix-database.md
+++ b/content/howto8/data-models/migrating-your-mendix-database.md
@@ -97,7 +97,7 @@ Having configured the Mendix project, just run the application locally and it wi
 
 ### 4.1 Exporting a PostgreSQL Database
 
-To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
+To export a PostgreSQL database, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to create a backup of your new PostgreSQL database.
 
 ### 4.2 Uploading an Exported PostgreSQL Database to the Mendix Cloud Database
 
@@ -111,7 +111,7 @@ Export the Mendix cloud database via the Developer Portal. This can be accessed 
 
 ### 5.1 Importing into an On-premises PostgreSQL Database
 
-To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/9.5/static/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to restore your downloaded database file.
+To import a PostgreSQL database using the downloaded database file, refer to either the [pg_dump](https://www.postgresql.org/docs/current/backup-dump.html) command line tool or the [PG Admin](https://www.pgadmin.org/docs/) visual tool documentation to understand how to restore your downloaded database file.
 
 ### 5.2 Migrating a PostgreSQL Database To a Non-PostgreSQL Database
 

--- a/content/refguide/mysql.md
+++ b/content/refguide/mysql.md
@@ -17,7 +17,7 @@ Mendix only supports the InnoDB storage engine, with row-based logging enabled.
 
 ## 3 Transaction Isolation
 
-Mendix uses the `Read Committed` transaction isolation level by default. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/mariadb/replication-and-binary-log-server-system-variables/#binlog_format).
+Mendix uses the `Read Committed` transaction isolation level by default. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#binlog_format).
 
 ## 4 SAVEPOINT Exception Does Not Exist
 
@@ -29,7 +29,7 @@ Mendix supports functionality to extract a part of a date and time in a query. I
 
 In Mendix, DateTimes are stored in the UTC time zone. For these functions to work correctly, it is important that the database supports converting dates and times from UTC to another time zone. If this is not possible, the functions will operate on the date and time in the UTC time zone. That can lead to incorrect results if the user expects the date to work in their time zone.
 
-MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [10.6 MySQL Server Time Zone Support](http://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
+MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [5.1.15 MySQL Server Time Zone Support](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
 
 MariaDB supports an identical configuration for time zone conversions.
 

--- a/content/refguide/xpath-week-from-datetime.md
+++ b/content/refguide/xpath-week-from-datetime.md
@@ -30,7 +30,7 @@ The HSQLDB database used for testing locally uses JVM's [Calendar.WEEK_OF_YEAR](
 
 PostgreSQL, Oracle, and MySQL follow [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
 
-* [PostgreSQL](https://www.postgresql.org/docs/11/functions-datetime.html)
+* [PostgreSQL](https://www.postgresql.org/docs/current/functions-datetime.html)
 * [Oracle](https://docs.oracle.com/cd/B28359_01/olap.111/b28126/dml_commands_1029.htm#OLADM780)
 * [MySQL](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_week)
 

--- a/content/refguide7/mysql.md
+++ b/content/refguide7/mysql.md
@@ -16,7 +16,7 @@ Mendix only supports the InnoDB storage engine, with row-based logging enabled.
 
 ## 3 Transaction Isolation
 
-Mendix uses the `Read Committed` transaction isolation level by default, starting with the release of Mendix 7.2. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/mariadb/replication-and-binary-log-server-system-variables/#binlog_format).
+Mendix uses the `Read Committed` transaction isolation level by default, starting with the release of Mendix 7.2. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#binlog_format).
 
 ## 4 SAVEPOINT Exception Does Not Exist
 
@@ -28,7 +28,7 @@ Mendix supports functionality to extract a part of a date and time in a query. I
 
 In Mendix, DateTimes are stored in the UTC time zone. For these functions to work correctly, it is important that the database supports converting dates and times from UTC to another time zone. If this is not possible, the functions will operate on the date and time in the UTC time zone. That can lead to incorrect results if the user expects the date to work in their time zone.
 
-MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [10.6 MySQL Server Time Zone Support](http://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
+MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [5.1.15 MySQL Server Time Zone Support](http://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
 
 MariaDB supports an identical configuration for time zone conversions.
 

--- a/content/refguide8/mysql.md
+++ b/content/refguide8/mysql.md
@@ -17,7 +17,7 @@ Mendix only supports the InnoDB storage engine, with row-based logging enabled.
 
 ## 3 Transaction Isolation
 
-Mendix uses the `Read Committed` transaction isolation level by default. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/mariadb/replication-and-binary-log-server-system-variables/#binlog_format).
+Mendix uses the `Read Committed` transaction isolation level by default. Only row-based logging can be used in the case of this transaction isolation level. You should set the `binlog_format` database configuration value to `ROW` or `MIXED`. For more information, see [`binlog_format` for MySQL](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format) or [`binlog_format` for MariaDB](https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#binlog_format).
 
 ## 4 SAVEPOINT Exception Does Not Exist
 
@@ -29,7 +29,7 @@ Mendix supports functionality to extract a part of a date and time in a query. I
 
 In Mendix, DateTimes are stored in the UTC time zone. For these functions to work correctly, it is important that the database supports converting dates and times from UTC to another time zone. If this is not possible, the functions will operate on the date and time in the UTC time zone. That can lead to incorrect results if the user expects the date to work in their time zone.
 
-MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [10.6 MySQL Server Time Zone Support](http://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
+MySQL does not fully support time zone conversion out-of-the-box. You have to fill in some time zone tables (for more details, see [5.1.14 MySQL Server Time Zone Support](http://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html)). You do not have to do this if you do not use this sort of function in your queries, or if you always want to work with UTC dates and times.
 
 MariaDB supports an identical configuration for time zone conversions.
 

--- a/content/refguide8/xpath-week-from-datetime.md
+++ b/content/refguide8/xpath-week-from-datetime.md
@@ -34,7 +34,7 @@ The HSQLDB database used for testing locally uses JVM's [Calendar.WEEK_OF_YEAR](
 
 PostgreSQL, Oracle, and MySQL follow [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
 
-* [PostgreSQL](https://www.postgresql.org/docs/11/functions-datetime.html)
+* [PostgreSQL](https://www.postgresql.org/docs/current/functions-datetime.html)
 * [Oracle](https://docs.oracle.com/cd/B28359_01/olap.111/b28126/dml_commands_1029.htm#OLADM780)
 * [MySQL](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_week)
 


### PR DESCRIPTION
I noticed a few of our pages point to old versions (9.5 for Postgres, 5.x for MySQL). These links have been updated.