### PR TITLE
Update thresholds for Application Container Memory Percentage alert

### DIFF
--- a/content/developerportal/operate/monitoring-application-health.md
+++ b/content/developerportal/operate/monitoring-application-health.md
@@ -76,8 +76,8 @@ Application Container Memory Percentage | |
 :---|:---|
 Description | Track the memory utilization for the database belonging to the application |
 Example message | Application container 34234543-6543-6543-6543-153d247b6543 - Instance Index: 0 has high memory usage: 90.5
-Warning Threshold | Memory utilization is between 75% and 85%. |
-Critical Threshold | memory utilization is higher than 85%.
+Warning Threshold | Memory utilization is between 90% and 95%. |
+Critical Threshold | memory utilization is higher than 95%.
 First actions to take | Inspect the trends for **Application node operating system memory** combined with all **Application Statistics** for anomalies and correlate those with application behavior. |
 
 Application Server Memory | |

--- a/content/releasenotes/developer-portal/deployment.md
+++ b/content/releasenotes/developer-portal/deployment.md
@@ -12,10 +12,10 @@ Follow the links in the table below to see the release notes you want:
 
 | Type of Deployment | Last Updated |
 | --- | --- |
-| [Mendix Cloud](mendix-cloud) | February 17th, 2022 |
-| [Mendix for Private Cloud](mendix-for-private-cloud) | February 10th, 2022 |
-| [SAP Business Technology Platform (SAP BTP)](sap-cloud-platform) | December 9th, 2021 |
-| [Other Deployment Options](on-premises) | October 26th, 2020 |
+| [Mendix Cloud](mendix-cloud) | Mar 2nd, 2022 |
+| [Mendix for Private Cloud](mendix-for-private-cloud) | Feb 10th, 2022 |
+| [SAP Business Technology Platform (SAP BTP)](sap-cloud-platform) | Mar 2nd, 2022 |
+| [Other Deployment Options](on-premises) | Oct 26th, 2020 |
 
 The release notes for the buildpacks are held in their respective GitHub repos:
 

--- a/content/releasenotes/developer-portal/mendix-cloud.md
+++ b/content/releasenotes/developer-portal/mendix-cloud.md
@@ -12,6 +12,12 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## 2022
 
+### March 2nd, 2022
+
+#### Improvements
+
+* We have adjusted the thresholds for the Application Container Memory Percentage alert. It will now send a warning alert when the memory utilization is above 90% and a critical alert when its above 95%.
+
 ### February 17th, 2022
 
 #### Fixes

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -8,7 +8,7 @@
 	<li><a href="/releasenotes/studio/9.7-and-above">Studio 9.7 & Above</a> – Feb 24th, 2022</li>
 	<li><a href="/releasenotes/mobile/nt-6-rn">Native Template 6.2.12</a> – Jan 25th, 2022</li>	
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Feb 24th, 2022</li>
-	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Feb 17th, 2022</li>
+	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Mar 2nd, 2022</li>
 	<li><a href="/releasenotes/data-hub">Data Hub 2.21.0</a> – Feb 24th, 2022</li>
 	<li><a href="/releasenotes/app-store">Marketplace</a> – Feb 24th, 2022</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.60.0</a> – Feb 16th, 2022</li>


### PR DESCRIPTION
We have adjusted the thresholds for the Application Container Memory Percentage alert for Mendix Cloud v4. It will now send a warning alert when the memory utilization is above 90% and a critical alert when its above 95%.