### PR TITLE
Add more aliases to redirect from previous addresses ending in .html

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,6 +8,8 @@ description: Browse the documentation per product, read about latest releases, a
 aliases:
     - /docs/index.html
     - /docs/Overview.html
+    - /docs/Overview
+    - /search.html
     - /search/
 cascade:
     - no_list: true

--- a/content/en/docs/addons/apd-addon/ig/ig-two.md
+++ b/content/en/docs/addons/apd-addon/ig/ig-two.md
@@ -5,6 +5,7 @@ parent: "ig"
 weight: 1
 aliases:
     - /apm/installation-guide.html
+    - /apm/installation-guide
 ---
 
 ## 1 Introduction

--- a/content/en/docs/addons/apd-addon/rg-apd/rg-two-apm/_index.md
+++ b/content/en/docs/addons/apd-addon/rg-apd/rg-two-apm/_index.md
@@ -5,6 +5,7 @@ parent: "rg-apd"
 weight: 1
 aliases:
     - /apm/reference-guide/rg-2/reference-guide-2.html
+    - /apm/reference-guide/rg-2/reference-guide-2
 ---
 
 ## 1 Introduction

--- a/content/en/docs/appstore/creating-content/prepare.md
+++ b/content/en/docs/appstore/creating-content/prepare.md
@@ -8,6 +8,8 @@ tags: ["marketplace", "vendor", "app service"]
 aliases:
     - /appstore/general/sell.html
     - /appstore/creating-content/as-sell.html
+    - /appstore/general/sell
+    - /appstore/creating-content/as-sell
 ---
 
 ## 1 Introduction

--- a/content/en/docs/appstore/general/app-store-content-support.md
+++ b/content/en/docs/appstore/general/app-store-content-support.md
@@ -8,6 +8,8 @@ description: "Describes the various levels of support available for using Market
 aliases:
     - /community/app-store-content-support.html
     - /developerportal/app-store/app-store-content-support.html
+    - /community/app-store-content-support
+    - /developerportal/app-store/app-store-content-support
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/appstore/general/app-store-content.md
+++ b/content/en/docs/appstore/general/app-store-content.md
@@ -9,6 +9,9 @@ aliases:
     - /community/app-store/use-app-store-content-in-the-modeler.html
     - /developerportal/app-store/app-store-content.html
     - /developerportal/app-store/use-app-store-content-in-the-modeler.html
+    - /community/app-store/use-app-store-content-in-the-modeler
+    - /developerportal/app-store/app-store-content
+    - /developerportal/app-store/use-app-store-content-in-the-modeler
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchors "downloading", "widget", and "project-layout" below are mapped, so they should not be removed or changed.
 ---

--- a/content/en/docs/appstore/general/app-store-overview.md
+++ b/content/en/docs/appstore/general/app-store-overview.md
@@ -8,6 +8,8 @@ tags: ["marketplace",  "widget", "connector", "module", "partner"]
 aliases:
     - /community/app-store/app-store-overview.html
     - /developerportal/app-store/app-store-overview.html
+    - /community/app-store/app-store-overview
+    - /developerportal/app-store/app-store-overview
 ---
 
 ## 1 Introduction

