### PR TITLE
Update version control guide with MxToolSet

### DIFF
--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -297,13 +297,13 @@ The second method should be used if the first method is not possible for some re
 3. Commit your changes using Studio Pro. 
 4. Reopen the main line app in Studio Pro only after overwriting the files.
 
-#### 7.2.5 Merging using git in the command line
+#### 7.2.5 Merging Using Git in the Command Line
 
-In order for merging MPRs using git in a command line to work, it is necessary to attach mx.exe’s merge feature to git as a driver.
+For merging MPRs using Git in the command line to work, it is necessary to attach mx.exe merge feature to Git as a driver.
 
-When doing a "git merge" operation on 2 branches in a command line, git will attempt to merge the binaries of the MPRs, which will not work. For that, we need to apply Studio Pro's merge algorithm and that’s where mx.exe as a driver comes into play.
+When doing a `git merge` operation on two branches in the command line, Git attempts to merge the binaries of MPRs, which does not work. You need to apply Studio Pro merge algorithm and that is where mx.exe as a driver is needed.
 
-Navigate to the .gitconfig file in C:/Users/[USER_NAME] and add the following lines:
+Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
 
 ```
 [core]
@@ -313,17 +313,17 @@ Navigate to the .gitconfig file in C:/Users/[USER_NAME] and add the following li
   driver = [MX.EXE_PATH] merge %O %A %B
 ```
 
