### PR TITLE
Datetime fields are not supported as keys

### DIFF
--- a/content/refguide/consumed-odata-service-requirements.md
+++ b/content/refguide/consumed-odata-service-requirements.md
@@ -45,7 +45,7 @@ This feature of using entities with keys that do not have a maximum length speci
 {{% /alert %}}
 
 {{% alert type="info" %}}
-Please note that the list above for supported key fields does not include `Date` or `DateTime` data types.
+The list above for supported key fields does not include `Date` or `DateTime` data types.
 {{% /alert %}}
 
 ### 3.2 Attributes

--- a/content/refguide/consumed-odata-service-requirements.md
+++ b/content/refguide/consumed-odata-service-requirements.md
@@ -44,6 +44,10 @@ Furthermore, an entity can only be used if it is uniquely identifiable with a ke
 This feature of using entities with keys that do not have a maximum length specified in the contract applies to version 9.3.0 and above. In previous versions of Studio Pro, you must change the contract to ensure that `MaxLength` is specified.
 {{% /alert %}}
 
+{{% alert type="info" %}}
+Please note that the list above for supported key fields does not include `Date` or `DateTime` data types.
+{{% /alert %}}
+
 ### 3.2 Attributes
 
 {{% alert type="warning" %}}


### PR DESCRIPTION
Call out fact that date and datetime fields cannot be used in odata entity keys.