### PR TITLE
Insert linktitle parameter

### DIFF
--- a/content/en/docs/addons/ats-addon/ht/ht-one/ht-one-install-ats-helper-recorder.md
+++ b/content/en/docs/addons/ats-addon/ht/ht-one/ht-one-install-ats-helper-recorder.md
@@ -1,5 +1,6 @@
 ---
 title: "Install the ATS Helper and the ATS Recorder"
+linktitle: "Install ATS Helper & Recorder"
 url: /addons/ats-addon/ht-one-install-ats-helper-recorder/
 weight: 2
 description: "Describes how to install the ATS Helper and the ATS Recorder tool."

--- a/content/en/docs/addons/ats-addon/ht/ht-two/ht-two-connect-stories-to-testcases.md
+++ b/content/en/docs/addons/ats-addon/ht/ht-two/ht-two-connect-stories-to-testcases.md
@@ -1,5 +1,6 @@
 ---
 title: "Link Test Cases & Test Suites to User Stories"
+linktitle: "Link Test Cases & Suites to User Stories"
 url: /addons/ats-addon/ht-two-connect-stories-to-testcases/
 description: "Describes the steps for linking Test Cases and Test Suites to User Stories."
 tags: ["ATS", "testing"]

--- a/content/en/docs/addons/ats-addon/ht/ht-two/ht-two-increase-recorder-helper-coverage.md
+++ b/content/en/docs/addons/ats-addon/ht/ht-two/ht-two-increase-recorder-helper-coverage.md
@@ -1,5 +1,6 @@
 ---
 title: "Increase ATS Recorder and Helper Coverage"
+linktitle: "Increase ATS Recorder & Helper Coverage"
 url: /addons/ats-addon/ht-two-increase-recorder-helper-coverage/
 description: "Describes how to increase the ATS Recorder and Helper coverage of your application"
 tags: ["ATS", "testing"]

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/client-apis-for-pluggable-widgets-8.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/client-apis-for-pluggable-widgets-8.md
@@ -1,6 +1,6 @@
 ---
 title: "Client APIs Available to Pluggable Widgets"
-linktitle: "Client APIs"
+linktitle: "Client APIs for Pluggable Widgets"
 url: /apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets-8/
 weight: 10
 description: A guide for understanding the client APIs available to pluggable widgets.

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/client-apis-for-pluggable-widgets-8.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/client-apis-for-pluggable-widgets-8.md
@@ -1,5 +1,6 @@
 ---
 title: "Client APIs Available to Pluggable Widgets"
+linktitle: "Client APIs"
 url: /apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets-8/
 weight: 10
 description: A guide for understanding the client APIs available to pluggable widgets.

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/differences-between-pluggable-and-custom-widgets.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/differences-between-pluggable-and-custom-widgets.md
@@ -1,5 +1,6 @@
 ---
 title: "Differences Between Pluggable and Custom Widgets"
+linktitle: "Pluggable & Custom Widget Differences"
 url: /apidocs-mxsdk/apidocs/differences-between-pluggable-and-custom-widgets/
 description: This document explains the differences between pluggable and custom widgets.
 tags: ["Widget", "Pluggable",  "JavaScript"]

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/differences-between-pluggable-and-custom-widgets.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/differences-between-pluggable-and-custom-widgets.md
@@ -1,6 +1,6 @@
 ---
 title: "Differences Between Pluggable and Custom Widgets"
-linktitle: "Pluggable & Custom Widget Differences"
+linktitle: "Compare Pluggable & Custom Widgets"
 url: /apidocs-mxsdk/apidocs/differences-between-pluggable-and-custom-widgets/
 description: This document explains the differences between pluggable and custom widgets.
 tags: ["Widget", "Pluggable",  "JavaScript"]

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/studio-apis-for-pluggable-widgets-8.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/studio-apis-for-pluggable-widgets-8.md
@@ -1,5 +1,6 @@
 ---
 title: "Preview Appearance APIs for Pluggable Widgets"
+linktitle: "Preview Appearance APIs"
 url: /apidocs-mxsdk/apidocs/studio-apis-for-pluggable-widgets-8/
 weight: 30
 description: A guide for understanding the APIs which influence pluggable widget preview appearances.

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Client APIs Available to Pluggable Widgets"
-linktitle: "Client APIs"
+linktitle: "Client APIs for Pluggable Widgets"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/
 description: A guide for understanding the client APIs available to pluggable widgets.
 tags: ["Widget", "Pluggable",  "JavaScript"]

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -1,9 +1,9 @@
 ---
 title: "Client APIs Available to Pluggable Widgets"
+linktitle: "Client APIs"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/
 description: A guide for understanding the client APIs available to pluggable widgets.
 tags: ["Widget", "Pluggable",  "JavaScript"]
-
 weight: 20
 aliases:
  - /apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
@@ -1,9 +1,9 @@
 ---
 title: "Preview Appearance APIs for Pluggable Widgets"
+linktitle: "Preview Appearance APIs"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-studio-apis/
 description: A guide for understanding the APIs which influence pluggable widget preview appearances.
 tags: ["Widget", "Pluggable", "Custom", "JavaScript", "React", "Preview"]
-
 weight: 30
 aliases:
 - /apidocs-mxsdk/apidocs/studio-apis-for-pluggable-widgets

--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-howtos/sdk-old-versions-howtos/old-creating-your-first-script.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-howtos/sdk-old-versions-howtos/old-creating-your-first-script.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Script (Old Versions)"
+linktitle: "Create Your First Script"
 url: /apidocs-mxsdk/mxsdk/old-creating-your-first-script/
 weight: 2
 ---

--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-howtos/sdk-old-versions-howtos/old-setting-up-your-development-environment.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-howtos/sdk-old-versions-howtos/old-setting-up-your-development-environment.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Your Development Environment (Old Versions)"
+linktitle: "Set Up Development Environment"
 url: /apidocs-mxsdk/mxsdk/old-setting-up-your-development-environment/
 weight: 1
 ---

--- a/content/en/docs/data-hub/data-hub-catalog/register-data.md
+++ b/content/en/docs/data-hub/data-hub-catalog/register-data.md
@@ -1,5 +1,6 @@
 ---
 title: "Register OData Resources in the Data Hub Catalog"
+linktitle: "Register OData Resources"
 url: /data-hub/data-hub-catalog/register-data/
 description: "How to register OData resources in the Data Hub Catalog: through the Mendix Cloud, using the Registration API, or in the UI form"
 category: "Data Hub Catalog"

--- a/content/en/docs/data-hub/data-hub-catalog/register-non-odata-resources.md
+++ b/content/en/docs/data-hub/data-hub-catalog/register-non-odata-resources.md
@@ -1,5 +1,6 @@
 ---
 title: "Register Non-OData Resources in the Data Hub Catalog"
+linktitle: "Register Non-OData Resources"
 url: /data-hub/data-hub-catalog/register-non-odata-resources/
 category: "Data Hub Catalog"
 weight: 40

--- a/content/en/docs/developerportal/community-tools/mendix-profile/warden.md
+++ b/content/en/docs/developerportal/community-tools/mendix-profile/warden.md
@@ -1,5 +1,6 @@
 ---
 title: "Create a Personal Access Token with Warden"
+linktitle: "Warden Personal Access Token"
 url: /developerportal/community-tools/warden/
 weight: 10
 description: "Explains the concept of Personal Access Tokens (PATs) and how platform users can use these security tokens to give application access to Mendix Platform services on their behalf."

--- a/content/en/docs/developerportal/community-tools/mendix-profile/warden.md
+++ b/content/en/docs/developerportal/community-tools/mendix-profile/warden.md
@@ -1,6 +1,6 @@
 ---
 title: "Create a Personal Access Token with Warden"
-linktitle: "Warden Personal Access Token"
+linktitle: "Create a PAT with Warden"
 url: /developerportal/community-tools/warden/
 weight: 10
 description: "Explains the concept of Personal Access Tokens (PATs) and how platform users can use these security tokens to give application access to Mendix Platform services on their behalf."

--- a/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/activate-a-mendix-license-on-microsoft-windows.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/activate-a-mendix-license-on-microsoft-windows.md
@@ -1,5 +1,6 @@
 ---
 title: "MS Windows: Activate a Mendix License on Microsoft Windows"
+linktitle: "MS Windows: Activate Mendix License"
 url: /developerportal/deploy/activate-a-mendix-license-on-microsoft-windows/
 weight: 10
 tags: ["license", "Windows", "on-premises", "Mendix Service Console"]

--- a/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/activate-a-mendix-license-on-microsoft-windows.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/activate-a-mendix-license-on-microsoft-windows.md
@@ -1,5 +1,5 @@
 ---
-title: "MS Windows: Activate a Mendix License on Microsoft Windows"
+title: "Activate a Mendix License on Microsoft Windows"
 linktitle: "MS Windows: Activate Mendix License"
 url: /developerportal/deploy/activate-a-mendix-license-on-microsoft-windows/
 weight: 10

--- a/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/deploy-mendix-ha-on-windows-in-microsoft-azure.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/deploy-mendix-ha-on-windows-in-microsoft-azure.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Mendix on Windows in Microsoft Azure"
+linktitle: "Deploy Mendix in MS Azure"
 url: /developerportal/deploy/deploy-mendix-ha-on-windows-in-microsoft-azure/
 description: "How to install and configure Mendix in an HA setup on servers running Windows in Microsoft Azure"
 weight: 5

--- a/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/troubleshooting-iis.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/deploy-mendix-on-microsoft-windows/troubleshooting-iis.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting IIS (Internet Information Services) "
+linktitle: "Troubleshooting IIS"
 url: /developerportal/deploy/troubleshooting-iis/
 description: "Help on fixing issues with Microsoft IIS, including the use of application logs and other troubleshooting features"
 weight: 40

--- a/content/en/docs/developerportal/deploy/on-premises-design/security-checklist-for-your-on-premises-installation.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/security-checklist-for-your-on-premises-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Security for Your On-Premises Installation"
+linktitle: "On-Premises Installation Security"
 url: /developerportal/deploy/security-checklist-for-your-on-premises-installation/
 description: "A checklist for implementing security when deploying Mendix on premises"
 weight: 10

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-cli-non-interactive.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-cli-non-interactive.md
@@ -1,5 +1,6 @@
 ---
 title: "Install and Configure Mendix for Private Cloud Non-interactive Mode"
+linktitle: "Non-interactive Mode"
 url: /developerportal/deploy/private-cloud-cli-non-interactive/
 description: "Describes how to install and configure Mendix for Private Cloud in non-interactive mode"
 weight: 5

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -1,6 +1,6 @@
 ---