-Where [MX.EXE_PATH] should be substituted the path mx.exe, with only forward slashes and pointing to a drive like /C/ instead of C:/
+Where [MX.EXE_PATH] should substitute the mx.exe path with only forward slashes and pointing to a drive with */C/* instead of *C:/*.
 
-Additionally, create a .gitattributes file in the same folder, with the following contents:
+Additionally, create a .gitattributes file in the same folder with the following contents:
 
 ```
 *.mpr merge=custom
 ```
 
-Save the files and now whenever 'git merge' is run and it involves MPR files, the 'mx.exe merge' feature will kick in and run Studio Pro’s merge algorithm before git can finish with its merge.
+Save the files and now whenever `git merge` is run and it involves MPR files, the `mx.exe merge` feature will run Studio Pro merge algorithm before Git finishes the merge.
 
-Note: the changes to .gitconfig can also be made locally, per project:
+Changes to `.gitconfig` can also be made locally per app:
 
 ```
 git config merge.custom.name "custom merge driver for specific files"

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -299,9 +299,9 @@ The second method should be used if the first method is not possible for some re
 
 #### 7.2.5 Merging Using Git in the Command Line
 
-For merging MPRs using Git in the command line to work, it is necessary to attach mx.exe merge feature to Git as a driver.
+For merging MPRs using Git in the command line to work, it is necessary to attach mx.exe merge to Git as a driver.
 
-When doing a `git merge` operation on two branches in the command line, Git attempts to merge the binaries of MPRs, which does not work. You need to apply Studio Pro merge algorithm and that is where mx.exe as a driver is needed.
+When doing a **git merge** operation on two branches in the command line, Git attempts to merge the binaries of MPRs, which does not work. You need to apply Studio Pro merge algorithm and that is where mx.exe as a driver is needed.
 
 Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
 
@@ -313,17 +313,17 @@ Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
   driver = [MX.EXE_PATH] merge %O %A %B
 ```
 
-Where [MX.EXE_PATH] should substitute the mx.exe path with only forward slashes and pointing to a drive with */C/* instead of *C:/*.
+Where *[MX.EXE_PATH]* should be replaced by the mx.exe path with only forward slashes pointing to a drive with */C/* instead of *C:/*.
 
-Additionally, create a .gitattributes file in the same folder with the following contents:
+Additionally, create a *.gitattributes* file in the same folder with the following contents:
 
 ```
 *.mpr merge=custom
 ```
 
-Save the files and now whenever `git merge` is run and it involves MPR files, the `mx.exe merge` feature will run Studio Pro merge algorithm before Git finishes the merge.
+Save the files and now whenever **git merge** is run and it involves MPR files, the mx.exe merge will run Studio Pro merge algorithm before Git finishes the merge.
 
-Changes to `.gitconfig` can also be made locally per app:
+You can also change the *.gitconfig* file locally per app using the following:
 
 ```
 git config merge.custom.name "custom merge driver for specific files"

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -315,7 +315,14 @@ Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
 
 Where *[MX.EXE_PATH]* should be replaced by the mx.exe path with only forward slashes pointing to a drive using */C/* instead of *C:/*.
 
-Additionally, create a *.gitattributes* file in the same folder with the following contents:
+You can also configure the git driver locally per repository using the following commands:
+
+```
+git config merge.custom.name "custom merge driver for specific files"
+git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
+```
+
+After setting up the driver either locally or globally, create a *.gitattributes* file in the same folder with the following contents:
 
 ```
 *.mpr merge=custom

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -305,7 +305,7 @@ When doing a **git merge** operation on two branches in the command line, Git at
 
 Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
 
-```
+```text {linenos=false}
 [core]
   attributesfile = ~/.gitattributes
 [merge "custom"]
@@ -317,25 +317,19 @@ Where *[MX.EXE_PATH]* should be replaced by the mx.exe path with only forward sl
 
 You can also configure the git driver locally per repository using the following commands:
 
-```
+```text {linenos=false}
 git config merge.custom.name "custom merge driver for specific files"
 git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
 ```
 
 After setting up the driver either locally or globally, create a *.gitattributes* file in the same folder with the following contents:
 
-```
+```text {linenos=false}
 *.mpr merge=custom
 ```
 
 Save the files and now when **git merge** is run and it involves *.mpr* files, the mx.exe merge will run Studio Pro merge algorithm before Git finishes the merge.
 
-You can also change the *.gitconfig* file locally per app using the following:
-
-```
-git config merge.custom.name "custom merge driver for specific files"
-git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
-```
 
 ## 8 Versioning an App Deployed to the Cloud {#versioning-app}
 

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -297,6 +297,39 @@ The second method should be used if the first method is not possible for some re
 3. Commit your changes using Studio Pro. 
 4. Reopen the main line app in Studio Pro only after overwriting the files.
 
+#### 7.2.5 Merging using git in the command line
+
+In order for merging MPRs using git in a command line to work, it is necessary to attach mx.exe’s merge feature to git as a driver.
+
+When doing a "git merge" operation on 2 branches in a command line, git will attempt to merge the binaries of the MPRs, which will not work. For that, we need to apply Studio Pro's merge algorithm and that’s where mx.exe as a driver comes into play.
+
+Navigate to the .gitconfig file in C:/Users/[USER_NAME] and add the following lines:
+
+```
+[core]
+  attributesfile = ~/.gitattributes
+[merge "custom"]
+  name = custom merge driver for specific files
+  driver = [MX.EXE_PATH] merge %O %A %B
+```
+
+Where [MX.EXE_PATH] should be substituted the path mx.exe, with only forward slashes and pointing to a drive like /C/ instead of C:/
+
+Additionally, create a .gitattributes file in the same folder, with the following contents:
+
+```
+*.mpr merge=custom
+```
+
+Save the files and now whenever 'git merge' is run and it involves MPR files, the 'mx.exe merge' feature will kick in and run Studio Pro’s merge algorithm before git can finish with its merge.
+
+Note: the changes to .gitconfig can also be made locally, per project:
+
+```
+git config merge.custom.name "custom merge driver for specific files"
+git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
+```
+
 ## 8 Versioning an App Deployed to the Cloud {#versioning-app}
 
 ### 8.1 Deploying Locally

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -299,9 +299,9 @@ The second method should be used if the first method is not possible for some re
 
 #### 7.2.5 Merging Using Git in the Command Line
 
-For merging MPRs using Git in the command line to work, it is necessary to attach mx.exe merge to Git as a driver.
+For merging *.mpr* files using Git in the command line to work, it is necessary to attach mx.exe merge to Git as a driver.
 
-When doing a **git merge** operation on two branches in the command line, Git attempts to merge the binaries of MPRs, which does not work. You need to apply Studio Pro merge algorithm and that is where mx.exe as a driver is needed.
+When doing a **git merge** operation on two branches in the command line, Git attempts to merge the binaries of *.mpr* files, which does not work. You need to apply Studio Pro merge algorithm and that is where mx.exe as a driver is needed.
 
 Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
 
@@ -313,7 +313,7 @@ Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
   driver = [MX.EXE_PATH] merge %O %A %B
 ```
 
-Where *[MX.EXE_PATH]* should be replaced by the mx.exe path with only forward slashes pointing to a drive with */C/* instead of *C:/*.
+Where *[MX.EXE_PATH]* should be replaced by the mx.exe path with only forward slashes pointing to a drive using */C/* instead of *C:/*.
 
 Additionally, create a *.gitattributes* file in the same folder with the following contents:
 
@@ -321,7 +321,7 @@ Additionally, create a *.gitattributes* file in the same folder with the followi
 *.mpr merge=custom
 ```
 
-Save the files and now whenever **git merge** is run and it involves MPR files, the mx.exe merge will run Studio Pro merge algorithm before Git finishes the merge.
+Save the files and now when **git merge** is run and it involves *.mpr* files, the mx.exe merge will run Studio Pro merge algorithm before Git finishes the merge.
 
 You can also change the *.gitconfig* file locally per app using the following:
 


### PR DESCRIPTION
New MxToolSet Merge feature allows the user to merge projects using git on a command line