--- a/content/en/docs/appstore/general/share-app-store-content.md
+++ b/content/en/docs/appstore/general/share-app-store-content.md
@@ -7,6 +7,7 @@ description: "Describes how to create and share Mendix Marketplace content."
 tags: ["marketplace", "public app store", "private app store", widget", "module"]
 aliases:
     - /developerportal/app-store/share-app-store-content.html
+    - /developerportal/app-store/share-app-store-content
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/data-hub/data-hub-catalog/register-data.md
+++ b/content/en/docs/data-hub/data-hub-catalog/register-data.md
@@ -6,7 +6,8 @@ category: "Data Hub Catalog"
 weight: 35
 tags: ["data hub catalog", "data hub", "external entities", "register", "published OData service" ,"how to", "registration"]
 aliases:
-    /data-hub/data-hub-catalog/register.html
+    - /data-hub/data-hub-catalog/register.html
+    - /data-hub/data-hub-catalog/register
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 #The anchor registration-form below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/data-hub/share-data/_index.md
+++ b/content/en/docs/data-hub/share-data/_index.md
@@ -7,6 +7,7 @@ weight: 10
 aliases:
     - /data-hub/data-hub-catalog/use-data-catalog.html
     - /datahub/general/share-data/index.html
+    - /data-hub/data-hub-catalog/use-data-catalog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/developerportal/collaborate/team-server.md
+++ b/content/en/docs/developerportal/collaborate/team-server.md
@@ -8,6 +8,8 @@ tags: ["Studio Pro", "Team Server", "Developer Portal", "commit", "branch"]
 aliases:
     - /refguide/team-server.html
     - /developerportal/develop/team-server.html
+    - /refguide/team-server
+    - /developerportal/develop/team-server
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/collaborate/team/app-roles.md
+++ b/content/en/docs/developerportal/collaborate/team/app-roles.md
@@ -10,6 +10,10 @@ aliases:
     - /developerportal/company-app-roles.html
     - /developerportal/company-app-roles/technical-contact.html
     - /developerportal/app-roles/index.html
+    - /developerportal/settings/technical-contact
+    - /developerportal/general/technical-contact
+    - /developerportal/company-app-roles
+    - /developerportal/company-app-roles/technical-contact
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/community-tools/mendix-mvp-program.md
+++ b/content/en/docs/developerportal/community-tools/mendix-mvp-program.md
@@ -7,6 +7,7 @@ description: "Describes how the Mendix Community MVP program works."
 tags: ["community", "mvp"]
 aliases:
     - /community/tools/the-mendix-mvp-program.html
+    - /community/tools/the-mendix-mvp-program
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/developerportal/control-center/_index.md
+++ b/content/en/docs/developerportal/control-center/_index.md
@@ -6,6 +6,7 @@ tags: ["control center", "mendix admin", "developer portal", "role", "permission
 weight: 20
 aliases:
     - /developerportal/company-app-roles/users.html
+    - /developerportal/company-app-roles/users
 ---
 
 ## 1 Introduction

--- a/content/en/docs/developerportal/deploy/cloud-foundry-deploy.md
+++ b/content/en/docs/developerportal/deploy/cloud-foundry-deploy.md
@@ -9,7 +9,10 @@ aliases:
     - /deployment/cloud-foundry/index.html
     - /howto/deploying-a-mendix-app-to-cloud-foundry.html
     - /howto7/deploying-a-mendix-app-to-cloud-foundry.html
-    - /refguide/deploying-a-mendix-app-to-cloud-foundry.html    
+    - /refguide/deploying-a-mendix-app-to-cloud-foundry.html
+    - /howto/deploying-a-mendix-app-to-cloud-foundry
+    - /howto7/deploying-a-mendix-app-to-cloud-foundry
+    - /refguide/deploying-a-mendix-app-to-cloud-foundry
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/_index.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/_index.md
@@ -8,6 +8,8 @@ tags: ["Deploy","Mendix Cloud","Developer Portal", "Free App", "licensed", "limi
 aliases:
     - /developerportal/howto/deploying-to-the-cloud.html
     - /mendixcloud/deploying-to-the-cloud.html
+    - /developerportal/howto/deploying-to-the-cloud
+    - /mendixcloud/deploying-to-the-cloud
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor #plans, below, is mapped from the Control Center within the Developer Portal.

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
@@ -7,6 +7,8 @@ tags: ["client certificate", "certification authority", "PKCS12", "connections"]
 aliases:
     - /deployment/mendixcloud/certificates.html
     - /refguide/certificates.html
+    - /deployment/mendixcloud/certificates
+    - /refguide/certificates
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/custom-domains.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/custom-domains.md
@@ -8,6 +8,8 @@ tags: ["Custom Domain","Mendix Cloud","Developer Portal", "certificates"]
 aliases:
     - /mendixcloud/custom-domains.html
     - /howtogeneral/mendixcloud/custom-domains.html
+    - /mendixcloud/custom-domains
+    - /howtogeneral/mendixcloud/custom-domains
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #Linked from Developer Portal > Environments > Custom Domains

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/licensing-apps/_index.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/licensing-apps/_index.md
@@ -10,6 +10,9 @@ aliases:
     - /developerportal/howto/how-to-link-a-different-app-to-a-node.html
     - /developerportal/howto/how-to-link-app-to-node.html
     - /mendixcloud/how-to-link-app-to-node.html
+    - /developerportal/howto/how-to-link-a-different-app-to-a-node
+    - /developerportal/howto/how-to-link-app-to-node
+    - /mendixcloud/how-to-link-app-to-node
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/maintenance-windows.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/maintenance-windows.md
@@ -7,6 +7,7 @@ description: "How to configure the maintenance windows for your node environment
 tags: ["Deploy","App","Developer Portal", "maintenance"]
 aliases:
     - /mendixcloud/maintenance-windows.html
+    - /mendixcloud/maintenance-windows
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-cloud-status.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-cloud-status.md
@@ -7,6 +7,7 @@ description: "Describes where to find the current status of the Mendix Cloud."
 tags: ["Status","Mendix Cloud","Developer Portal", "Issue", "Maintenance", "Subscribe"]
 aliases:
     - /developerportal/operate/mendix-cloud-status.html
+    - /developerportal/operate/mendix-cloud-status
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mxcloudv4/migrating-to-v4.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mxcloudv4/migrating-to-v4.md
@@ -7,6 +7,7 @@ description: "How to migrate your app from a Mendix Cloud v3 node to a Mendix Cl
 tags: ["App","Migrate","Developer Portal","v3","v4","Node"]
 aliases:
     - /developerportal/howto/migrating-to-v4.html
+    - /developerportal/howto/migrating-to-v4
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/sending-email.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/sending-email.md
@@ -7,6 +7,7 @@ description: "How to use external email providers in Mendix, and how to configur
 tags: ["email", "smtp", "sending policy framework", "Cloud v3", "SPF"]
 aliases:
     - /deployment/mendixcloud/sending-email.html
+    - /deployment/mendixcloud/sending-email
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/developerportal/deploy/on-premises-design/_index.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/_index.md
@@ -7,6 +7,7 @@ weight: 80
 tags: ["Deployment", "On premises", "Environment"]
 aliases:
     - /deployment/on-premises.html
+    - /deployment/on-premises
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/_index.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/_index.md
@@ -7,6 +7,7 @@ weight: 50
 tags: ["deploy", "Windows", "On Premises", "Microsoft", "Mendix Service Console", "IIS", "URL Rewrite", "Client Cache", "Reverse Inbound Proxy", "Host Header"]
 aliases:
     - /deployment/on-premises/deploy-mendix-on-microsoft-windows.html
+    - /deployment/on-premises/deploy-mendix-on-microsoft-windows
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
 

--- a/content/en/docs/developerportal/operate/metrics/trends.md
+++ b/content/en/docs/developerportal/operate/metrics/trends.md
@@ -7,6 +7,7 @@ description: "Describes how to interpret various graphs and trends in the Mendix
 tags: ["Trends","v3","Mendix Cloud","Developer Portal"]
 aliases:
     - /howtogeneral/mendixcloud/trends.html
+    - /howtogeneral/mendixcloud/trends
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #Please do not rename the anchors in this document as they are used in links from the Developer Portal.

--- a/content/en/docs/developerportal/operate/monitoring-application-health/_index.md
+++ b/content/en/docs/developerportal/operate/monitoring-application-health/_index.md
@@ -8,6 +8,8 @@ tags: ["Monitoring","Mendix Cloud","Developer Portal","Performance","Health", "D
 aliases:
     - /mendixcloud/monitoring-application-health.html
     - /howtogeneral/mendixcloud/monitoring-application-health.html
+    - /mendixcloud/monitoring-application-health
+    - /howtogeneral/mendixcloud/monitoring-application-health
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/developerportal/support/new-app-node-request-template.md
+++ b/content/en/docs/developerportal/support/new-app-node-request-template.md
@@ -6,6 +6,7 @@ weight: 3
 tags: ["Support", "app node", "node", "license", "subscription secret"]
 aliases:
     - /developerportal/support/new-app-request-template.html
+    - /developerportal/support/new-app-request-template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/developerportal/support/prepare-your-project.md
+++ b/content/en/docs/developerportal/support/prepare-your-project.md
@@ -7,6 +7,7 @@ description: "Describes what you need to do with an on-premises app to prepare i
 tags: ["on-premises", "support"]
 aliases:
     - /developerportal/support/change-affected-apps.html
+    - /developerportal/support/change-affected-apps
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/howto/front-end/ux-best-practices.md
+++ b/content/en/docs/howto/front-end/ux-best-practices.md
@@ -6,6 +6,7 @@ weight: 10
 tags: ["ux", "ui", "ux designer", "user experience", "design", "menu", "button", "typography", "card", "front end"]
 aliases:
     - /howtogeneral/bestpractices/ux-best-practices.html
+    - /howtogeneral/bestpractices/ux-best-practices
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto/general/community-best-practices-for-app-performance.md
+++ b/content/en/docs/howto/general/community-best-practices-for-app-performance.md
@@ -6,6 +6,7 @@ weight: 8
 tags: ["best practice", "performance", "community"]
 aliases:
     - /howtogeneral/bestpractices/best-practices-for-app-performance-in-mendix-7.html
+    - /howtogeneral/bestpractices/best-practices-for-app-performance-in-mendix-7
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto/security/best-practices-security.md
+++ b/content/en/docs/howto/security/best-practices-security.md
@@ -7,6 +7,7 @@ description: "A set of security aspects and checks to use when developing your M
 tags: ["security", "best practices", "access rules", "authentication", "encryption", "password", "ssl", "identity provider", "mendix cloud"]
 aliases:
     - /howtogeneral/bestpractices/best-practices-security-and-improvements-for-mendix-applications.html
+    - /howtogeneral/bestpractices/best-practices-security-and-improvements-for-mendix-applications
 #The anchor request-handlers below is mapped, so it should not be removed or changed.
 ---
 

--- a/content/en/docs/howto7/front-end/configuring-your-theme.md
+++ b/content/en/docs/howto7/front-end/configuring-your-theme.md
@@ -6,6 +6,7 @@ weight: 15
 tags: ["theming", "UX", "front end"]
 aliases:
     - /howto7/ux/configuring-your-theme.html
+    - /howto7/ux/configuring-your-theme
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/howto7/monitoring-troubleshooting/solving-load-and-import-errors.md
+++ b/content/en/docs/howto7/monitoring-troubleshooting/solving-load-and-import-errors.md
@@ -6,6 +6,7 @@ weight: 11
 tags: ["monitoring", "troubleshooting", "load", "import", "error"]
 aliases:
     - /howto7/solving-load-and-import-errors.html
+    - /howto7/solving-load-and-import-errors
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/howto8/collaboration-requirements-management/contribute-to-a-github-repository.md
+++ b/content/en/docs/howto8/collaboration-requirements-management/contribute-to-a-github-repository.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["GitHub"]
 aliases:
     - /howto8/collaboration-project-management/contribute-to-a-github-repository.html
+    - /howto8/collaboration-project-management/contribute-to-a-github-repository
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto8/front-end/atlas-ui/_index.md
+++ b/content/en/docs/howto8/front-end/atlas-ui/_index.md
@@ -7,6 +7,8 @@ tags: ["Atlas", "UI", "UX", "user experience"]
 aliases:
     - /howto8/front-end/create-a-custom-theme-with-the-mendix-ui-framework.html
     - /howto8/ux/create-a-custom-theme-with-the-mendix-ui-framework.html
+    - /howto8/front-end/create-a-custom-theme-with-the-mendix-ui-framework
+    - /howto8/ux/create-a-custom-theme-with-the-mendix-ui-framework
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto8/front-end/configuring-your-theme.md
+++ b/content/en/docs/howto8/front-end/configuring-your-theme.md
@@ -6,6 +6,7 @@ weight: 15
 tags: ["theming", "UX", "front end"]
 aliases:
     - /howto8/ux/configuring-your-theme.html
+    - /howto8/ux/configuring-your-theme
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/customizing-phonegap-build-packages.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/customizing-phonegap-build-packages.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["mobile", "marketplace", "phonegap"]
 aliases:
     - /refguide8/customizing-phonegap-build-packages.html
+    - /refguide8/customizing-phonegap-build-packages
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["mobile", "marketplace", "phonegap"]
 aliases:
     - /refguide8/publish-packages-to-mobile-stores.html
+    - /refguide8/publish-packages-to-mobile-stores
 ---
 ## 1 Introduction
 

--- a/content/en/docs/howto8/monitoring-troubleshooting/solving-load-and-import-errors.md
+++ b/content/en/docs/howto8/monitoring-troubleshooting/solving-load-and-import-errors.md
@@ -6,6 +6,7 @@ weight: 11
 tags: ["monitoring", "troubleshooting", "load", "import", "error"]
 aliases:
     - /howto8/solving-load-and-import-errors.html
+    - /howto8/solving-load-and-import-errors
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/partners/sap/use-sap-odata-model-creator.md
+++ b/content/en/docs/partners/sap/use-sap-odata-model-creator.md
@@ -7,6 +7,7 @@ description: "Presents the use of the OData Model Creator for SAP solutions."
 tags: ["SAP", "OData", "integration", "SAP services"]
 aliases:
     - /howto/sap/use-sap-odata-model-creator.html
+    - /howto/sap/use-sap-odata-model-creator
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-module-details.md
+++ b/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-module-details.md
@@ -8,6 +8,8 @@ tags: ["MindSphere"]
 aliases:
     - /refguide/mindsphere/mindsphere-module-details.html
     - /refguide/siemens/mindsphere-module-details.html
+    - /refguide/mindsphere/mindsphere-module-details
+    - /refguide/siemens/mindsphere-module-details
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchors #mssso, #msosbar and #msthemepack below are mapped from the Siemens MindSphere documentation site, so they should not be removed or changed.
 ---

--- a/content/en/docs/refguide/modeling/_index.md
+++ b/content/en/docs/refguide/modeling/_index.md
@@ -8,6 +8,9 @@ aliases:
     - /refguide/desktop-modeler.html
     - /refguide/modeler.html
     - /refguide/Modeler.html
+    - /refguide/desktop-modeler
+    - /refguide/modeler
+    - /refguide/Modeler
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.1 Introduction
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/expressions/_index.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/_index.md
@@ -7,6 +7,7 @@ description: "Describes the expressions that can be used in Mendix for a variety
 tags: ["studio pro", "expressions", "microflow expressions"]
 aliases:
     - /refguide/microflow-expressions.html
+    - /refguide/microflow-expressions
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/close-page.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/close-page.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "close page", "client activity"]
 aliases:
     - /refguide/Close+Form.html
     - /refguide/close-form.html
+    - /refguide/Close+Form
+    - /refguide/close-form
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/download-file.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/download-file.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "download file", "client activities"]
 aliases:
     - /refguide/Download+File.html
+    - /refguide/Download+File
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-home-page.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-home-page.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["studio pro", "show home page", "home page", "client activities"]
 aliases:
     - /refguide/Show+Home+Page.html
+    - /refguide/Show+Home+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-message.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-message.md
@@ -6,6 +6,7 @@ weight: 4
 tags: ["studio pro", "show message", "client activities"]
 aliases:
     - /refguide/Show+Message.html
+    - /refguide/Show+Message
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-page.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/show-page.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "show page", "client activity"]
 aliases:
     - /refguide/Show+Page.html
+    - /refguide/Show+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/validation-feedback.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/validation-feedback.md
@@ -6,6 +6,7 @@ weight: 70
 tags: ["studio pro", "validation feedback", "client activities"]
 aliases:
     - /refguide/Validation+Feedback.html
+    - /refguide/Validation+Feedback
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/annotation.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/annotation.md
@@ -6,6 +6,7 @@ weight: 60
 tags: ["studio pro", "annotation", annotation flow]
 aliases:
     - /refguide/annotation-flow.html
+    - /refguide/annotation-flow
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/decision.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/decision.md
@@ -6,6 +6,7 @@ weight: 3
 tags: ["studio pro", "decision", "exclusive split"]
 aliases:
     - /refguide/exclusive-split.html
+    - /refguide/exclusive-split
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/object-type-decision.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/object-type-decision.md
@@ -6,6 +6,7 @@ weight: 2
 tags: ["studio pro", "object type decision", "decisions"]
 aliases:
     - /refguide/inheritance-split.html
+    - /refguide/inheritance-split
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/integration/consumed-odata-services/consumed-odata-service.md
+++ b/content/en/docs/refguide/modeling/integration/consumed-odata-services/consumed-odata-service.md
@@ -4,6 +4,8 @@ url: /refguide/consumed-odata-service/
 parent: "consumed-odata-services"
 weight: 10
 tags: ["studio pro", "data hub", "odata service", "consumed odata service"]
+aliases:
+    - /refguide/consumed-odata-service-properties
 ---
 
 ## 1 Introduction

--- a/content/en/docs/refguide/modeling/integration/mapping-documents/select--elements.md
+++ b/content/en/docs/refguide/modeling/integration/mapping-documents/select--elements.md
@@ -5,6 +5,7 @@ parent: "mapping-documents"
 tags: ["studio pro"]
 aliases:
     - /refguide/Select++Elements.html
+    - /refguide/Select++Elements
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/menus/file-menu/new-project.md
+++ b/content/en/docs/refguide/modeling/menus/file-menu/new-project.md
@@ -7,6 +7,7 @@ description: "This document describes the New App flow and the App Settings dial
 tags: ["studio pro", "create app", "new app", "creating new app"]
 aliases:
     - /refguide/app-settings-dialog.html
+    - /refguide/app-settings-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/menus/file-menu/open-app-dialog.md
+++ b/content/en/docs/refguide/modeling/menus/file-menu/open-app-dialog.md
@@ -7,6 +7,7 @@ description: "Describes the Open App flow and the Open App dialog box"
 tags: ["studio pro", "open app"]
 aliases:
     - /refguide/open-project-dialog.html
+    - /refguide/open-project-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/menus/version-control-menu/download-from-version-control-dialog.md
+++ b/content/en/docs/refguide/modeling/menus/version-control-menu/download-from-version-control-dialog.md
@@ -6,6 +6,7 @@ weight: 60
 tags: ["studio pro"]
 aliases:
     - /refguide/download-from-team-server-dialog.html
+    - /refguide/download-from-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/menus/version-control-menu/upload-to-version-control-dialog.md
+++ b/content/en/docs/refguide/modeling/menus/version-control-menu/upload-to-version-control-dialog.md
@@ -6,6 +6,7 @@ weight: 70
 tags: ["studio pro"]
 aliases:
     - /refguide/upload-to-team-server-dialog.html
+    - /refguide/upload-to-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/project-explorer/security/module-security.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/project-explorer/security/module-security.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "module security", "security", "module"]
 aliases:
     - /refguide/module-role.html