-title: "Migrating data in Private Cloud environments (preview)"
-linktitle: "Migrate data (Preview)"
+title: "Migrating Data in Private Cloud Environments (Preview)"
+linktitle: "Migrate Data (Preview)"
 url: /developerportal/deploy/private-cloud-data-transfer/
 description: "Describes how to migrate data between Private Cloud environments"
 weight: 32

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating data in Private Cloud environments (preview)"
+linktitle: "Migrate data (preview)"
 url: /developerportal/deploy/private-cloud-data-transfer/
 description: "Describes how to migrate data between Private Cloud environments"
 weight: 32

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating data in Private Cloud environments (preview)"
-linktitle: "Migrate data (preview)"
+linktitle: "Migrate data (Preview)"
 url: /developerportal/deploy/private-cloud-data-transfer/
 description: "Describes how to migrate data between Private Cloud environments"
 weight: 32

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploying a Mendix App to a Private Cloud Cluster"
+linktitle: "Deploy Mendix App"
 url: /developerportal/deploy/private-cloud-deploy/
 description: "Describes the processes for deploying a Mendix app in the Private Cloud"
 weight: 20

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-environments.md
@@ -1,5 +1,6 @@
 ---
 title: "Environment Planning for Private Cloud Clusters"
+linktitle: "Environment Planning"
 url: /developerportal/deploy/private-cloud-environments/
 description: "Best Practices for Private Cloud Environments"
 weight: 40

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-monitor.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-monitor.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring Environments in Mendix for Private Cloud"
+linktitle: "Monitor Environments"
 url: /developerportal/deploy/private-cloud-monitor/
 description: "Describes the processes for setting up a monitoring solution for Mendix environments in the Private Cloud"
 weight: 31

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Command Line to Deploy a Mendix App to a Private Cloud Cluster"
+linktitle: "Use CLI to Deploy"
 url: /developerportal/deploy/private-cloud-operator/
 description: "Describes the processes for using the Mendix Operator directly to deploy a Mendix app in the Private Cloud"
 weight: 30

--- a/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/_index.md
+++ b/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Work with On-Premises Version Control Server"
+linktitle: "On-Premises Version Control Server"
 url: /howto/collaboration-requirements-management/on-premises-howto/
 category: "Collaboration"
 weight: 60

--- a/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/on-premises-git-howto/_index.md
+++ b/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/on-premises-git-howto/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Work with Git On-Premises Version Control Server"
+linktitle: "Git On-Premises Version Control Server"
 url: /howto/collaboration-requirements-management/on-premises-git-howto/
 weight: 20
 tags: ["on-premises", "git", "version control"]

--- a/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/on-premises-svn-howto.md
+++ b/content/en/docs/howto/collaboration-requirements-management/on-premises-howto/on-premises-svn-howto.md
@@ -1,5 +1,6 @@
 ---
 title: "Work with SVN On-Premises Version Control Server"
+linktitle: "SVN On-Premises Version Control Server"
 url: /howto/collaboration-requirements-management/on-premises-svn-howto/
 weight: 10
 tags: ["on-premises", "svn", "version control"]

--- a/content/en/docs/howto/collaboration-requirements-management/set-up-repo.md
+++ b/content/en/docs/howto/collaboration-requirements-management/set-up-repo.md
@@ -1,6 +1,6 @@
 ---
 title: "Set Up a GitHub Repo to Publish a Marketplace Item"
-linktitle: "GitHub Repo to Publish Marketplace Item"
+linktitle: "Publish from GitHub to Marketplace"
 url: /howto/collaboration-requirements-management/set-up-repo/
 category: "Collaboration"
 weight: 30

--- a/content/en/docs/howto/collaboration-requirements-management/set-up-repo.md
+++ b/content/en/docs/howto/collaboration-requirements-management/set-up-repo.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up a GitHub Repo to Publish a Marketplace Item"
+linktitle: "GitHub Repo to Publish Marketplace Item"
 url: /howto/collaboration-requirements-management/set-up-repo/
 category: "Collaboration"
 weight: 30

--- a/content/en/docs/howto/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
+++ b/content/en/docs/howto/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshoot Network Issues for Connecting to the Team Server"
+linktitle: "Team Server Network Issues"
 url: /howto/collaboration-requirements-management/troubleshoot-network-issues-for-team-server/
 category: "Collaboration"
 weight: 14

--- a/content/en/docs/howto/extensibility/best-practices-javascript-actions.md
+++ b/content/en/docs/howto/extensibility/best-practices-javascript-actions.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for JavaScript Actions"
+linktitle: "JavaScript Actions Best Practices"
 url: /howto/extensibility/best-practices-javascript-actions/
 category: "Extensibility"
 weight: 60

--- a/content/en/docs/howto/extensibility/build-javascript-actions/write-javascript-actions.md
+++ b/content/en/docs/howto/extensibility/build-javascript-actions/write-javascript-actions.md
@@ -1,5 +1,6 @@
 ---
 title: "Build JavaScript Actions: Part 1 (Basic)"
+linktitle: "1. Build JavaScript Actions"
 url: /howto/extensibility/write-javascript-actions/
 weight: 10
 description: "This how-to will teach you to create a JavaScript action."

--- a/content/en/docs/howto/extensibility/build-javascript-actions/write-javascript-github.md
+++ b/content/en/docs/howto/extensibility/build-javascript-actions/write-javascript-github.md
@@ -1,5 +1,6 @@
 ---
 title: "Build JavaScript Actions: Part 2 (Advanced)"
+linktitle: "2. Build JavaScript Actions"
 url: /howto/extensibility/write-javascript-github/
 weight: 20
 description: "This advanced how-to will teach you to make a JavaScript action which can search for GitHub users."

--- a/content/en/docs/howto/extensibility/howto-connector-kit.md
+++ b/content/en/docs/howto/extensibility/howto-connector-kit.md
@@ -5,9 +5,6 @@ category: "Extensibility"
 description: "Describes creating custom Microflow actions using Java."
 weight: 80
 tags: ["java", "connector kit", "microflow action", "parameter type", "generic actions", "type parameters", "mappings", "java action"]
-output:
-  word_document: default
-  html_document: default
 #To update screenshots of these microflows in Studio Pro, use the SlackRekognition-main-master app, which is saved locally in Other Resources > Documentation Backups (No Update).
 ---
 

--- a/content/en/docs/howto/extensibility/howto-datastorage-api.md
+++ b/content/en/docs/howto/extensibility/howto-datastorage-api.md
@@ -1,13 +1,11 @@
 ---
 title: "Use Mendix Data Storage APIs to Build Reusable Microflow Actions"
+linktitle: "Data Storage APIs for Reusable Microflows"
 url: /howto/extensibility/howto-datastorage-api/
 category: "Extensibility"
 weight: 90
 description: "Describes creating custom microflow actions using Data Storage APIs."
 tags: ["java", "microflow action", "parameter type", "sql", "xpath", "oql", "datastorage"]
-output:
-  word_document: default
-  html_document: default
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Pluggable Web Widget: Part 1"
+linktitle: "1. Build Pluggable Web Widget"
 url: /howto/extensibility/create-a-pluggable-widget-one/
 weight: 10
 description: "This how-to will teach you to create a pluggable web widget."

--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-two.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-two.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Pluggable Web Widget: Part 2 (Advanced)"
+linktitle: "2. Build Pluggable Web Widget"
 url: /howto/extensibility/create-a-pluggable-widget-two/
 weight: 20
 description: "This how-to will teach you how to add advanced features to your TextBox input widget."

--- a/content/en/docs/howto/front-end/charts-tutorials/charts-advanced-tuning.md
+++ b/content/en/docs/howto/front-end/charts-tutorials/charts-advanced-tuning.md
@@ -1,5 +1,6 @@
 ---
 title: "Fine-Tune a Chart with Advanced Settings"
+linktitle: "Chart Advanced Tuning"
 url: /howto/front-end/charts-advanced-tuning/
 weight: 30
 description: "Describes the settings you can use to change chart layouts and types"

--- a/content/en/docs/howto/front-end/charts-tutorials/charts-plotly-images-rest.md
+++ b/content/en/docs/howto/front-end/charts-tutorials/charts-plotly-images-rest.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the Plotly Images REST Service Endpoint"
+linktitle: "Plotly Images REST Endpoint"
 url: /howto/front-end/charts-plotly-images-rest/
 weight: 70
 tags: ["Charts", "Plotly", "REST", "Studio Pro", "Widget"]

--- a/content/en/docs/howto/front-end/create-your-first-two-overview-and-detail-pages.md
+++ b/content/en/docs/howto/front-end/create-your-first-two-overview-and-detail-pages.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Two Overview & Detail Pages"
+linktitle: "Create Overview & Detail Pages"
 url: /howto/front-end/create-your-first-two-overview-and-detail-pages/
 category: "Front End"
 weight: 25

--- a/content/en/docs/howto/general/community-best-practices-for-app-performance.md
+++ b/content/en/docs/howto/general/community-best-practices-for-app-performance.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Community Best Practices for App Performance"
+linktitle: "Best Practices for App Performance"
 url: /howto/general/community-best-practices-for-app-performance/
 category: "General Info"
 weight: 8

--- a/content/en/docs/howto/general/dev-best-practices.md
+++ b/content/en/docs/howto/general/dev-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Mendix Best Practices for Development"
+linktitle: "Best Practices for Development"
 url: /howto/general/dev-best-practices/
 category: "General Info"
 weight: 7

--- a/content/en/docs/howto/general/minimize-number.md
+++ b/content/en/docs/howto/general/minimize-number.md
@@ -1,5 +1,6 @@
 ---
 title: "Minimize the Number of In-Use Objects in Your Session"
+linktitle: "Minimize Objects in Session"
 url: /howto/general/minimize-number/
 category: "General Info"
 weight: 6

--- a/content/en/docs/howto/integration/execute-an-sql-statement-on-an-external-database.md
+++ b/content/en/docs/howto/integration/execute-an-sql-statement-on-an-external-database.md
@@ -1,5 +1,6 @@
 ---
 title: "Execute an SQL Statement on an External Database"
+linktitle: "Execute SQL on External Database"
 url: /howto/integration/execute-an-sql-statement-on-an-external-database/
 category: "Integration"
 weight: 17

--- a/content/en/docs/howto/integration/implement-cicd-pipeline.md
+++ b/content/en/docs/howto/integration/implement-cicd-pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: "Implement a Simple CI/CD Pipeline with Mendix APIs"
-linktitle: "Implement CI/CD Pipeline"
+linktitle: "CI/CD Pipeline for Mendix Cloud"
 url: /howto/integration/implement-cicd-pipeline/
 category: "Integration"
 tags: ["cicd", "continuous", "integration", "delivery", "deployment", "automation", "testing"]

--- a/content/en/docs/howto/integration/implement-cicd-pipeline.md
+++ b/content/en/docs/howto/integration/implement-cicd-pipeline.md
@@ -1,5 +1,6 @@
 ---
-title: "Implement a Simple CICD Pipeline with Mendix APIs"
+title: "Implement a Simple CI/CD Pipeline with Mendix APIs"
+linktitle: "Implement CI/CD Pipeline"
 url: /howto/integration/implement-cicd-pipeline/
 category: "Integration"
 tags: ["cicd", "continuous", "integration", "delivery", "deployment", "automation", "testing"]

--- a/content/en/docs/howto/integration/integrating-a-legacy-system-into-a-mendix-app.md
+++ b/content/en/docs/howto/integration/integrating-a-legacy-system-into-a-mendix-app.md
@@ -1,6 +1,6 @@
 ---
 title: "Integrate a Legacy System into a Mendix App"
