### PR TITLE
Adjust code block line height and button location

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -4,13 +4,13 @@
 	// Highlighted code.
     .highlight {
         @extend .card;
-	
+
         margin: 2rem 0;
         padding: 0;
-	    
+
         pre {
             margin: 0;
-            padding: 1rem;
+            padding: 1.75rem 1rem 1rem 0.75rem;  // NK - changed padding
         }
     }
 
@@ -23,7 +23,7 @@
         word-break: normal;
         background-color: rgba($info, 0.07); // NK - changed background color
         border-radius: $border-radius;
-		border: 1px solid rgba($info, 0.1);  // NK - added border and color
+        border: 1px solid rgba($info, 0.1);  // NK - added border and color
 
         br {
             display: none;
@@ -36,9 +36,8 @@
         word-wrap: normal;
         background-color: $gray-100;
         padding: $spacer;
-		line-height: 1.1; // NK - added to match code text
-		font-size: 1em; // NK - added to match code text
-     
+        line-height: 1.25; // NK - added to match code text
+        font-size: 1em; // NK - added to match code text
 
         > code {
 	    background-color: inherit !important;

--- a/static/css/prism.css
+++ b/static/css/prism.css
@@ -18,7 +18,7 @@ pre[class*="language-"] {
 	word-spacing: normal;
 	word-break: normal;
 	word-wrap: normal;
-	line-height: 1.1; /* NK - changed from 1.5 */
+	line-height: 1.25; /* NK - changed from 1.5 */
 
 	-moz-tab-size: 4;
 	-o-tab-size: 4;
@@ -155,7 +155,7 @@ pre[class*="language-"].line-numbers > code {
 .line-numbers .line-numbers-rows {
 	position: absolute;
 	pointer-events: none;
-	top: 0;
+	top: 0.3em; /* NK - to accomodate moving toolbar buttons left */
 	font-size: 100%;
 	left: -3.8em;
 	width: 3em; /* works for line-numbers below 1000 lines */
@@ -189,7 +189,7 @@ div.code-toolbar {
 div.code-toolbar > .toolbar {
 	position: absolute;
 	top: .3em;
-	right: .2em;
+	left: .1em; /* NK - move toolbar buttons left */
 	transition: opacity 0.3s ease-in-out;
 	opacity: 0;
 }


### PR DESCRIPTION
The changes cover the following:

- move the language and copy buttons to the upper left of the code block
- adjust line height so no text gets cut off

I could not get highlighting to work on the entire row, still needs looking into.