### PR TITLE
Mention runtime image library dependencies

### DIFF
--- a/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
+++ b/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
@@ -59,6 +59,8 @@ If a file with an extension that is not allowed is selected, a [system text](/re
 
 Uploaded images are read by the runtime. We currently use the [TwelveMonkeys ImageIO library](https://haraldk.github.io/TwelveMonkeys/) which supports a wide variety of image formats.
 
+For SVG files TwelveMonkeys ImageIO itself delegates to the Batik library which is known to have some issues with specifically formatted files. An overview of Batik's feature support can be found [here](https://xmlgraphics.apache.org/batik/status.html).
+
 #### 2.4.3 Thumbnail Width
 
 **Thumbnail width** determines the width of the generated thumbnail in pixels. However, the aspect ratio of the image will remain the same during thumbnail generation.

--- a/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
+++ b/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
@@ -57,9 +57,9 @@ You can specify file extensions that users are allowed to upload. If no extensio
 
 If a file with an extension that is not allowed is selected, a [system text](/refguide/system-texts/) for **File manager/dynamic image** > **Error: incorrect file extension** will be shown below the file manager.
 
-Uploaded images are read by the runtime. We currently use the [TwelveMonkeys ImageIO library](https://haraldk.github.io/TwelveMonkeys/) which supports a wide variety of image formats.
+Uploaded images are read by the runtime. Mendix use the [TwelveMonkeys ImageIO](https://haraldk.github.io/TwelveMonkeys/) library which supports a wide variety of image formats.
 
-For SVG files TwelveMonkeys ImageIO itself delegates to the Batik library which is known to have some issues with specifically formatted files. An overview of Batik's feature support can be found [here](https://xmlgraphics.apache.org/batik/status.html).
+For SVG files, TwelveMonkeys ImageIO itself delegates to the Batik library—which is known to have issues with specifically formatted files. For full information on Batik's feature support, see this [Batik documentation](https://xmlgraphics.apache.org/batik/status.html).
 
 #### 2.4.3 Thumbnail Width
 

--- a/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
+++ b/content/en/docs/refguide/modeling/pages/image-and-file-widgets/image-uploader.md
@@ -53,9 +53,11 @@ Default: *5*
 
 #### 2.4.2 Allowed Extensions {#allowed-extensions}
 
-You can specify file extensions that users are allowed to upload. If no extension is specified, all file extensions are allowed. Separate multiple extensions by a semi-colon (for example, `txt;doc`).
+You can specify file extensions that users are allowed to upload. If no extension is specified, all file extensions are allowed. Separate multiple extensions by a semi-colon (for example, `jpeg;png`).
 
 If a file with an extension that is not allowed is selected, a [system text](/refguide/system-texts/) for **File manager/dynamic image** > **Error: incorrect file extension** will be shown below the file manager.
+
+Uploaded images are read by the runtime. We currently use the [TwelveMonkeys ImageIO library](https://haraldk.github.io/TwelveMonkeys/) which supports a wide variety of image formats.
 
 #### 2.4.3 Thumbnail Width
 


### PR DESCRIPTION
Recently some issues came up regarding SVG image support in the runtime, which were traced to the image libraries we depend on. To make our limitations more clear, this PR:
- adds a reference to the image library we directly depend on ([TwelveMonkeys ImageIO](https://haraldk.github.io/TwelveMonkeys/))
- adds a specific reference to the SVG library we transitively depend on ([Batik](https://xmlgraphics.apache.org/batik/))

As the runtime only processes images when an `Image` object is _uploaded_, I chose to add this information to the place where this would be most likely encountered: the **Image Uploader** widget. Do note that this behavior is triggered whenever an `Image` (which is a specialization of `FileDocument`) is uploaded. E.g. I think it is possible to do that with a **File manager** widget as well, but that would be a very non-obvious place to put this content.