### PR TITLE
Quickstart Improvements

### DIFF
--- a/content/en/docs/refguide/quickstart-guide/_index.md
+++ b/content/en/docs/refguide/quickstart-guide/_index.md
@@ -11,8 +11,8 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 Welcome to the Mendix quickstart guide for building an app. These tutorials will cover the essentials of Mendix development. When you are done you will have mastered the basics of building and hosting apps with Mendix and you will have your first app:
 
-* Part 1: [Design in a Responsive Web Profile](/refguide/quickstart-part1/) (estimated time to complete: 25 minutes)
-* Part 2: [Upgrade to a Native Mobile App](/refguide/quickstart-part2/) (estimated time to complete: 25 minutes)
+* Part 1: [Build a Responsive Web App](/refguide/quickstart-part1/) (estimated time to complete: 25 minutes)
+* Part 2: [Add a Native Mobile App](/refguide/quickstart-part2/) (estimated time to complete: 25 minutes)
 
 {{% alert type="info" %}}
 While you can start with Part 2, we recommend you at least read Part 1 to understand the basics of Mendix.

--- a/content/en/docs/refguide/quickstart-guide/_index.md
+++ b/content/en/docs/refguide/quickstart-guide/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart for Building an App"
+title: "Quickstart"
 url: /refguide/quickstart-guide/
 parent: "_index"
 weight: 9

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
@@ -9,7 +9,7 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 ## 1 Introduction 
 
-Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. This is Part 1 of the quickstart, where you will learn the basics of the Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
+Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. This is Part 1 of the quickstart, where you will learn the basics of Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
 
 When you complete Part 1, you will have an app that can capture and save images using dynamic data.
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
@@ -9,17 +9,21 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 ## 1 Introduction 
 
