### PR TITLE
Workflow Commons: changes in v2.1.0 for Mx 9.12 and above

### DIFF
--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -54,7 +54,7 @@ Download and install the following modules:
         2. Views personal performance in the Task Dashboard.
         3. Views workflow progress in the My Initiated Workflows overview.
 3. Make sure the correct user entity is set in the **App Settings**: open **App Settings** > **Workflows** tab and set **User entity** to *Administration.Account*.
-4. For Workflow Commons v2.1.0 and above, you need to configure the state change event microflows in the **App Settings**: open **App Settings** > **Workflows** tab to configure the following state change microflows:
+4. For Workflow Commons v2.1.0 and above, you need to configure the state change microflows in the **App Settings**: open **App Settings** > **Workflows** tab to configure the following state change microflows:
     1. **Workflow state change**: *OCh_Workflow_State*
     2. **User task state change**: *OCh_WorkflowUserTask_State*
 

--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -48,15 +48,15 @@ Download and install the following modules:
 2. Add Administrator and User module roles to the required App roles:
     1. Administrator role does the following:
         1. Administers workflows.
-        2. Views workflow and task performance in the Admin Workflow Dashboard.
+        2. Views workflow and task performance in the **Admin Workflow Dashboard**.
     2. User role does the following:
         1. Executes workflows by completing user tasks.
-        2. Views personal performance in the Task Dashboard.
-        3. Views workflow progress in the My Initiated Workflows overview.
+        2. Views personal performance in the **Task Dashboard**.
+        3. Views workflow progress in the **My Initiated Workflows** overview.
 3. Make sure the correct user entity is set in the **App Settings**: open **App Settings** > **Workflows** tab and set **User entity** to *Administration.Account*.
 4. For Workflow Commons v2.1.0 and above, you need to configure the state change microflows in the **App Settings**: open **App Settings** > **Workflows** tab to configure the following state change microflows:
-    1. **Workflow state change**: *OCh_Workflow_State*
-    2. **User task state change**: *OCh_WorkflowUserTask_State*
+    1. Set **Workflow state change** to *OCh_Workflow_State*
+    2. Set **User task state change** to *OCh_WorkflowUserTask_State*
 
 ## 4 Usage
 

--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -48,10 +48,15 @@ Download and install the following modules:
 2. Add Administrator and User module roles to the required App roles:
     1. Administrator role does the following:
         1. Administers workflows.
-        2. Views workflow performance in the Admin Workflow Dashboard.
+        2. Views workflow and task performance in the Admin Workflow Dashboard.
     2. User role does the following:
         1. Executes workflows by completing user tasks.
+        2. Views personal performance in the Task Dashboard.
+        3. Views workflow progress in the My Initiated Workflows overview.
 3. Make sure the correct user entity is set in the **App Settings**: open **App Settings** > **Workflows** tab and set **User entity** to *Administration.Account*.
+4. For Workflow Commons v2.1.0 and above, you need to configure the state change event microflows in the **App Settings**: open **App Settings** > **Workflows** tab to configure the following state change microflows:
+    1. **Workflow state change**: *OCh_Workflow_State*
+    2. **User task state change**: *OCh_WorkflowUserTask_State*
 
 ## 4 Usage
 

--- a/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
+++ b/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
@@ -17,6 +17,9 @@ Before adding the Workflow Commons module to your app, make sure you have comple
 * Upgrade your application to Mendix 9
 * Install Atlas 3 from the Mendix Marketplace, as Workflow Commons depends on it 
 * As a result of installing Atlas 3, your app should contain the following modules that Workflow Commons depends on: Atlas Core, Atlas Web Content, and Data Widgets
+* The dashboards and metrics in Workflow Commons v2.1.0 and above depend on state change microflows. Make sure to configure the following state change microflows in the **App Settings** > **Workflows** tab:
+    * **Workflow state change**: *OCh_Workflow_State*
+    * **User task state change**: *OCh_WorkflowUserTask_State*
 
 ## 2 Workflow Commons Components {#components}
 
@@ -28,6 +31,8 @@ Multiple pages are provided with the Workflow Commons module to get you and your
 You can find the following pages in Workflow Commons:
 
 *   **DefaultWorkflowAdmin** – The default workflow admin page that a workflow administrator can use to view and manage a workflow instance. This page can be used in the **Show workflow admin page** microflow activity and button action.
+*   **MyInitiatedWorkflows** – This page gives end users an overview of all their initiated workflows. They can view the current state, task timeline and can withdraw workflows that are in progress, paused, or incompatible.
+*   **TaskDashboard** –  This page gives end-users an overview of their performance in your app's workflows. It contains information such as how many tasks have been completed, how long it took on average to complete a task, and what percentage of tasks were completed within the deadline.
 *   **TaskInbox** – This page contains a list of all tasks that a user can interact with. **My open tasks** shows the tasks assigned to current users, **All open tasks** is a list of tasks they could pick up and **Unassigned tasks** shows all unassigned tasks.
 *   **WorkflowAdminCenter** – A navigational page for workflow administrators. From here, a workflow administrator can go the the **Workflow Dashboard**, which gives them general statistics of workflows. Workflow administrators also gain access to **Workflow management**, where they can see all the instances of specific workflows and make changes to their data or even abort workflows.
 *   **WorkflowDashboard** – This page gives you workflow/task based metrics and direct access to all *Workflow* and *WorkflowUserTask* data. When you want to use the Workflow Dashboard as your only admin go-to page, add this to the navigation instead of the **WorkflowAdminCenter**. 
