### PR TITLE
9.12.1 support for scheduled events conversion

### DIFF
--- a/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
+++ b/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
@@ -42,9 +42,7 @@ Mendix versions 9.12.0 and above supports the following schedule types:
 
 ## 3 Migration{#migration}
 
-When migrating to Mendix version 9.12.0 or above, Studio Pro will attempt to convert legacy scheduled events into task queue-based events,
-when possible. In cases where this is not possible a deprecation warning will be shown (versions 9.12.1 and above). Right-click on the warning to see
-possible options for fixing it. If none of the options is suitable, you should perform the conversion manually.
+When migrating to version [9.12.0](/releasenotes/studio-pro/9.12/#9120) or above, Studio Pro will attempt to convert legacy scheduled events into task queue-based events, when possible. In cases where this is not possible, a deprecation warning will be shown (in versions [9.12.1](/releasenotes/studio-pro/9.12/#9121) and above). Right-click the warning to see possible options for fixing it. If none of the options is suitable, you should perform the conversion manually.
 
 The following cases cannot be converted automatically when the model is upgraded to Mendix version 9.12.0 or above:
 

--- a/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
+++ b/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
@@ -43,7 +43,7 @@ Mendix versions 9.12.0 and above supports the following schedule types:
 ## 3 Migration{#migration}
 
 When migrating to Mendix version 9.12.0 or above, Studio Pro will attempt to convert legacy scheduled events into task queue-based events,
-when possible. In cases where this is not possible a deprecation warning will be shown (since 9.12.1). Right-click on the warning to see
+when possible. In cases where this is not possible a deprecation warning will be shown (versions 9.12.1 and above). Right-click on the warning to see
 possible options for fixing it. If none of the options is suitable, you should perform the conversion manually.
 
 The following cases cannot be converted automatically when the model is upgraded to Mendix version 9.12.0 or above:

--- a/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
+++ b/content/en/docs/refguide/modeling/resources/scheduled-events/_index.md
@@ -43,7 +43,8 @@ Mendix versions 9.12.0 and above supports the following schedule types:
 ## 3 Migration{#migration}
 
 When migrating to Mendix version 9.12.0 or above, Studio Pro will attempt to convert legacy scheduled events into task queue-based events,
-when possible.
+when possible. In cases where this is not possible a deprecation warning will be shown (since 9.12.1). Right-click on the warning to see
+possible options for fixing it. If none of the options is suitable, you should perform the conversion manually.
 
 The following cases cannot be converted automatically when the model is upgraded to Mendix version 9.12.0 or above:
 


### PR DESCRIPTION
Added note on 9.12.1 support for converting deprecated scheduled events.