-linktitle: "Legacy System in Mendix App"
+linktitle: "Integrate Legacy System"
 url: /howto/integration/integrating-a-legacy-system-into-a-mendix-app/
 category: "Integration"
 weight: 1

--- a/content/en/docs/howto/integration/integrating-a-legacy-system-into-a-mendix-app.md
+++ b/content/en/docs/howto/integration/integrating-a-legacy-system-into-a-mendix-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Integrate a Legacy System into a Mendix App"
+linktitle: "Legacy System in Mendix App"
 url: /howto/integration/integrating-a-legacy-system-into-a-mendix-app/
 category: "Integration"
 weight: 1

--- a/content/en/docs/howto/logic-business-rules/add-action-to-workflow-toolbox.md
+++ b/content/en/docs/howto/logic-business-rules/add-action-to-workflow-toolbox.md
@@ -1,5 +1,6 @@
 ---
 title: "Add a Custom Action to the Workflow Toolbox"
+linktitle: "Add Custom Action to Workflow Toolbox"
 url: /howto/logic-business-rules/add-action-to-workflow-toolbox/
 category: "Logic & Business Rules"
 description: "Describes how to expose a microflow as a workflow action in Mendix Studio Pro."

--- a/content/en/docs/howto/logic-business-rules/extending-your-application-with-custom-java.md
+++ b/content/en/docs/howto/logic-business-rules/extending-your-application-with-custom-java.md
@@ -1,5 +1,6 @@
 ---
 title: "Extend Your Application with Custom Java"
+linktitle: "Extend App with Custom Java"
 url: /howto/logic-business-rules/extending-your-application-with-custom-java/
 category: "Logic & Business Rules"
 weight: 120

--- a/content/en/docs/howto/logic-business-rules/filtering-data-on-an-overview-page.md
+++ b/content/en/docs/howto/logic-business-rules/filtering-data-on-an-overview-page.md
@@ -1,5 +1,6 @@
 ---
 title: "Filter Data on an Overview Page Using XPath"
+linktitle: "Filter Data Using XPath"
 url: /howto/logic-business-rules/filtering-data-on-an-overview-page/
 category: "Logic & Business Rules"
 weight: 150

--- a/content/en/docs/howto/logic-business-rules/server-side-paging.md
+++ b/content/en/docs/howto/logic-business-rules/server-side-paging.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Server-Side Paging and Sorting for a Microflow Data Source"
+linktitle: "Server-Side Paging & Sorting"
 url: /howto/logic-business-rules/server-side-paging/
 category: "Logic & Business Rules"
 description: "This how-to will teach you how to create a data grid with a microflow data source which retrieves data from a REST service, and then add server-side paging and sorting to it."

--- a/content/en/docs/howto/logic-business-rules/workflow-how-to-configure.md
+++ b/content/en/docs/howto/logic-business-rules/workflow-how-to-configure.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a Workflow in Studio Pro for the Employee Onboarding Process"
+linktitle: "Workflow for Employee Onboarding"
 url: /howto/logic-business-rules/workflow-how-to-configure/
 category: "Logic & Business Rules"
 description: "Describes how to configure a workflow in Mendix Studio Pro."

--- a/content/en/docs/howto/security/best-practices-security.md
+++ b/content/en/docs/howto/security/best-practices-security.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for App Security"
+linktitle: "Best Practices for App Security"
 url: /howto/security/best-practices-security/
 category: "Security"
 weight: 20

--- a/content/en/docs/howto/testing/testing-microflows-using-the-unittesting-module.md
+++ b/content/en/docs/howto/testing/testing-microflows-using-the-unittesting-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Test Microflows Using the Unit Testing Module"
+linktitle: "Test Microflows Using Unit Test Module"
 url: /howto/testing/testing-microflows-using-the-unittesting-module/
 category: "Testing"
 weight: 10

--- a/content/en/docs/howto7/collaboration-requirements-management/on-premises-svn-howto.md
+++ b/content/en/docs/howto7/collaboration-requirements-management/on-premises-svn-howto.md
@@ -1,5 +1,6 @@
 ---
 title: "Work with an On-Premises Version Control Server"
+linktitle: "On-Premises Version Control Server"
 url: /howto7/collaboration-requirements-management/on-premises-svn-howto/
 category: "Collaboration & Requirements Management"
 weight: 60

--- a/content/en/docs/howto7/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
+++ b/content/en/docs/howto7/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshoot Network Issues for Connecting to Team Server"
+linktitle: "Team Server Network Issues"
 url: /howto7/collaboration-requirements-management/troubleshoot-network-issues-for-team-server/
 category: "Collaboration & Requirements Management"
 weight: 14

--- a/content/en/docs/howto7/extensibility/charts-tutorials/charts-advanced-tuning.md
+++ b/content/en/docs/howto7/extensibility/charts-tutorials/charts-advanced-tuning.md
@@ -1,5 +1,6 @@
 ---
 title: "Fine-Tune a Chart with Advanced Settings"
+linktitle: "Chart Advanced Tuning"
 url: /howto7/extensibility/charts-advanced-tuning/
 weight: 30
 description: "Describes the settings you can use to change chart layouts and types"

--- a/content/en/docs/howto7/extensibility/charts-tutorials/charts-plotly-images-rest.md
+++ b/content/en/docs/howto7/extensibility/charts-tutorials/charts-plotly-images-rest.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the Plotly Images REST Service Endpoint"
+linktitle: "Plotly Images REST Endpoint"
 url: /howto7/extensibility/charts-plotly-images-rest/
 weight: 70
 tags: ["Charts", "Plotly", "REST", "Desktop Modeler", "Widget"]

--- a/content/en/docs/howto7/extensibility/howto-connector-kit.md
+++ b/content/en/docs/howto7/extensibility/howto-connector-kit.md
@@ -1,13 +1,11 @@
 ---
 title: "Build Microflow Actions Using the Mendix Connector Kit"
+linktitle: "Microflow Actions Using Connector Kit"
 url: /howto7/extensibility/howto-connector-kit/
 category: "Extensibility"
 description: "Describes creating custom Microflow actions using advanced Connector Kit options."
 weight: 4
 tags: ["java", "connector kit", "microflow action", "parameter type", "aws", "amazon web services"]
-output:
-  word_document: default
-  html_document: default
 #To update screenshots of these microflows in the Desktop Modeler, use the SlackRekognition-main-master app, which is saved locally in Other Resources > Documentation Backups (No Update).
 ---
 

--- a/content/en/docs/howto7/extensibility/howto-datastorage-api.md
+++ b/content/en/docs/howto7/extensibility/howto-datastorage-api.md
@@ -1,13 +1,11 @@
 ---
 title: "Use Mendix Data Storage APIs to Build Reusable microflow Actions"
+linktitle: "Data Storage APIs for Reusable Microflows"
 url: /howto7/extensibility/howto-datastorage-api/
 category: "Extensibility"
 weight: 5
 description: "Describes creating custom microflow actions using Data Storage APIs."
 tags: ["java", "connector kit", "microflow action", "parameter type", "sql", "xpath", "oql", "datastorage"]
-output:
-  word_document: default
-  html_document: default
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto7/front-end/atlas-ui/create-custom-preview-images-for-building-blocks-and-page-templates.md
+++ b/content/en/docs/howto7/front-end/atlas-ui/create-custom-preview-images-for-building-blocks-and-page-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Custom Preview Images for Building Blocks & Page Templates"
+linktitle: "Custom Preview Images"
 url: /howto7/front-end/create-custom-preview-images-for-building-blocks-and-page-templates/
 weight: 50
 tags: ["Atlas", "UI", "UX", "user experience"]

--- a/content/en/docs/howto7/front-end/atlas-ui/extend-design-properties-to-customize-the-web-modeler-experience.md
+++ b/content/en/docs/howto7/front-end/atlas-ui/extend-design-properties-to-customize-the-web-modeler-experience.md
@@ -1,5 +1,6 @@
 ---
 title: "Extend Design Properties to Customize Your Web Modeler Experience"
+linktitle: "Extend Design Properties"
 url: /howto7/front-end/extend-design-properties-to-customize-the-web-modeler-experience/
 weight: 60
 tags: ["Atlas", "UI", "UX", "user experience", "customize", "custom", "studio"]

--- a/content/en/docs/howto7/front-end/create-your-first-two-overview-and-detail-pages.md
+++ b/content/en/docs/howto7/front-end/create-your-first-two-overview-and-detail-pages.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Two Overview & Detail Pages"
+linktitle: "Create Overview & Detail Pages"
 url: /howto7/front-end/create-your-first-two-overview-and-detail-pages/
 category: "Front End"
 weight: 20

--- a/content/en/docs/howto7/general/community-best-practices-for-app-performance.md
+++ b/content/en/docs/howto7/general/community-best-practices-for-app-performance.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Community Best Practices for App Performance"
+linktitle: "Best Practices for App Performance"
 url: /howto7/general/community-best-practices-for-app-performance/
 category: "General"
 weight: 4

--- a/content/en/docs/howto7/general/dev-best-practices.md
+++ b/content/en/docs/howto7/general/dev-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for Development"
+linktitle: "Best Practices for Development"
 url: /howto7/general/dev-best-practices/
 category: "General"
 weight: 3

--- a/content/en/docs/howto7/general/minimize-number.md
+++ b/content/en/docs/howto7/general/minimize-number.md
@@ -1,5 +1,6 @@
 ---
 title: "Minimize the Number of In-Use Objects in Your Session"
+linktitle: "Minimize Objects in Session"
 url: /howto7/general/minimize-number/
 category: "General"
 weight: 8

--- a/content/en/docs/howto7/integration/execute-an-sql-statement-on-an-external-database.md
+++ b/content/en/docs/howto7/integration/execute-an-sql-statement-on-an-external-database.md
@@ -1,5 +1,6 @@
 ---
 title: "Execute an SQL Statement on an External Database"
+linktitle: "Execute SQL on External Database"
 url: /howto7/integration/execute-an-sql-statement-on-an-external-database/
 category: "Integration"
 weight: 17

--- a/content/en/docs/howto7/integration/implement-cicd-pipeline.md
+++ b/content/en/docs/howto7/integration/implement-cicd-pipeline.md
@@ -1,5 +1,6 @@
 ---
-title: "Implement a Simple CICD Pipeline with Mendix APIs"
+title: "Implement a Simple CI/CD Pipeline with Mendix APIs"
+linktitle: "Implement CI/CD Pipeline"
 url: /howto7/integration/implement-cicd-pipeline/
 category: "Integration"
 tags: ["cicd", "continuous", "integration", "delivery", "deployment", "automation", "testing"]

--- a/content/en/docs/howto7/integration/integrating-a-legacy-system-into-a-mendix-app.md
+++ b/content/en/docs/howto7/integration/integrating-a-legacy-system-into-a-mendix-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Integrate a Legacy System into a Mendix App"
+linktitle: "Legacy System in Mendix App"
 url: /howto7/integration/integrating-a-legacy-system-into-a-mendix-app/
 category: "Integration"
 weight: 1

--- a/content/en/docs/howto7/integration/integrating-a-legacy-system-into-a-mendix-app.md
+++ b/content/en/docs/howto7/integration/integrating-a-legacy-system-into-a-mendix-app.md
@@ -1,6 +1,6 @@
 ---
 title: "Integrate a Legacy System into a Mendix App"
