### PR TITLE
Adjust formatting of no_list results

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -5,6 +5,7 @@
 .td-content {
     order: 1;
     margin-left: 2rem; // NK - custom edit
+    max-width: 90%;  // NK - fixed width of all content to 90%
 
     p, li, td {
         font-weight: $font-weight-body-text;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -10,7 +10,7 @@
 @import "sidebar-toc";
 @import "sidebar-tree";
 @import "tables";
-
+@import "section-index";
 
 // Adjust anchors vs the fixed menu.
 @include media-breakpoint-up(md) {

--- a/assets/scss/section-index.scss
+++ b/assets/scss/section-index.scss
@@ -1,0 +1,18 @@
+.section-index {
+
+    .entry {
+        padding: 0; // NK - removes padding around entry div
+    }
+
+    h5 {
+        margin-bottom: 0;
+
+        a {
+            font-weight: 700;
+        }
+    }
+
+    p {
+        margin-top: 0;
+    }
+}

--- a/assets/scss/support/_utilities.scss
+++ b/assets/scss/support/_utilities.scss
@@ -76,7 +76,7 @@
 
 .td-max-width-on-larger-screens {
     @include media-breakpoint-up(lg) {
-        max-width: 90%; // NK - changed from 80%, to fill up more of the screen
+        max-width: 100%; // NK - changed from 80%, to fill up more of the screen
     }
 
 }

--- a/content/en/docs/addons/_index.md
+++ b/content/en/docs/addons/_index.md
@@ -4,6 +4,7 @@ url: /addons/
 description: "Presents guides for APM, AQM, and ATS."
 weight: 55
 no_list: false
+description_list: true
 cascade:
     - space: "Quality Add-ons Guide"
     - mendix_version: ""

--- a/content/en/docs/apidocs-mxsdk/_index.md
+++ b/content/en/docs/apidocs-mxsdk/_index.md
@@ -4,6 +4,7 @@ url: /apidocs-mxsdk/
 description: "Presents the Mendix API documentation as well as the documentation for the Mendix Platform SDK."
 weight: 50
 no_list: false
+description_list: true
 cascade:
     - space: "APIs & SDK"
     - mendix_version: ""

--- a/content/en/docs/appstore/app-services/_index.md
+++ b/content/en/docs/appstore/app-services/_index.md
@@ -4,6 +4,7 @@ url: /appstore/app-services/
 description: "Presents details on the app services available in the Mendix Marketplace."
 tags: ["marketplace", "marketplace component", "app service"]
 no_list: false
+description_list: true
 weight: 30
 ---
 

--- a/content/en/docs/appstore/connectors/_index.md
+++ b/content/en/docs/appstore/connectors/_index.md
@@ -5,6 +5,7 @@ description: "Presents details on the connectors available in the Mendix Marketp
 tags: ["marketplace",  "marketplace component", "connector"]
 weight: 40
 no_list: false
+description_list: true
 ---
 
 ## 1 Introduction

--- a/content/en/docs/developerportal/_index.md
+++ b/content/en/docs/developerportal/_index.md
@@ -5,6 +5,7 @@ description: "Describes the sections of the Mendix Developer Portal and links to
 tags: ["mendix", "developer portal", "platform services", "buzz", "apps", "community", "marketplace", "academy", "forum", "docs", "documentation"]
 weight: 30
 no_list: false
+description_list: true
 cascade:
     - space: "Developer Portal Guide"
     - mendix_version: ""

--- a/content/en/docs/howto/_index.md
+++ b/content/en/docs/howto/_index.md
@@ -5,6 +5,7 @@ description: "Step-by-step guides on various Mendix topics that will teach you h
 tags: ["studio pro"]
 weight: 15
 no_list: false
+description_list: true
 cascade:
     - space: "Studio Pro 9 How-tos"
     - mendix_version: "9"

--- a/content/en/docs/howto7/_index.md
+++ b/content/en/docs/howto7/_index.md
@@ -5,6 +5,7 @@ notoc: true
 description: "Step-by-step guides on various Mendix topics that will teach you how to build and customize apps."
 weight: 85
 no_list: false
+description_list: true
 cascade:
     - space: "Mendix 7 How-tos"
     - mendix_version: "7"

--- a/content/en/docs/howto8/_index.md
+++ b/content/en/docs/howto8/_index.md
@@ -5,6 +5,7 @@ description: "Step-by-step guides on various Mendix topics that will teach you h
 tags: ["studio pro"]
 weight: 65
 no_list: false
+description_list: true
 cascade:
     - space: "Studio Pro 8 How-tos"
     - mendix_version: "8"

--- a/content/en/docs/partners/_index.md
+++ b/content/en/docs/partners/_index.md
@@ -5,6 +5,7 @@ description: "Documentation for IBM, SAP, and Siemens widgets written and mainta
 tags: ["strategic partners", "ibm", "sap", "siemens"]
 weight: 45
 no_list: false
+description_list: true
 cascade:
     - space: "Strategic Partners Guide"
     - mendix_version: ""

--- a/content/en/docs/refguide/_index.md
+++ b/content/en/docs/refguide/_index.md
@@ -5,6 +5,7 @@ description: "The various sections of the Mendix Studio Pro Guide provide detail
 tags: ["studio pro"]
 weight: 10
 no_list: false
+description_list: true
 cascade:
     - space: "Studio Pro 9 Guide"
     - mendix_version: "9"

--- a/content/en/docs/refguide7/_index.md
+++ b/content/en/docs/refguide7/_index.md
@@ -5,6 +5,7 @@ notoc: true
 description: "The various sections of the reference guide provide details on the features and functionality of the Mendix Platform."
 weight: 80
 no_list: false
+description_list: true
 cascade:
     - space: "Mendix 7 Reference Guide"
     - mendix_version: "7"

--- a/content/en/docs/refguide8/_index.md
+++ b/content/en/docs/refguide8/_index.md
@@ -5,6 +5,7 @@ description: "The various sections of the Mendix Studio Pro Guide provide detail
 tags: ["studio pro"]
 weight: 60
 no_list: false
+description_list: true
 cascade:
     - space: "Studio Pro 8 Guide"
     - mendix_version: "8"

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,7 +5,7 @@ notoc: true
 description: "The release notes for the Mendix Platform are divided into various product categories and versions."
 weight: 5
 no_list: false
-description_list: true
+simple_list: true
 cascade:
     - space: "Release Notes"
     - mendix_version: ""

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,6 +5,7 @@ notoc: true
 description: "The release notes for the Mendix Platform are divided into various product categories and versions."
 weight: 5
 no_list: false
+description_list: true
 cascade:
     - space: "Release Notes"
     - mendix_version: ""

--- a/content/en/docs/releasenotes/studio-pro/7/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/7/_index.md
@@ -5,6 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 7 of the Mendix Desktop Modeler."
 weight: 30
 no_list: false
+description_list: true
 ---
 
 These are the release notes for the Mendix Desktop Modeler version 7:

--- a/content/en/docs/releasenotes/studio-pro/7/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/7/_index.md
@@ -5,7 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 7 of the Mendix Desktop Modeler."
 weight: 30
 no_list: false
-description_list: true
+simple_list: true
 ---
 
 These are the release notes for the Mendix Desktop Modeler version 7:

--- a/content/en/docs/releasenotes/studio-pro/8/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/8/_index.md
@@ -5,7 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 8 of Mendix Studio Pro."
 weight: 20
 no_list: false
-description_list: true
+simple_list: true
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/8/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/8/_index.md
@@ -5,6 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 8 of Mendix Studio Pro."
 weight: 20
 no_list: false
+description_list: true
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/9/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/9/_index.md
@@ -5,7 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 9 of Mendix Studio Pro."
 weight: 10
 no_list: false
-description_list: true
+simple_list: true
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/content/en/docs/releasenotes/studio-pro/9/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/9/_index.md
@@ -5,6 +5,7 @@ category: "Studio Pro"
 description: "The release notes for version 9 of Mendix Studio Pro."
 weight: 10
 no_list: false
+description_list: true
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,0 +1,31 @@
+<div class="section-index">
+    {{ $parent := .Page }}
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $pages = (where $pages "Type" "!=" "search") }}
+    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
+    {{ $pages = (where $pages ".Parent" "!=" nil) }}
+    {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
+    {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
+    {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}
+    {{ else if $parent.Params.simple_list }}
+    {{/* If simple_list is true we show a bulleted list of subpages */}}
+        <ul>
+            {{ range $pages }}
+                {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
+            {{ end }}
+        </ul>
+    {{ else }}
+    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
+        {{/* NK - adjusted formatting of no_list to look more like a list */}}
+        {{ range $pages }}
+            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+            <div class="entry">
+                <ul>
+                    <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
+                    <p>{{ .Description | markdownify }}</p>
+                </ul>
+            </div>
+        {{ end }}
+    {{ end }}
+</div>

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -15,9 +15,8 @@
                 <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
             {{ end }}
         </ul>
-    {{ else }}
-    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
-        {{/* NK - adjusted formatting of no_list to look more like a list */}}
+    {{ else if $parent.Params.description_list }}
+    {{/* If description_list is true we show a bulleted list of subpages, with a description */}}
         {{ range $pages }}
             {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
             <div class="entry">
@@ -25,6 +24,18 @@
                     <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
                     <p>{{ .Description | markdownify }}</p>
                 </ul>
+            </div>
+        {{ end }}
+    {{ else }}
+    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
+    <hr class="panel-line">
+        {{ range $pages }}
+            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+            <div class="entry">
+                <h5>
+                    <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
+                </h5>
+                <p>{{ .Description | markdownify }}</p>
             </div>
         {{ end }}
     {{ end }}


### PR DESCRIPTION
The PR adjusts the list generated for immediate children of a page, when `no_list` metadata parameter is set to `false`.
I removed the horizontal line above the list, and made each child page appear as a list item with a description (if available).
The max-width changes were needed due to no_list elements taking up more width than the rest of content.

![image](https://user-images.githubusercontent.com/83953175/168106335-acaba891-a031-4342-8767-08a8115edcc6.png)