-Get up and running with the Mendix Platform and start developing your first app after you create your [free account](https://signup.mendix.com/link/signup/?source=direct)⁠—which takes only two minutes to finish. Then [download](https://marketplace.mendix.com/index3.html) and [install](/howto/general/install/) Mendix Studio Pro. 
+Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. During this part of the Quickstart, you will learn the basics of the Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
 
-If you are working on a Mac, please complete [How To Configure Parallels](/howto/general/using-mendix-studio-pro-on-a-mac/) to install Studio Pro on your Mac.
+[Mendix Studio Pro](https://marketplace.mendix.com/link/studiopro/) is the Mendix integrated development environment (IDE) for professional developers. This tutorial will use Studio Pro version 9.12.1, but you can use a later version if you wish.
 
 Every app created with us automatically provisions a [Free Cloud Environment](/developerportal/deploy/mendix-cloud-deploy/#free-app) the first time it is deployed, so you do not have to waste time provisioning a testing environment.
 
 You will not need any additional software configured on your device in order to start.
 
-### 1.1 What is Mendix Studio Pro?
+## 2 Prerequisites 
 
-[Mendix Studio Pro](https://marketplace.mendix.com/link/studiopro/) is the Mendix integrated development environment (IDE) for professional developers. This tutorial will use Studio Pro version 9.12.1, but you can use a later version if you wish.
+Before starting this guide, make sure you have completed the following prerequisites:
+
+* Create your [free account](https://signup.mendix.com/link/signup/?source=direct)⁠—which takes only two minutes to finish
+* [Download](https://marketplace.mendix.com/index3.html) and [install](/howto/general/install/) Mendix Studio Pro
+* If you are working on a Mac, please complete [How To Configure Parallels](/howto/general/using-mendix-studio-pro-on-a-mac/) to install Studio Pro on your Mac
 
 ## 2 Choosing an App Template with a Responsive Navigation Profile
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
@@ -9,7 +9,7 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 ## 1 Introduction 
 
-Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. During this part of the Quickstart, you will learn the basics of the Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
+Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. This is Part 1 of the quickstart, where you will learn the basics of the Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
 
 [Mendix Studio Pro](https://marketplace.mendix.com/link/studiopro/) is the Mendix integrated development environment (IDE) for professional developers. This tutorial will use Studio Pro version 9.12.1, but you can use a later version if you wish.
 
@@ -227,4 +227,9 @@ Congratulations! You successfully completed Part 1, you have your first Mendix A
 
 To continue learning, see Part 2: [Upgrade to a Native Mobile App](/refguide/quickstart-part2/).
 
-You can also go to [Mendix Academy](https://academy.mendix.com/) or [Mendix Documentation](https://docs.mendix.com/) to learn more about the Mendix topics which interest you most.
+## 6 Read More
+
+* [Mendix Academy](https://academy.mendix.com/) – complete learning paths to build general Mendix skills
+    * [Crash Course](https://academy.mendix.com/link/paths/82/Crash-Course) – the course we recommend for new users who are also experienced developers
+* [Mendix Documentation](https://docs.mendix.com/) – learn about the parts of Mendix which interest you most
+* [General Info](/refguide/general/) – learn more about the fundamentals of Studio Pro

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
@@ -1,5 +1,5 @@
 ---
-title: "Design in a Responsive Web Profile"
+title: "Build a Responsive Web App"
 url: /refguide/quickstart-part1/
 parent: "_index"
 weight: 10
@@ -10,6 +10,8 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 ## 1 Introduction 
 
 Get up and running with the Mendix Platform and start developing your first app in Mendix Studio Pro. This is Part 1 of the quickstart, where you will learn the basics of the Studio Pro, handle data using the Domain Model, populate your app's pages with dynamic data, and create custom app logic using a microflow.
+
+When you complete Part 1, you will have an app that can capture and save images using dynamic data.
 
 [Mendix Studio Pro](https://marketplace.mendix.com/link/studiopro/) is the Mendix integrated development environment (IDE) for professional developers. This tutorial will use Studio Pro version 9.12.1, but you can use a later version if you wish.
 
@@ -223,9 +225,9 @@ You have finished your responsive app! You can run your app and test it by press
 Launching your app compiles your app locally on your development machine, your local host. Publishing your app will push your app to a cloud environment or web container connected to your app. If none exists, an environment will be initialized for your app on the Mendix Cloud v4 Free Tier.
 {{% /alert %}}
 
-Congratulations! You successfully completed Part 1, you have your first Mendix App to prove it, and it works on almost any device. Well done! 
+Congratulations! You successfully completed Part 1 of the quickstart guide. You have your first Mendix app to prove it, and it works on almost any device. Well done! 
 
-To continue learning, see Part 2: [Upgrade to a Native Mobile App](/refguide/quickstart-part2/).
+To continue learning, see Part 2: [Add a Native Mobile App](/refguide/quickstart-part2/).
 
 ## 6 Read More
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part1.md
@@ -21,7 +21,9 @@ You will not need any additional software configured on your device in order to 
 
 [Mendix Studio Pro](https://marketplace.mendix.com/link/studiopro/) is the Mendix integrated development environment (IDE) for professional developers. This tutorial will use Studio Pro version 9.12.1, but you can use a later version if you wish.
 
-## 2 Create an Image Gallery in the Responsive Navigation Profile
+## 2 Choosing an App Template with a Responsive Navigation Profile
+
+Here you will choose an app starting point. It is key that you choose a starting point with a configured responsive web navigation profile, as the app you will make in this guide needs to work for web browsers:
 
 1.  Starting from Studio Pro, click **Create New App**:
 
@@ -35,7 +37,7 @@ You will not need any additional software configured on your device in order to 
 
     {{< figure src="/attachments/refguide/quickstart-guide/part1/home-web.png" width="450px" alt="Home Web page">}}
 
-## 3 Explore Studio Pro
+## 3 Exploring Studio Pro
 
 Now that you have completed your first tasks in Studio Pro, this section will give you a quick and optional tour. If you know Studio Pro well already, you can skip this section.
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
@@ -9,7 +9,7 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 ## 1 Introduction 
 
-This document is Part 2 of the [Quickstart for Building an App](/refguide/quickstart-guide/). Here you will be adding on to the app created in [Part 1: Design in a Responsive Web Profile](/refguide/quickstart-part1/). If you decided to skip Part 1, you can [download a copy of its completed app package](https://quickstartguidev1.s3.eu-west-2.amazonaws.com/Quickstart_App.mpk) in order to start this document right away.
+This document is Part 2 of the [Quickstart](/refguide/quickstart-guide/) for building an app. Here you will be adding on to the app created in [Part 1: Design in a Responsive Web Profile](/refguide/quickstart-part1/). If you decided to skip Part 1, you can [download a copy of its completed app package](https://quickstartguidev1.s3.eu-west-2.amazonaws.com/Quickstart_App.mpk) in order to start this document right away.
 
 In this document you will learn to use a native mobile navigation profile. You will create a small native mobile app to take pictures and upload them to the same database so they can be viewed in a browser or in a native app on your mobile device. You will also use the Make it Native app to test your app on a mobile device.
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrade to a Native Mobile App"
+title: "Add a Native Mobile App"
 url: /refguide/quickstart-part2/
 parent: "_index"
 weight: 20
@@ -9,7 +9,7 @@ tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 
 ## 1 Introduction 
 
-This document is Part 2 of the [Quickstart](/refguide/quickstart-guide/) for building an app. Here you will be adding on to the app created in [Part 1: Design in a Responsive Web Profile](/refguide/quickstart-part1/). If you decided to skip Part 1, you can [download a copy of its completed app package](https://quickstartguidev1.s3.eu-west-2.amazonaws.com/Quickstart_App.mpk) in order to start this document right away.
+This document is Part 2 of the [Quickstart](/refguide/quickstart-guide/) guide for building an app. Here you will be adding on to the app created in [Part 1: Build a Responsive Web App](/refguide/quickstart-part1/). If you decided to skip Part 1, you can [download a copy of its completed app package](https://quickstartguidev1.s3.eu-west-2.amazonaws.com/Quickstart_App.mpk) in order to start this document right away.
 
 In this document you will learn to use a native mobile navigation profile. You will create a small native mobile app to take pictures and upload them to the same database so they can be viewed in a browser or in a native app on your mobile device. You will also use the Make it Native app to test your app on a mobile device.
 
@@ -19,7 +19,7 @@ Mendix native mobile apps are native mobile apps based on React Native. These ap
 
 Before starting this guide, make sure you have completed the following prerequisite:
 
-* Read through [Part 1: Design in a Responsive Web Profile](/refguide/quickstart-part1/)
+* Read through [Part 1: Build a Responsive Web App](/refguide/quickstart-part1/)
 * Download the [Make It Native 9](/refguide/getting-the-make-it-native-app/) app on your mobile device
 * If you are working on a Mac, please complete [How To Configure Parallels](/howto/general/using-mendix-studio-pro-on-a-mac/) to install Studio Pro on your Mac
 
@@ -169,7 +169,7 @@ After taking a photo with your native mobile app and tapping the **Save** button
 
 {{< figure src="/attachments/refguide/quickstart-guide/part2/responsive-app.png" width="450px" alt="Browser view">}}
 
-Congratulations on successfully completing the quickstart guide for building an app! You are definitely on your way to succeed with the Mendix platform.
+Congratulations on successfully completing Part 2 of the quickstart guide! You are definitely on your way to succeed with the Mendix platform.
 
 For more information on building and deploying apps with Mendix, see [Build Native Apps](/howto/mobile/build-native-apps/). Put simply, Mendix lets you [build an app for distribution](/howto/mobile/deploying-native-app/) and get it running on a native device. After you develop further, you can [debug native app issues](/howto/mobile/native-debug/) to improve your users' experience. Then, you can add [custom fonts](/howto/mobile/native-custom-fonts/) to make your app feel more like your brand. And if you ever need help, we have [troubleshooting help](/howto/mobile/common-issues/) for you just in case.
 

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
@@ -175,4 +175,7 @@ For more information on building and deploying apps with Mendix, see [Build Nati
 
 ## 5 Read More
 
-To continue learning, go to [Mendix Academy](https://academy.mendix.com/) and choose a learning path that interests you (we recommend the [Crash Course](https://academy.mendix.com/link/paths/82/Crash-Course) for new users who are also experienced developers) or go the [Mendix Documentation](https://docs.mendix.com/) home page to learn more about the Mendix topics which interest you most.
+* [Mendix Academy](https://academy.mendix.com/) – complete learning paths to build general Mendix skills
+    * [Crash Course](https://academy.mendix.com/link/paths/82/Crash-Course) – the course we recommend for new users who are also experienced developers
+* [Mendix Documentation](https://docs.mendix.com/) – learn about the parts of Mendix which interest you most
+* [General Info](/refguide/general/) – learn more about the fundamentals of Studio Pro

--- a/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
+++ b/content/en/docs/refguide/quickstart-guide/quickstart-part2.md
@@ -23,7 +23,7 @@ Before starting this guide, make sure you have completed the following prerequis
 * Download the [Make It Native 9](/refguide/getting-the-make-it-native-app/) app on your mobile device
 * If you are working on a Mac, please complete [How To Configure Parallels](/howto/general/using-mendix-studio-pro-on-a-mac/) to install Studio Pro on your Mac
 
-### 2.1 What is the Make It Native 9 App?
+### 2.1 Downloading the Make It Native 9 App
 
 The [Make it Native 9](/refguide/getting-the-make-it-native-app/) mobile app is available for Android and iOS devices. Once installed, the app lets you quickly test your native mobile app as you develop it. 
 

--- a/layouts/partials/landingpage/product-cards.html
+++ b/layouts/partials/landingpage/product-cards.html
@@ -7,7 +7,7 @@
 		</div>
 		<p class="card-text"><ul class="landing-list">
 		  <!-- Change links HERE -->
-		  <li class="link-list"><a href="/refguide/general/">Studio Pro Overview</a></li>
+		  <li class="link-list"><a href="/refguide/quickstart-guide/">Quickstart</a></li>
 		  <li class="link-list"><a href="/refguide/modeling/">App Modeling</a></li>
 		  <li class="link-list"><a href="/refguide/mobile/">Mobile</a></li></ul></p>
 	  </div>


### PR DESCRIPTION
- [x] Sections should have gerunds wherever possible
- [x] Clarify aim of Part 1 in intro
- [x] Align Part 1 section 2 header w/ section's content
- [x] Change Overview to Quickstart in landing page card
- [x] Change title of parent to Quickstart and examine parent, and parts’ intro/conclusions for text to alter after this change