+    - /refguide/module-role
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/project-explorer/security/project-security/user-roles.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/project-explorer/security/project-security/user-roles.md
@@ -6,6 +6,7 @@ weight: 10
 tags: ["studio pro", "user role", "app security", "security"]
 aliases:
     - /refguide/user-role.html
+    - /refguide/user-role
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/button-widgets/_index.md
+++ b/content/en/docs/refguide/modeling/pages/button-widgets/_index.md
@@ -9,6 +9,10 @@ aliases:
     - /refguide/drop-down-button.html
     - /refguide/link-button.html
     - /refguide/sign-out-button.html
+    - /refguide/action-button
+    - /refguide/drop-down-button
+    - /refguide/link-button
+    - /refguide/sign-out-button
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/data-widgets/grids/control-bar.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/grids/control-bar.md
@@ -15,6 +15,16 @@ aliases:
     - /refguide/search-button.html
     - /refguide/select-all-button.html
     - /refguide/select-button.html
+    - /refguide/add-button
+    - /refguide/deselect-all-button
+    - /refguide/export-to-csv-button
+    - /refguide/export-to-excel-button
+    - /refguide/grid-action-button
+    - /refguide/grid-new-button
+    - /refguide/remove-button
+    - /refguide/search-button
+    - /refguide/select-all-button
+    - /refguide/select-button
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/data-widgets/grids/search-bar.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/grids/search-bar.md
@@ -8,6 +8,9 @@ aliases:
     - /refguide/comparison-search-field.html
     - /refguide/drop-down-search-field.html
     - /refguide/range-search-field.html
