### PR TITLE
mx check add performance

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -40,7 +40,7 @@ The `OPTIONS` are described in the table below:
 | `--help` | `-h` | Displays the help text and exits. |
 | `--warnings` | `-w` | Include warnings in the output |
 | `--deprecations` | `-d` | Include deprecations in the output |
-| `--performance` | `-p` | Include performance checks in the output (performance recommendations are only output if there are no errors) |
+| `--performance` | `-p` | [version 9.16+] Include performance checks in the output (performance recommendations are only output if there are no errors) |
 
 {{% alert color="info" %}}
 Errors in the MPR are always reported.
@@ -58,7 +58,7 @@ Examples of commands are described in the table below:
 | `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
 | `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations and performance recommendations. |
 
 #### 3.1.3 Return Codes
 

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -21,7 +21,7 @@ The mx tool performs the commands described below.
 
 ### 3.1 mx check Command [version 9.10+]
 
-The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance Recommendations.
+The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations, or Performance Recommendations.
 
 {{% alert color="info" %}}
 The MPR file must be the same version as mx.
@@ -58,7 +58,7 @@ Examples of commands are described in the table below:
 | `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
 | `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |
 
 #### 3.1.3 Return Codes
 
@@ -72,7 +72,7 @@ Return codes are described in the table below:
 | 4 | Deprecations were found. |
 | 8 | Performance recommendations were found. |
 
-Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations or performance recommendations.
+Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations, or performance recommendations.
 
 For example:
 - 3 if errors and warnings found

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -21,7 +21,7 @@ The mx tool performs the commands described below.
 
 ### 3.1 mx check Command [version 9.10+]
 
-The `mx check` command checks the app MPR file for issues such as Errors, Warnings or Deprecations.
+The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance Recommendations.
 
 {{% alert color="info" %}}
 The MPR file must be the same version as mx.
@@ -40,6 +40,7 @@ The `OPTIONS` are described in the table below:
 | `--help` | `-h` | Displays the help text and exits. |
 | `--warnings` | `-w` | Include warnings in the output |
 | `--deprecations` | `-d` | Include deprecations in the output |
+| `--performance` | `-p` | Include performance checks in the output (performance recommendations are only output if there are no errors) |
 
 {{% alert color="info" %}}
 Errors in the MPR are always reported.
@@ -55,7 +56,9 @@ Examples of commands are described in the table below:
 | --- | --- |
 | `mx check --help` | Displays the help text for the check command. |
 | `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
-| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings and deprecations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |
 
 #### 3.1.3 Return Codes
 
@@ -67,8 +70,9 @@ Return codes are described in the table below:
 | 1 | Errors were found. |
 | 2 | Warnings were found. |
 | 4 | Deprecations were found. |
+| 8 | Performance recommendations were found. |
 
-Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations.
+Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations or performance recommendations.
 
 For example:
 - 3 if errors and warnings found

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -19,7 +19,7 @@ Mendix Studio Pro comes with the mx command-line tool. The executable `mx.exe` f
 
 The mx tool performs the commands described below.
 
-### 3.1 mx check Command [version 9.10+]
+### 3.1 mx check Command [version 9.10+] {#check}
 
 The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance Recommendations.
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/mx-assist-performance-bot/_index.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/mx-assist-performance-bot/_index.md
@@ -123,7 +123,11 @@ To auto-fix the issue, follow the steps below:
 
 After the issue is auto-fixed, a pop-up window listing the changes appears. You can click **Show the fix** to view the changed document and element. 
 
-## 4 Read More
+## 4 Using Performance Bot from the command line
+
+Performance Bot may also be executed from the command line, via the [mx Command-Line Tool](/refguide/mx-command-line-tool/#check).
+
+## 5 Read More
 
 * [Mendix Assist](/refguide/mx-assist-studio-pro/)
 * [MxAssist Logic Bot](/refguide/mx-assist-logic-bot/)


### PR DESCRIPTION
Adds the `--performance` option to `mx check` command.

So, when `mx check` is run, the user can choose to include any performance recommendations in the check.

SP version: 9.16

* [x] rebase when this other PR has been merged: https://github.com/mendix/docs/pull/4721 

note: this is mxassist-client reference AA-3747
