### PR TITLE
Fix CF buildpack header links

### DIFF
--- a/content/en/docs/developerportal/deploy/mendix-app-on-industrial-edge.md
+++ b/content/en/docs/developerportal/deploy/mendix-app-on-industrial-edge.md
@@ -110,7 +110,7 @@ Once you have created the Mendix app on IEM side, you must create a version of y
 
 Mendix Applications on Industrial Edge support Configuration Files. You can add a configuration file for each Edge device, with specific environment variables in addition to the default variables which are configured within the docker compose file.
 
-The container will search the location, specified in the environment variable: `IEM_CONFIG_PATH`, for files with the extention `.env`. The `.env` files can contain one or more environment variables, which will be added to the environment variables of the container. This can be used to set Edge device specific constants, scheduled events, or custom runtime settings. Check the [configuring constants](https://github.com/mendix/cf-mendix-buildpack#configuring-constants) section of the Mendix buildpack for the syntax to use. 
+The container will search the location, specified in the environment variable: `IEM_CONFIG_PATH`, for files with the extention `.env`. The `.env` files can contain one or more environment variables, which will be added to the environment variables of the container. This can be used to set Edge device specific constants, scheduled events, or custom runtime settings. Check the [Constants](https://github.com/mendix/cf-mendix-buildpack#constants) section of the Mendix buildpack for the syntax to use. 
 
 See the next section for an example compose file including the `IEM_CONFIG_PATH`, which is set in the example to `/cfg-data'.
 

--- a/content/en/docs/developerportal/deploy/on-premises-design/setting-up-monitoring-with-new-relic.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/setting-up-monitoring-with-new-relic.md
@@ -59,4 +59,4 @@ After you restart the application, your data should show up in New Relic. This r
 * [Finding the Root Cause of Runtime Errors](/howto/monitoring-troubleshooting/finding-the-root-cause-of-runtime-errors/)
 * [Clearing Warning Messages in Mendix](/howto/monitoring-troubleshooting/clear-warning-messages/)
 * [Testing Web Services Using SoapUI](/howto/testing/testing-web-services-using-soapui/)
-* [Monitoring Tools](https://github.com/mendix/cf-mendix-buildpack#monitoring-tools) in the *cf-mendix-buildpack* repo on GitHub
+* [New Relic](https://github.com/mendix/cf-mendix-buildpack#new-relic) in the *cf-mendix-buildpack* repo on GitHub

--- a/content/en/docs/howto/monitoring-troubleshooting/manage-app-performance/_index.md
+++ b/content/en/docs/howto/monitoring-troubleshooting/manage-app-performance/_index.md
@@ -16,11 +16,11 @@ For apps deployed to the **Mendix Cloud** you can use the standard metrics as de
 
 ### 1.2 Other Deployment Options
 
-Outside the Mendix Cloud, you can use Datadog, or there are alternative monitoring tools you can use. You can see these under [Monitoring Tools](https://github.com/mendix/cf-mendix-buildpack#monitoring-tools) in the Mendix *Cloud Foundry Buildback*.
+Outside the Mendix Cloud, you can use Datadog, or there are alternative monitoring tools you can use. You can see these under [Telemetry Configuration](https://github.com/mendix/cf-mendix-buildpack#telemetry-configuration) in the Mendix *Cloud Foundry Buildback*.
 
 {{% alert color="warning" %}}
 Only Datadog and AppDynamics are supported for apps deployed to the Mendix Cloud.
 {{% /alert %}}
 
 * **New Relic** – see [Manage App Performance with New Relic](/howto/monitoring-troubleshooting/manage-app-performance-with-new-relic/)
-* **Dynatrace** – for apps deployed to SAP BTP, see [SAP Business Technology Platform](/developerportal/deploy/sap-cloud-platform/#runtime-tab), for other platforms see [Monitoring Tools](https://github.com/mendix/cf-mendix-buildpack#monitoring-tools) in the Mendix *Cloud Foundry Buildback*.
+* **Dynatrace** – for apps deployed to SAP BTP, see [SAP Business Technology Platform](/developerportal/deploy/sap-cloud-platform/#runtime-tab), for other platforms see [Telemetry Configuration](https://github.com/mendix/cf-mendix-buildpack#telemetry-configuration) in the Mendix *Cloud Foundry Buildback*.

--- a/content/en/docs/howto/monitoring-troubleshooting/manage-app-performance/manage-app-performance-with-new-relic.md
+++ b/content/en/docs/howto/monitoring-troubleshooting/manage-app-performance/manage-app-performance-with-new-relic.md
@@ -101,4 +101,4 @@ For more information on New Relic, see the [New Relic documentation](https://doc
 * [Clear Warning Messages in Mendix](/howto/monitoring-troubleshooting/clear-warning-messages/)
 * [Monitor Mendix Using JMX](/howto/monitoring-troubleshooting/monitoring-mendix-using-jmx/)
 * [Debug Java Actions Remotely](/howto/monitoring-troubleshooting/debug-java-actions-remotely/)
-* [Monitoring Tools](https://github.com/mendix/cf-mendix-buildpack#monitoring-tools) in the *cf-mendix-buildpack* repo on GitHub
+* [Telemetry Configuration](https://github.com/mendix/cf-mendix-buildpack#telemetry-configuration) in the *cf-mendix-buildpack* repo on GitHub

--- a/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-development-considerations.md
+++ b/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-development-considerations.md
@@ -360,7 +360,7 @@ In particular, this means that you cannot use entities which are specializations
 
 You can store small amounts of binary information in persistable entities. However, the database management system (DBMS) will have strict limits on the size of binary attributes and using them as a replacement for FileDocument entities can lead to performance issues.
 
-Alternatively, you can use a separate AWS S3 bucket. See [Configuring External Filestore](https://github.com/mendix/cf-mendix-buildpack#configuring-external-filestore) in the *Mendix Cloud Foundry Buildpack GitHub Repository*. Refer to [Cloud Foundry Environment Variables](#cfenvvars), above, for instructions on changing Cloud Foundry environment variables.
+Alternatively, you can use a separate AWS S3 bucket. See [Connect an External Filestore](https://github.com/mendix/cf-mendix-buildpack#connect-an-external-filestore) in the *Mendix Cloud Foundry Buildpack GitHub Repository*. Refer to [Cloud Foundry Environment Variables](#cfenvvars), above, for instructions on changing Cloud Foundry environment variables.
 
 ### 9.2 App Name {#appname}
 

--- a/content/en/docs/refguide/runtime/custom-settings/_index.md
+++ b/content/en/docs/refguide/runtime/custom-settings/_index.md
@@ -24,7 +24,7 @@ If you are running on SAP Cloud, you can add custom settings as User-Provided Va
 
 When you are running your app locally, you can set these values in a [Configuration](/refguide/configuration/#custom).
 
-There is more information on how this is done in the Cloud Foundry buildpack in [Configuring Custom Runtime Settings](https://github.com/mendix/cf-mendix-buildpack#configuring-custom-runtime-settings) in the GitHub repo.
+There is more information on how this is done in the Cloud Foundry buildpack in [Custom Runtime Settings](https://github.com/mendix/cf-mendix-buildpack#custom-runtime-settings) in the GitHub repo.
 
 ### 1.1 Duration/Interval Settings
 

--- a/content/en/docs/refguide8/runtime/custom-settings/_index.md
+++ b/content/en/docs/refguide8/runtime/custom-settings/_index.md
@@ -20,7 +20,7 @@ Each custom setting consists of a name and a value. For example, to enable persi
 
 If you are running your app on the Mendix Cloud, you can access these settings in the Developer Portal via **Environments** > **Environment Details** > **Runtime** > **Custom Runtime Settings**. For more information see the [Runtime Tab](/developerportal/deploy/environments-details/#runtime-tab) section of *Environment Details*.
 
-If you are running on SAP Cloud, you can add custom settings as User-Provided Variables prefixed with `MXRUNTIME_`. If the setting contains a dot `.` you can use an underscore `_` in the variable. [Reference](https://github.com/mendix/cf-mendix-buildpack#configuring-custom-runtime-settings)
+If you are running on SAP Cloud, you can add custom settings as User-Provided Variables prefixed with `MXRUNTIME_`. If the setting contains a dot `.` you can use an underscore `_` in the variable. [Reference](https://github.com/mendix/cf-mendix-buildpack#custom-runtime-settings)
 
 ## 2 General Settings{#general}
 


### PR DESCRIPTION
The upcoming buildpack release will have [restructured documentation](https://github.com/mendix/cf-mendix-buildpack/tree/docs-update).

This PR fixes the hashed links to the headers in the revised buildpack documentation.