+    - /refguide/comparison-search-field
+    - /refguide/drop-down-search-field
+    - /refguide/range-search-field
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/data-widgets/grids/sort-bar.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/grids/sort-bar.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "sort bar", "grid"]
 aliases:
     - /refguide/Sort+Bar.html
+    - /refguide/Sort+Bar
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image.md
+++ b/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "image", "image widget"]
 aliases:
     - /refguide/image-property.html
+    - /refguide/image-property
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/input-widgets/drop-down.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/drop-down.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["Drop-down", "input", "page", "widget", "enumeration", "studio pro"]
 aliases:
     - /refguide/drop-down-widget.html
+    - /refguide/drop-down-widget
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/on-click-event.md
+++ b/content/en/docs/refguide/modeling/pages/on-click-event.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "events section", "properties", "widget", "on click", "acti
 aliases:
     - /refguide/opening-pages.html
     - /refguide/starting-microflows.html
+    - /refguide/opening-pages
+    - /refguide/starting-microflows
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/page-resources/menu.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/menu.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "menu", "menu item", "page resource"]
 aliases:
     - /refguide/menu-item.html
+    - /refguide/menu-item
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 #The anchor <menu-item> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide/modeling/pages/page-resources/page-templates.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/page-templates.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "page template", "page resource"]
 aliases:
     - /refguide/page-template.html
+    - /refguide/page-template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/structure-widgets/scroll-container.md
+++ b/content/en/docs/refguide/modeling/pages/structure-widgets/scroll-container.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "scroll container", "container widget", "widget"]
 aliases:
     - /refguide/horizontal-split-pane.html
     - /refguide/vertical-split-pane.html
+    - /refguide/horizontal-split-pane
+    - /refguide/vertical-split-pane
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/pages/structure-widgets/tab-container.md
+++ b/content/en/docs/refguide/modeling/pages/structure-widgets/tab-container.md
@@ -6,6 +6,7 @@ weight: 40
 tags: ["studio pro", "tab container", "tab page", "container widget", "widget"]
 aliases:
     - /refguide/tab-page.html
+    - /refguide/tab-page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor <tab-page> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide/modeling/resources/document-templates/_index.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/_index.md
@@ -6,6 +6,7 @@ weight: 90
 tags: ["studio pro", "document template"]
 aliases:
     - /refguide/Document+Templates.html
+    - /refguide/Document+Templates
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/data-grid-document-template/_index.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/data-grid-document-template/_index.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Data+Grid+(document+template).html
     - /refguide/data-grid-(document-template).html
+    - /refguide/Data+Grid+(document+template)
+    - /refguide/data-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/data-grid-document-template/columns-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/data-grid-document-template/columns-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/columns-(document-template).html
     - /refguide/Columns+(document+template).html
+    - /refguide/columns-(document-template)
+    - /refguide/Columns+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/data-view-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/data-view-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Data+View+(document+template).html
     - /refguide/data-view-(document-template).html
+    - /refguide/Data+View+(document+template)
+    - /refguide/data-view-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/dynamic-image-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/dynamic-image-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Dynamic+Image+(document+template).html
     - /refguide/dynamic-image-(document-template).html
+    - /refguide/Dynamic+Image+(document+template)
+    - /refguide/dynamic-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/dynamic-label-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/dynamic-label-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Dynamic+label+(document+template).html
     - /refguide/dynamic-label-(document-template).html
+    - /refguide/Dynamic+label+(document+template)
+    - /refguide/dynamic-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/footer-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/footer-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/footer-(document-template).html
     - /refguide/Footer+(document+template).html
+    - /refguide/footer-(document-template)
+    - /refguide/Footer+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/header-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/header-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/header-(document-template).html
     - /refguide/Header+(document+template).html
+    - /refguide/header-(document-template)
+    - /refguide/Header+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/line-break-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/line-break-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Line+Break+(document+template).html
     - /refguide/line-break-(document-template).html
+    - /refguide/Line+Break+(document+template)
+    - /refguide/line-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/page-break-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/page-break-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Page+Break+(document+template).html
     - /refguide/page-break-(document-template).html
+    - /refguide/Page+Break+(document+template)
+    - /refguide/page-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/static-image-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/static-image-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Static+Image+(document+template).html
     - /refguide/static-image-(document-template).html
+    - /refguide/Static+Image+(document+template)
+    - /refguide/static-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/static-label-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/static-label-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Static+label+(document+template).html
     - /refguide/static-label-(document-template).html
