### PR TITLE
Add TODO message to Travis Log

### DIFF
--- a/layouts/shortcodes/todo.html
+++ b/layouts/shortcodes/todo.html
@@ -1,4 +1,4 @@
 {{- if (ne hugo.Environment "production") -}}
-<div class="alert alert-warning todo" role="alert"><strong>{{.Inner}}</strong></div>
+<div class="alert alert-warning todo" role="alert">To Do<br /><strong>{{.Inner}}</strong></div>
 {{ warnf "File %s \n\t\t\t\tTO DO item: %s\n " .Page.File.Path .Inner }}
 {{- end -}}

--- a/layouts/shortcodes/todo.html
+++ b/layouts/shortcodes/todo.html
@@ -1,4 +1,4 @@
 {{- if (ne hugo.Environment "production") -}}
 <div class="alert alert-warning todo" role="alert"><strong>{{.Inner}}</strong></div>
-{{ warnf "File %s \n\t\t\t\tcontains a TO DO item\n " .Page.File.Path }}
+{{ warnf "File %s \n\t\t\t\tTO DO item: %s\n " .Page.File.Path .Inner }}
 {{- end -}}


### PR DESCRIPTION
Add the actual text of the TODO to the Hugo warnings so you can see why there is a TODO in the build log and don't have to look at the actual file.