### PR TITLE
Sprintr 2022.05.19 release

### DIFF
--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -17,6 +17,16 @@ To see the current status of the Mendix Developer Portal and Control Center, see
 
 ## 2022
 
+### May 19th, 2022
+
+#### Fixes
+
+* We fixed an issue where replies on feedback emails were not correctly processed into comments.
+
+#### Improvements
+
+* We added a download button for feedback images, so that you can see them in full size more easily.
+
 ### May 5th, 2022 {#may-fifth}
 
 #### Fixes


### PR DESCRIPTION
These are the release notes for Sprintr. We will release the new version of Sprintr on May 19 2022 (07:00 CET)