+    - /refguide/Static+label+(document+template)
+    - /refguide/static-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/_index.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/_index.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide/table-(document-template).html
     - /refguide/Table+(document+template.html
+    - /refguide/table-(document-template)
+    - /refguide/Table+(document+template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/row-document-template/_index.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/row-document-template/_index.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/row-(document-template).html
     - /refguide/Row+(document+template).html
+    - /refguide/row-(document-template)
+    - /refguide/Row+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/row-document-template/cell-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/table-document-template/row-document-template/cell-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/cell-(document-template).html
     - /refguide/Cell+(document+template).html
+    - /refguide/cell-(document-template)
+    - /refguide/Cell+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/template-grid-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/template-grid-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/Template+Grid+(document+template).html
     - /refguide/template-grid-(document-template).html
+    - /refguide/Template+Grid+(document+template)
+    - /refguide/template-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/document-templates/title-document-template.md
+++ b/content/en/docs/refguide/modeling/resources/document-templates/title-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide/title-(document-template).html
     - /refguide/Title+(document+template).html
+    - /refguide/title-(document-template)
+    - /refguide/Title+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide/modeling/resources/enumerations.md
+++ b/content/en/docs/refguide/modeling/resources/enumerations.md
@@ -6,6 +6,7 @@ weight: 40
 tags: ["studio pro", "enumeration", "enumeration values", "enumeration value"]
 aliases:
     - /refguide/enumeration-values.html
+    - /refguide/enumeration-values
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 #The anchor <enum-value-properties> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide/modeling/studio-pro-overview/_index.md
+++ b/content/en/docs/refguide/modeling/studio-pro-overview/_index.md
@@ -7,6 +7,7 @@ weight: 10
 tags: ["Studio Pro"]
 aliases:
     - /refguide/desktop-modeler-overview.html
+    - /refguide/desktop-modeler-overview
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/close-page.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/close-page.md
@@ -5,6 +5,8 @@ parent: "client-activities"
 aliases:
     - /refguide7/Close+Form.html
     - /refguide7/close-form.html
+    - /refguide7/Close+Form
+    - /refguide7/close-form
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/download-file.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/download-file.md
@@ -4,6 +4,7 @@ url: /refguide7/download-file/
 parent: "client-activities"
 aliases:
     - /refguide7/Download+File.html
+    - /refguide7/Download+File
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-home-page.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-home-page.md
@@ -4,6 +4,7 @@ url: /refguide7/show-home-page/
 parent: "client-activities"
 aliases:
     - /refguide7/Show+Home+Page.html
+    - /refguide7/Show+Home+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-message.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-message.md
@@ -4,6 +4,7 @@ url: /refguide7/show-message/
 parent: "client-activities"
 aliases:
     - /refguide7/Show+Message.html
+    - /refguide7/Show+Message
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-page.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/show-page.md
@@ -4,6 +4,7 @@ url: /refguide7/show-page/
 parent: "client-activities"
 aliases:
     - /refguide7/Show+Page.html
+    - /refguide7/Show+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/validation-feedback.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/activities/client-activities/validation-feedback.md
@@ -4,6 +4,7 @@ url: /refguide7/validation-feedback/
 parent: "client-activities"
 aliases:
     - /refguide7/Validation+Feedback.html
+    - /refguide7/Validation+Feedback
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/_index.md
@@ -4,6 +4,7 @@ url: /refguide7/expressions/
 parent: "common-elements"
 aliases:
     - /refguide7/microflow-expressions.html
+    - /refguide7/microflow-expressions
 description: "Describes the expressions that can be used in Mendix for a variety of purposes (for example, to change a member of an object based on logic)."
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide7/desktop-modeler/desktop-modeler-overview.md
+++ b/content/en/docs/refguide7/desktop-modeler/desktop-modeler-overview.md
@@ -8,6 +8,8 @@ tags: ["desktop modeler"]
 aliases:
     - /refguide7/modeler.html
     - /refguide7/Modeler.html
+    - /refguide7/modeler
+    - /refguide7/Modeler
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/dialogs/download-from-version-control-dialog.md
+++ b/content/en/docs/refguide7/desktop-modeler/dialogs/download-from-version-control-dialog.md
@@ -4,6 +4,7 @@ url: /refguide7/download-from-version-control-dialog/
 parent: "dialogs"
 aliases:
     - /refguide7/download-from-team-server-dialog.html
+    - /refguide7/download-from-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/dialogs/open-app-dialog.md
+++ b/content/en/docs/refguide7/desktop-modeler/dialogs/open-app-dialog.md
@@ -4,6 +4,7 @@ url: /refguide7/open-app-dialog/
 parent: "dialogs"
 aliases:
     - /refguide7/open-project-dialog.html
+    - /refguide7/open-project-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/dialogs/upload-to-version-control-dialog.md
+++ b/content/en/docs/refguide7/desktop-modeler/dialogs/upload-to-version-control-dialog.md
@@ -4,6 +4,7 @@ url: /refguide7/upload-to-version-control-dialog/
 parent: "dialogs"
 aliases:
     - /refguide7/upload-to-team-server-dialog.html
+    - /refguide7/upload-to-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 ## 1 Introduction

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/_index.md
@@ -4,6 +4,7 @@ url: /refguide7/document-templates/
 category: "Desktop Modeler"
 aliases:
     - /refguide7/Document+Templates.html
+    - /refguide7/Document+Templates
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/data-grid-document-template/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/data-grid-document-template/_index.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Data+Grid+(document+template).html
     - /refguide7/data-grid-(document-template).html
+    - /refguide7/Data+Grid+(document+template)
+    - /refguide7/data-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/data-grid-document-template/columns-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/data-grid-document-template/columns-document-template.md
@@ -5,6 +5,8 @@ parent: "data-grid-document-template"
 aliases:
     - /refguide7/Columns+(document+template).html
     - /refguide7/columns-(document-template).html
+    - /refguide7/Columns+(document+template)
+    - /refguide7/columns-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/data-view-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/data-view-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Data+View+(document+template).html
     - /refguide7/data-view-(document-template).html
+    - /refguide7/Data+View+(document+template)
+    - /refguide7/data-view-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/dynamic-image-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/dynamic-image-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Dynamic+Image+(document+template).html
     - /refguide7/dynamic-image-(document-template).html
+    - /refguide7/Dynamic+Image+(document+template)
+    - /refguide7/dynamic-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/dynamic-label-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/dynamic-label-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Dynamic+label+(document+template).html
     - /refguide7/dynamic-label-(document-template).html
+    - /refguide7/Dynamic+label+(document+template)
+    - /refguide7/dynamic-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/footer-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/footer-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Footer+(document+template).html
     - /refguide7/footer-(document-template).html
+    - /refguide7/Footer+(document+template)
+    - /refguide7/footer-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/header-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/header-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Header+(document+template).html
     - /refguide7/header-(document-template).html
+    - /refguide7/Header+(document+template)
+    - /refguide7/header-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/line-break-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/line-break-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Line+Break+(document+template).html
     - /refguide7/line-break-(document-template).html
+    - /refguide7/Line+Break+(document+template)
+    - /refguide7/line-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/page-break-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/page-break-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Page+Break+(document+template).html
     - /refguide7/page-break-(document-template).html
+    - /refguide7/Page+Break+(document+template)
+    - /refguide7/page-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/static-image-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/static-image-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Static+Image+(document+template).html
     - /refguide7/static-image-(document-template).html
+    - /refguide7/Static+Image+(document+template)
+    - /refguide7/static-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/static-label-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/static-label-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Static+label+(document+template).html
     - /refguide7/static-label-(document-template).html
+    - /refguide7/Static+label+(document+template)
+    - /refguide7/static-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/_index.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Table+(document+template.html
     - /refguide7/table-(document-template).html
+    - /refguide7/Table+(document+template
+    - /refguide7/table-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/row-document-template/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/row-document-template/_index.md
@@ -5,6 +5,8 @@ parent: "table-document-template"
 aliases:
     - /refguide7/Row+(document+template).html
     - /refguide7/row-(document-template).html
+    - /refguide7/Row+(document+template)
+    - /refguide7/row-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/row-document-template/cell-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/table-document-template/row-document-template/cell-document-template.md
@@ -5,6 +5,8 @@ parent: "row-document-template"
 aliases:
     - /refguide7/Cell+(document+template).html
     - /refguide7/cell-(document-template).html
+    - /refguide7/Cell+(document+template)
+    - /refguide7/cell-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/template-grid-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/template-grid-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Template+Grid+(document+template).html
     - /refguide7/template-grid-(document-template).html
+    - /refguide7/Template+Grid+(document+template)
+    - /refguide7/template-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/document-templates/title-document-template.md
+++ b/content/en/docs/refguide7/desktop-modeler/document-templates/title-document-template.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide7/Title+(document+template).html
     - /refguide7/title-(document-template).html
+    - /refguide7/Title+(document+template)
+    - /refguide7/title-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/integration/mapping-documents/select--elements.md
+++ b/content/en/docs/refguide7/desktop-modeler/integration/mapping-documents/select--elements.md
@@ -4,6 +4,7 @@ url: /refguide7/select--elements/
 parent: "mapping-documents"
 aliases:
     - /refguide7/Select++Elements.html
+    - /refguide7/Select++Elements
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/integration/published-odata-services/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/integration/published-odata-services/_index.md
@@ -4,6 +4,7 @@ url: /refguide7/published-odata-services/
 parent: "integration"
 aliases:
     - /refguide7/consumed-odata-services.html
+    - /refguide7/consumed-odata-services
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/button-widgets/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/button-widgets/_index.md
@@ -4,6 +4,7 @@ url: /refguide7/button-widgets/
 parent: "pages"
 aliases:
     - /refguide7/sign-out-button.html
+    - /refguide7/sign-out-button
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/button-widgets/action-button.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/button-widgets/action-button.md
@@ -4,6 +4,7 @@ url: /refguide7/action-button/
 parent: "button-widgets"
 aliases:
     - /refguide7/link-button.html
+    - /refguide7/link-button
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/container-widgets/scroll-container/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/container-widgets/scroll-container/_index.md
@@ -5,6 +5,8 @@ parent: "container-widgets"
 aliases:
     - /refguide7/horizontal-split-pane.html
     - /refguide7/vertical-split-pane.html
+    - /refguide7/horizontal-split-pane
+    - /refguide7/vertical-split-pane
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/data-widgets/data-grid/sort-bar.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/data-widgets/data-grid/sort-bar.md
@@ -4,6 +4,7 @@ url: /refguide7/sort-bar/
 parent: "data-grid"
 aliases:
     - /refguide7/Sort+Bar.html
+    - /refguide7/Sort+Bar
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/input-widgets/drop_down.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/input-widgets/drop_down.md
@@ -5,6 +5,7 @@ parent: "input-widgets"
 tags: ["Drop-down", "input", "page", "widget", "enumeration"]
 aliases:
     - /refguide7/drop-down-widget.html
+    - /refguide7/drop-down-widget
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/pages/page-templates.md
+++ b/content/en/docs/refguide7/desktop-modeler/pages/page-templates.md
@@ -4,6 +4,7 @@ url: /refguide7/page-templates/
 parent: "pages"
 aliases:
     - /refguide7/page-template.html
+    - /refguide7/page-template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide7/general/moving-from-6-to-7.md
+++ b/content/en/docs/refguide7/general/moving-from-6-to-7.md
@@ -7,6 +7,8 @@ description: "Provides details on updating your project from Mendix 6 to Mendix 
 aliases:
     - /refguide/moving-from-6-to-7.html
     - /releasenotes/studio-pro/6.10.html
+    - /refguide/moving-from-6-to-7
+    - /releasenotes/studio-pro/6.10
 ---
 
 ## 1 Introduction

--- a/content/en/docs/refguide7/mobile/developing-hybrid-mobile-apps/_index.md
+++ b/content/en/docs/refguide7/mobile/developing-hybrid-mobile-apps/_index.md
@@ -4,6 +4,7 @@ url: /refguide7/developing-hybrid-mobile-apps/
 category: "Mobile Development"
 aliases:
     - /refguide7/Developing+Hybrid+Mobile+Apps.html
+    - /refguide7/Developing+Hybrid+Mobile+Apps
 ---
 
 ## 1 Introduction

--- a/content/en/docs/refguide7/version-control/collaborative-development/_index.md
+++ b/content/en/docs/refguide7/version-control/collaborative-development/_index.md
@@ -9,6 +9,10 @@ aliases:
     - /refguide7/desktop-webmodeler.html
     - /refguide7/sync-webmodeler-desktopmodeler.html
     - /web-modeler/general-sync-webmodeler-desktopmodeler-wm.html
+    - /howto/web-modeler/syncing-webmodeler-desktop
+    - /refguide7/desktop-webmodeler
+    - /refguide7/sync-webmodeler-desktopmodeler
+    - /web-modeler/general-sync-webmodeler-desktopmodeler-wm
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/mobile/hybrid-mobile/developing-hybrid-mobile-apps/_index.md
+++ b/content/en/docs/refguide8/mobile/hybrid-mobile/developing-hybrid-mobile-apps/_index.md
@@ -5,6 +5,7 @@ parent: "hybrid-mobile"
 tags: ["studio pro"]
 aliases:
     - /refguide8/Developing+Hybrid+Mobile+Apps.html
+    - /refguide8/Developing+Hybrid+Mobile+Apps
 ---
 
 ## 1 Introduction

--- a/content/en/docs/refguide8/modeling/_index.md
+++ b/content/en/docs/refguide8/modeling/_index.md
@@ -8,6 +8,9 @@ aliases:
     - /refguide8/desktop-modeler.html
     - /refguide8/modeler.html
     - /refguide8/Modeler.html
+    - /refguide8/desktop-modeler
+    - /refguide8/modeler
+    - /refguide8/Modeler
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.1 Introduction
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/close-page.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/close-page.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "close page", "client activity"]
 aliases:
     - /refguide8/Close+Form.html
     - /refguide8/close-form.html
+    - /refguide8/Close+Form
+    - /refguide8/close-form
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/download-file.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/download-file.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "download file", "client activities"]
 aliases:
     - /refguide8/Download+File.html
+    - /refguide8/Download+File
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-home-page.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-home-page.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["studio pro", "show home page", "home page", "client activities"]
 aliases:
     - /refguide8/Show+Home+Page.html
+    - /refguide8/Show+Home+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-message.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-message.md
@@ -6,6 +6,7 @@ weight: 4
 tags: ["studio pro", "show message", "client activities"]
 aliases:
     - /refguide8/Show+Message.html
+    - /refguide8/Show+Message
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-page.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/show-page.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "show page", "client activity"]
 aliases:
     - /refguide8/Show+Page.html
+    - /refguide8/Show+Page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/validation-feedback.md
+++ b/content/en/docs/refguide8/modeling/application-logic/activities/client-activities/validation-feedback.md
@@ -6,6 +6,7 @@ weight: 70
 tags: ["studio pro", "validation feedback", "client activities"]
 aliases:
     - /refguide8/Validation+Feedback.html
+    - /refguide8/Validation+Feedback
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/annotation.md
+++ b/content/en/docs/refguide8/modeling/application-logic/annotation.md
@@ -6,6 +6,7 @@ weight: 60
 tags: ["studio pro", "annotation", annotation flow]
 aliases:
     - /refguide8/annotation-flow.html
+    - /refguide8/annotation-flow
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/decisions/decision.md
+++ b/content/en/docs/refguide8/modeling/application-logic/decisions/decision.md
@@ -6,6 +6,7 @@ weight: 3
 tags: ["studio pro", "decision", "exclusive split"]
 aliases:
     - /refguide8/exclusive-split.html
+    - /refguide8/exclusive-split
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/decisions/object-type-decision.md
+++ b/content/en/docs/refguide8/modeling/application-logic/decisions/object-type-decision.md
@@ -6,6 +6,7 @@ weight: 2
 tags: ["studio pro", "object type decision", "decisions"]
 aliases:
     - /refguide8/inheritance-split.html
+    - /refguide8/inheritance-split
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/application-logic/expressions/_index.md
+++ b/content/en/docs/refguide8/modeling/application-logic/expressions/_index.md
@@ -7,6 +7,7 @@ description: "Describes the expressions that can be used in Mendix for a variety
 tags: ["studio pro", "expressions", "microflow expressions"]
 aliases:
     - /refguide8/microflow-expressions.html
+    - /refguide8/microflow-expressions
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/integration/mapping-documents/select--elements.md
+++ b/content/en/docs/refguide8/modeling/integration/mapping-documents/select--elements.md
@@ -5,6 +5,7 @@ parent: "mapping-documents"
 tags: ["studio pro"]
 aliases:
     - /refguide8/Select++Elements.html
+    - /refguide8/Select++Elements
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/integration/published-odata-services/_index.md
+++ b/content/en/docs/refguide8/modeling/integration/published-odata-services/_index.md
@@ -5,6 +5,7 @@ parent: "integration"
 tags: ["studio pro"]
 aliases:
     - /refguide8/consumed-odata-services.html
+    - /refguide8/consumed-odata-services
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/file-menu/export-project-package-dialog.md
+++ b/content/en/docs/refguide8/modeling/menus/file-menu/export-project-package-dialog.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["studio pro", "export app", "export project package"]
 aliases:
     - /developerportal/support/export-a-project-package.html
+    - /developerportal/support/export-a-project-package
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/file-menu/new-project.md
+++ b/content/en/docs/refguide8/modeling/menus/file-menu/new-project.md
@@ -7,6 +7,7 @@ description: "This document describes the New Project (New App) flow and the App
 tags: ["studio pro", "create app", "new app", "new project", "creating new app"]
 aliases:
     - /refguide8/app-settings-dialog.html
+    - /refguide8/app-settings-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/file-menu/open-app-dialog.md
+++ b/content/en/docs/refguide8/modeling/menus/file-menu/open-app-dialog.md
@@ -7,6 +7,7 @@ description: "Describes the Open Project (app) flow and the Open App dialog box"
 tags: ["studio pro", "open app", "open project"]
 aliases:
     - /refguide8/open-project-dialog.html
+    - /refguide8/open-project-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/version-control-menu/download-from-version-control-dialog.md
+++ b/content/en/docs/refguide8/modeling/menus/version-control-menu/download-from-version-control-dialog.md
@@ -6,6 +6,7 @@ weight: 60
 tags: ["studio pro"]
 aliases:
     - /refguide8/download-from-team-server-dialog.html
+    - /refguide8/download-from-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/version-control-menu/upload-to-version-control-dialog.md
+++ b/content/en/docs/refguide8/modeling/menus/version-control-menu/upload-to-version-control-dialog.md
@@ -6,6 +6,7 @@ weight: 70
 tags: ["studio pro"]
 aliases:
     - /refguide8/upload-to-team-server-dialog.html
+    - /refguide8/upload-to-team-server-dialog
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/module-security.md
+++ b/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/module-security.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "module security", "security", "module"]
 aliases:
     - /refguide8/module-role.html
