### PR TITLE
Update offline installation instructions

### DIFF
--- a/content/en/docs/howto/general/install.md
+++ b/content/en/docs/howto/general/install.md
@@ -64,7 +64,7 @@ Sometimes you can run into problems when installing Studio Pro. One work-around 
 
 The prerequisites are the following:
 
-* [Microsoft .NET Desktop Runtime 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+* [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – we recommend using version 6.0.6 or above
 * [AdoptOpenJDK 11](https://cdn.mendix.com/installer/AdoptOpenJDK/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi)
 * [Microsoft Visual C++ 2010 SP1 Redistributable Package](https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe)
 * [Microsoft Visual C++ 2019 Redistributable Package](https://aka.ms/vs/16/release/vc_redist.x64.exe)
@@ -85,11 +85,12 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 3. Create a folder with the name **Dependencies** in the same location where the Mendix Studio Pro installer was placed.
 4. Download the prerequisites listed in the [Troubleshooting](#troubleshooting) section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
-	* The `Microsoft .NET Desktop Runtime 6.0` executable to `windowsdesktop-runtime-6.0.3-win-x64.exe`
-	* The `Java Development Kit 11 (x64)` *msi* to `adoptopenjdk_11_x64.msi`
-
- 	* The `Visual C++ 2010 SP1 Redistributable (x64)` executable to `vcredist2010_x64.exe`
- 	* The `Visual C++ Redistributable for Visual Studio 2019 (x64)` executable to `vcredist2019_x64.exe`
+	* The `Microsoft .NET Desktop Runtime 6.0.x` executable (`dotnet.exe`) to `windowsdesktop-runtime-6.0.3-win-x64.exe` 
+	* The `Java Development Kit 11 (x64)` *msi* (for example `OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi`) to one of the following - depending on the Mendix Studio Pro version:
+        * `adoptiumjdk_11_x64.msi` – for versions 9.14.0 and above
+        * `adoptopenjdk_11_x64.msi` – for versions 9.13.x and below
+ 	* The `Visual C++ 2010 SP1 Redistributable (x64)` executable (for example `vcredist_x64.exe`) to `vcredist2010_x64.exe`
+ 	* The `Visual C++ Redistributable for Visual Studio 2019 (x64)` (for example `VC_redist.x64.exe`) executable to `vcredist2019_x64.exe`
  	* The `latest` executable to `mendix_native_mobile_builder.exe`
 6. Run the installer as described in the [Installing Mendix Studio Pro](#install) section above.
 


### PR DESCRIPTION
This addresses issues #4788 and #4803 which identify issues with the offline installation instructions with later versions of Mendix Studio Pro 9