### PR TITLE
Add a limitation to the video player widget

### DIFF
--- a/content/en/docs/appstore/widgets/video-player.md
+++ b/content/en/docs/appstore/widgets/video-player.md
@@ -24,7 +24,7 @@ The [Video Player](https://marketplace.mendix.com/link/component/110700/) widget
 ### 1.2 Limitations
 
 * File hosted in Mendix Server cannot be played in the Safari browser
-* Using this widget with video files stored in file documents in a Mendix app is not entirely recommended, as Mendix Runtime is not designed to perform as a media server.
+* Using this widget with video files stored in file documents is not recommended, as the Mendix Runtime is not designed to perform as a media server
 
 ## 2 Configuration
 

--- a/content/en/docs/appstore/widgets/video-player.md
+++ b/content/en/docs/appstore/widgets/video-player.md
@@ -24,6 +24,7 @@ The [Video Player](https://marketplace.mendix.com/link/component/110700/) widget
 ### 1.2 Limitations
 
 * File hosted in Mendix Server cannot be played in the Safari browser
+* Using this widget with video files stored in file documents in a Mendix app is not entirely recommended, as Mendix Runtime is not designed to perform as a media server.
 
 ## 2 Configuration
 


### PR DESCRIPTION
Following the support team's suggestion, we're adding a new limitation when using this widget with files stored in the file documents.