### PR TITLE
KI: When you double click a line in the Variables Tool Window

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -23,7 +23,7 @@ weight: 89
 ### Known Issues
 
 * When you double-click a multi-column tree (for example, in the **Debug Windows** > [Variables](/refguide/view-menu/#variables) pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
-	* Workaround: double-click the first column where this issue is happening.
+	* Workaround: Double-click the first column where this issue is occurring.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
 * The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
@@ -97,7 +97,7 @@ weight: 89
 * <a name="ki-135420"></a>In expression editors, an expression displayed as valid might be interpreted as invalid later (for example, upon clicking **OK** on the **Edit Change Item** dialog box, the grid in the **Change Object** dialog box that was initially opened from a microflow object marks the valid expression as invalid, accompanied with an error icon in the grid). This affects the user data consisting of this expression field (which is saved into storage with an invalid escaped character, causing the expression field to be interpreted as an invalid one even when restarting Studio Pro). In addition, the auto-completion list pop-up window of a text editor might display no suggestions or incorrect suggestions as hints for auto-completing an expression. 
 	* Fixed in [9.11.1](#135420).
 * When you double-click a multi-column tree (for example, in the **Debug Windows** > [Variables](/refguide/view-menu/#variables) pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
-	* Workaround: double-click the first column where this issue is happening.
+	* Workaround: Double-click the first column where this issue is occurring.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
 * The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.

--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -5,6 +5,7 @@ parent: "9"
 description: "The release notes for Mendix Studio Pro version 9.11 (including all patches) with details on new features, bug fixes, and known issues."
 weight: 89
 #When updating, remember to update the Latest Mendix Releases file
+#KI: "When you double click a line in the Variables Tool Window" - CTRL-2047
 #KI: "The stories shown" - SPVC-1461
 #KI: "When you update a consumed OData service" - DTML-358
 ---
@@ -24,6 +25,8 @@ weight: 89
 * The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
+* When you double-click a multi-column tree grid view is not selecting the line (except if clicked in the first column), for instance, the **Variables Tool Window** is not selecting the line when double-click it, making it hard to copy the variable value.
+	* A workaround is to double-click in the first column where this issue is happening.
 
 ## 9.11.0 {#9110}
 
@@ -96,3 +99,5 @@ weight: 89
 * The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
+* When you double-click a multi-column tree grid view is not selecting the line (except if clicked in the first column), for instance, the **Variables Tool Window** is not selecting the line when double-click it, making it hard to copy the variable value.
+	* A workaround is to double-click in the first column where this issue is happening.

--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -5,7 +5,7 @@ parent: "9"
 description: "The release notes for Mendix Studio Pro version 9.11 (including all patches) with details on new features, bug fixes, and known issues."
 weight: 89
 #When updating, remember to update the Latest Mendix Releases file
-#KI: "When you double click a line in the Variables Tool Window" - CTRL-2047
+#KI: "When you double-click" - CTRL-2047
 #KI: "When you update a consumed OData service" - DTML-358
 #KI: "The stories shown" - SPVC-1461
 ---

--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -22,7 +22,7 @@ weight: 89
 
 ### Known Issues
 
-* When you double-click a multi-column tree (for example, in the the **Variables Tool Window**), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+* When you double-click a multi-column tree (for example, in the **Variables Tool** pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
 	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
@@ -96,7 +96,7 @@ weight: 89
 
 * <a name="ki-135420"></a>In expression editors, an expression displayed as valid might be interpreted as invalid later (for example, upon clicking **OK** on the **Edit Change Item** dialog box, the grid in the **Change Object** dialog box that was initially opened from a microflow object marks the valid expression as invalid, accompanied with an error icon in the grid). This affects the user data consisting of this expression field (which is saved into storage with an invalid escaped character, causing the expression field to be interpreted as an invalid one even when restarting Studio Pro). In addition, the auto-completion list pop-up window of a text editor might display no suggestions or incorrect suggestions as hints for auto-completing an expression. 
 	* Fixed in [9.11.1](#135420).
-* When you double-click a multi-column tree (for example, in the the **Variables Tool Window**), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+* When you double-click a multi-column tree (for example, in the **Variables Tool** pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
 	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.

--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -6,8 +6,8 @@ description: "The release notes for Mendix Studio Pro version 9.11 (including al
 weight: 89
 #When updating, remember to update the Latest Mendix Releases file
 #KI: "When you double click a line in the Variables Tool Window" - CTRL-2047
-#KI: "The stories shown" - SPVC-1461
 #KI: "When you update a consumed OData service" - DTML-358
+#KI: "The stories shown" - SPVC-1461
 ---
 
 ## 9.11.1 {#9111}
@@ -22,11 +22,11 @@ weight: 89
 
 ### Known Issues
 
-* The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
+* When you double-click a multi-column tree (for example, in the the **Variables Tool Window**), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
-* When you double-click a multi-column tree grid view is not selecting the line (except if clicked in the first column), for instance, the **Variables Tool Window** is not selecting the line when double-click it, making it hard to copy the variable value.
-	* A workaround is to double-click in the first column where this issue is happening.
+* The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
 
 ## 9.11.0 {#9110}
 
@@ -96,8 +96,8 @@ weight: 89
 
 * <a name="ki-135420"></a>In expression editors, an expression displayed as valid might be interpreted as invalid later (for example, upon clicking **OK** on the **Edit Change Item** dialog box, the grid in the **Change Object** dialog box that was initially opened from a microflow object marks the valid expression as invalid, accompanied with an error icon in the grid). This affects the user data consisting of this expression field (which is saved into storage with an invalid escaped character, causing the expression field to be interpreted as an invalid one even when restarting Studio Pro). In addition, the auto-completion list pop-up window of a text editor might display no suggestions or incorrect suggestions as hints for auto-completing an expression. 
 	* Fixed in [9.11.1](#135420).
-* The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.
+* When you double-click a multi-column tree (for example, in the the **Variables Tool Window**), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
-* When you double-click a multi-column tree grid view is not selecting the line (except if clicked in the first column), for instance, the **Variables Tool Window** is not selecting the line when double-click it, making it hard to copy the variable value.
-	* A workaround is to double-click in the first column where this issue is happening.
+* The stories shown in the [Related stories](/refguide/commit-dialog/#stories) tab in the **Commit** dialog box are not currently being filtered by their completed status. Their text is also wrapped and aligned incorrectly. Finally, double-clicking a story in the [Stories](/refguide/stories-pane/) pane does not show the **Story Details** pop-up window with the story information.

--- a/content/en/docs/releasenotes/studio-pro/9/9.11.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.11.md
@@ -22,7 +22,7 @@ weight: 89
 
 ### Known Issues
 
-* When you double-click a multi-column tree (for example, in the **Variables Tool** pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+* When you double-click a multi-column tree (for example, in the **Debug Windows** > [Variables](/refguide/view-menu/#variables) pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
 	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.
@@ -96,7 +96,7 @@ weight: 89
 
 * <a name="ki-135420"></a>In expression editors, an expression displayed as valid might be interpreted as invalid later (for example, upon clicking **OK** on the **Edit Change Item** dialog box, the grid in the **Change Object** dialog box that was initially opened from a microflow object marks the valid expression as invalid, accompanied with an error icon in the grid). This affects the user data consisting of this expression field (which is saved into storage with an invalid escaped character, causing the expression field to be interpreted as an invalid one even when restarting Studio Pro). In addition, the auto-completion list pop-up window of a text editor might display no suggestions or incorrect suggestions as hints for auto-completing an expression. 
 	* Fixed in [9.11.1](#135420).
-* When you double-click a multi-column tree (for example, in the **Variables Tool** pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
+* When you double-click a multi-column tree (for example, in the **Debug Windows** > [Variables](/refguide/view-menu/#variables) pane), the grid view does not select the line (except if clicked in the first column), which makes it hard to copy the variable value.
 	* Workaround: double-click the first column where this issue is happening.
 * When you update a [consumed OData service](/refguide/consumed-odata-service/) with a new version from [Mendix Data Hub](/data-hub/) but close the document without saving, the blue arrow icon will no longer be shown to notify you about the available update for that service.
 	* Workaround: Closing your app and opening it again fixes this issue.


### PR DESCRIPTION
Includes known-issue in 9.11 that double-clicking a multi-column tree item is not selecting the item.