-linktitle: "Legacy System in Mendix App"
+linktitle: "Integrate Legacy System"
 url: /howto7/integration/integrating-a-legacy-system-into-a-mendix-app/
 category: "Integration"
 weight: 1

--- a/content/en/docs/howto7/integration/publish-data-to-other-mendix-apps-using-an-app-service.md
+++ b/content/en/docs/howto7/integration/publish-data-to-other-mendix-apps-using-an-app-service.md
@@ -1,5 +1,6 @@
 ---
 title: "Publish Data to Other Mendix Apps Using an App Service"
+linktitle: "Publish Data Using App Service"
 url: /howto7/integration/publish-data-to-other-mendix-apps-using-an-app-service/
 category: "Integration"
 weight: 14

--- a/content/en/docs/howto7/logic-business-rules/create-your-first-microflow-hello-world.md
+++ b/content/en/docs/howto7/logic-business-rules/create-your-first-microflow-hello-world.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Microflow: Hello World!"
+linktitle: "Your First Microflow"
 url: /howto7/logic-business-rules/create-your-first-microflow-hello-world/
 category: "Logic & Business Rules"
 weight: 1

--- a/content/en/docs/howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow.md
+++ b/content/en/docs/howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow.md
@@ -1,6 +1,6 @@
 ---
 title: "Drag Microflows & Pages into a Microflow"
-linktitle: "Drag Items into Microflow"
+linktitle: "Drag App Documents into Microflow"
 url: /howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow/
 category: "Logic & Business Rules"
 weight: 4

--- a/content/en/docs/howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow.md
+++ b/content/en/docs/howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow.md
@@ -1,5 +1,6 @@
 ---
 title: "Drag Microflows & Pages into a Microflow"
+linktitle: "Drag Items into Microflow"
 url: /howto7/logic-business-rules/drag-microflows-and-pages-into-a-microflow/
 category: "Logic & Business Rules"
 weight: 4

--- a/content/en/docs/howto7/logic-business-rules/filtering-data-on-an-overview-page.md
+++ b/content/en/docs/howto7/logic-business-rules/filtering-data-on-an-overview-page.md
@@ -1,5 +1,6 @@
 ---
 title: "Filter Data on an Overview Page Using XPath"
+linktitle: "Filter Data Using XPath"
 url: /howto7/logic-business-rules/filtering-data-on-an-overview-page/
 category: "Logic & Business Rules"
 tags: ["filter", "xpath"]

--- a/content/en/docs/howto7/mobile/feedback-widget-ios.md
+++ b/content/en/docs/howto7/mobile/feedback-widget-ios.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure the Mendix Feedback Widget for iOS"
+linktitle: "Configure iOS Mendix Feedback Widget"
 url: /howto7/mobile/feedback-widget-ios/
 category: "Mobile Development"
 weight: 20

--- a/content/en/docs/howto7/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/en/docs/howto7/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement SSO on a Hybrid App with Mendix & SAML"
+linktitle: "SSO on Hybrid App with SAML"
 url: /howto7/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml/
 category: "Mobile Development"
 weight: 30

--- a/content/en/docs/howto7/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
+++ b/content/en/docs/howto7/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
@@ -1,5 +1,6 @@
 ---
 title: "Publish a Mendix Hybrid Mobile App in Mobile App Stores"
+linktitle: "Publish Hybrid App in App Stores"
 url: /howto7/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores/
 category: "Mobile Development"
 weight: 60

--- a/content/en/docs/howto7/mobile/push-notifications/setting-up-apple-push-notification-server.md
+++ b/content/en/docs/howto7/mobile/push-notifications/setting-up-apple-push-notification-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up the Apple Push Notification Server"
+linktitle: "Apple Push Notification Server"
 url: /howto7/mobile/setting-up-apple-push-notification-server/
 weight: 30
 tags: ["mobile", "push notification", "apple", "server"]

--- a/content/en/docs/howto7/mobile/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/howto7/mobile/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up the Google Firebase Cloud Messaging Server"
+linktitle: "Set Up Firebase Cloud Messaging"
 url: /howto7/mobile/setting-up-google-firebase-cloud-messaging-server/
 weight: 40
 tags: ["mobile", "push notification", "google", "firebase", "server"]

--- a/content/en/docs/howto7/monitoring-troubleshooting/manage-application-performance-with-new-relic.md
+++ b/content/en/docs/howto7/monitoring-troubleshooting/manage-application-performance-with-new-relic.md
@@ -1,5 +1,6 @@
 ---
 title: "Manage Application Performance with New Relic"
+linktitle: "New Relic App Performance"
 url: /howto7/monitoring-troubleshooting/manage-application-performance-with-new-relic/
 category: "Monitoring & Troubleshooting"
 weight: 13

--- a/content/en/docs/howto7/security/best-practices-security.md
+++ b/content/en/docs/howto7/security/best-practices-security.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for App Security"
+linktitle: "Best Practices for App Security"
 url: /howto7/security/best-practices-security/
 category: "Security"
 weight: 20

--- a/content/en/docs/howto7/testing/testing-mendix-applications-using-selenium-ide.md
+++ b/content/en/docs/howto7/testing/testing-mendix-applications-using-selenium-ide.md
@@ -1,5 +1,6 @@
 ---
 title: "Test Mendix Applications Using Selenium IDE"
+linktitle: "Test Apps Using Selenium IDE"
 url: /howto7/testing/testing-mendix-applications-using-selenium-ide/
 category: "Testing"
 weight: 40

--- a/content/en/docs/howto7/testing/testing-microflows-using-the-unittesting-module.md
+++ b/content/en/docs/howto7/testing/testing-microflows-using-the-unittesting-module.md
@@ -1,5 +1,6 @@
 ---
-title: "Test Microflows Using the UnitTesting Module"
+title: "Test Microflows Using the Unit Testing Module"
+linktitle: "Test Microflows Using Unit Test Module"
 url: /howto7/testing/testing-microflows-using-the-unittesting-module/
 category: "Testing"
 weight: 10

--- a/content/en/docs/howto7/widget-development/add-a-preview-image-for-custom-widget.md
+++ b/content/en/docs/howto7/widget-development/add-a-preview-image-for-custom-widget.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Preview Image for a Custom Widget"
+linktitle: "Preview Image for Custom Widget"
 url: /howto7/widget-development/add-a-preview-image-for-custom-widget/
 category: "Widget Development"
 tags: ["image", "preview", "widget", "custom"]

--- a/content/en/docs/howto7/widget-development/scaffold-a-widget-with-the-yeoman-widget-generator.md
+++ b/content/en/docs/howto7/widget-development/scaffold-a-widget-with-the-yeoman-widget-generator.md
@@ -1,5 +1,6 @@
 ---
 title: "Scaffold a Widget with the Yeoman Widget Generator"
+linktitle: "Scaffold Widget with Yeoman"
 url: /howto7/widget-development/scaffold-a-widget-with-the-yeoman-widget-generator/
 category: "Widget Development"
 tags: ["widget", "develop widget", "scaffold", "yeoman"]

--- a/content/en/docs/howto7/widget-development/use-the-widget-development-plugin-for-adobe-brackets.md
+++ b/content/en/docs/howto7/widget-development/use-the-widget-development-plugin-for-adobe-brackets.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the Widget Development Plugin for Adobe Brackets"
+linktitle: "Adobe Brackets Widget Development Plugin"
 url: /howto7/widget-development/use-the-widget-development-plugin-for-adobe-brackets/
 category: "Widget Development"
 tags: ["widget", "develop widget", "plugin", "adobe", "brackets"]

--- a/content/en/docs/howto8/collaboration-requirements-management/on-premises-svn-howto.md
+++ b/content/en/docs/howto8/collaboration-requirements-management/on-premises-svn-howto.md
@@ -1,5 +1,6 @@
 ---
 title: "Work with an On-Premises Version Control Server"
+linktitle: "On-Premises Version Control Server"
 url: /howto8/collaboration-requirements-management/on-premises-svn-howto/
 category: "Collaboration"
 weight: 60

--- a/content/en/docs/howto8/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
+++ b/content/en/docs/howto8/collaboration-requirements-management/troubleshoot-network-issues-for-team-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshoot Network Issues for Connecting to Team Server"
+linktitle: "Team Server Network Issues"
 url: /howto8/collaboration-requirements-management/troubleshoot-network-issues-for-team-server/
 category: "Collaboration"
 weight: 14

--- a/content/en/docs/howto8/extensibility/best-practices-javascript-actions.md
+++ b/content/en/docs/howto8/extensibility/best-practices-javascript-actions.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for JavaScript Actions"
+linktitle: "JavaScript Actions Best Practices"
 url: /howto8/extensibility/best-practices-javascript-actions/
 category: "Extensibility"
 weight: 60

--- a/content/en/docs/howto8/extensibility/build-javascript-actions/write-javascript-actions.md
+++ b/content/en/docs/howto8/extensibility/build-javascript-actions/write-javascript-actions.md
@@ -1,5 +1,6 @@
 ---
 title: "Build JavaScript Actions: Part 1 (Basic)"
+linktitle: "1. Build JavaScript Actions"
 url: /howto8/extensibility/write-javascript-actions/
 weight: 10
 description: "This how-to will teach you to create a JavaScript action."

--- a/content/en/docs/howto8/extensibility/build-javascript-actions/write-javascript-github.md
+++ b/content/en/docs/howto8/extensibility/build-javascript-actions/write-javascript-github.md
@@ -1,5 +1,6 @@
 ---
 title: "Build JavaScript Actions: Part 2 (Advanced)"
+linktitle: "2. Build JavaScript Actions"
 url: /howto8/extensibility/write-javascript-github/
 weight: 20
 description: "This advanced how-to will teach you to make a JavaScript action which can search for GitHub users."

--- a/content/en/docs/howto8/extensibility/howto-connector-kit.md
+++ b/content/en/docs/howto8/extensibility/howto-connector-kit.md
@@ -1,13 +1,11 @@
 ---
 title: "Build Microflow Actions Using the Mendix Connector Kit"
+linktitle: "Microflow Actions Using Connector Kit"
 url: /howto8/extensibility/howto-connector-kit/
 category: "Extensibility"
 description: "Describes creating custom Microflow actions using advanced Connector Kit options."
 weight: 80
 tags: ["java", "connector kit", "microflow action", "parameter type", "aws", "amazon web services"]
-output:
-  word_document: default
-  html_document: default
 #To update screenshots of these microflows in Studio Pro, use the SlackRekognition-main-master app, which is saved locally in Other Resources > Documentation Backups (No Update).
 ---
 

--- a/content/en/docs/howto8/extensibility/howto-datastorage-api.md
+++ b/content/en/docs/howto8/extensibility/howto-datastorage-api.md
@@ -1,13 +1,11 @@
 ---
 title: "Use Mendix Data Storage APIs to Build Reusable Microflow Actions"
