### PR TITLE
Introducing the insertable capability in published OData

### DIFF
--- a/content/refguide/odata-query-options.md
+++ b/content/refguide/odata-query-options.md
@@ -154,7 +154,7 @@ If the OData query is too long to be sent as a `GET` request, clients can send t
 The body must adhere to *URL encoding* principles. So, for instance, spaces, tabs, and newlines are not allowed.
 {{% /alert %}}
 
-## 10 Updating objects {#updating-objects}
+## 10 Updating Objects {#updating-objects}
 
 When a published resource has the [Updatable](published-odata-resource#capabilities) capability, clients can update its attributes and associations by sending a `PATCH` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`). 
 
@@ -201,11 +201,11 @@ Clients can only update an association from the entity that is the [owner](assoc
 The *updating attributes* functionality was introduced in Studio Pro [9.6.0](/releasenotes/studio-pro/9.6). The *updating associations* functionality was introduced in Studio Pro [9.8.0](/releasenotes/studio-pro/9.8).
 {{% /alert %}}
 
-## 10 Inserting objects {#inserting-objects}
+## 10 Inserting Objects {#inserting-objects}
 
 When a published resource has the [Insertable](published-odata-resource#capabilities) capability, clients can create new objects by sending a `POST` request to the URL of the entity set (for example, `POST /odata/myservice/v1/Exployees`). 
 
-The body of the request may specify attribute and association values just as with updates. There is one difference: when the association refers to multiple objects, objects are specified without using `@delta``, for example:
+The body of the request may specify attribute and association values just as with updates. There is one difference: when the association refers to multiple objects, objects are specified without using `@delta`. For example:
 
 ```json
 {

--- a/content/refguide/odata-query-options.md
+++ b/content/refguide/odata-query-options.md
@@ -156,7 +156,7 @@ The body must adhere to *URL encoding* principles. So, for instance, spaces, tab
 
 ## 10 Updating objects {#updating-objects}
 
-When a published resource has the [Updatable (write)](published-odata-resource#capabilities) capability, clients can update its attributes and associations by sending a `PATCH` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`). 
+When a published resource has the [Updatable](published-odata-resource#capabilities) capability, clients can update its attributes and associations by sending a `PATCH` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`). 
 
 Specify new values for attributes in the body of the request. Here is an example:
 
@@ -198,5 +198,26 @@ When the association refers to multiple objects, add objects to or remove object
 Clients can only update an association from the entity that is the [owner](associations).
 
 {{% alert type="info" %}}
-The updating attributes functionality was introduced in Studio Pro [9.6.0](/releasenotes/studio-pro/9.6). The updating associations functionality was introduced in Studio Pro [9.8.0](/releasenotes/studio-pro/9.8).
+The *updating attributes* functionality was introduced in Studio Pro [9.6.0](/releasenotes/studio-pro/9.6). The *updating associations* functionality was introduced in Studio Pro [9.8.0](/releasenotes/studio-pro/9.8).
+{{% /alert %}}
+
+## 10 Inserting objects {#inserting-objects}
+
+When a published resource has the [Insertable](published-odata-resource#capabilities) capability, clients can create new objects by sending a `POST` request to the URL of the entity set (for example, `POST /odata/myservice/v1/Exployees`). 
+
+The body of the request may specify attribute and association values just as with updates. There is one difference: when the association refers to multiple objects, objects are specified without using `@delta``, for example:
+
+```json
+{
+  "Customers": [
+    { "@id": "Customers(484)" },
+    { "@id": "Customers(712)" }
+  ]
+}
+```
+
+Clients can only set values for an association from the entity that is the [owner](associations).
+
+{{% alert type="info" %}}
+The *inserting objects* functionality was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12.0).
 {{% /alert %}}

--- a/content/refguide/published-odata-resource.md
+++ b/content/refguide/published-odata-resource.md
@@ -102,13 +102,30 @@ The **Capabilities** section gives an overview of what operations the resource s
 This *Capabilities* section was introduced in Studio Pro [9.6.0](/releasenotes/studio-pro/9.6).
 {{% /alert %}}
 
-## 8.1 Readable
+## 8.1 Insertable
+
+Check the check box for **Insertable** to indicate that clients can insert new objects.
+
+When the app receives a request to insert a new object, it does the following:
+
+1. It checks that the request is formatted correctly, rejecting things like specifying a string value for an integer attribute.
+2. It checks that the requested changes are valid, rejecting things like strings that are longer than the maximum length and empty values for required attributes.
+3. It creates a new object with the values specified in the request.
+4. It commits the object to the database.
+
+This is the behavior when you choose the action **Write to database**.
+
+{{% alert type="info" %}}
+Insertable capability was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12).
+{{% /alert %}}
+
+## 8.2 Readable
 
 A published OData resource is always readable.
 
-## 8.2 Updatable
+## 8.3 Updatable
 
-Select the check box for **Updatable (write)** to indicate that clients can update the values of attributes and associations.
+Check the check box for **Updatable** to indicate that clients can update the values of attributes and associations.
 
 When the app receives a request to change values, it does the following:
 
@@ -118,9 +135,9 @@ When the app receives a request to change values, it does the following:
 
 This is the behavior when you choose the action **Write to database**.
 
-### 8.2.1 Call a Microflow Instead of Writing to Database
+### 8.4 Call a Microflow Instead of Write to Database
 
-The **Call a microflow** action allows you to replace the third step (committing the changes to the database) with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](http-request-and-response-entities) parameter. In the microflow, you can use the [Commit](committing-objects) activity to commit the changes to the database. If the microflow reports [validation feedback](validation-feedback), the runtime informs the client that the update request has failed.
+The **Call a microflow** action allows you to replace the last step (committing to the database) of the *Insertable* or *Updatable* capability with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](http-request-and-response-entities) parameter. In the microflow, you can use the [Commit](committing-objects) activity to commit the changes to the database. If the microflow reports [validation feedback](validation-feedback), the runtime informs the client that the update request has failed.
 
 {{% alert type="info" %}}
 This **Call a microflow** action was introduced in Studio Pro [9.11.0](/releasenotes/studio-pro/9.11).

--- a/content/refguide/published-odata-resource.md
+++ b/content/refguide/published-odata-resource.md
@@ -104,7 +104,7 @@ This *Capabilities* section was introduced in Studio Pro [9.6.0](/releasenotes/s
 
 ## 8.1 Insertable
 
-Check the check box for **Insertable** to indicate that clients can insert new objects.
+Select the check box for **Insertable** to indicate that clients can insert new objects.
 
 When the app receives a request to insert a new object, it does the following:
 
@@ -116,7 +116,7 @@ When the app receives a request to insert a new object, it does the following:
 This is the behavior when you choose the action **Write to database**.
 
 {{% alert type="info" %}}
-Insertable capability was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12).
+The *Insertable* capability was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12).
 {{% /alert %}}
 
 ## 8.2 Readable

--- a/content/refguide/published-odata-resource.md
+++ b/content/refguide/published-odata-resource.md
@@ -135,7 +135,7 @@ When the app receives a request to change values, it does the following:
 
 This is the behavior when you choose the action **Write to database**.
 
-### 8.4 Call a Microflow Instead of Write to Database
+## 8.4 Call a Microflow Instead of Write to Database
 
 The **Call a microflow** action allows you to replace the last step (committing to the database) of the *Insertable* or *Updatable* capability with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](http-request-and-response-entities) parameter. In the microflow, you can use the [Commit](committing-objects) activity to commit the changes to the database. If the microflow reports [validation feedback](validation-feedback), the runtime informs the client that the update request has failed.
 


### PR DESCRIPTION
In Studio Pro 9.12, published OData resources have a new capability: Insertable.
This capability allows clients to send a POST request to create new objects.