+    - /refguide8/module-role
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
 

--- a/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/project-security/user-roles.md
+++ b/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/project-security/user-roles.md
@@ -6,6 +6,7 @@ weight: 10
 tags: ["studio pro", "user role", "project security", "security"]
 aliases:
     - /refguide8/user-role.html
+    - /refguide8/user-role
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/common-widgets/image.md
+++ b/content/en/docs/refguide8/modeling/pages/common-widgets/image.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "image", "image widget"]
 aliases:
     - /refguide8/image-property.html
+    - /refguide8/image-property
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/container-widgets/scroll-container.md
+++ b/content/en/docs/refguide8/modeling/pages/container-widgets/scroll-container.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "scroll container", "container widget", "widget"]
 aliases:
     - /refguide8/horizontal-split-pane.html
     - /refguide8/vertical-split-pane.html
+    - /refguide8/horizontal-split-pane
+    - /refguide8/vertical-split-pane
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/container-widgets/tab-container.md
+++ b/content/en/docs/refguide8/modeling/pages/container-widgets/tab-container.md
@@ -6,6 +6,7 @@ weight: 40
 tags: ["studio pro", "tab container", "tab page", "container widget", "widget"]
 aliases:
     - /refguide8/tab-page.html
+    - /refguide8/tab-page
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #The anchor <tab-page> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide8/modeling/pages/data-widgets/grids/control-bar.md
+++ b/content/en/docs/refguide8/modeling/pages/data-widgets/grids/control-bar.md
@@ -15,6 +15,16 @@ aliases:
     - /refguide8/search-button.html
     - /refguide8/select-all-button.html
     - /refguide8/select-button.html
