### PR TITLE
Update for MxSSO adapter microflows in Administration module

### DIFF
--- a/content/en/docs/appstore/modules/administration.md
+++ b/content/en/docs/appstore/modules/administration.md
@@ -3,7 +3,7 @@ title: "Administration"
 url: /appstore/modules/administration/
 category: "Modules"
 description: "Describes the configuration and usage of the Administration module, which is available in the Mendix Marketplace."
-tags: ["marketplace", "marketplace component", "any chart", "plotly.js", "platform support"]
+tags: ["marketplace", "marketplace component", "administration", "user management", "platform support"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
 
@@ -27,18 +27,14 @@ The [Administration](https://marketplace.mendix.com/link/component/23513) module
 
 ## 2. Installation
 
-Follow the instructions in [How to Use Marketplace Content in Studio Pro](https://docs.mendix.com/appstore/general/app-store-content/) to import the Administrator module into your app.
+Follow the instructions in [How to Use Marketplace Content in Studio Pro](https://docs.mendix.com/appstore/general/app-store-content/) to import the Administration module into your app.
 
 ## 3 Using the Administration Module with Mendix SSO
 
 To use the Administration module with Mendix SSO, perform the following steps:
 
-1. Follow the instructions to import the [Mendix SSO](https://marketplace.mendix.com/link/component/111349) module into your app.
+1. Make sure that your project contains the [Mendix SSO](https://marketplace.mendix.com/link/component/111349) module. If your project does not contain the Mendix SSO module yet, import the module from the [Marketplace](https://marketplace.mendix.com/link/component/111349).
 
-2. Make sure to either exclude or delete the microflows in the **MOVE_THIS** folder from the MendixSSO module.
-
-3. Include the microflows with the prefix **MendixSSO_** in the **Mendix SSO** folder from the Administration module.
-
-4. Configure the **MendixSSO_AfterStartup** microflow from the Administration module as the [after startup](/refguide/app-settings/#after-startup) microflow. If there is already an after startup microflow, do not replace it, but add the **MendixSSO_AfterStartup** microflow as a sub-microflow in the existing microflow.
+2. Configure the **MendixSSO_AfterStartup** microflow from the Administration module as the [after startup](/refguide/app-settings/#after-startup) microflow. If there is already an after startup microflow, do not replace it, but add the **MendixSSO_AfterStartup** microflow as a sub-microflow in the existing microflow.
 
 {{% alert color="info" %}}If you previously used the Mendix SSO in your application, use the **MendixSSO_MigrateUsersToAccount** microflow to migrate users from the `MendixSSOUser` to the `Administration.Account` specialization. Before executing the migration, carefully read the instructions in the microflow.{{% /alert %}}

--- a/content/en/docs/appstore/modules/administration.md
+++ b/content/en/docs/appstore/modules/administration.md
@@ -33,7 +33,7 @@ Follow the instructions in [How to Use Marketplace Content in Studio Pro](https:
 
 To use the Administration module with Mendix SSO, perform the following steps:
 
-1. Make sure that your project contains the [Mendix SSO](https://marketplace.mendix.com/link/component/111349) module. If your project does not contain the Mendix SSO module yet, import the module from the [Marketplace](https://marketplace.mendix.com/link/component/111349).
+1. Make sure that your project contains the Mendix SSO module. If it doesn't, import the [Mendix SSO](https://marketplace.mendix.com/link/component/111349) module from the Marketplace.
 
 2. Configure the **MendixSSO_AfterStartup** microflow from the Administration module as the [after startup](/refguide/app-settings/#after-startup) microflow. If there is already an after startup microflow, do not replace it, but add the **MendixSSO_AfterStartup** microflow as a sub-microflow in the existing microflow.
 

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-sso.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-sso.md
@@ -219,7 +219,7 @@ To make a copy of the module, do the following:
 
 3. Copy the **MendixSSOUser** entity from the **MendixSSO** module domain model, to the domain model of your new module. In these examples it is called **CustomMendixSSOUser**.
 
-    {{% alert color="info" %}}You can also create an entity from scratch, provided is uses **System.User** as its generalization.{{% /alert %}}
+    {{% alert color="info" %}}You can also create an entity from scratch, provided it uses **System.User** as its generalization.{{% /alert %}}
 
 4. Set the entity **Access rules** for the **User** and **Administrator** module roles.
 
@@ -262,6 +262,10 @@ Mendix SSO will now use your new entity to administer the users. You can edit th
 {{% alert color="info" %}}
 Remember that data which comes from the end-user's Mendix ID via SSO (for example, **EmailAddress**) will overwrite any changes you make within your app.
 {{% /alert %}}
+
+#### 5.2.4 Using the microflows in the Administration module
+
+The [Administration](https://marketplace.mendix.com/link/component/23513) module contains a set of microflows to configure Mendix SSO to use **Administration.Account** as the user entity. Follow the instructions in [Using the Administration Module with Mendix SSO](https://docs.mendix.com/appstore/modules/administration/#3-using-the-administration-module-with-mendix-sso) to use the Administration module with Mendix SSO.
 
 ## 6 Tokens
 

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-sso.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/mendix-sso.md
@@ -167,21 +167,21 @@ Your app is now configured to use Mendix Single Sign-on when it is deployed to t
 
 ## 5 Customizing Mendix SSO {#customizing}
 
-{{% alert color="warning" %}}
-This section only applies to version 2 of Mendix SSO. The administration functionality is removed and the domain model has changed in Mendix SSO v3.0 and above.
-{{% /alert %}}
-
 {{% alert color="info" %}}
 In version 2 of the [Mendix SSO module](/appstore/modules/mendix-sso/) there was a default implementation of end-user administration. This had dependencies on specific versions of Atlas UI and was removed so that Mendix SSO v3.0 and above retains compatibility with all Mendix apps, whichever UI they are using.
 {{% /alert %}}
 
-This section explains how to use this in your apps, and how to base your own administration module on this section if you want to do things in a different way.
+This section explains how to use this in your apps, and how to base your own user administration module on this section if you want to do things in a different way.
 
-There are two ways you can modify the Mendix SSO module. You can use snippets from the Marketplace module Mendix SSO in your pages, or you can modify the Mendix SSO module in any way you like to support your end-user administration requirements.
+There are three ways you can modify the Mendix SSO module. You can use snippets from the Marketplace module Mendix SSO in your pages, you can modify the Mendix SSO module in any way you like to support your end-user administration requirements, or you can use the microflows available in the Administration module.
 
-These two ways are described below.
+These three ways are described below.
 
 ### 5.1 Using Snippets
+
+{{% alert color="warning" %}}
+This section only applies to version 2 of Mendix SSO. The administration functionality is removed and the domain model has changed in Mendix SSO v3.0 and above.
+{{% /alert %}}
 
 The default Mendix SSO implementation is based on snippets. You can use these snippets in your own pages to customize the administration of the end-users. If you look at how they are used in the default implementation, you can see how to use them in your own pages. The snippets are:
 
@@ -263,7 +263,7 @@ Mendix SSO will now use your new entity to administer the users. You can edit th
 Remember that data which comes from the end-user's Mendix ID via SSO (for example, **EmailAddress**) will overwrite any changes you make within your app.
 {{% /alert %}}
 
-#### 5.2.4 Using the microflows in the Administration module
+### 5.3 Using the Administration module
 
 The [Administration](https://marketplace.mendix.com/link/component/23513) module contains a set of microflows to configure Mendix SSO to use **Administration.Account** as the user entity. Follow the instructions in [Using the Administration Module with Mendix SSO](https://docs.mendix.com/appstore/modules/administration/#3-using-the-administration-module-with-mendix-sso) to use the Administration module with Mendix SSO.
 


### PR DESCRIPTION
The Administration module contains a set of 'adapter' microflows that can be used to configure Mendix SSO v3.0.0 or higher to use **Administration.Account** as the user entity. 

This PR adds a section in chapter 5 of the MendixSSO documentation (Customizing Mendix SSO) to point users towards the adapter microflows that are available in the Administration module when configuring Mendix SSO. Also, the documentation for the Administration module has been updated to remove the steps that are no longer necessary.

This PR replaces #4732