### PR TITLE
Removed statements about supporting AWS Aurora in Mx4PC (no release date)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
@@ -175,7 +175,6 @@ A standard PostgreSQL database is an unmodified PostgreSQL database installed fr
 The following managed PostgreSQL databases are supported:
 
 * [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) 
-* [Amazon Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/)
 * [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/).
 * [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres).
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
@@ -54,7 +54,7 @@ Mendix for Private Cloud has built-in features to create and delete tenants on a
 
 You can also create a “Dedicated” database manually, and the Operator will just pass the database credentials directly to the Mendix Runtime. Dedicated databases cannot be shared between environments.
 
-Mendix for Private Cloud will not install, create, or maintain the database server – you will need to provide the database server and maintain it. You can use any compatible database server, as long as the database server is officially supported by Mendix for Private Cloud (for example a geo-redundant AWS Aurora).
+Mendix for Private Cloud will not install, create, or maintain the database server – you will need to provide the database server and maintain it. You can use any compatible database server, as long as the database server is officially supported by Mendix for Private Cloud (for example AWS RDS).
 
 For apps that don't need persistence (for example demo or frontend apps), an ephemeral database can be used. The Mendix Runtime will use an in-memory database which will not persist any data between restarts.
 


### PR DESCRIPTION
This PR is not linked to any release and can be reviewed and published at any convenient moment.

The Mx4PC Operator supports Amazon Aurora, however the Mendix Runtime doesn't officially support Mendix apps with an Aurora database.
Until there's a confirmation that Mendix fully supports AWS Aurora (or there's a list of known issues), support asked to remove AWS Aurora from the list of supported databases.