### PR TITLE
Updated OpenShift versions supported by Mx4PC (no release date)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
@@ -35,7 +35,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.22
+* Kubernetes versions 1.19 through 1.23
 * OpenShift 4.6 through 4.10
 
 {{% alert color="warning" %}}

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
@@ -36,7 +36,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
 * Kubernetes versions 1.19 through 1.22
-* OpenShift 4.6 through 4.8
+* OpenShift 4.6 through 4.10
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.


### PR DESCRIPTION
This is a small change not linked to any release, and can be published at any moment.

A few customers are asking if/when newer Kubernetes and OpenShift versions are supported.
We now have confirmation that Kubernetes 1.23 and OpenShift 4.10 are supported out of the box, with no changes required in Mx4PC components.