### PR TITLE
Adjust vertical spacing and list indents

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -10,6 +10,14 @@
         font-weight: $font-weight-body-text;
     }
 
+    // NK - custom additions for margin styling in lists
+    li p:first-child {
+        margin-bottom: 0.25rem;
+    }
+    li p:not(:first-child), li figure, li .alert {
+        margin-bottom: 0.5rem;
+    }
+
     > h1 {
         font-weight: $font-weight-light; // NK - changed from bold
         margin-bottom: 1rem;
@@ -38,7 +46,8 @@
         @extend .img-fluid;
     }
 
-    > table {
+    // NK - added li table to have stying applied to tables in lists
+    > table, li table {
         @extend .table-striped;
 
         @extend .table-responsive;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -8,7 +8,6 @@
 
     p, li, td {
         font-weight: $font-weight-body-text;
-        margin-bottom: 0; // NK - decrease vertical space after paragraph
     }
 
     > h1 {
@@ -23,16 +22,16 @@
     }
 
     > h2:not(:first-child) {
-        margin-top: 1rem;  // NK - decrease space between sections
+        margin-top: 1.5rem; // NK - decrease space between sections
     }
 
     > h2 + h3 {
-         margin-top: 1rem;
+         margin-top: 1.5rem; // NK - decrease space between sections
     }
 
     > h3, > h4, > h5, > h6 {
         margin-bottom: 1rem;
-        margin-top: 1rem; // NK - decrease space between sections
+        margin-top: 1.5rem; // NK - decrease space between sections
     }
 
     img {

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -8,6 +8,7 @@
 
     p, li, td {
         font-weight: $font-weight-body-text;
+        margin-bottom: 0; // NK - decrease vertical space after paragraph
     }
 
     > h1 {
@@ -22,7 +23,7 @@
     }
 
     > h2:not(:first-child) {
-        margin-top: 2rem;  // NK - decrease space between sections
+        margin-top: 1rem;  // NK - decrease space between sections
     }
 
     > h2 + h3 {
@@ -31,7 +32,7 @@
 
     > h3, > h4, > h5, > h6 {
         margin-bottom: 1rem;
-        margin-top: 2rem;
+        margin-top: 1rem; // NK - decrease space between sections
     }
 
     img {
@@ -60,7 +61,12 @@
     /* ordered lists inside ordered lists will be displayed using letters */
     ol ol {
         list-style-type: lower-alpha;
+        padding-left: 2rem; // NK - decrease indent
     }
+    ul ol, ul ul, ol ul {
+        padding-left: 2rem; // NK - decrease indent
+    }
+
 
     strong {
         font-weight: $font-weight-bold;

--- a/content/en/docs/developerportal/community-tools/contribute-to-the-mendix-documentation/indentation-spacing-test.md
+++ b/content/en/docs/developerportal/community-tools/contribute-to-the-mendix-documentation/indentation-spacing-test.md
@@ -27,6 +27,8 @@ Another paragraph here.
 
 ## 1 Indents and Spacing
 
+See [Section Spacing Tests](#spacing) for multiple examples of spacing. 
+
 ### 1.1 Indents with Four Spaces
 
 Paragraph text here.
@@ -77,7 +79,7 @@ Paragraph text here.
 3. And another item.  
     Indenting with **4** spaces and **1** or **2** trailing spaces **works**.
 
-### 1.3 Indents with Tabs and a Line Break - DO NOT USE TABS
+### 1.3 Indents with Tabs and a Line Break – DO NOT USE TABS
 
 Paragraph text here.
 
@@ -100,7 +102,7 @@ Paragraph text here.
 DO NOT USE TABS
 {{% / alert %}}
 
-### 1.4 Indents with Tabs and Trailing Spaces - DO NOT USE TABS
+### 1.4 Indents with Tabs and Trailing Spaces – DO NOT USE TABS
 
 Paragraph text here.
 
@@ -137,14 +139,14 @@ Code blocks do NOT need a line break to work. Not part of list indent.
     Code blocks do NOT need trailing spaces to be indented.
     Indents must be spaces, not tabs, otherwise a bug shows in rendering an extra '`' symbol.
     It does not matter if a code block contains special characters, like {{}}, neither if
-    - a line starts with a hyphen.
+    – a line starts with a hyphen.
     ```
 
 {{% alert color="danger" %}}
 Do not add a double-space between the number (or bullet point) and first letter of first word in a list item. This can break code block formatting.
 {{% / alert %}}
 
-### 1.7 Indent Between List Items and Code Block (Highlight Shortcode) - DO NOT USE HIGHLIGHT
+### 1.7 Indent Between List Items and Code Block (Highlight Shortcode) – DO NOT USE HIGHLIGHT
 
 1. First list item
 2. Second list item
@@ -257,3 +259,99 @@ The current advice is to avoid using tables indented in numbered/bulleted lists,
 | Numbered list | Bullet point list |
 | --- | --- |
 | <ol><li>numbered item</li><li>numbered item</li><li>numbered item</li></ol> | <ul><li>bullet point</li><li>bullet point</li><li>bullet point</li></ul> |
+
+## 3 Section Spacing Tests<br />==================={#spacing}
+
+## Level 2 Section – Paragraph after
+
+With a paragraph
+
+## Level 2 Section – Level 2 after
+
+## Level 2 Section – Level 3  after
+
+### Level 3 Section – Level 2 after
+
+## Level 2 Section – List after
+
+* List item 1
+* List item 2
+* List item 3
+
+### Level 3 section after list – list after
+
+* List item 1
+* List item 2
+* List item 3
+
+## Level 2 section – followed by deeper levels
+
+### Level 3 section
+
+#### Level 4 section
+
+##### Level 5 section
+
+###### Level 6 section
+
+## Level 2 section – followed by deeper levels separated by paragraphs
+
+With a paragraph
+
+### Level 3 section
+
+With a paragraph
+
+#### Level 4 section
+
+With a paragraph
+
+##### Level 5 section
+
+With a paragraph
+
+###### Level 6 section
+
+## Paragraphs and lists
+
+Paragraph followed by a list
+
+* List item 1
+* List item 2
+* List item 3
+
+A new list
+
+* A new list with multiple indents
+* Item 2
+    * Subitem 1
+    * Subitem 2
+        * Subsubitem 1
+        * Subsubitem 2
+    * Subitem 3
+    * Subitem 4
+* Item 3
+
+Several paragraphs one
+
+after another, which should be nicely spaced
+
+And clearly different from Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Parturient montes nascetur ridiculus mus mauris. In eu mi bibendum neque egestas congue. Pellentesque sit amet porttitor eget dolor. Nec tincidunt praesent semper feugiat nibh sed pulvinar proin gravida. Pulvinar etiam non quam lacus. Non quam lacus suspendisse faucibus interdum posuere lorem. Non tellus orci ac auctor augue mauris augue neque. Id ornare arcu odio ut sem nulla pharetra diam. Ultricies tristique nulla aliquet enim tortor at auctor urna.
+
+Paragraph followed by a list
+
+1. List item 1
+1. List item 2
+1. List item 3
+
+A new list
+
+1. A new list with multiple indents
+1. Item 2
+    1. Subitem 1
+    1. Subitem 2
+        * Subsubitem 1
+        * Subsubitem 2
+    1. Subitem 3
+    1. Subitem 4
+1. Item 3

--- a/content/en/docs/developerportal/community-tools/contribute-to-the-mendix-documentation/indentation-spacing-test.md
+++ b/content/en/docs/developerportal/community-tools/contribute-to-the-mendix-documentation/indentation-spacing-test.md
@@ -7,23 +7,67 @@ banner: "This is a draft and will not be rendered in the production website.
 Use this page to test how spacing and indents will render with various elements and shortcodes."
 ---
 
+## Heading 2
+
+Paragraph text here.
+
+### Heading 3
+
+Paragraph text here.
+
+#### Heading 4
+
+Paragraph text here.
+
+##### Heading 5
+
+Paragraph text here.
+
+Another paragraph here.
+
 ## 1 Indents and Spacing
 
 ### 1.1 Indents with Four Spaces
 
+Paragraph text here.
+
+* unordered list
+    1. ordered list
+        * unordered list
+
+Paragraph text here.
+
 1. First list item
 1. Second list item
     * Unordered sub-list indenting **works with 4** spaces.
+        * another sub-list
 1. Third list item
     1. Ordered sub-list **works with 4** spaces.
         1. Another level of sublist
-3. And another item. Line break below this line.
+3. And another item.
+    A new line with an indentation of **4** spaces and no trailing spaces does nothing. 
 
-    Indenting with **4** spaces **works**, but each parent element is wrapped in `<p>`, adding a gap around each parent, and above the child.
+Without this text, the lower list was treated as part of the upper numbered list.
 
-    Adding a line break between this line and the one above gives the same result.
+1. Another list.
+1. Another list.
+1. Another list. Line break below this line.
+
+    If a line break is placed between the list and indented line, each parent element gets wrapped in `<p>`, adding a gap around each entry.
+
+{{% alert color="warning" %}}
+Two line breaks between the numbered lists were not enough to make them separate lists.
+{{% / alert %}}
 
 ### 1.2 Indents with Four Spaces and Trailing Space(s)
+
+Paragraph text here.
+
+* unordered list  
+    1. ordered list  
+        * unordered list
+
+Paragraph text here.
 
 1. First list item  
 1. Second list item  
@@ -31,15 +75,17 @@ Use this page to test how spacing and indents will render with various elements 
 1. Third list item  
     1. Ordered sub-list **works with 4** spaces.
 3. And another item.  
-    Indenting with **4** spaces and **1** or **2** trailing spaces **works**. The indented sentence is part of the numbered list item, with a `<br>` between.
-
-{{% alert color="info" %}}
-The style produced with trailing spaces looks best on page.
-
-We will try to adjust spacing between paragraph (`<p>`) elements, to make the examples in headings 1 and 2 closer.
-{{% / alert %}}
+    Indenting with **4** spaces and **1** or **2** trailing spaces **works**.
 
 ### 1.3 Indents with Tabs and a Line Break - DO NOT USE TABS
+
+Paragraph text here.
+
+* unordered list
+	1. ordered list
+		* unordered list
+
+Paragraph text here.
 
 1. First list item
 1. Second list item
@@ -55,6 +101,14 @@ DO NOT USE TABS
 {{% / alert %}}
 
 ### 1.4 Indents with Tabs and Trailing Spaces - DO NOT USE TABS
+
+Paragraph text here.
+
+* unordered list  
+	1. ordered list  
+		* unordered list  
+
+Paragraph text here.
 
 1. First list item  
 	* Unordered sub-list.
@@ -79,7 +133,6 @@ Code blocks do NOT need a line break to work. Not part of list indent.
 
 1. First list item
 2. Second list item
-
     ```
     Code blocks do NOT need trailing spaces to be indented.
     Indents must be spaces, not tabs, otherwise a bug shows in rendering an extra '`' symbol.
@@ -95,7 +148,6 @@ Do not add a double-space between the number (or bullet point) and first letter 
 
 1. First list item
 2. Second list item
-
     {{< highlight go >}}
     Code blocks with shortcode HIGHLIGHT do NOT need trailing spaces to be indented. They don't need to be indented either, as long as there is no blank line between.
     Highight does NEED a language specified, otherwise the shortcode errors.
@@ -110,10 +162,6 @@ Do not add a double-space between the number (or bullet point) and first letter 
     {{< figure src="/attachments/refguide/general/moving-from-8-to-9/moving-from-atlas-2-to-3/set-hybrid-nav.png" >}}
     * Indenting with **4 spaces** and a line break works, keeping the image in line with list item 2. The line break causes the parent element, list item 2 to be wrapped in `<p>`, making a gap between 1 and 2.
 3. Third item
-
-{{% alert color="success" %}}
-The style produced with a line break between list and image looks best on page.
-{{% / alert %}}
 
 ### 1.9 Spacing Between List Items and Images, No Line Breaks
 


### PR DESCRIPTION
The PR does the following:

- removes extra vertical padding after a paragraph
- evens out spacing between different heading types
- decreases the indentation of sub-items in lists 

Please see the images below for examples.
![image](https://user-images.githubusercontent.com/83953175/167581713-35d2dfc7-5a92-4755-9d7e-65d4f724b844.png)
![image](https://user-images.githubusercontent.com/83953175/167581770-32fcd0d8-c1ff-4d11-9acc-a0641882d667.png)