+linktitle: "Data Storage APIs for Reusable Microflows"
 url: /howto8/extensibility/howto-datastorage-api/
 category: "Extensibility"
 weight: 90
 description: "Describes creating custom microflow actions using Data Storage APIs."
 tags: ["java", "connector kit", "microflow action", "parameter type", "sql", "xpath", "oql", "datastorage"]
-output:
-  word_document: default
-  html_document: default
 ---
 
 ## 1 Introduction

--- a/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Pluggable Web Widget: Part 1"
+linktitle: "1. Build Pluggable Web Widget"
 url: /howto8/extensibility/create-a-pluggable-widget-one/
 weight: 10
 description: "This how-to will teach you to create a pluggable web widget."

--- a/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-two.md
+++ b/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-two.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Pluggable Web Widget: Part 2 (Advanced)"
+linktitle: "2. Build Pluggable Web Widget"
 url: /howto8/extensibility/create-a-pluggable-widget-two/
 weight: 20
 description: "This how-to will teach you how to add advanced features to your TextBox input widget."

--- a/content/en/docs/howto8/extensibility/widget-development/add-a-preview-image-for-custom-widget.md
+++ b/content/en/docs/howto8/extensibility/widget-development/add-a-preview-image-for-custom-widget.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Preview Image for a Custom Widget"
+linktitle: "Preview Image for Custom Widget"
 url: /howto8/extensibility/add-a-preview-image-for-custom-widget/
 tags: ["image", "preview", "widget", "custom"]
 ---

--- a/content/en/docs/howto8/front-end/atlas-ui/create-custom-preview-images-for-building-blocks-and-page-templates.md
+++ b/content/en/docs/howto8/front-end/atlas-ui/create-custom-preview-images-for-building-blocks-and-page-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Custom Preview Images for Building Blocks & Page Templates"
+linktitle: "Custom Preview Images"
 url: /howto8/front-end/create-custom-preview-images-for-building-blocks-and-page-templates/
 weight: 50
 tags: ["Atlas", "UI", "UX", "user experience"]

--- a/content/en/docs/howto8/front-end/atlas-ui/extend-design-properties-to-customize.md
+++ b/content/en/docs/howto8/front-end/atlas-ui/extend-design-properties-to-customize.md
@@ -1,5 +1,6 @@
 ---
 title: "Extend Design Properties to Customize Your Studio Experience"
+linktitle: "Extend Design Properties"
 url: /howto8/front-end/extend-design-properties-to-customize/
 weight: 60
 tags: ["Atlas", "UI", "UX", "user experience", "Studio", "customize", "custom"]

--- a/content/en/docs/howto8/front-end/charts-tutorials/charts-advanced-tuning.md
+++ b/content/en/docs/howto8/front-end/charts-tutorials/charts-advanced-tuning.md
@@ -1,5 +1,6 @@
 ---
 title: "Fine-Tune a Chart with Advanced Settings"
+linktitle: "Chart Advanced Tuning"
 url: /howto8/front-end/charts-advanced-tuning/
 weight: 30
 description: "Describes the settings you can use to change chart layouts and types"

--- a/content/en/docs/howto8/front-end/charts-tutorials/charts-plotly-images-rest.md
+++ b/content/en/docs/howto8/front-end/charts-tutorials/charts-plotly-images-rest.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the Plotly Images REST Service Endpoint"
+linktitle: "Plotly Images REST Endpoint"
 url: /howto8/front-end/charts-plotly-images-rest/
 weight: 70
 tags: ["Charts", "Plotly", "REST", "Studio Pro", "Widget"]

--- a/content/en/docs/howto8/front-end/create-your-first-two-overview-and-detail-pages.md
+++ b/content/en/docs/howto8/front-end/create-your-first-two-overview-and-detail-pages.md
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Two Overview & Detail Pages"
+linktitle: "Create Overview & Detail Pages"
 url: /howto8/front-end/create-your-first-two-overview-and-detail-pages/
 category: "Front End"
 weight: 25

--- a/content/en/docs/howto8/general/community-best-practices-for-app-performance.md
+++ b/content/en/docs/howto8/general/community-best-practices-for-app-performance.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Community Best Practices for App Performance"
+linktitle: "Best Practices for App Performance"
 url: /howto8/general/community-best-practices-for-app-performance/
 category: "General Info"
 weight: 8

--- a/content/en/docs/howto8/general/dev-best-practices.md
+++ b/content/en/docs/howto8/general/dev-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Mendix Best Practices for Development"
+linktitle: "Best Practices for Development"
 url: /howto8/general/dev-best-practices/
 category: "General Info"
 weight: 7

--- a/content/en/docs/howto8/general/minimize-number.md
+++ b/content/en/docs/howto8/general/minimize-number.md
@@ -1,5 +1,6 @@
 ---
 title: "Minimize the Number of In-Use Objects in Your Session"
+linktitle: "Minimize Objects in Session"
 url: /howto8/general/minimize-number/
 category: "General Info"
 weight: 6

--- a/content/en/docs/howto8/integration/execute-an-sql-statement-on-an-external-database.md
+++ b/content/en/docs/howto8/integration/execute-an-sql-statement-on-an-external-database.md
@@ -1,5 +1,6 @@
 ---
 title: "Execute an SQL Statement on an External Database"
+linktitle: "Execute SQL on External Database"
 url: /howto8/integration/execute-an-sql-statement-on-an-external-database/
 category: "Integration"
 weight: 17

--- a/content/en/docs/howto8/integration/implement-cicd-pipeline.md
+++ b/content/en/docs/howto8/integration/implement-cicd-pipeline.md
@@ -1,5 +1,6 @@
 ---
-title: "Implement a Simple CICD Pipeline with Mendix APIs"
+title: "Implement a Simple CI/CD Pipeline with Mendix APIs"
+linktitle: "Implement CI/CD Pipeline"
 url: /howto8/integration/implement-cicd-pipeline/
 category: "Integration"
 tags: ["cicd", "continuous", "integration", "delivery", "deployment", "automation", "testing"]

--- a/content/en/docs/howto8/logic-business-rules/extending-your-application-with-custom-java.md
+++ b/content/en/docs/howto8/logic-business-rules/extending-your-application-with-custom-java.md
@@ -1,5 +1,6 @@
 ---
 title: "Extend Your Application with Custom Java"
+linktitle: "Extend App with Custom Java"
 url: /howto8/logic-business-rules/extending-your-application-with-custom-java/
 category: "Logic & Business Rules"
 weight: 12

--- a/content/en/docs/howto8/logic-business-rules/filtering-data-on-an-overview-page.md
+++ b/content/en/docs/howto8/logic-business-rules/filtering-data-on-an-overview-page.md
@@ -1,5 +1,6 @@
 ---
 title: "Filter Data on an Overview Page Using XPath"
+linktitle: "Filter Data Using XPath"
 url: /howto8/logic-business-rules/filtering-data-on-an-overview-page/
 category: "Logic & Business Rules"
 tags: ["filter", "xpath"]

--- a/content/en/docs/howto8/logic-business-rules/server-side-paging.md
+++ b/content/en/docs/howto8/logic-business-rules/server-side-paging.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Server-Side Paging and Sorting for a Microflow Data Source"
+linktitle: "Server-Side Paging & Sorting"
 url: /howto8/logic-business-rules/server-side-paging/
 category: "Logic & Business Rules"
 description: "This how-to will teach you how to create a data grid with a microflow data source which retrieves data from a REST service, and then add server-side paging and sorting to it."

--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores.md
@@ -1,5 +1,6 @@
 ---
 title: "Publish a Mendix Hybrid Mobile App in Mobile App Stores"
+linktitle: "Publish Hybrid Mobile App in App Stores"
 url: /howto8/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores/
 weight: 20
 tags: ["mobile", "marketplace", "phonegap"]

--- a/content/en/docs/howto8/mobile/hybrid-mobile/feedback-widget-ios.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/feedback-widget-ios.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure the Mendix Feedback Widget for iOS"
+linktitle: "Configure iOS Mendix Feedback Widget"
 url: /howto8/mobile/feedback-widget-ios/
 weight: 20
 description: "How to configure ios security settings to render the feedback widget's content"

--- a/content/en/docs/howto8/mobile/hybrid-mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement SSO on a Hybrid App with Mendix & SAML"
+linktitle: "SSO on Hybrid App with SAML"
 url: /howto8/mobile/implement-sso-on-a-hybrid-app-with-mendix-and-saml/
 weight: 30
 description: "Describes how to address the challenges of implementing SSO in hybrid mobile apps."

--- a/content/en/docs/howto8/mobile/hybrid-mobile/push-notifications/setting-up-apple-push-notification-server.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/push-notifications/setting-up-apple-push-notification-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up the Apple Push Notification Server"
+linktitle: "Apple Push Notification Server"
 url: /howto8/mobile/setting-up-apple-push-notification-server/
 weight: 30
 tags: ["mobile", "push notification", "apple", "server"]

--- a/content/en/docs/howto8/mobile/hybrid-mobile/push-notifications/testing-the-implementation.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/push-notifications/testing-the-implementation.md
@@ -1,5 +1,6 @@
 ---
 title: "Test the Push Notifications Implementation"
+linktitle: "Test Push Notifications"
 url: /howto8/mobile/testing-the-implementation/
 weight: 60
 tags: ["mobile", "push notification"]

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/deploying-native-app.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/deploying-native-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Your First Mendix Native Mobile App"
+linktitle: "Deploy Mendix Native Mobile App"
 url: /howto8/mobile/deploying-native-app/
 weight: 10
 description: Describes how to deploy your first Mendix native mobile app with the Mendix Native Mobile Builder.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/native-build-locally-manually.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/native-build-locally-manually.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Mendix Native Mobile App Locally Manually"
+linktitle: "Local Native Mobile App Manual Build"
 url: /howto8/mobile/native-build-locally-manually/
 weight: 30
 description: Describes how to build your first Mendix native mobile app locally manually.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/native-build-locally.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/native-build-locally.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Mendix Native Mobile App Locally using Mendix Native Builder"
+linktitle: "Build Local Native Mobile App"
 url: /howto8/mobile/native-build-locally/
 weight: 30
 description: Describes how to build your first Mendix native mobile app locally using the Mendix Native Mobile Builder.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/_index.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Build Apps Using the Native Builder CLI"
+linktitle: "Build Apps Using Native Builder CLI"
 url: /howto8/mobile/use-cli-docs/
 weight: 89
 description: Tutorials for building native mobile apps using the Native Builder CLI.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/deploying-native-app-cli.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/deploying-native-app-cli.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Your First Mendix Native Mobile App with the Native Builder CLI"
+linktitle: "Deploy Mobile App with Native Builder CLI"
 url: /howto8/mobile/deploying-native-app-cli/
 weight: 20
 description: Describes how to deploy your first Mendix native mobile app with the Native Builder.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/how-to-devapps-cli.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/how-to-devapps-cli.md
@@ -1,5 +1,6 @@
 ---
 title: "Create a Custom Developer App with the Native Builder CLI"
+linktitle: "Custom Developer App with Native Builder CLI"
 url: /howto8/mobile/how-to-devapps-cli/
 weight: 30
 description: A tutorial for creating custom developer apps.