+    - /refguide8/add-button
+    - /refguide8/deselect-all-button
+    - /refguide8/export-to-csv-button
+    - /refguide8/export-to-excel-button
+    - /refguide8/grid-action-button
+    - /refguide8/grid-new-button
+    - /refguide8/remove-button
+    - /refguide8/search-button
+    - /refguide8/select-all-button
+    - /refguide8/select-button
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/data-widgets/grids/search-bar.md
+++ b/content/en/docs/refguide8/modeling/pages/data-widgets/grids/search-bar.md
@@ -8,6 +8,9 @@ aliases:
     - /refguide8/comparison-search-field.html
     - /refguide8/drop-down-search-field.html
     - /refguide8/range-search-field.html
+    - /refguide8/comparison-search-field
+    - /refguide8/drop-down-search-field
+    - /refguide8/range-search-field
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/data-widgets/grids/sort-bar.md
+++ b/content/en/docs/refguide8/modeling/pages/data-widgets/grids/sort-bar.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "sort bar", "grid"]
 aliases:
     - /refguide8/Sort+Bar.html
+    - /refguide8/Sort+Bar
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/input-widgets/drop-down.md
+++ b/content/en/docs/refguide8/modeling/pages/input-widgets/drop-down.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["Drop-down", "input", "page", "widget", "enumeration", "studio pro"]
 aliases:
     - /refguide8/drop-down-widget.html
