### PR TITLE
Remove remaining apostrophes in how-tos

### DIFF
--- a/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/_index.md
+++ b/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/_index.md
@@ -6,7 +6,7 @@ weight: 60
 tags: ["on-premises", "studio pro", "svn", "git", "version control"]
 ---
 
-The following how-to’s will guide you through the process of configuring your Mendix apps to work with your own (on-premises) version control system:
+The following how-tos will guide you through the process of configuring your Mendix apps to work with your own (on-premises) version control system:
 
 * [How to Work with SVN On-Premises Version Control Server](/howto/collaboration-requirements-management/on-premises-svn-howto/)
 * [How to Work with Git On-Premises Version Control Server](/howto/collaboration-requirements-management/on-premises-git-howto/)

--- a/content/en/docs/howto/mobile/native-mobile/ar-parent/_index.md
+++ b/content/en/docs/howto/mobile/native-mobile/ar-parent/_index.md
@@ -9,7 +9,7 @@ tags: ["AR", "VR", "mixed reality", "augmented reality", "virtual reality"]
 
 These step-by-step guides will teach you to set up and use augmented reality (AR) using Mendix Studio Pro and your native mobile device.
 
-The following how-to’s are available here:
+The following how-tos are available here:
 
 - [Get Started with AR](/howto/mobile/how-to-ar-simple-cube/)
 - [Create An AR Business Card](/howto/mobile/how-to-ar-business-card/)

--- a/content/en/docs/howto/mobile/native-mobile/distribution/_index.md
+++ b/content/en/docs/howto/mobile/native-mobile/distribution/_index.md
@@ -9,7 +9,7 @@ tags: ["native", "mobile", "start", "quickstart"]
 
 How-tos in this section will help you distribute native apps to app stores, as well as push changes using over-the-air updates.
 
-The following how-to’s are available here:
+The following how-tos are available here:
 
 * [Build Native Apps](/howto/mobile/build-native-apps/)
 * [Release Over the Air Updates with Mendix](/howto/mobile/how-to-ota/)

--- a/content/en/docs/howto/mobile/native-mobile/get-started/_index.md
+++ b/content/en/docs/howto/mobile/native-mobile/get-started/_index.md
@@ -9,7 +9,7 @@ tags: ["native", "mobile", "start", "quickstart"]
 
 How-tos in this section will help you begin using the power of native apps.
 
-The following how-to’s are available here:
+The following how-tos are available here:
 
 * [Get Started with Native Mobile](/howto/mobile/getting-started-with-native-mobile/)
 * [Troubleshoot Common Native Mobile Issues](/howto/mobile/common-issues/)

--- a/content/en/docs/howto/mobile/native-mobile/implementation/_index.md
+++ b/content/en/docs/howto/mobile/native-mobile/implementation/_index.md
@@ -9,7 +9,7 @@ tags: ["native", "mobile", "start", "quickstart"]
 
 How-tos in this section will help you implement key features of native apps.
 
-The following how-to’s are available here:
+The following how-tos are available here:
 
 * [Add Fonts to Your Native Mobile App](/howto/mobile/native-custom-fonts/)
 * [Implement Native Mobile Styling](/howto/mobile/native-styling/)

--- a/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/_index.md
+++ b/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/_index.md
@@ -7,7 +7,7 @@ description: "This how-to describes the process of configuring a decision in Men
 tags: ["studio", "microflows", "decision", "domain model", "how to"]
 ---
 
-The following how-to’s will guide you through the process of configuring a decision in Mendix Studio:
+The following how-tos will guide you through the process of configuring a decision in Mendix Studio:
 
 * [Step 1: Build the Domain Model & Configure a Microflow](/studio-how-to/microflows-how-to-configure-decision-p1/)
 * [Step 2: Embed the Microflow in Your App](/studio-how-to/microflows-how-to-configure-decision-p2/)

--- a/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/_index.md
+++ b/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/_index.md
@@ -7,7 +7,7 @@ description: "This how-to describes the process of configuring a decision in Men
 tags: ["studio", "microflows", "decision", "domain model", "how to"]
 ---
 
-The following how-to’s will guide you through the process of configuring a decision in Mendix Studio:
+The following how-tos will guide you through the process of configuring a decision in Mendix Studio:
 
 * [Step 1: Build the Domain Model & Configure a Microflow](/studio-how-to8/microflows-how-to-configure-decision-p1/)
 * [Step 2: Embed the Microflow in Your App](/studio-how-to8/microflows-how-to-configure-decision-p2/)

--- a/content/en/docs/studio/work-with-data/domain-models/domain-models-association-properties.md
+++ b/content/en/docs/studio/work-with-data/domain-models/domain-models-association-properties.md
@@ -58,7 +58,7 @@ Delete behavior defines what should happen to the associated object when an obje
 | Delete {name of entity} object(s) as well                    | When an object is deleted, the associated object(s) are also deleted. |
 | Delete {name of entity} object only if it is not associated with {name of other entity} object(s) | An object can only be deleted if it is not associated with any other object(s). <br />You can also specify an error message for your end-users when they try to delete an object that is associated with other entity's objects. For example: "You cannot delete this location, because a course is associated with it." |
 
-For examples of delete behavior configuring, see [Delete Behavior](/howto/data-models/create-a-basic-data-layer/#delete-behavior) section in *How to Create a Basic Data Layer* in the *Mendix Studio Pro How-to’s*.
+For examples of delete behavior configuring, see [Delete Behavior](/howto/data-models/create-a-basic-data-layer/#delete-behavior) section in *How to Create a Basic Data Layer* in the *Mendix Studio Pro How-tos*.
 
 
 ## 5 Cross-Module Associations {#cross-module-associations}

--- a/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/_index.md
+++ b/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/_index.md
@@ -7,7 +7,7 @@ description: "This how-to describes the process of configuring a decision in Men
 tags: ["studio", "microflows", "decision", "domain model", "how to"]
 ---
 
-The following how-to’s will guide you through the process of configuring a decision in Mendix Studio:
+The following how-tos will guide you through the process of configuring a decision in Mendix Studio:
 
 * [Step 1: Build the Domain Model & Configure a Microflow](/studio7/microflows-how-to-configure-decision-p1/)
 * [Step 2: Embed the Microflow in Your App](/studio7/microflows-how-to-configure-decision-p2/)


### PR DESCRIPTION
I missed a few apostrophes in the original removal because the ’ character was used instead of the ' character. Here are the remaining removals!