--- a/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/how-to-ota-cli.md
+++ b/content/en/docs/howto8/mobile/native-mobile/build-native-apps/use-cli-docs/how-to-ota-cli.md
@@ -1,5 +1,6 @@
 ---
 title: "Release Over the Air Updates with App Center's CodePush using the CLI"
+linktitle: "Over the Air Updates with CodePush & CLI"
 url: /howto8/mobile/how-to-ota-cli/
 weight: 71
 description: A tutorial for pushing over the air updates (OTA).

--- a/content/en/docs/howto8/mobile/native-mobile/how-to-ota.md
+++ b/content/en/docs/howto8/mobile/native-mobile/how-to-ota.md
@@ -1,5 +1,6 @@
 ---
 title: "Release Over the Air Updates with App Center's CodePush"
+linktitle: "Over the Air Updates with CodePush"
 url: /howto8/mobile/how-to-ota/
 weight: 71
 description: A tutorial for pushing over the air updates (OTA) using App Center's CodePush.

--- a/content/en/docs/howto8/mobile/native-mobile/native-deep-link.md
+++ b/content/en/docs/howto8/mobile/native-mobile/native-deep-link.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Deep Links in Native Mobile Apps"
+linktitle: "Deep Links in Native Mobile Apps"
 url: /howto8/mobile/native-deep-link/
 weight: 75
 description: "Connect URLs to your native mobile app by adding a deep link."

--- a/content/en/docs/howto8/mobile/native-mobile/notifications/notif-build-native.md
+++ b/content/en/docs/howto8/mobile/native-mobile/notifications/notif-build-native.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Native App with Push Notifications Enabled"
+linktitle: "Native App with Push Notifications"
 url: /howto8/mobile/notif-build-native/
 weight: 60
 description: Tutorial for building a native app with push notifications enabled.

--- a/content/en/docs/howto8/mobile/native-mobile/notifications/notif-implement-module.md
+++ b/content/en/docs/howto8/mobile/native-mobile/notifications/notif-implement-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement the Push Notifications Module"
+linktitle: "Push Notifications Module"
 url: /howto8/mobile/notif-implement-module/
 weight: 54
 description: Tutorial for implementing the push notification module.

--- a/content/en/docs/howto8/mobile/native-mobile/notifications/notif-implement-native.md
+++ b/content/en/docs/howto8/mobile/native-mobile/notifications/notif-implement-native.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Push Notifications in Your Native App"
+linktitle: "Push Notifications in Native App"
 url: /howto8/mobile/notif-implement-native/
 weight: 58
 description: Tutorial for implementing push notifications in a native app.

--- a/content/en/docs/howto8/mobile/native-mobile/notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/howto8/mobile/native-mobile/notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Up the Google Firebase Cloud Messaging Server"
+linktitle: "Set Up Firebase Cloud Messaging"
 url: /howto8/mobile/setting-up-google-firebase-cloud-messaging-server/
 weight: 55
 tags: ["mobile", "push notification", "google", "firebase", "server"]

--- a/content/en/docs/howto8/mobile/native-mobile/ui-best-practices.md
+++ b/content/en/docs/howto8/mobile/native-mobile/ui-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for Native Mobile App UI"
+linktitle: "Native Mobile App UI Best Practices"
 url: /howto8/mobile/ui-best-practices/
 weight: 35
 description: "This document will teach you how to build a native mobile app's UI."

--- a/content/en/docs/howto8/security/best-practices-security.md
+++ b/content/en/docs/howto8/security/best-practices-security.md
@@ -1,5 +1,6 @@
 ---
 title: "Implement Best Practices for App Security"
+linktitle: "Best Practices for App Security"
 url: /howto8/security/best-practices-security/
 category: "Security"
 weight: 20

--- a/content/en/docs/howto8/testing/testing-microflows-using-the-unittesting-module.md
+++ b/content/en/docs/howto8/testing/testing-microflows-using-the-unittesting-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Test Microflows Using the Unit Testing Module"
+linktitle: "Test Microflows Using Unit Test Module"
 url: /howto8/testing/testing-microflows-using-the-unittesting-module/
 category: "Testing"
 weight: 10

--- a/content/en/docs/partners/sap/sap-autoscaler.md
+++ b/content/en/docs/partners/sap/sap-autoscaler.md
@@ -1,5 +1,6 @@
 ---
 title: "Application Autoscaler for SAP Business Technology Platform"
+linktitle: "Application Autoscaler for SAP BTP"
 url: /partners/sap/sap-autoscaler/
 category: "SAP"
 weight: 47

--- a/content/en/docs/partners/sap/sap-destination-with-rest.md
+++ b/content/en/docs/partners/sap/sap-destination-with-rest.md
@@ -1,5 +1,6 @@
 ---
 title: "Use an SAP Connectivity Service with REST and SOAP"
+linktitle: "Use SAP Connectivity Service with REST & SOAP"
 url: /partners/sap/sap-destination-with-rest/
 category: "SAP"
 weight: 25

--- a/content/en/docs/partners/sap/sap-postgresql-on-aws.md
+++ b/content/en/docs/partners/sap/sap-postgresql-on-aws.md
@@ -1,5 +1,6 @@
 ---
 title: "PostgreSQL on Amazon (AWS) for SAP Business Technology Platform"
+linktitle: "PostgreSQL on AWS for SAP BTP"
 url: /partners/sap/sap-postgresql-on-aws/
 category: "SAP"
 weight: 48

--- a/content/en/docs/partners/sap/sap-xsuaa-connector.md
+++ b/content/en/docs/partners/sap/sap-xsuaa-connector.md
@@ -1,5 +1,6 @@
 ---
 title: "XSUAA Connector for SAP Business Technology Platform"
+linktitle: "XSUAA Connector for SAP BTP"
 url: /partners/sap/sap-xsuaa-connector/
 category: "SAP"
 weight: 40

--- a/content/en/docs/partners/sap/use-sap-odata-connector.md
+++ b/content/en/docs/partners/sap/use-sap-odata-connector.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the OData Connector for SAP Solutions"
+linktitle: "Use OData Connector for SAP Solutions"
 url: /partners/sap/use-sap-odata-connector/
 category: "SAP"
 weight: 15

--- a/content/en/docs/partners/sap/use-sap-xsuaa-connector.md
+++ b/content/en/docs/partners/sap/use-sap-xsuaa-connector.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the XSUAA Connector for SAP Business Technology Platform"
+linktitle: "Use XSUAA Connector for SAP BTP"
 url: /partners/sap/use-sap-xsuaa-connector/
 category: "SAP"
 weight: 45

--- a/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-example-app.md
+++ b/content/en/docs/partners/siemens/mindsphere/mendix-on-mindsphere/mindsphere-example-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Use the Siemens MindSphere Operations Insight Example App"
+linktitle: "Siemens MindSphere Operations Insight App"
 url: /partners/siemens/mindsphere-example-app/
 weight: 110
 tags: ["Siemens", "MindSphere", "Example", "Operations Insight", "Time Series", "REST", "API"]

--- a/content/en/docs/refguide/mobile/distributing-mobile-apps/_index.md
+++ b/content/en/docs/refguide/mobile/distributing-mobile-apps/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Building, Testing, and Distributing Apps"
+linktitle: "Build, Test, Distribute Apps"
 url: /refguide/mobile/distributing-mobile-apps/
 category: Mobile
 weight: 50

--- a/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/deploying-native-app.md
+++ b/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/deploying-native-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Your First Mendix Native Mobile App"
+linktitle: "Deploy Mendix Native Mobile App"
 url: /refguide/mobile/distributing-mobile-apps/building-native-apps/deploying-native-app/
 weight: 10
 description: Describes how to deploy your first Mendix native mobile app with the Mendix Native Mobile Builder.

--- a/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/native-build-locally-manually.md
+++ b/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/native-build-locally-manually.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Mendix Native App Locally Manually"
+linktitle: "Native App Local Manual Build"
 url: /refguide/mobile/distributing-mobile-apps/building-native-apps/native-build-locally-manually/
 weight: 30
 description: Describes how to build your first Mendix native mobile app locally, without using the Mendix Native Mobile Builder.

--- a/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: "Native App Prerequisites and Troubleshooting" 
+linktitle: "Prerequisites and Troubleshooting"
 url: /refguide/mobile/getting-started-with-mobile/prerequisites/
 weight: 10
 description: Troubleshoot common issues associated with building and running native mobile apps.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-add-module-depends.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-add-module-depends.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 1: Add Module Dependencies"
+linktitle: "1. Add Module Dependencies"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-add-module-depends/
 weight: 20
 description: Tutorial for adding push notification module dependencies.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-build-native.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-build-native.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 6: Build a Native App with Push Notifications Enabled"
+linktitle: "6. Native App with Push Notifications"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-build-native/
 weight: 70
 description: Tutorial for building a native app with push notifications enabled.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-config-push.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-config-push.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 4: Configure Push Notifications"
+linktitle: "4. Configure Push Notifications"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-config-push/
 weight: 50
 description: Tutorial for configuring push notifications.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-module.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 2: Implement the Push Notifications Module"
+linktitle: "2. Push Notifications Module"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-module/
 weight: 30
 description: Tutorial for implementing the push notification module.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-native.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-native.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 5: Implement Push Notifications in Your Native App"
+linktitle: "5. Push Notifications in Native App"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-implement-native/
 weight: 60
 description: Tutorial for implementing push notifications in a native app.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-mult-devices.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-mult-devices.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 8: Send Notifications to Multiple Devices"
+linktitle: "8. Notifications to Multiple Devices"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-mult-devices/
 weight: 90
 description: Learn to send notifications to multiple devices with the Native Mobile Builder.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-send-test.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/notif-send-test.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 7: Send Your First Test Push Notification"
+linktitle: "7. Test Push Notification"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/notif-send-test/
 weight: 80
 description: Tutorial for testing your push notifications.

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Part 3: Set Up the Google Firebase Cloud Messaging Server"
+linktitle: "3. Set Up Firebase Cloud Messaging"
 url: /refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server/
 weight: 40
 description: Tutorial for configuring push notifications.

--- a/content/en/docs/refguide/modeling/application-logic/expressions/subtract-date-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/subtract-date-function-calls.md
@@ -1,7 +1,6 @@
 ---
 title: "Subtract Date Function Calls"
 url: /refguide/subtract-date-function-calls/
-parent: "expressions"
 weight: 115
 tags: ["studio pro", "expressions", "subtract date function"]
 ---

--- a/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
+++ b/content/en/docs/refguide/modeling/application-logic/workflows/workflow-setting-up-app.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding a Workflow to an Existing App: Setting Up the Basics"
+linktitle: "Add Workflow to Existing App: Basics"
 url: /refguide/workflow-setting-up-app/
 description: "Describes how to use Workflow Commons in an existing app in Mendix Studio Pro."
 weight: 55

--- a/content/en/docs/refguide/modeling/domain-model/generalization-and-association.md
+++ b/content/en/docs/refguide/modeling/domain-model/generalization-and-association.md
@@ -1,5 +1,6 @@
 ---
 title: "Generalization vs One-to-One Associations"
+linktitle: "Generalization vs 1-to-1 Associations"
 url: /refguide/generalization-and-association/
 weight: 50
 tags: ["domain model", "association", "inheritance", "one-to-one", "generalization"]

