### PR TITLE
Add menu scrolling

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -3,8 +3,8 @@
 //
 .td-sidebar-toc {
     border-left: 0; // NK - changed to 0, the actual border moved to td-main main, to fully span height of screen
-    font-size: 0.9rem; // NK - decrased
-    line-height: 1.2; // NK - decrased
+    font-size: 0.9rem; // NK - decreased
+    line-height: 1.2; // NK - decreased
 
     @supports (position: sticky) {
         position: sticky;
@@ -28,6 +28,9 @@
 }
 
 .td-toc {
+
+    height: calc(100vh - 180px); // NK - added to allow scrolling
+    overflow-x:hidden !important; // NK - added to allow scrolling
 
     a {
         display: block;

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -132,7 +132,10 @@
     }
 
     &__inner {
-        order: 0;
+                order: 0;
+                overflow-y: auto;
+                max-height: 100vh;
+                scrollbar-width: none;
 
         @include media-breakpoint-up(md) {
             @supports (position: sticky) {

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -132,17 +132,16 @@
     }
 
     &__inner {
-                order: 0;
-                overflow-y: auto;
-                max-height: 100vh;
-                scrollbar-width: none;
+            order: 0;
+            height: calc(100vh - 75px); // NK - added to allow scrolling
+            overflow-x: hidden !important; // NK - added to allow scrolling
 
         @include media-breakpoint-up(md) {
             @supports (position: sticky) {
                 position: sticky;
                 top: 4rem; // NK - added to work with height change
                 z-index: 10;
-                height: max-content;// NK - changed from calc(100vh - 10rem);
+                height: calc(100vh - 75px);// NK - changed to allow scrolling
             }
         }
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,7 +1,7 @@
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
 {{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
 {{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
-<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }} overflow-auto"> <!-- NK - added overflow-auto for scrolling -->
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,7 @@
+{{ if not .Params.notoc }}
+{{ with .TableOfContents }}
+{{ if ge (len .) 200 }}
+<div class="td-toc container-fluid overflow-auto">{{ . }}</div><!-- NK - added overflow-auto for scrolling -->
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
The changes in bootstrap class and SCSS styling add a vertical scroll bar to the left and right menus. If the content fits in the menu section, the scroll bar is not visible.