@@ -37,9 +42,11 @@ You can find the following pages in Workflow Commons:
 Workflow Commons contains page templates to easily get you started with building workflow-related pages. These templates are automatically suggested to you when you make a new page from either the user task or workflow properties. 
 You can find the following page templates in Workflow Commons:
 
+*   **MyInitiatedWorkflows** – This page template allows users who initiate workflows keep track of their progress. A user is also able to withdraw a workflow if it is still in progress.
 *   **UserTask_Basic** – A basic template that shows a header with the task name and description, a sidebar with details about the assignee and status of the task, and a main view where input elements and buttons to complete the task are generated.
 *   **UserTask_Extended** –  This page template does exactly the same as the basic user task template, but extends it by adding attachments and comments sections, as well as an activity timeline to see what has previously happened in this workflow.
 *   **Workflow_Admin** – This template can be used to easily generate an overview page for a specific workflow. It contains a header with the name of the workflow, as well as an action menu for administrators. There are three tabs, **General information**, **Task details**, and **Notes and attachments**. In the **General information** tab, you see the current state of the workflow, start and end date and time, as well as the due date and potential reasons for failure. The activity timeline is displayed, and there is a section with generated input elements that allows administrators to make changes to the data in the workflow. In the **Task details** tab, you can view information on individual tasks: who worked on them and who would have been able to pick them up. Finally, the **Notes and attachments** tab provides an overview of all the notes and attachments that were added for this workflow.
+*   **Workflow_TaskDashboard** – This page template can be used to generate your own **TaskDashboard**, for example, when you want to use your own metrics or add context information.
 *   **Workflow_TaskInbox** – This page template can be used to generate your own ***TaskInbox*** page, for example, when you would like to add context information from your business data to this page.
 
 ### 2.3 Snippets

--- a/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
+++ b/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
@@ -17,9 +17,9 @@ Before adding the Workflow Commons module to your app, make sure you have comple
 * Upgrade your application to Mendix 9
 * Install Atlas 3 from the Mendix Marketplace, as Workflow Commons depends on it 
 * As a result of installing Atlas 3, your app should contain the following modules that Workflow Commons depends on: Atlas Core, Atlas Web Content, and Data Widgets
-* The dashboards and metrics in Workflow Commons v2.1.0 and above depend on state change microflows. Make sure to configure the following state change microflows in the **App Settings** > **Workflows** tab:
-    * **Workflow state change**: *OCh_Workflow_State*
-    * **User task state change**: *OCh_WorkflowUserTask_State*
+* Dashboards and metrics in Workflow Commons v2.1.0 and above depend on state change microflows. Make sure to configure the following state change microflows in the **App Settings** > **Workflows** tab:
+    * Set **Workflow state change** to *OCh_Workflow_State*
+    * Set **User task state change** to *OCh_WorkflowUserTask_State*
 
 ## 2 Workflow Commons Components {#components}
 
@@ -31,8 +31,8 @@ Multiple pages are provided with the Workflow Commons module to get you and your
 You can find the following pages in Workflow Commons:
 
 *   **DefaultWorkflowAdmin** – The default workflow admin page that a workflow administrator can use to view and manage a workflow instance. This page can be used in the **Show workflow admin page** microflow activity and button action.
-*   **MyInitiatedWorkflows** – This page gives end users an overview of all their initiated workflows. They can view the current state, task timeline and can withdraw workflows that are in progress, paused, or incompatible.
-*   **TaskDashboard** –  This page gives end-users an overview of their performance in your app's workflows. It contains information such as how many tasks have been completed, how long it took on average to complete a task, and what percentage of tasks were completed within the deadline.
+*   **MyInitiatedWorkflows** – This page gives end-users an overview of all their initiated workflows. They can view the current state, task timeline and can withdraw workflows that are in progress, paused, or incompatible.
+*   **TaskDashboard** –  This page gives end-users an overview of their performance. It contains such information as the number of completed tasks, average time spent to complete a task, and percentage of completed tasks within a deadline.
 *   **TaskInbox** – This page contains a list of all tasks that a user can interact with. **My open tasks** shows the tasks assigned to current users, **All open tasks** is a list of tasks they could pick up and **Unassigned tasks** shows all unassigned tasks.
 *   **WorkflowAdminCenter** – A navigational page for workflow administrators. From here, a workflow administrator can go the the **Workflow Dashboard**, which gives them general statistics of workflows. Workflow administrators also gain access to **Workflow management**, where they can see all the instances of specific workflows and make changes to their data or even abort workflows.
 *   **WorkflowDashboard** – This page gives you workflow/task based metrics and direct access to all *Workflow* and *WorkflowUserTask* data. When you want to use the Workflow Dashboard as your only admin go-to page, add this to the navigation instead of the **WorkflowAdminCenter**. 


### PR DESCRIPTION
This PR contains an update to the WFC docs for the configuration of the state change event microflows that have been introduced with Mendix 9.12. Also, some pages and templates that were removed with the Mendix 9.10 release and docs have now been re-introduced.