--- a/content/en/docs/refguide/modeling/import-and-export/_index.md
+++ b/content/en/docs/refguide/modeling/import-and-export/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Importing and Exporting Apps, Modules, Widgets, and Documents"
+linktitle: "Importing & Exporting Elements"
 url: /refguide/import-and-export/
 category: "App Modeling"
 weight: 12

--- a/content/en/docs/refguide/modeling/integration/published-rest-services/publish-microflow-as-rest-operation.md
+++ b/content/en/docs/refguide/modeling/integration/published-rest-services/publish-microflow-as-rest-operation.md
@@ -1,5 +1,6 @@
 ---
 title: "Publishing a Microflow as a REST Operation"
+linktitle: "Publish Microflow as REST Operation"
 url: /refguide/publish-microflow-as-rest-operation/
 weight: 30
 description: "How to publish a Microflow as a REST Operation"

--- a/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/modules/configure-add-on-and-solution-modules.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/modules/configure-add-on-and-solution-modules.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuring Add-on and Solution Modules for Publishing"
-linktitle: "Add-on & Solution Modules for Publishing"
+linktitle: "Publish Add-on & Solution Modules"
 url: /refguide/configure-add-on-and-solution-modules/
 weight: 20
 tags: ["studio pro", "add-on", "solution", "module", "modules"]

--- a/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/modules/configure-add-on-and-solution-modules.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/modules/configure-add-on-and-solution-modules.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Add-on and Solution Modules for Publishing"
+linktitle: "Add-on & Solution Modules for Publishing"
 url: /refguide/configure-add-on-and-solution-modules/
 weight: 20
 tags: ["studio pro", "add-on", "solution", "module", "modules"]

--- a/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/security/studio-security-enabled.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/app-explorer/security/studio-security-enabled.md
@@ -1,5 +1,6 @@
 ---
 title: "Model Changes When Security Is Enabled in Studio"
+linktitle: "Model Changes When Security Enabled"
 url: /refguide/studio-security-enabled/
 description: "Describes checks and changes in the app when security is enabled in Mendix Studio."
 tags: ["studio pro", "security", "studio"]

--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -1,5 +1,6 @@
 ---
 title: "Communication Patterns in the Mendix Runtime"
+linktitle: "Communication Patterns"
 url: /refguide/communication-patterns/
 category: "Mendix Runtime"
 tags: ["studio pro", "Mendix Runtime", "Communications", "Runtime Server", "Mendix Client"]

--- a/content/en/docs/refguide/runtime/custom-settings/tricky-custom-runtime-settings.md
+++ b/content/en/docs/refguide/runtime/custom-settings/tricky-custom-runtime-settings.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Custom Settings in Mendix Runtime"
+linktitle: "Advanced Custom Settings"
 url: /refguide/tricky-custom-runtime-settings/
 description: "Describes advanced custom settings in Mendix Runtime and how to configure them."
 tags: ["Support", "custom settings"]

--- a/content/en/docs/refguide/version-control/new-merge-algorithm.md
+++ b/content/en/docs/refguide/version-control/new-merge-algorithm.md
@@ -1,5 +1,6 @@
 ---
 title: "New Merge Algorithm with Fine-Grained Conflict Resolution"
+linktitle: "Merge Algorithm & Conflict Resolution"
 url: /refguide/new-merge-algorithm/
 category: "Version Control"
 weight: 30

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/parse-and-format-decimal-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/parse-and-format-decimal-function-calls.md
@@ -1,5 +1,6 @@
 ---
 title: "Parsing and Formatting Decimal Function Calls"
+linktitle: "Parse & Format Decimal Function Calls"
 url: /refguide7/parse-and-format-decimal-function-calls/
 ---
 

--- a/content/en/docs/refguide7/desktop-modeler/domain-model/entities/generalization-and-1-1-association.md
+++ b/content/en/docs/refguide7/desktop-modeler/domain-model/entities/generalization-and-1-1-association.md
@@ -1,5 +1,6 @@
 ---
 title: "Generalization & One-to-One Associations"
+linktitle: "Generalization & 1-to-1 Associations"
 url: /refguide7/generalization-and-1-1-association/
 weight: 5
 #tags: ["domain model", "association", "inheritance", "one-to-one", "generalization"]

--- a/content/en/docs/refguide7/desktop-modeler/integration/published-rest-services/publish-microflow-as-rest-operation.md
+++ b/content/en/docs/refguide7/desktop-modeler/integration/published-rest-services/publish-microflow-as-rest-operation.md
@@ -1,5 +1,6 @@
 ---
 title: "Publish a Microflow as a REST Operation"
+linktitle: "Publish Microflow as REST Operation"
 url: /refguide7/publish-microflow-as-rest-operation/
 weight: 30
 description: "How to publish a Microflow as a REST Operation"

--- a/content/en/docs/refguide7/desktop-modeler/project/navigation-conversion-to-74.md
+++ b/content/en/docs/refguide7/desktop-modeler/project/navigation-conversion-to-74.md
@@ -1,5 +1,6 @@
 ---
 title: "Solving Issues with Navigation Profile Conversion to 7.4"
+linktitle: "Navigation Profile 7.4 Conversion Issues"
 url: /refguide7/navigation-conversion-to-74/
 description: "Describes requirements and possible fixes for navigation profile conversion from Mendix versions 7.2 and 7.3 to Mendix 7.4."
 ---

--- a/content/en/docs/refguide7/desktop-modeler/project/navigation-conversion-to-74.md
+++ b/content/en/docs/refguide7/desktop-modeler/project/navigation-conversion-to-74.md
@@ -1,6 +1,6 @@
 ---
 title: "Solving Issues with Navigation Profile Conversion to 7.4"
-linktitle: "Navigation Profile 7.4 Conversion Issues"
+linktitle: "Converting to 7.4 - Navigation Profile Issues"
 url: /refguide7/navigation-conversion-to-74/
 description: "Describes requirements and possible fixes for navigation profile conversion from Mendix versions 7.2 and 7.3 to Mendix 7.4."
 ---

--- a/content/en/docs/refguide7/desktop-modeler/project/navigation-in-72-and-73/_index.md
+++ b/content/en/docs/refguide7/desktop-modeler/project/navigation-in-72-and-73/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Navigation in Mendix Versions 7.2 & 7.3"
+linktitle: "Navigation in 7.2 & 7.3"
 url: /refguide7/navigation-in-72-and-73/
 description: "Describes the concept of navigation in apps and the properties of a profile for Mendix versions 7.2 and 7.3."
 ---

--- a/content/en/docs/refguide7/desktop-modeler/project/navigation-in-72-and-73/navigation-profile-in-72-and-73.md
+++ b/content/en/docs/refguide7/desktop-modeler/project/navigation-in-72-and-73/navigation-profile-in-72-and-73.md
@@ -1,5 +1,6 @@
 ---
-title: "Navigation Profile In Mendix Versions 7.2 and 7.3"
+title: "Navigation Profile in Mendix Versions 7.2 and 7.3"
+linktitle: "Navigation Profile in 7.2 and 7.3"
 url: /refguide7/navigation-profile-in-72-and-73/
 description: "Describes the profile properties and profile buttons for Mendix version 7.2 and 7.3."
 ---

--- a/content/en/docs/refguide7/mobile/configuring-hybrid-mobile-apps-to-run-offline.md
+++ b/content/en/docs/refguide7/mobile/configuring-hybrid-mobile-apps-to-run-offline.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Hybrid Mobile Apps To Run Offline"
+linktitle: "Offline Hybrid Mobile Apps"
 url: /refguide7/configuring-hybrid-mobile-apps-to-run-offline/
 category: "Mobile Development"
 ---

--- a/content/en/docs/refguide7/runtime/custom-settings/tricky-custom-runtime-settings.md
+++ b/content/en/docs/refguide7/runtime/custom-settings/tricky-custom-runtime-settings.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Custom Settings in Mendix Runtime"
+linktitle: "Advanced Custom Settings"
 url: /refguide7/tricky-custom-runtime-settings/
 description: "Describes advanced custom settings in Mendix Runtime and how to configure them."
 tags: ["Support", "custom settings"]

--- a/content/en/docs/refguide7/version-control/using-version-control-in-the-dm.md
+++ b/content/en/docs/refguide7/version-control/using-version-control-in-the-dm.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Version Control in the Desktop Modeler"
+linktitle: "Version Control"
 url: /refguide7/using-version-control-in-the-dm/
 category: "Version Control"
 weight: 10

--- a/content/en/docs/refguide8/general/moving-from-7-to-8/_index.md
+++ b/content/en/docs/refguide8/general/moving-from-7-to-8/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Moving from Desktop Modeler Version 7 to Studio Pro 8"
+linktitle: "Desktop Modeler 7 to Studio Pro 8"
 url: /refguide8/moving-from-7-to-8/
 category: "General Info"
 weight: 20

--- a/content/en/docs/refguide8/mobile/hybrid-mobile/configuring-hybrid-mobile-apps-to-run-offline.md
+++ b/content/en/docs/refguide8/mobile/hybrid-mobile/configuring-hybrid-mobile-apps-to-run-offline.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Hybrid Mobile Apps To Run Offline"
+linktitle: "Offline Hybrid Mobile Apps"
 url: /refguide8/configuring-hybrid-mobile-apps-to-run-offline/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide8/modeling/domain-model/generalization-and-association.md
+++ b/content/en/docs/refguide8/modeling/domain-model/generalization-and-association.md
@@ -1,5 +1,6 @@
 ---
 title: "Generalization vs One-to-One Associations"
+linktitle: "Generalization vs 1-to-1 Associations"
 url: /refguide8/generalization-and-association/
 weight: 50
 tags: ["domain model", "association", "inheritance", "one-to-one", "generalization"]

--- a/content/en/docs/refguide8/modeling/integration/published-rest-services/publish-microflow-as-rest-operation.md
+++ b/content/en/docs/refguide8/modeling/integration/published-rest-services/publish-microflow-as-rest-operation.md
@@ -1,5 +1,6 @@
 ---
 title: "Publish a Microflow as a REST Operation"
+linktitle: "Publish Microflow as REST Operation"
 url: /refguide8/publish-microflow-as-rest-operation/
 weight: 30
 description: "How to publish a Microflow as a REST Operation"

--- a/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/studio-security-enabled.md
+++ b/content/en/docs/refguide8/modeling/menus/view-menu/project-explorer/security/studio-security-enabled.md
@@ -1,5 +1,6 @@
 ---
 title: "Model Changes When Security Is Enabled in Studio"
+linktitle: "Model Changes When Security Enabled"
 url: /refguide8/studio-security-enabled/
 description: "Describes checks and changes in the project when security is enabled in Mendix Studio."
 tags: ["studio pro", "security", "studio"]

--- a/content/en/docs/refguide8/runtime/communication-patterns.md
+++ b/content/en/docs/refguide8/runtime/communication-patterns.md
@@ -1,5 +1,6 @@
 ---
 title: "Communication Patterns in the Mendix Runtime"
