### PR TITLE
Update trends-v4.md

### DIFF
--- a/content/en/docs/developerportal/operate/metrics/trends-v4.md
+++ b/content/en/docs/developerportal/operate/metrics/trends-v4.md
@@ -346,7 +346,7 @@ You will not see this if you are using the [Basic License](/developerportal/depl
 
 {{< figure src="/attachments/developerportal/operate/metrics/trends-v4/db-cpu-usage.png" >}}
 
-### 5.7 Database Node Disk Throughput{#Trends-dbdiskstatsthroughput}
+### 5.7 Database Node Disk Throughput (in Bytes){#Trends-dbdiskstatsthroughput}
 
 The **Database node disk throughput** graph shows the amount of data that is being read from and written to disk.
 


### PR DESCRIPTION
5.7 Database Node Disk Throughput does not currently state the unit of measurement. Assumption is (since all the other are in Bytes) that the unit of measurement is Bytes here. But this should be checked and adjusted if it is not in Bytes.
Regards,
Ronald