### PR TITLE
Add anchor to Performance Bot options page

### DIFF
--- a/content/refguide/mx-assist-performance-bot.md
+++ b/content/refguide/mx-assist-performance-bot.md
@@ -28,7 +28,7 @@ The pane gives you information on each anti-pattern and contains MxAssist Perfor
 
 ![Performance Bot Pane](attachments/mx-assist-performance-bot/performance-bot-pane.png)
 
-### 2.1 Options and Configuration
+### 2.1 Options and Configuration {#options}
 
 At the top of the **MxAssist Performance Bot** pane you can see the following options: 
 


### PR DESCRIPTION
Add anchor to Performance Bot options page

why: so we can link to the correct part of that page.

MxAssist-Client ref = AA-3600

SP version = 9.13