### PR TITLE
Remote entities are now called external entities

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/9/9.12.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.12.md
@@ -23,7 +23,7 @@ This is the preferred [MTS](/releasenotes/studio-pro/lts-mts/#mts) release for a
 ### Fixes
 
 * We fixed an issue where navigation was broken if a user tried to navigate during a page transition. (Ticket 105484)
-* We fixed a NullPointerException during startup that occurred after renaming a module with a remote entity that was created before Studio Pro version [9.6.3](/releasenotes/studio-pro/9.6/#963). (Ticket 142150)
+* We fixed a NullPointerException during startup that occurred after renaming a module with an external entity that was created before Studio Pro version [9.6.3](/releasenotes/studio-pro/9.6/#963). (Ticket 142150)
 * We fixed a bug in scheduled events where a schedule with an offset of 59 minutes crashed. (Ticket 145833)
 * We fixed an issue that prevented a pluggable widget from loading if it contained a dependency that used the new JSX Transform introduced in React 17.
 * We fixed an issue with native list views and pagination. Native list views did not become scrollable if the initial number of items was not overflowing, which rendered "scroll to load more" unusable. Now, native list views attempt to load as many items as they can to fill their content. The pagination limits are respected for any "scroll to load more" event thereafter.

--- a/content/en/docs/releasenotes/studio-pro/9/9.6.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.6.md
@@ -36,7 +36,7 @@ If updating is not possible, customers using Log4j version 2.10–2.15 can set t
 
 * We fixed an issue where navigation was broken if a user tried to navigate during a page transition. (Ticket 105484)
 * We fixed an issue where the import mapping selected an incorrect version of the Xerces library that resulted in a Java error. (Ticket 141679)
-* We fixed a NullPointerException during startup that occurred after renaming a module with a remote entity that was created before Studio Pro version [9.6.3](/releasenotes/studio-pro/9.6/#963). (Ticket 142150)
+* We fixed a NullPointerException during startup that occurred after renaming a module with an external entity that was created before Studio Pro version [9.6.3](/releasenotes/studio-pro/9.6/#963). (Ticket 142150)
 * We fixed an issue where offline PWA users lose their valid sessions upon a new deployment. (Ticket 144836)
 * We fixed an issue with native list views and pagination. Native list views did not become scrollable if the initial number of items was not overflowing, which rendered "scroll to load more" unusable. Now, native list views attempt to load as many items as they can to fill their content. The pagination limits are respected for any "scroll to load more" event thereafter.
 


### PR DESCRIPTION
What we used to call remote entities are now called external entities