### PR TITLE
Mention MariaDB 10.6 support to be added in 9.12

### DIFF
--- a/content/refguide/system-requirements.md
+++ b/content/refguide/system-requirements.md
@@ -159,7 +159,7 @@ Mendix tries to support the most recent and patched database server versions fro
 Current support:
 
 * [IBM DB2](db2) 11.1 and 11.5 for Linux, Unix, and Windows
-* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5
+* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5, 10.6
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2017, 2019
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 140 or higher
 * [MySQL](mysql) 8.0

--- a/content/refguide7/system-requirements.md
+++ b/content/refguide7/system-requirements.md
@@ -61,7 +61,7 @@ The browser you use needs to have JavaScript turned on.
 ### 5.3 Database Server
 
 * [IBM DB2](db2) 11.1, 11.5 for Linux, Unix, and Windows
-* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5
+* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5, 10.6
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2017, 2019
 * Azure SQL v12 (support is not independently verified and is available only through compatible versions of SQL Server)
 * [MySQL](mysql) 8.0

--- a/content/refguide8/system-requirements.md
+++ b/content/refguide8/system-requirements.md
@@ -114,7 +114,7 @@ Mendix tries to support the most recent and patched database server versions fro
 Current support:
 
 * [IBM DB2](db2) 11.1 and 11.5 for Linux, Unix, and Windows
-* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5
+* [MariaDB](mysql) 10.2, 10.3, 10.4, 10.5, 10.6
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server) 2017, 2019
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 140 or higher
 * [MySQL](mysql) 8.0


### PR DESCRIPTION
For LTS Mendix versions, support will be mentioned in RN in corresponding releases. Still, MariaDB 10.6 is already supported in all LTS versions, so it should be fine to update system requirements for all versions once 9.12 is released.