### PR TITLE
Revert "Revert "Fix statement about changed date""

### DIFF
--- a/content/en/docs/refguide/modeling/domain-model/entities/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/_index.md
@@ -152,7 +152,7 @@ This property defines whether the entity contains the system attribute 'changedD
 | False *(default)* | Entity does not contain the system attribute 'changedDate'. |
 
 {{% alert color="info" %}}
-The 'changedDate' property is only updated on real changes. Simply changing and committing an entity with the same attribute values does not update 'changedDate'.
+The 'changedDate' property is updated when a value is set. Setting an attribute to the value it already had and committing the entity also updates the 'changedDate'.
 {{% /alert %}}
 
 {{% alert color="info" %}}

--- a/content/en/docs/refguide/modeling/domain-model/entities/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/_index.md
@@ -152,7 +152,7 @@ This property defines whether the entity contains the system attribute 'changedD
 | False *(default)* | Entity does not contain the system attribute 'changedDate'. |
 
 {{% alert color="info" %}}
-The 'changedDate' property is updated when a value is set. Setting an attribute to the value it already had and committing the entity also updates the 'changedDate'.
+The 'changedDate' property is updated when a value is set.  [In Mendix version 9.5.0 and above, setting an attribute to the value it already had and committing the entity updates the 'changedDate'](/releasenotes/studio-pro/9.5/#breaking-changes). In Mendix versions below 9.5.0 the behavior is the same as for Mendix version 8 and the 'changedDate' property is only updated when the value is different.
 {{% /alert %}}
 
 {{% alert color="info" %}}


### PR DESCRIPTION
Need to discuss with the developers.
This behaviour is not consistent for all versions of Mendix and behaviour in 9.5 and before needs to be mentioned.
Reverts mendix/docs#4728