### PR TITLE
Improve substring function entry

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -138,7 +138,7 @@ The output is described in the table below:
 
 {{% alert color="warning" %}}
 The function will output an error for the following:
-* When the start position of the substring is larger than the position of the last character
+* When the start position of the substring is after the last character in the string
 * When the desired length of the result is larger than the length of the substring
 {{% /alert %}}
 

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -136,6 +136,10 @@ The output is described in the table below:
 | ------------------------------------------------------------ | ------ |
 | A part of the original string, starting at the start position with a length equal to the desired length. If no desired length is specified, will return a substring starting at the start position and ending at the end of the string. | String |
 
+{{% alert color="warning" %}}
+If the length of the string is less than the start position of the string, the function will output an error. The same will happen if the (optional) desired length of the result is larger than the length of the substring.
+{{% /alert %}}
+
 ### 5.3 Example
 
 If you use the following input:
@@ -153,13 +157,13 @@ The output is the following:
 Another example of an input is:
 
 ```java
-substring('mendixapp', 6,3)
+substring('funwithmendixapps', 7,6)
 ```
 
 The output is the following:
 
 ```java
-'app'
+'mendix'
 ```
 
 ## 6 find

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -137,7 +137,9 @@ The output is described in the table below:
 | A part of the original string, starting at the start position with a length equal to the desired length. If no desired length is specified, will return a substring starting at the start position and ending at the end of the string. | String |
 
 {{% alert color="warning" %}}
-If the length of the string is less than the start position of the string, the function will output an error. The same will happen if the (optional) desired length of the result is larger than the length of the substring.
+The function will output an error for the following:
+* When the start position of the substring is larger than the position of the last character
+* When the desired length of the result is larger than the length of the substring
 {{% /alert %}}
 
 ### 5.3 Example

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -139,7 +139,7 @@ The output is described in the table below:
 {{% alert color="warning" %}}
 The function will output an error for the following:
 * When the start position of the substring is after the last character in the string
-* When the desired length of the result is larger than the length of the substring
+* When the desired length of the result is longer than the substring
 {{% /alert %}}
 
 ### 5.3 Example


### PR DESCRIPTION
The edits below were based on two different user feedback items for the `substring` function. 
One user asked for a better example when using all function parameters. The old example would give the same result without the optional parameter just because the end of the string was reached.
Another user asked us to include an example to check string `length`, before calling `substring`, to avoid errors. I opted to list the possible cases when an error might occur, this seems more in line with the rest of the document.

This PR has two goals:
- give a better example for `substring` when all function parameters are used
- list situations when errors will occur

