### PR TITLE
remove again the error-causing styling props in "create-a-pluggable-widget-one#label-input"

### DIFF
--- a/content/howto/extensibility/create-a-pluggable-widget-one.md
+++ b/content/howto/extensibility/create-a-pluggable-widget-one.md
@@ -303,11 +303,13 @@ While the Mendix input elements come with labels, you will need to add one to Te
 
 	![edit text box two](attachments/pluggable-part-one/edittextboxtwo.png)
 
-2. Preview the label in the page editor:
+2. In *TextBox.tsx* remove the usages of `{this.props.style}` and `{this.props.class}` because labeled widgets do not have them and the styling is applied to the surrounding FormGroup.
+
+3. Preview the label in the page editor:
 
 	![edit data view one](attachments/pluggable-part-one/editdataviewone.png)
 
-3. This will result in a label above or next to the input depending on the available space, data view `Form orientation`, and the `Label width (weight)`:
+4. This will result in a label above or next to the input depending on the available space, data view `Form orientation`, and the `Label width (weight)`:
 
 	![input elements with label](attachments/pluggable-part-one/inputwidgetswithlabel.png)
 

--- a/content/howto/extensibility/create-a-pluggable-widget-two.md
+++ b/content/howto/extensibility/create-a-pluggable-widget-two.md
@@ -59,8 +59,6 @@ To add these restrictions, follow the instructions below:
 		const value = this.props.textAttribute.value || "";
 		return <TextInput
 			value={value}
-			style={this.props.style}
-			className={this.props.class}
 			tabIndex={this.props.tabIndex}
 			onUpdate={this.onUpdateHandle}
 			disabled={this.props.textAttribute.readOnly}
@@ -184,8 +182,6 @@ This section will teach you to add validation to your TextBox widget. Using micr
 		return <Fragment>
 			<TextInput
 				value={value}
-				style={this.props.style}
-				className={this.props.class}
 				tabIndex={this.props.tabIndex}
 				onUpdate={this.onUpdateHandle}
 				disabled={this.props.textAttribute.readOnly}
@@ -320,8 +316,6 @@ Until now the components did not keep any state. Each keystroke passed through t
 			return <Fragment>
 				<TextInput
 					value={value}
-					style={this.props.style}
-					className={this.props.class}
 					tabIndex={this.props.tabIndex}
 					disabled={this.isReadOnly()}
 					onLeave={this.onLeaveHandle}
@@ -432,8 +426,6 @@ To make the input widget more accessible for people using screen readers, you wi
 			<TextInput
 				id={this.props.id}
 				value={value}
-				style={this.props.style}
-				className={this.props.class}
 				tabIndex={this.props.tabIndex}
 				disabled={this.isReadOnly()}
 				onLeave={this.onLeaveHandle}


### PR DESCRIPTION
https://forum.mendix.com/link/questions/112443
https://github.com/mendix/widgets-resources/pull/260

> Labeled widgets do not have a style prop, as it is already applied to surrounding FormGroup