### PR TITLE
Update debug-microflows-remotely.md

### DIFF
--- a/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
@@ -19,9 +19,7 @@ If you are debugging in the cloud, be aware of other app end-users. Breakpoints 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
-**It is currently not possible to debug Nanoflows remotely.**
-
-If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled, as it is not currently possible to debug nanoflows remotely.
+**It is currently not possible to debug nanoflows remotely.** If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled.
 {{% /alert %}}
 
 **This how-to will teach you how to do the following:**

--- a/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
@@ -18,6 +18,12 @@ These instructions are for apps running in Mendix Cloud v4. If you are running a
 If you are debugging in the cloud, be aware of other app end-users. Breakpoints in the debugger will pause processes for all users of the app in this environment.
 {{% /alert %}}
 
+{{% alert type="warning" %}}
+**It is currently not possible to debug Nanoflows remotely.**
+
+If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled, as it is not currently possible to debug nanoflows remotely.
+{{% /alert %}}
+
 **This how-to will teach you how to do the following:**
 
 * Connect the debugger in Studio Pro to your Mendix Cloud v4 environment


### PR DESCRIPTION
Dear Mx,

Sending this request to add a sentence on remote nanoflow debugging (which isn't possible) - the menu structure of the documentation section did suggest it is possible + the error message given in Studio Pro is not clear as to why the breakpoint is disabled. Hence suggest adding this section. Please also refer to Mx Support ticket 141362.

Best regards,

Wouter Penris