### PR TITLE
Fix xpath code example

### DIFF
--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/_index.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/_index.md
@@ -53,7 +53,7 @@ In some cases, it might also be useful define sub-constraints to restrict the da
 This query retrieves all users that have the role Administrator:
 
 ```java
-//Sales.User[id = '[%UserRole_Administrator%]']]
+//Sales.User[id = '[%UserRole_Administrator%]']
 ```
 
 This query retrieves all customers who live in Rotterdam or Losdun:


### PR DESCRIPTION
The PR addresses issue [#4821](https://github.com/mendix/docs/issues/4821) and removes an extra ']' from the example.