### PR TITLE
Remove mentioning of node version

### DIFF
--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -25,10 +25,7 @@ Clone this [code sample](https://github.com/mendix/text-box-sample) from GitHub 
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
-* Install the LTS version of [Node.js](https://nodejs.org).
-    * For Windows, install using this [official installer](https://nodejs.org/en/download/package-manager/#windows)
-    * For Mac, install using [Homebrew](https://docs.brew.sh/Installation) and
-      these [official tools](https://nodejs.org/en/download/package-manager/#macos)
+* Install the LTS version of [Node.js](https://nodejs.org/en/download/).
 * Install [Yeoman](https://yeoman.io/) with the following command:
 
     ```shell

--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -25,7 +25,7 @@ Clone this [code sample](https://github.com/mendix/text-box-sample) from GitHub 
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
-* Install the LTS version of [Node.js](https://nodejs.org) (we recommend using Node 14).
+* Install the LTS version of [Node.js](https://nodejs.org).
     * For Windows, install using this [official installer](https://nodejs.org/en/download/package-manager/#windows)
     * For Mac, install using [Homebrew](https://docs.brew.sh/Installation) and
       these [official tools](https://nodejs.org/en/download/package-manager/#macos)


### PR DESCRIPTION
Tutorial mentions Node.js version number while mentioning LTS at the same time. We need to always refer to the current LTS, not to a fixed version.