+    - /refguide8/drop-down-widget
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/on-click-event.md
+++ b/content/en/docs/refguide8/modeling/pages/on-click-event.md
@@ -7,6 +7,8 @@ tags: ["studio pro", "events section", "properties", "widget", "on click", "acti
 aliases:
     - /refguide8/opening-pages.html
     - /refguide8/starting-microflows.html
+    - /refguide8/opening-pages
+    - /refguide8/starting-microflows
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/pages/page-resources/menu.md
+++ b/content/en/docs/refguide8/modeling/pages/page-resources/menu.md
@@ -6,6 +6,7 @@ weight: 50
 tags: ["studio pro", "menu", "menu item", "page resource"]
 aliases:
     - /refguide8/menu-item.html
+    - /refguide8/menu-item
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 #The anchor <menu-item> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide8/modeling/pages/page-resources/page-templates.md
+++ b/content/en/docs/refguide8/modeling/pages/page-resources/page-templates.md
@@ -6,6 +6,7 @@ weight: 20
 tags: ["studio pro", "page template", "page resource"]
 aliases:
     - /refguide8/page-template.html
+    - /refguide8/page-template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/_index.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/_index.md
@@ -6,6 +6,7 @@ weight: 90
 tags: ["studio pro", "document template"]
 aliases:
     - /refguide8/Document+Templates.html
+    - /refguide8/Document+Templates
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/data-grid-document-template/_index.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/data-grid-document-template/_index.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Data+Grid+(document+template).html
     - /refguide8/data-grid-(document-template).html
+    - /refguide8/Data+Grid+(document+template)
+    - /refguide8/data-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/data-grid-document-template/columns-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/data-grid-document-template/columns-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/columns-(document-template).html
     - /refguide8/Columns+(document+template).html
+    - /refguide8/columns-(document-template)
+    - /refguide8/Columns+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/data-view-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/data-view-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Data+View+(document+template).html
     - /refguide8/data-view-(document-template).html
+    - /refguide8/Data+View+(document+template)
+    - /refguide8/data-view-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/dynamic-image-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/dynamic-image-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Dynamic+Image+(document+template).html
     - /refguide8/dynamic-image-(document-template).html
+    - /refguide8/Dynamic+Image+(document+template)
+    - /refguide8/dynamic-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/dynamic-label-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/dynamic-label-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Dynamic+label+(document+template).html
     - /refguide8/dynamic-label-(document-template).html
+    - /refguide8/Dynamic+label+(document+template)
+    - /refguide8/dynamic-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/footer-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/footer-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/footer-(document-template).html
     - /refguide8/Footer+(document+template).html
+    - /refguide8/footer-(document-template)
+    - /refguide8/Footer+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/header-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/header-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/header-(document-template).html
     - /refguide8/Header+(document+template).html
+    - /refguide8/header-(document-template)
+    - /refguide8/Header+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/line-break-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/line-break-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Line+Break+(document+template).html
     - /refguide8/line-break-(document-template).html
+    - /refguide8/Line+Break+(document+template)
+    - /refguide8/line-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/page-break-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/page-break-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Page+Break+(document+template).html
     - /refguide8/page-break-(document-template).html
+    - /refguide8/Page+Break+(document+template)
+    - /refguide8/page-break-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/static-image-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/static-image-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Static+Image+(document+template).html
     - /refguide8/static-image-(document-template).html
+    - /refguide8/Static+Image+(document+template)
+    - /refguide8/static-image-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/static-label-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/static-label-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Static+label+(document+template).html
     - /refguide8/static-label-(document-template).html
+    - /refguide8/Static+label+(document+template)
+    - /refguide8/static-label-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/_index.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/_index.md
@@ -5,6 +5,8 @@ parent: "document-templates"
 aliases:
     - /refguide8/table-(document-template).html
     - /refguide8/Table+(document+template.html
+    - /refguide8/table-(document-template)
+    - /refguide8/Table+(document+template
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/row-document-template/_index.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/row-document-template/_index.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/row-(document-template).html
     - /refguide8/Row+(document+template).html
+    - /refguide8/row-(document-template)
+    - /refguide8/Row+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/row-document-template/cell-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/table-document-template/row-document-template/cell-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/cell-(document-template).html
     - /refguide8/Cell+(document+template).html
+    - /refguide8/cell-(document-template)
+    - /refguide8/Cell+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/template-grid-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/template-grid-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/Template+Grid+(document+template).html
     - /refguide8/template-grid-(document-template).html
+    - /refguide8/Template+Grid+(document+template)
+    - /refguide8/template-grid-(document-template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/document-templates/title-document-template.md
+++ b/content/en/docs/refguide8/modeling/resources/document-templates/title-document-template.md
@@ -6,6 +6,8 @@ tags: ["studio pro"]
 aliases:
     - /refguide8/title-(document-template).html
     - /refguide8/Title+(document+template).html
+    - /refguide8/title-(document-template)
+    - /refguide8/Title+(document+template)
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/refguide8/modeling/resources/enumerations.md
+++ b/content/en/docs/refguide8/modeling/resources/enumerations.md
@@ -6,6 +6,7 @@ weight: 40
 tags: ["studio pro", "enumeration", "enumeration values", "enumeration value"]
 aliases:
     - /refguide8/enumeration-values.html
+    - /refguide8/enumeration-values
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 #The anchor <enum-value-properties> below is mapped, so it should not be removed or changed.
 ---

--- a/content/en/docs/refguide8/modeling/studio-pro-overview.md
+++ b/content/en/docs/refguide8/modeling/studio-pro-overview.md
@@ -7,6 +7,7 @@ weight: 10
 tags: ["Studio Pro"]
 aliases:
     - /refguide8/desktop-modeler-overview.html
+    - /refguide8/desktop-modeler-overview
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---

--- a/content/en/docs/refguide8/runtime/data-storage/uniqueness-constraint-migration.md
+++ b/content/en/docs/refguide8/runtime/data-storage/uniqueness-constraint-migration.md
@@ -6,6 +6,7 @@ weight: 30
 tags: ["studio pro"]
 aliases:
     - /refguide/uniqueness-constraint-migration.html
+    - /refguide/uniqueness-constraint-migration
 # referred to in M2EE error message
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.0.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.0.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.0 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.0.html
+    - /releasenotes/desktop-modeler/7.0
 weight: 100
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.1.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.1.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.1 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.1.html
+    - /releasenotes/desktop-modeler/7.1
 weight: 99
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.10.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.10.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.10 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.10.html
+    - /releasenotes/desktop-modeler/7.10
 weight: 90
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.11.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.11.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.11 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.11.html
+    - /releasenotes/desktop-modeler/7.11
 weight: 89
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.12.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.12.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.12 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.12.html
+    - /releasenotes/desktop-modeler/7.12
 weight: 88
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.13.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.13.md
@@ -6,6 +6,7 @@ description: "The release notes for Mendix Desktop Modeler version 7.13 (includi
 tags: ["Desktop Modeler", "Release Notes"]
 aliases:
     - /releasenotes/desktop-modeler/7.13.html
+    - /releasenotes/desktop-modeler/7.13
 weight: 87
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.14.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.14.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.14 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.14.html
+    - /releasenotes/desktop-modeler/7.14
 weight: 86
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.15.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.15.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.15 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.15.html
+    - /releasenotes/desktop-modeler/7.15
 weight: 85
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.16.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.16.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.16 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.16.html
+    - /releasenotes/desktop-modeler/7.16
 weight: 84
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.17.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.17.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.17 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.17.html
+    - /releasenotes/desktop-modeler/7.17
 weight: 83
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.18.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.18.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.18 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.18.html
+    - /releasenotes/desktop-modeler/7.18
 weight: 82
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.19.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.19.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.19 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.19.html
+    - /releasenotes/desktop-modeler/7.19
 weight: 81
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.2.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.2.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.2 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.2.html
+    - /releasenotes/desktop-modeler/7.2
 weight: 98
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.20.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.20.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.20 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.20.html
+    - /releasenotes/desktop-modeler/7.20
 weight: 80
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.21.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.21.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.21 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.21.html
+    - /releasenotes/desktop-modeler/7.21
 weight: 79
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.22.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.22.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.22 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.22.html
+    - /releasenotes/desktop-modeler/7.22
 weight: 78
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.23.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.23.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.23 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.23.html
+    - /releasenotes/desktop-modeler/7.23
 weight: 77
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.3.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.3.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.3 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.3.html
+    - /releasenotes/desktop-modeler/7.3
 weight: 97
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.4.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.4.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.4 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.4.html
+    - /releasenotes/desktop-modeler/7.4
 weight: 96
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.5.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.5.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Modeler version 7.5 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.5.html
+    - /releasenotes/desktop-modeler/7.5
 weight: 95
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.6.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.6.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.6 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.6.html
+    - /releasenotes/desktop-modeler/7.6
 weight: 94
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.7.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.7.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.7 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.7.html
+    - /releasenotes/desktop-modeler/7.7
 weight: 93
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.8.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.8.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.8 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.8.html
+    - /releasenotes/desktop-modeler/7.8
 weight: 92
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/7/7.9.md
+++ b/content/en/docs/releasenotes/studio-pro/7/7.9.md
@@ -5,6 +5,7 @@ parent: "7"
 description: "The release notes for Mendix Desktop Modeler version 7.9 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/7.9.html
+    - /releasenotes/desktop-modeler/7.9
 weight: 91
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/8/8.0.md
+++ b/content/en/docs/releasenotes/studio-pro/8/8.0.md
@@ -5,6 +5,7 @@ parent: "8"
 description: "The release notes Mendix Studio Pro version 8.0 (including all patches) with details on new features, bug fixes, and known issues."
 aliases:
     - /releasenotes/desktop-modeler/8.0.html
+    - /releasenotes/desktop-modeler/8.0
 weight: 100
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/windows-service.md
+++ b/content/en/docs/releasenotes/studio-pro/windows-service.md
@@ -5,6 +5,7 @@ category: "Studio Pro"
 weight: 40
 aliases:
     - /releasenotes/desktop-modeler/windows-service.html
+    - /releasenotes/desktop-modeler/windows-service
 ---
 
 To download the Windows Service, go to the [Get Studio Pro](https://marketplace.mendix.com/link/studiopro/) page in the Mendix Marketplace and click the **Related Downloads** button.

--- a/content/en/docs/studio/collaboration/collaborative-development.md
+++ b/content/en/docs/studio/collaboration/collaborative-development.md
@@ -7,6 +7,7 @@ tags: ["studio", "collaborative development", "sync"]
 weight: 10
 aliases:
     - /studio/general-collaborative-development.html
+    - /studio/general-collaborative-development
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/studio/expressions/_index.md
+++ b/content/en/docs/studio/expressions/_index.md
@@ -6,6 +6,7 @@ description: "Describes the microflow expressions available in Mendix Studio."
 tags: ["studio", "microflow", "expressions", "expression", "set value", "variable"]
 aliases:
     - /studio/microflows-expressions.html
+    - /studio/microflows-expressions
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/studio/general/_index.md
+++ b/content/en/docs/studio/general/_index.md
@@ -7,6 +7,7 @@ tags: ["studio", "studio pro"]
 aliases:
     - /howto/tutorials/index.html
     - /howto/tutorials/mendix-tutorials.html
+    - /howto/tutorials/mendix-tutorials
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 


### PR DESCRIPTION
All aliases ending in .html (except index.html) have been added to the aliases list without the .html extension. Safety precaution for product redirects.