### PR TITLE
Update links to Atlas files and Chart module

### DIFF
--- a/content/en/docs/appstore/modules/charts/_index.md
+++ b/content/en/docs/appstore/modules/charts/_index.md
@@ -9,7 +9,7 @@ tags: ["marketplace", "marketplace component", "charts", "platform support", "ar
 
 ## 1 Introduction
 
-The [Chart Widgets module](https://marketplace.mendix.com/link/component/120527) hosts a collection of updated and improved chart widgets. Beside widget improvements, this module introduces a shared settings file that allows you to define common properties for all your charts in your app.
+The [Chart Widgets module](https://marketplace.mendix.com/link/component/105695) hosts a collection of updated and improved chart widgets. Beside widget improvements, this module introduces a shared settings file that allows you to define common properties for all your charts in your app.
 
 For information on migrating an older version of the [Charts widget](https://marketplace.mendix.com/link/component/105695) to the newer chart widgets module, see the [Migrating to the Chart Widgets Module](#migrate-to-module) section below.
 

--- a/content/en/docs/refguide/general/moving-from-8-to-9/moving-from-atlas-2-to-3/_index.md
+++ b/content/en/docs/refguide/general/moving-from-8-to-9/moving-from-atlas-2-to-3/_index.md
@@ -37,7 +37,7 @@ To upgrade your theme directory to Atlas 3 specifications, please complete the f
 
 	{{< figure src="/attachments/refguide/general/moving-from-8-to-9/moving-from-atlas-2-to-3/atlas2-themefolder.png" alt="Atlas2 folder" >}}
 
-1.  Download the Atlas 3 [theme.zip](https://www.dropbox.com/s/guffms4u5idx3us/theme.zip?dl=1) and extract it into the root of your Mendix app folder. The folder structure should look similar to the example below. **Mendix app root**, then **theme**, then **web** and **native**:
+1.  Download the Atlas 3 [theme.zip](https://github.com/mendix/widgets-resources/releases/download/atlas-ui-theme-dist/theme.zip) and extract it into the root of your Mendix app folder. The folder structure should look similar to the example below. **Mendix app root**, then **theme**, then **web** and **native**:
 
 	{{< figure src="/attachments/refguide/general/moving-from-8-to-9/moving-from-atlas-2-to-3/atlas3-themefolder.png" alt="Atlas 3 folder" >}}
 


### PR DESCRIPTION
Update the file link to theme.zip on the atlas 2 to atlas 3 migration path. 