### PR TITLE
Introducing the deletable capability

### DIFF
--- a/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
@@ -225,7 +225,7 @@ The *inserting objects* functionality was introduced in Studio Pro [9.12.0](/rel
 
 ## 11 Deleting Objects {#deleting-objects}
 
-When a published resource has the [Deletable](/refguide/published-odata-resource/#capabilities) capability, clients can update its attributes and associations by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`).
+When a published resource has the [Deletable](/refguide/published-odata-resource/#capabilities) capability, clients can delete an object by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`).
 
 {{% alert type="info" %}}
 The *deleting objects* functionality was introduced in Studio Pro [9.13.0](/releasenotes/studio-pro/9.13/).

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
@@ -221,3 +221,12 @@ Clients can only set values for an association from the entity that is the [owne
 
 {{% alert type="info" %}}
 The *inserting objects* functionality was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12/).
+{{% /alert %}}
+
+## 11 Deleting Objects {#deleting-objects}
+
+When a published resource has the [Deletable](/refguide/published-odata-resource/#capabilities) capability, clients can update its attributes and associations by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`).
+
+{{% alert type="info" %}}
+The *deleting objects* functionality was introduced in Studio Pro [9.13.0](/releasenotes/studio-pro/9.13/).
+{{% /alert %}}

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/odata-query-options.md
@@ -17,21 +17,21 @@ We currently only support the options described here.
 
 ### 2.1 Retrieving All Objects
 
-All objects can be retrieved by specifying the URI. For example: `/odata/myservice/v1/Exployees`. You can see this if you specify the URI in a browser.
+All objects can be retrieved by specifying the URI. For example: `/odata/myservice/v1/Employees`. You can see this if you specify the URI in a browser.
 
 ### 2.2 Retrieving a Single Object
 
-A single object can be retrieved by passing the object identifier in the URI. For example: `/odata/myservice/v1/Exployees(8444249301330581)`.
+A single object can be retrieved by passing the object identifier in the URI. For example: `/odata/myservice/v1/Employees(8444249301330581)`.
 
 ### 2.3 Retrieving Associated Objects
 
-Associated objects can be retrieved by passing the `$expand` query parameter. For example: `/odata/myservice/v1/Exployees?$expand=Cars,Address($expand=City)` (OData 4) or `/odata/myservice/v1/Exployees?$expand=Cars,Address/City` (OData 3).
+Associated objects can be retrieved by passing the `$expand` query parameter. For example: `/odata/myservice/v1/Employees?$expand=Cars,Address($expand=City)` (OData 4) or `/odata/myservice/v1/Employees?$expand=Cars,Address/City` (OData 3).
 
 ## 3 Counting the Number of Objects
 
 ### 3.1 Retrieving a Count of Objects
 
-You can find out how many objects there are by passing the `$count` query option. In this case, the result is an integer which is the number of objects. For example: `/odata/myservice/v1/Exployees/$count`.
+You can find out how many objects there are by passing the `$count` query option. In this case, the result is an integer which is the number of objects. For example: `/odata/myservice/v1/Employees/$count`.
 
 ### 3.2 (Inline) Count
 
@@ -157,7 +157,7 @@ The body must adhere to *URL encoding* principles. So, for instance, spaces, tab
 
 ## 10 Updating Objects {#updating-objects}
 
-When a published resource has the [Updatable](/refguide/published-odata-resource/#capabilities) capability, clients can update its attributes and associations by sending a `PATCH` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`).
+When a published resource has the [Updatable](/refguide/published-odata-resource/#capabilities) capability, clients can update its attributes and associations by sending a `PATCH` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Employees(8444249301330581)`).
 
 Specify new values for attributes in the body of the request. Here is an example:
 
@@ -204,7 +204,7 @@ The *updating attributes* functionality was introduced in Studio Pro [9.6.0](/re
 
 ## 10 Inserting Objects {#inserting-objects}
 
-When a published resource has the [Insertable](/refguide/published-odata-resource/#capabilities) capability, clients can create new objects by sending a `POST` request to the URL of the entity set (for example, `POST /odata/myservice/v1/Exployees`). 
+When a published resource has the [Insertable](/refguide/published-odata-resource/#capabilities) capability, clients can create new objects by sending a `POST` request to the URL of the entity set (for example, `POST /odata/myservice/v1/Employees`). 
 
 The body of the request may specify attribute and association values just as with updates. There is one difference: when the association refers to multiple objects, objects are specified without using `@delta`. For example:
 
@@ -225,7 +225,7 @@ The *inserting objects* functionality was introduced in Studio Pro [9.12.0](/rel
 
 ## 11 Deleting Objects {#deleting-objects}
 
-When a published resource has the [Deletable](/refguide/published-odata-resource/#capabilities) capability, clients can delete an object by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Exployees(8444249301330581)`).
+When a published resource has the [Deletable](/refguide/published-odata-resource/#capabilities) capability, clients can delete an object by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Employees(8444249301330581)`).
 
 {{% alert type="info" %}}
 The *deleting objects* functionality was introduced in Studio Pro [9.13.0](/releasenotes/studio-pro/9.13/).

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -128,7 +128,7 @@ A published OData resource is always readable.
 
 ### 8.3 Updatable
 
-Check the check box for **Updatable** to indicate that clients can update the values of attributes and associations.
+Select the check box for **Updatable** to indicate that clients can update the values of attributes and associations.
 
 When the app receives a request to change values, it does the following:
 

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -138,10 +138,20 @@ This is the behavior when you choose the action **Write to database**.
 
 ## 8.4 Call a Microflow Instead of Write to Database
 
-The **Call a microflow** action allows you to replace the last step (committing to the database) of the *Insertable* or *Updatable* capability with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the update request has failed.
+The **Call a microflow** action allows you to replace the last step (committing to the database) of the *Insertable* or *Updatable* capability with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
 
 {{% alert color="info" %}}
 This **Call a microflow** action was introduced in Studio Pro [9.11.0](/releasenotes/studio-pro/9.11/).
 {{% /alert %}}
 
 For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
+
+## 8.5 Deletable
+
+Check the check box for **Deletable** to indicate that clients can update the values of attributes and associations.
+
+Choose whether the object should be deleted in the database directly, or whether to call a microflow. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Delete](/refguide/deleting-objects/) activity to delete the object in the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
+
+{{% alert type="info" %}}
+The *Deletable* capability was introduced in Studio Pro [9.13.0](/releasenotes/studio-pro/9.13/).
+{{% /alert %}}

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -140,7 +140,7 @@ This is the behavior when you choose the action **Write to database**.
 
 You can also choose the **Call a microflow** action to use your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed. For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
 
-### 8.4 Deletable
+### 8.4 Deletable {#deletable}
 
 Select the check box for **Deletable** to indicate that clients can delete the values of attributes and associations.
 

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -103,7 +103,7 @@ The **Capabilities** section gives an overview of what operations the resource s
 This *Capabilities* section was introduced in Studio Pro [9.6.0](/releasenotes/studio-pro/9.6/).
 {{% /alert %}}
 
-## 8.1 Insertable
+### 8.1 Insertable
 
 Select the check box for **Insertable** to indicate that clients can insert new objects.
 
@@ -116,15 +116,17 @@ When the app receives a request to insert a new object, it does the following:
 
 This is the behavior when you choose the action **Write to database**.
 
-{{% alert type="info" %}}
-The *Insertable* capability was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12/).
+You can also choose the **Call a microflow** action to use your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed. For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
+
+{{% alert color="info" %}}
+This **Call a microflow** action was introduced in Studio Pro [9.11.0](/releasenotes/studio-pro/9.11/). The *Insertable* capability was introduced in Studio Pro [9.12.0](/releasenotes/studio-pro/9.12/).
 {{% /alert %}}
 
-## 8.2 Readable
+### 8.2 Readable
 
 A published OData resource is always readable.
 
-## 8.3 Updatable
+### 8.3 Updatable
 
 Check the check box for **Updatable** to indicate that clients can update the values of attributes and associations.
 
@@ -136,21 +138,13 @@ When the app receives a request to change values, it does the following:
 
 This is the behavior when you choose the action **Write to database**.
 
-## 8.4 Call a Microflow Instead of Write to Database
+You can also choose the **Call a microflow** action to use your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed. For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
 
-The **Call a microflow** action allows you to replace the last step (committing to the database) of the *Insertable* or *Updatable* capability with your own logic. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Commit](/refguide/committing-objects/) activity to commit the changes to the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
+### 8.4 Deletable
 
-{{% alert color="info" %}}
-This **Call a microflow** action was introduced in Studio Pro [9.11.0](/releasenotes/studio-pro/9.11/).
-{{% /alert %}}
+Select the check box for **Deletable** to indicate that clients can delete the values of attributes and associations.
 
-For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
-
-## 8.5 Deletable
-
-Check the check box for **Deletable** to indicate that clients can update the values of attributes and associations.
-
-Choose whether the object should be deleted in the database directly, or whether to call a microflow. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Delete](/refguide/deleting-objects/) activity to delete the object in the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
+Choose whether the object should be deleted from the database directly, or whether to call a microflow. Specify a microflow that takes the entity as a parameter, and optionally a [System.HttpRequest](/refguide/http-request-and-response-entities/) parameter. In the microflow, you can use the [Delete](/refguide/deleting-objects/) activity to delete the object from the database. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
 
 {{% alert type="info" %}}
 The *Deletable* capability was introduced in Studio Pro [9.13.0](/releasenotes/studio-pro/9.13/).


### PR DESCRIPTION
Studio Pro 9.13.0 introduces the Deletable capability for published OData resources. This is the last of the 4 CRUD capabilities (Create, Read, Update, Delete)