### PR TITLE
New version of htmltest - uses data-proofer-ignore

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/_index.md
@@ -16,7 +16,7 @@ Your organization may have a requirement to use a private cloud, perhaps as part
 
 You can use Mendix for Private Cloud with the *connected* option to keep the simplicity of one-click deployments from the Developer Portal, or utilize the *standalone* Mendix Operator to deploy Mendix apps through your own DevOps process, which is particularly useful for private clouds with an *air-gap* isolating them from the internet. See [Connected and Standalone Clusters](#connected-standalone), below, for more information.
 
-Please see [Supported Providers](/developerportal/deploy/private-cloud-supported-environments/) for a list of platforms supported by Mendix for Private Cloud.
+Please see [Supported Providers](/developerportal/deploy/private-cloud-badlink-supported-environments/) for a list of platforms supported by Mendix for Private Cloud.
 
 There are two steps required to achieve this, listed below.
 
@@ -53,7 +53,7 @@ If you have chosen to register a connected cluster, the Mendix Gateway Agent wil
 
 Using this channel, any Mendix user who has been given the correct authority can pass instructions to the Mendix Operator and receive status information about the cluster. This includes instructions needed to deploy an app, or to configure the environment.
 
-{{< figure src="/attachments/developerportal/deploy/private-cloud/mx4pc-architecture.png" >}}
+{{< figure src="/attachments/developerportal/deploy/private-cloud/mx4pc-badlinkarchitecture.png" >}}
 
 ### 2.2 Standalone Architecture
 

--- a/content/en/docs/developerportal/deploy/private-cloud/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/_index.md
@@ -16,7 +16,7 @@ Your organization may have a requirement to use a private cloud, perhaps as part
 
 You can use Mendix for Private Cloud with the *connected* option to keep the simplicity of one-click deployments from the Developer Portal, or utilize the *standalone* Mendix Operator to deploy Mendix apps through your own DevOps process, which is particularly useful for private clouds with an *air-gap* isolating them from the internet. See [Connected and Standalone Clusters](#connected-standalone), below, for more information.
 
-Please see [Supported Providers](/developerportal/deploy/private-cloud-badlink-supported-environments/) for a list of platforms supported by Mendix for Private Cloud.
+Please see [Supported Providers](/developerportal/deploy/private-cloud-supported-environments/) for a list of platforms supported by Mendix for Private Cloud.
 
 There are two steps required to achieve this, listed below.
 
@@ -53,7 +53,7 @@ If you have chosen to register a connected cluster, the Mendix Gateway Agent wil
 
 Using this channel, any Mendix user who has been given the correct authority can pass instructions to the Mendix Operator and receive status information about the cluster. This includes instructions needed to deploy an app, or to configure the environment.
 
-{{< figure src="/attachments/developerportal/deploy/private-cloud/mx4pc-badlinkarchitecture.png" >}}
+{{< figure src="/attachments/developerportal/deploy/private-cloud/mx4pc-architecture.png" >}}
 
 ### 2.2 Standalone Architecture
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -15,10 +15,10 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap stretch-main">
-          <aside data-stt-ignore class="d-none d-lg-block col-lg-4 col-xl-3 td-sidebar d-print-none"> <!-- NK - adjusted resizing for different screens -->
+          <aside data-stt-ignore class="d-none d-lg-block col-lg-4 col-xl-3 td-sidebar d-print-none" data-proofer-ignore> <!-- NK - adjusted resizing for different screens/MvM - ignore for htmltest and translation -->
             {{ partial "sidebar.html" . }}
           </aside>
-          <aside data-stt-ignore class="d-none d-xl-block col-xl-3 td-sidebar-toc d-print-none"> <!-- NK - adjusted resizing for different screens -->
+          <aside data-stt-ignore class="d-none d-xl-block col-xl-3 td-sidebar-toc d-print-none" data-proofer-ignore> <!-- NK - adjusted resizing for different screens/MvM - ignore for htmltest and translation -->
             {{ partial "page-meta-links.html" . }}
                 <!-- NK - insert of layout element for line break and ToC title -->
                 <span class="d-block p-2">

--- a/layouts/docs/landingpage.html
+++ b/layouts/docs/landingpage.html
@@ -15,7 +15,7 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap stretch-main">
-          <aside data-stt-ignore class="d-none d-lg-block col-lg-4 col-xl-3 td-sidebar d-print-none"> <!-- NK - adjusted resizing for different screens -->
+          <aside data-stt-ignore class="d-none d-lg-block col-lg-4 col-xl-3 td-sidebar d-print-none" data-proofer-ignore> <!-- NK - adjusted resizing for different screens/MvM - ignore for htmltest and translation -->
             {{ partial "sidebar.html" . }}
           </aside>
           {{/* NK - deactivated toc
@@ -88,7 +88,7 @@
             </div>
           </div>
         </main>
-          <aside data-stt-ignore class="d-none d-xl-block col-xl-3 td-sidebar d-print-none">
+          <aside data-stt-ignore class="d-none d-xl-block col-xl-3 td-sidebar d-print-none" data-proofer-ignore>
           </aside>
         </div>
       </div>


### PR DESCRIPTION
Add `data-proofer-ignore` tag to auto-generated sidebars.
Use a version of htmltest which removes child nodes from html nodes with `data-proofer-ignore` set.
New version of htmltest built from this PR: https://github.com/wjdp/htmltest/pull/188