+linktitle: "Communication Patterns"
 url: /refguide8/communication-patterns/
 category: "Mendix Runtime"
 tags: ["studio pro", "Mendix Runtime", "Communications", "Runtime Server", "Mendix Client"]

--- a/content/en/docs/refguide8/runtime/custom-settings/tricky-custom-runtime-settings.md
+++ b/content/en/docs/refguide8/runtime/custom-settings/tricky-custom-runtime-settings.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Custom Settings in Mendix Runtime"
+linktitle: "Advanced Custom Settings"
 url: /refguide8/tricky-custom-runtime-settings/
 description: "Describes advanced custom settings in Mendix Runtime and how to configure them."
 tags: ["Support", "custom settings"]

--- a/content/en/docs/releasenotes/studio-pro/9/9.15.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.15.md
@@ -1,7 +1,6 @@
 ---
 title: "9.15"
 url: /releasenotes/studio-pro/9.15/
-parent: "9"
 description: "The release notes for Mendix Studio Pro version 9.15 (including all patches) with details on new features, bug fixes, and known issues."
 weight: 85
 #KI: "When you update a consumed OData service" - DTML-358

--- a/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
+++ b/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 1: Build the Domain Model & Configure a Microflow"
+linktitle: "1. Build Domain Model & Configure Microflow"
 url: /studio-how-to/microflows-how-to-configure-decision-p1/
 description: "This how-to describes the process of configuring a decision in Mendix Studio."
 weight: 10

--- a/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
+++ b/content/en/docs/studio-how-to/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 2: Embed the Microflow in Your App"
+linktitle: "2. Embed Microflow"
 url: /studio-how-to/microflows-how-to-configure-decision-p2/
 description: "This how to describes the process of configuring a decision in in Mendix Studio."
 weight: 20

--- a/content/en/docs/studio-how-to/microflows/microflows-how-to-merge-and-change-object.md
+++ b/content/en/docs/studio-how-to/microflows/microflows-how-to-merge-and-change-object.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure Merge & Change Object Activities"
+linktitle: "Merge & Change Object Activities"
 url: /studio-how-to/microflows-how-to-merge-and-change-object/
 category: "Microflows"
 weight: 70

--- a/content/en/docs/studio-how-to/microflows/microflows-how-to-merge-and-change-object.md
+++ b/content/en/docs/studio-how-to/microflows/microflows-how-to-merge-and-change-object.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure Merge & Change Object Activities"
-linktitle: "Merge & Change Object Activities"
+linktitle: "Create Merge & Configure Change Object"
 url: /studio-how-to/microflows-how-to-merge-and-change-object/
 category: "Microflows"
 weight: 70

--- a/content/en/docs/studio-how-to/pages/pages-how-to-configure-form.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-configure-form.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a Form and Show Items Related to It"
+linktitle: "Configure Form & Show Items"
 url: /studio-how-to/pages-how-to-configure-form/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to/pages/pages-how-to-configure-form.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-configure-form.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Form and Show Items Related to It"
-linktitle: "Configure Form & Show Items"
+linktitle: "Configure Form & Show Form Items"
 url: /studio-how-to/pages-how-to-configure-form/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/_index.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a List and View List Item Details"
+linktitle:  "Configure List & View List Item Details"
 url: /studio-how-to/pages-how-to-configure-list/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/pages-how-to-configure-list-and-details-on-one-page.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/pages-how-to-configure-list-and-details-on-one-page.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a List and View List Item Details on One Page"
+linktitle: "Configure List & View Details on 1 Page"
 url: /studio-how-to/pages-how-to-configure-list-and-details-on-one-page/
 description: "Describes how to configure a list of items in Mendix Studio."
 weight: 20

--- a/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/pages-how-to-configure-list-and-pop-up-page.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-configure-list/pages-how-to-configure-list-and-pop-up-page.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a List and a Pop-Up Page with List Item Details"
+linktitle: "Configure List & Pop-Up Page"
 url: /studio-how-to/pages-how-to-configure-list-and-pop-up-page/
 description: "Describes how to configure a list of items and show their details on a pop-up page in Mendix Studio."
 weight: 10

--- a/content/en/docs/studio-how-to/pages/pages-how-to-set-visibility.md
+++ b/content/en/docs/studio-how-to/pages/pages-how-to-set-visibility.md
@@ -1,5 +1,6 @@
 ---
 title: "Show Fields Only When Certain Conditions Are Met"
+linktitle: "Show Fields on Conditions"
 url: /studio-how-to/pages-how-to-set-visibility/
 category: "Pages"
 description: "Describes how to set conditional visibility in Mendix Studio."

--- a/content/en/docs/studio-how-to/security-how-to-configure-roles/_index.md
+++ b/content/en/docs/studio-how-to/security-how-to-configure-roles/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Secure Your App and Configure Access to Its Functionality"
+linktitle: "Secure App & Configure Access"
 url: /studio-how-to/security-how-to-configure-roles/
 description: "Describes how to configure security in Mendix Studio."
 weight: 40

--- a/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
+++ b/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 1: Build the Domain Model & Configure a Microflow"
+linktitle: "1. Build Domain Model & Configure Microflow"
 url: /studio-how-to8/microflows-how-to-configure-decision-p1/
 description: "This how-to describes the process of configuring a decision in Mendix Studio."
 weight: 10

--- a/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
+++ b/content/en/docs/studio-how-to8/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 2: Embed the Microflow in Your App"
+linktitle: "2. Embed Microflow"
 url: /studio-how-to8/microflows-how-to-configure-decision-p2/
 description: "This how to describes the process of configuring a decision in in Mendix Studio."
 weight: 20

--- a/content/en/docs/studio-how-to8/microflows/microflows-how-to-merge-and-change-object.md
+++ b/content/en/docs/studio-how-to8/microflows/microflows-how-to-merge-and-change-object.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure Merge & Change Object Activities"
+linktitle: "Merge & Change Object Activities"
 url: /studio-how-to8/microflows-how-to-merge-and-change-object/
 category: "Microflows"
 weight: 70

--- a/content/en/docs/studio-how-to8/microflows/microflows-how-to-merge-and-change-object.md
+++ b/content/en/docs/studio-how-to8/microflows/microflows-how-to-merge-and-change-object.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure Merge & Change Object Activities"
-linktitle: "Merge & Change Object Activities"
+linktitle: "Create Merge & Configure Change Object"
 url: /studio-how-to8/microflows-how-to-merge-and-change-object/
 category: "Microflows"
 weight: 70

--- a/content/en/docs/studio-how-to8/pages/pages-how-to-configure-form.md
+++ b/content/en/docs/studio-how-to8/pages/pages-how-to-configure-form.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a Form and Show Items Related to It"
+linktitle: "Configure Form & Show Items"
 url: /studio-how-to8/pages-how-to-configure-form/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to8/pages/pages-how-to-configure-form.md
+++ b/content/en/docs/studio-how-to8/pages/pages-how-to-configure-form.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Form and Show Items Related to It"
-linktitle: "Configure Form & Show Items"
+linktitle: "Configure Form & Show Form Items"
 url: /studio-how-to8/pages-how-to-configure-form/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to8/pages/pages-how-to-configure-list.md
+++ b/content/en/docs/studio-how-to8/pages/pages-how-to-configure-list.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure a List and View List Item Details"
+linktitle: "Configure List & View List Item Details"
 url: /studio-how-to8/pages-how-to-configure-list/
 category: "Pages"
 description: "Describes how to configure a list of items in Mendix Studio."

--- a/content/en/docs/studio-how-to8/pages/pages-how-to-set-visibility.md
+++ b/content/en/docs/studio-how-to8/pages/pages-how-to-set-visibility.md
@@ -1,5 +1,6 @@
 ---
 title: "Show Fields Only When Certain Conditions Are Met"
+linktitle: "Show Fields on Conditions"
 url: /studio-how-to8/pages-how-to-set-visibility/
 category: "Pages"
 description: "Describes how to set conditional visibility in Mendix Studio."

--- a/content/en/docs/studio-how-to8/security-how-to-configure-roles/_index.md
+++ b/content/en/docs/studio-how-to8/security-how-to-configure-roles/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Secure Your App and Configure Access to Its Functionality"
+linktitle: "Secure App & Configure Access"
 url: /studio-how-to8/security-how-to-configure-roles/
 description: "Describes how to configure security in Mendix Studio."
 weight: 40

--- a/content/en/docs/studio/general/language-support.md
+++ b/content/en/docs/studio/general/language-support.md
@@ -1,5 +1,6 @@
 ---
 title: "Translating Your App to Multiple Languages"
+linktitle: "Translate App to Multiple Languages"
 url: /studio/language-support/
 category: "General Info"
 weight: 20

--- a/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
+++ b/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p1.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 1: Build the Domain Model & Configure a Microflow"
+linktitle: "1. Build Domain Model & Configure Microflow"
 url: /studio7/microflows-how-to-configure-decision-p1/
 description: "This how-to describes the process of configuring a decision in Mendix Studio."
 weight: 10

--- a/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
+++ b/content/en/docs/studio7/microflows/microflows-how-to-configure-decision/microflows-how-to-configure-decision-p2.md
@@ -1,5 +1,6 @@
 ---
 title: "Step 2: Embed the Microflow in Your App"
+linktitle: "2. Embed Microflow"
 url: /studio7/microflows-how-to-configure-decision-p2/
 description: "This how to describes the process of configuring a decision in in Mendix Studio."
 weight: 20

--- a/content/en/docs/studio7/microflows/microflows-how-to-merge-and-change-object.md
+++ b/content/en/docs/studio7/microflows/microflows-how-to-merge-and-change-object.md
@@ -1,5 +1,6 @@
 ---
 title: "Configure Merge & Change Object Activities"
+linktitle: "Create Merge & Configure Change Object"
 url: /studio7/microflows-how-to-merge-and-change-object/
 category: "Microflows"
 weight: 70

--- a/content/en/docs/studio7/microflows/microflows-setting-and-changing-value.md
+++ b/content/en/docs/studio7/microflows/microflows-setting-and-changing-value.md
@@ -1,5 +1,6 @@
 ---
 title: "Set & Change a Value for Different Activities in the Microflows"
+linktitle: "Set & Change Value"
 url: /studio7/microflows-setting-and-changing-value/
 category: "Microflows"
 weight: 50

--- a/content/en/docs/studio8/microflows/microflows-setting-and-changing-value.md
+++ b/content/en/docs/studio8/microflows/microflows-setting-and-changing-value.md
@@ -1,5 +1,6 @@
 ---
 title: "Set & Change a Value for Different Activities"
+linktitle: "Set & Change Value"
 url: /studio8/microflows-setting-and-changing-value/
 category: "Microflows"
 weight: 50


### PR DESCRIPTION
This PR inserts `linktitle` parameter into docs front matter, to shorten the left hand menu link text. All titles over 40 characters were taken into consideration (around 200 documents), with the vast majority getting a `linktitle` that is shorter than 40 characters. For some it made more sense to leave them as they are.
I tried to make the link titles as short as possible, without muddling the meaning. Some general notes on shortening:

- took out words such as "a" and "the"
- turned "and" into "&"
- turned written out numbers into numerical characters
- shortened gerunds into imperatives, for example, "building" into "build"
