### PR TITLE
Small changes in Mx4PC documentation (no release date)

### DIFF
--- a/content/developerportal/deploy/private-cloud-supported-environments.md
+++ b/content/developerportal/deploy/private-cloud-supported-environments.md
@@ -98,7 +98,7 @@ Externally hosted registries are supported if they allow username/password authe
 * [quay.io](https://quay.io/)
 * [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/) (ACR)
 
-When using ACR in combination with Azure Combination Service, it is possible to set up [native authentication](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration#create-a-new-aks-cluster-with-acr-integration) for pulling images from ACR.
+When using ACR in combination with Azure Kubernetes Service, it is possible to set up [native authentication](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration#create-a-new-aks-cluster-with-acr-integration) for pulling images from ACR.
 
 ### 3.3 OpenShift Image Registry
 

--- a/content/developerportal/deploy/private-cloud-technical-appendix-01.md
+++ b/content/developerportal/deploy/private-cloud-technical-appendix-01.md
@@ -135,7 +135,7 @@ If you want to prevent developers from accessing secrets or other Kubernetes obj
 
 ### 3.5 Scope
 
-Mendix Operator is limited in scope to one namespace. If you need to use the Mendix Operator in multiple namespaces, you have to install it and configure it in each namespace. This allows the use of multiple versions of the Operator, with different configurations, in the same cluster - as long as each Operator runs in its own dedicated namespace.
+Mendix Operator is limited in scope to one namespace. If you need to use the Mendix Operator in multiple namespaces, you have to install it and configure it in each namespace. This allows the use of multiple versions of the Operator, with different configurations, in the same cluster — as long as each Operator runs in its own dedicated namespace.
 It is not possible to install one global instance of the Operator for the entire cluster.
 
 On the other hand, CRDs are global within the cluster. Since all Mendix Operators in a cluster will be using the same shared CRD, it is critical that the latest version of the CRDs are installed in a cluster.  See the [Private Cloud upgrade instructions](private-cloud-upgrade-guide) for more information.

--- a/content/developerportal/deploy/private-cloud-technical-appendix-01.md
+++ b/content/developerportal/deploy/private-cloud-technical-appendix-01.md
@@ -135,7 +135,7 @@ If you want to prevent developers from accessing secrets or other Kubernetes obj
 
 ### 3.5 Scope
 
-Mendix Operator is limited in scope to one namespace. If you need to use the Mendix Operator in multiple namespaces, you have to install it and configure it in each namespace. This allows the use of multiple versions of the Operator, with different configurations, in the same cluster.
+Mendix Operator is limited in scope to one namespace. If you need to use the Mendix Operator in multiple namespaces, you have to install it and configure it in each namespace. This allows the use of multiple versions of the Operator, with different configurations, in the same cluster - as long as each Operator runs in its own dedicated namespace.
 It is not possible to install one global instance of the Operator for the entire cluster.
 
 On the other hand, CRDs are global within the cluster. Since all Mendix Operators in a cluster will be using the same shared CRD, it is critical that the latest version of the CRDs are installed in a cluster.  See the [Private Cloud upgrade instructions](private-cloud-upgrade-guide) for more information.


### PR DESCRIPTION
A few small corrections in the Mx4PC documentation, to address user feedback:

* Fixed incorrect reference to AKS
* Added an explanation that multiple Operators cannot run in the same namespace (one Operator per namespace)