### PR TITLE
Removed AWS Code commit from supported systems

### DIFF
--- a/content/en/docs/refguide/general/system-requirements.md
+++ b/content/en/docs/refguide/general/system-requirements.md
@@ -91,9 +91,6 @@ BitBucket Server and BitBucket Data Center, on the other hand, still use the ter
 
 In both cases you need `repository write` permission.
 
-##### 2.4.5 AWS CodeCommit Limitation
-
-We have a compatibility limitation with AWS CodeCommit in Git Technology Preview for Studio Pro.
 
 ### 2.5 Graphics Card
 


### PR DESCRIPTION
Code commit does not support pushing multiple refs, which is required for Studio Pro to push metadata along with commits. Without this capability, we cannot support this system.