### PR TITLE
Remove (page).URL from our layouts as it is deprecated

### DIFF
--- a/layouts/_default/list.mxdocsalgolia.json
+++ b/layouts/_default/list.mxdocsalgolia.json
@@ -148,7 +148,7 @@ Define Global variables
                             {{- end -}}
                         {{- end -}}
                         {{- $scratch.SetInMap $uniqueHit "weight.tag_name" $tagName -}}
-                        {{- /* .URL takes into account any changes by using the url: tag in the front matter */ -}}
+                        {{- /* .RelPermalink gives the page address relative to the baseURL. It reflects any changes from the url: tag in the front matter */ -}}
                         {{- $scratch.SetInMap $uniqueHit "url" $pageDot.RelPermalink -}}
                         {{- $scratch.SetInMap $uniqueHit "slug" $pageDot.File.TranslationBaseName -}}
                         {{- $scratch.SetInMap $uniqueHit "unique_hierarchy" $uniqueHierarchy -}}

--- a/layouts/_default/list.mxdocsalgolia.json
+++ b/layouts/_default/list.mxdocsalgolia.json
@@ -149,7 +149,7 @@ Define Global variables
                         {{- end -}}
                         {{- $scratch.SetInMap $uniqueHit "weight.tag_name" $tagName -}}
                         {{- /* .URL takes into account any changes by using the url: tag in the front matter */ -}}
-                        {{- $scratch.SetInMap $uniqueHit "url" $pageDot.URL -}}
+                        {{- $scratch.SetInMap $uniqueHit "url" $pageDot.RelPermalink -}}
                         {{- $scratch.SetInMap $uniqueHit "slug" $pageDot.File.TranslationBaseName -}}
                         {{- $scratch.SetInMap $uniqueHit "unique_hierarchy" $uniqueHierarchy -}}
                     {{- end -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -19,7 +19,8 @@ other choice is to copy over all Docsy partials that call navbar.html
 				{{ $post := .Post }}
 				{{ $url := urls.Parse .URL }}
 				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
+                <!-- MvM - remove "{{ else }}{{ .URL | relLangURL }}" from .RelPermalink clause as Page.URL is deprecated -->
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}


### PR DESCRIPTION
Files are slightly different lengths, but cannot identify any differences.
Output compared in VS Code - no differences found
Formatted JSON in VS Code and compared first 150000 characters (cannot format entire file) - no differences found