### PR TITLE
[WTF-1126] Add documentation for linked association properties (9.17)

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -461,13 +461,13 @@ You can obtain an instance of `EditableValue` by using the `ListAttributeValue` 
 
 #### 3.2.2 Attribute ID, Sortable and Filterable Flags {#listattributevalue-id-sortable-filterable}
 
-`id` field of type `ListAttributeId` represents the unique randomly generated string identifier of an attribute. That identifier could be used when applying sorting and filtering on a linked data source property to identify which attribute should be used for sorting and/or filtering. Check [Sorting](#listvalue-sorting) and [Filtering](#listvalue-filtering) sections for more information.
+`id` field of type `ListAttributeId` represents the unique randomly generated string identifier of an attribute. That identifier could be used when applying sorting and filtering on a linked data source property to identify which attribute should be used for sorting and/or filtering. For more information, see the [Sorting](#listvalue-sorting) and [Filtering](#listvalue-filtering) sections.
 
-Fields `sortable` and `filterable` specify if the attribute could be used for sorting and/or filtering. Those flags have to be checked before a widget applies filtering or sorting on a data source property. An attempt to filter on a non-filterable attribute or sort on a non-sortable attribute would lead to an error during the execution time.
+Fields `sortable` and `filterable` specify if the attribute could be used for sorting and/or filtering. Those flags have to be checked before a widget applies filtering or sorting on a data source property. Any attempt to filter on a non-filterable attribute or sort on a non-sortable attribute leads to an error during the execution time.
 
 #### 3.2.3 Attribute Type
 
-[Attribute](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#attribute) property defines which attribute types could be configured for that property. For example, an attribute property may be configured to allow attributes of type `String` and `Integer` in order to present progress. While this is convenient for users it may require some additional work for a developer by processing different data types.
+The [attribute](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#attribute) property defines which attribute types can be configured for that property. For example, an attribute property may be configured to allow attributes of type `String` and `Integer` in order to present progress. While this is convenient for users, it may require additional work for developers by processing different data types.
 
 It is possible to determine the type of attribute by checking the `type` field on an attribute property. The following code sample shows how to check the attribute type on the property named `myAttributeOnDatasource`:
 
@@ -483,9 +483,9 @@ if (this.props.myAttributeOnDatasource.type === "String") {
 
 #### 3.2.4 Formatter and Universe
 
-`formatter` field represents the default formatter that is going to be used on values obtained by `get` function.
+The `formatter` field represents the default formatter that is going to be used on values obtained by `get` function.
 
-Optional `universe` field represents an array of possible values of an attribute. See `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value) for more information.
+Optional `universe` field represents an array of possible values of an attribute. For more information, see the `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value).
 
 ### 3.3 ListReferenceValue and ListReferenceSetValue {#listassociationvalue}
 
@@ -506,9 +506,9 @@ export interface ListAssociationValue<T extends ObjectItem | ObjectItem[]> {
 
 #### 3.3.1 Obtaining Association Values
 
-In order to work with an object or objects that are associated with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. 
+In order to work with an object or objects with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. 
 
-If the association property has been configured to allow both types of associations, the type of the property is defined as `ListReferenceValue | ListReferenceSetValue` and a check on its `type` should be done to narrow down the type. See [Association Type](#association-type) section for more information.
+If the association property has been configured to allow both types of associations, the type of the property is defined as `ListReferenceValue | ListReferenceSetValue` and a check on its `type` should be done to narrow down the type. For more information, see the [Association Type](#association-type) section.
 
 Consult the following example code, which assumes widget properties are configured with the `myAssociationOnDatasource` property allowing association of type `Reference`:
 
@@ -527,19 +527,19 @@ The following code example shows how to get a `DynamicValue<ObjectItem>` that re
 const associationValue = this.props.myAssociationOnDatasource.get(this.props.myDataSource.items[0]);
 ```
 
-This will return an `ObjectItem` representing the associated object, since in this example, the widget is configured to allow only singular associations. If you want to access the individual attribute values of this associated object, you may use an attribute property linked to the selectable objects' data source and pass the associated object to it. For more information, see [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value).
+This will return an `ObjectItem` representing the associated object, because in this example the widget is configured to allow only singular associations. If you want to access the individual attribute values of this associated object, you may use an attribute property linked to the selectable objects' data source and pass the associated object to it. For more information, see [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value).
 
 Please note these code samples omit checks of `myDataSource` status and availability of items for simplicity. See [DynamicValue section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#dynamic-value) for more information on the usages of `DynamicValue`.
 
 #### 3.3.2 Association ID and Filterable Flags {#listassociationvalue-id-filterable}
 
-`id` field of type `ListAssociationId` represents the unique randomly generated string identifier of an association. That identifier could be used when applying filtering on a linked data source property to identify which association should be used for filtering. Check [Filtering](#listvalue-filtering) sections for more information.
+The `id` field of type `ListAssociationId` represents the unique randomly-generated string identifier of an association. That identifier can be used when applying filtering on a linked data source property to identify which association should be used for filtering. For more information, see the [Filtering](#listvalue-filtering) section.
 
-`filterable` field specifies if the association could be used for filtering. This flag has to be checked before a widget applies filtering on a data source property. An attempt to filter on a non-filterable association would lead to an error during the execution time.
+THe `filterable` field specifies if the association can be used for filtering. This flag has to be checked before a widget applies filtering on a data source property. An attempt to filter on a non-filterable association leads to an error during the execution time.
 
 #### 3.3.3 Association Type {#association-type}
 
-[Association](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#association) property determines which association types could be configured for that property. For example, an association property may be configured to allow associations of type `Reference` and not `ReferenceSet`.
+The [association](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#association) property determines which association types could be configured for that property. For example, an association property may be configured to allow associations of type `Reference` and not `ReferenceSet`.
 
 It is possible to determine the type of association by checking the `type` field on an association property. This is useful if the property has been configured to allow both references and reference sets. The following code sample shows how to check the association type on the property named `myAssociationOnDatasource`:
 
@@ -554,8 +554,7 @@ if (this.props.myAssociationOnDatasource.type === "Reference") {
 
 ### 3.4 ListWidgetValue {#listwidgetvalue}
 
-`ListWidgetValue` represents a [widget property](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#widgets) that is linked to a data source. 
-This allows the client component to render child widgets with items from a `ListValue`.
+`ListWidgetValue` represents a [widget property](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#widgets) that is linked to a data source. This allows the client component to render child widgets with items from a `ListValue`.
 `ListWidgetValue` is an object and its definition is as follows:
 
 ```ts

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -269,7 +269,7 @@ if (this.props.myAssociationReference.filterable) {
 }
 ```
 
-Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects data source:
+Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable object's data source:
 
 ```ts
 import { association, literal, notEquals, contains } from "mendix/filters/builders";

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -483,9 +483,9 @@ if (this.props.myAttributeOnDatasource.type === "String") {
 
 #### 3.2.4 Formatter and Universe
 
-The `formatter` field represents the default formatter that is going to be used on values obtained by `get` function.
+The `formatter` field represents the default formatter used on values obtained by the `get` function.
 
-Optional `universe` field represents an array of possible values of an attribute. For more information, see the `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value).
+The optional `universe` field represents an attribute's possible array values. For more information, see the `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value).
 
 ### 3.3 ListReferenceValue and ListReferenceSetValue {#listassociationvalue}
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -239,9 +239,9 @@ if (this.props.myAttributeString.filterable) {
 }
 ```
 
-First step the code takes is checking for the possibility to use filtering on `myAttributeString` property by checking the `filterable` flag. Then `filterCond` filter condition is constructed which specifies that attribute represented by `myAttributeString` should start with character `"B"`. `setFilter` call applies the filter, and on the next re-render the component gets only items where the value of an attribute represented by property `myAttributeString` is starting with `"B"`.
+The first step the code takes is checking for the possibility to use filtering on `myAttributeString` property by checking the `filterable` flag. Then the `filterCond` filter condition is constructed, which specifies that attribute represented by `myAttributeString` should start with character `"B"`. The `setFilter` call applies the filter, and on the next re-render the component gets only items where the value of an attribute represented by property `myAttributeString` is starting with `"B"`.
 
-Similarly, to apply a condition where the value on an attribute represented by `myAttributeBoolean` property is set to true:
+Similarly, code like this can apply a condition where the value on an attribute represented by `myAttributeBoolean` property is set to true:
 
 ```ts
 import { attribute, literal, equals } from "mendix/filters/builders";
@@ -255,7 +255,7 @@ if (this.props.myAttributeBoolean.filterable) {
 }
 ```
 
-And, to apply a condition to match only objects that are associated with another object:
+Code like this can apply a condition to match only objects that are associated with another object:
 
 ```ts
 import { association, literal, notEquals, empty } from "mendix/filters/builders";
@@ -269,7 +269,7 @@ if (this.props.myAssociationReference.filterable) {
 }
 ```
 
-Similarly, to apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects data source:
+Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects data source:
 
 ```ts
 import { association, literal, notEquals, contains } from "mendix/filters/builders";
@@ -287,7 +287,7 @@ if (this.props.myAssociationReferenceSet.filterable) {
 }
 ```
 
-The following code sample shows how to remove current filtering condition:
+The following code sample shows how to remove the current filtering condition:
 
 ```ts
 this.props.myDataSource.setFilter(undefined);
@@ -489,8 +489,7 @@ Optional `universe` field represents an array of possible values of an attribute
 
 ### 3.3 ListReferenceValue and ListReferenceSetValue {#listassociationvalue}
 
-`ListReferenceValue` and `ListReferenceSetValue` are both used to represent an [association property](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#association) that is linked to a data source.
-This allows the client component to access associated values of individual items from a `ListValue`. `ListReferenceValue` and `ListReferenceSetValue` are both objects and their definitions are as follows:
+`ListReferenceValue` and `ListReferenceSetValue` are both used to represent an [association property](/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#association) that is linked to a data source. This allows the client component to access associated values of individual items from a `ListValue`. `ListReferenceValue` and `ListReferenceSetValue` are both objects and their definitions are as follows:
 
 ```ts
 export type ListReferenceValue = ListAssociationValue<ObjectItem> & { type: "Reference" };
@@ -505,11 +504,13 @@ export interface ListAssociationValue<T extends ObjectItem | ObjectItem[]> {
 }
 ```
 
-#### 3.3.1 Obtaining Association Value
+#### 3.3.1 Obtaining Association Values
 
-In order to work with an object or objects that are associated with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. If the association property has been configured to allow both types of associations, the type of the property is defined as `ListReferenceValue | ListReferenceSetValue` and a check on its `type` should be done to narrow down the type. See [Association Type](#association-type) section for more information.
+In order to work with an object or objects that are associated with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. 
 
-Let's take a look at some example. Assuming widget properties are configured as follows with `myAssociationOnDatasource` property allowing association of type `Reference`:
+If the association property has been configured to allow both types of associations, the type of the property is defined as `ListReferenceValue | ListReferenceSetValue` and a check on its `type` should be done to narrow down the type. See [Association Type](#association-type) section for more information.
+
+Consult the following example code, which assumes widget properties are configured with the `myAssociationOnDatasource` property allowing association of type `Reference`:
 
 ```ts
 interface MyListWidgetsProps {
@@ -520,16 +521,15 @@ interface MyListWidgetsProps {
 }
 ```
 
-The following code sample shows how to get a `DynamicValue<ObjectItem>` that represents a read-only value of an associated object of the first element from the `myDataSource`.
+The following code example shows how to get a `DynamicValue<ObjectItem>` that represents a read-only value of an associated object of the first element from the `myDataSource`:
 
 ```ts
 const associationValue = this.props.myAssociationOnDatasource.get(this.props.myDataSource.items[0]);
 ```
 
-This will return an `ObjectItem` representing the associated object, since in this example, the widget is configured to allow only singular associations.
-If you want to access the individual attribute values of this associated object, you can use an attribute property linked to the selectable objects data source and pass the associated object to it. Refer to [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value) for details on how to do this.
+This will return an `ObjectItem` representing the associated object, since in this example, the widget is configured to allow only singular associations. If you want to access the individual attribute values of this associated object, you may use an attribute property linked to the selectable objects' data source and pass the associated object to it. For more information, see [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value).
 
-Note: in this code sample checks of status of `myDataSource` and availability of items are omitted for simplicity. See [DynamicValue section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#dynamic-value) for more information about usage of `DynamicValue`.
+Please note these code samples omit checks of `myDataSource` status and availability of items for simplicity. See [DynamicValue section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#dynamic-value) for more information on the usages of `DynamicValue`.
 
 #### 3.3.2 Association ID and Filterable Flags {#listassociationvalue-id-filterable}
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -269,7 +269,7 @@ if (this.props.myAssociationReference.filterable) {
 }
 ```
 
-Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable object's data source:
+Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects' data source:
 
 ```ts
 import { association, literal, notEquals, contains } from "mendix/filters/builders";
@@ -485,7 +485,7 @@ if (this.props.myAttributeOnDatasource.type === "String") {
 
 The `formatter` field represents the default formatter used on values obtained by the `get` function.
 
-The optional `universe` field represents an attribute's possible array values. For more information, see the `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value).
+The optional `universe` field represents an array of possible values for an attribute. For more information, see the `universe` field of [EditableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#editable-value).
 
 ### 3.3 ListReferenceValue and ListReferenceSetValue {#listassociationvalue}
 
@@ -506,7 +506,7 @@ export interface ListAssociationValue<T extends ObjectItem | ObjectItem[]> {
 
 #### 3.3.1 Obtaining Association Values
 
-In order to work with an object or objects with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. 
+In order to work with an object or objects that are associated with a particular item returned by `ListValue`, first an instance of `DynamicValue<ObjectItem>` (for `ListReferenceValue`) or `DynamicValue<ObjectItem[]>` (for `ListReferenceSetValue`) should be obtained by calling `get` with the item. 
 
 If the association property has been configured to allow both types of associations, the type of the property is defined as `ListReferenceValue | ListReferenceSetValue` and a check on its `type` should be done to narrow down the type. For more information, see the [Association Type](#association-type) section.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -269,7 +269,7 @@ if (this.props.myAssociationReference.filterable) {
 }
 ```
 
-Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects' data source:
+Similarly, code like this can apply a condition to match only the objects that are associated with at least the first two objects from the selectable objects data source:
 
 ```ts
 import { association, literal, notEquals, contains } from "mendix/filters/builders";
@@ -527,7 +527,7 @@ The following code example shows how to get a `DynamicValue<ObjectItem>` that re
 const associationValue = this.props.myAssociationOnDatasource.get(this.props.myDataSource.items[0]);
 ```
 
-This will return an `ObjectItem` representing the associated object, because in this example the widget is configured to allow only singular associations. If you want to access the individual attribute values of this associated object, you may use an attribute property linked to the selectable objects' data source and pass the associated object to it. For more information, see [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value).
+This will return an `ObjectItem` representing the associated object, because in this example the widget is configured to allow only singular associations. If you want to access the individual attribute values of this associated object, you may use an attribute property linked to the selectable objects data source and pass the associated object to it. For more information, see [Obtaining Attribute Value section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#obtaining-attribute-value).
 
 Please note these code samples omit checks of `myDataSource` status and availability of items for simplicity. See [DynamicValue section](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#dynamic-value) for more information on the usages of `DynamicValue`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -524,7 +524,7 @@ This property type was introduced in Mendix [9.13](/releasenotes/studio-pro/9.13
 
 The association property type allows a widget to work directly with both reading and writing associations between entities. Depending on the widget's purposes, a widget should define association types it supports.
 
-If a `dataSource` attribute is not specified the client will receive a `ReferenceValue` for references (singular references), possibly a `ReferenceSetValue` for reference sets (multiple references), or a union of them (if the widget is configured to allow both). For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
+If a `dataSource` attribute is not specified the client will receive a `ReferenceValue` for references (singular references), a `ReferenceSetValue` for reference sets (multiple references), or a union of them. For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
 
 When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListReferenceValue` or `ListReferenceSetValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listassociationvalue) depending on the configuration of the property. For more information, see the [Datasource](#datasource) section below.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -68,13 +68,13 @@ The string property type is represented as a simple text input in Studio Pro. It
 
 #### 2.1.1 XML Attributes
 
-| Attribute      | Required | Attribute Type | Description                                                  |
-| -------------- | -------- | -------------- | ------------------------------------------------------------ |
-| `type`         | Yes      | String         | Must be `string`                                             |
-| `key`          | Yes      | String         | See [key](#key) |
-| `defaultValue` | No       | String         | Default value for the property                              |
-| `multiline`    | No       | Boolean        | `true` to enable multiline input in Studio, `false` otherwise |
-| `required`     | No       | Boolean        | Whether the property must be specified by the user, `true` by default |
+| Attribute      | Required | Attribute Type | Description                                                              |
+| -------------- | -------- | -------------- |--------------------------------------------------------------------------|
+| `type`         | Yes      | String         | Must be `string`                                                         |
+| `key`          | Yes      | String         | See [key](#key)                                                          |
+| `defaultValue` | No       | String         | Default value for the property                                           |
+| `multiline`    | No       | Boolean        | `true` to enable multiline input in Studio, `false` otherwise            |
+| `required`     | No       | Boolean        | Whether the property must be specified by the user, `true` by default    |
 
 #### 2.1.2 Studio Pro UI
 
@@ -137,11 +137,11 @@ Integer is represented as a number input in Studio Pro. It is passed as a `numbe
 
 #### 2.3.1 XML Attributes
 
-| Attribute      | Required | Attribute Type | Description                                                                                                                                                          |
-| -------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`         | Yes      | String         | Must be `integer`                                                                                                                                                    |
-| `key`          | Yes      | String         | See [key](#key) |
-| `defaultValue` | Yes      | Integer        | Default value for the property                                                                                                                                      |
+| Attribute      | Required | Attribute Type | Description                     |
+| -------------- | -------- | -------------- |---------------------------------|
+| `type`         | Yes      | String         | Must be `integer`               |
+| `key`          | Yes      | String         | See [key](#key)                 |
+| `defaultValue` | Yes      | Integer        | Default value for the property  |
 
 #### 2.3.2 Studio Pro UI
 
@@ -164,11 +164,11 @@ Properties of type decimal are represented as a number input in Studio Pro. They
 
 #### 2.4.1 XML Attributes
 
-| Attribute      | Required | Attribute Type | Description                                                                                                                                                          |
-| -------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`         | Yes      | String         | Must be `decimal`                                                                                                                                                    |
-| `key`          | Yes      | String         | See [key](#key) |
-| `defaultValue` | Yes      | Integer        | Default value for the property                                                                                                                                      |
+| Attribute      | Required | Attribute Type | Description                    |
+| -------------- | -------- | -------------- |--------------------------------|
+| `type`         | Yes      | String         | Must be `decimal`              |
+| `key`          | Yes      | String         | See [key](#key)                |
+| `defaultValue` | Yes      | Integer        | Default value for the property |
 
 #### 2.4.2 Studio Pro UI
 
@@ -191,11 +191,11 @@ The enumeration property type allows a user to select one out of multiple option
 
 #### 2.5.1 XML Attributes
 
-| Attribute      | Required | Attribute Type | Description                                                                                                                                                          |
-| -------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`         | Yes      | String         | Must be `enumeration`                                                                                                                                                |
-| `key`          | Yes      | String         | See [key](#key) |
-| `defaultValue` | Yes      | Integer        | Default value for the property                                                                                                                                      |
+| Attribute      | Required | Attribute Type | Description                    |
+| -------------- | -------- | -------------- |--------------------------------|
+| `type`         | Yes      | String         | Must be `enumeration`          |
+| `key`          | Yes      | String         | See [key](#key)                |
+| `defaultValue` | Yes      | Integer        | Default value for the property |
 
 #### 2.5.2 XML Elements
 
@@ -235,11 +235,11 @@ Properties of type icon allows a user to configure an icon similar to one used b
 
 #### 3.1.1 XML Attributes
 
-| Attribute  | Required | Attribute Type | Description                                                                                                                                                          |
-| ---------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`     | Yes      | String         | Must be `icon`                                                                                                                                                       |
-| `key`      | Yes      | String         | See [key](#key) |
-| `required` | No       | Boolean        | Whether the property must be specified by the user, `true` by default                                                                                                |
+| Attribute  | Required | Attribute Type | Description                                                           |
+| ---------- | -------- | -------------- |-----------------------------------------------------------------------|
+| `type`     | Yes      | String         | Must be `icon`                                                        |
+| `key`      | Yes      | String         | See [key](#key)                                                       |
+| `required` | No       | Boolean        | Whether the property must be specified by the user, `true` by default |
 
 #### 3.1.2 Studio Pro UI
 
@@ -266,11 +266,11 @@ GIF images are not supported in native mobile apps on Android devices.
 
 #### 3.2.1 XML Attributes
 
-| Attribute  | Required | Attribute Type | Description                                                                                                                                                          |
-| ---------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`     | Yes      | String         | Must be `image`                                                                                                                                                      |
-| `key`      | Yes      | String         | See [key](#key) |
-| `required` | No       | Boolean        | Whether the property must be specified by the user, `true` by default                                                                                                |
+| Attribute  | Required | Attribute Type | Description                                                           |
+| ---------- | -------- | -------------- |-----------------------------------------------------------------------|
+| `type`     | Yes      | String         | Must be `image`                                                       |
+| `key`      | Yes      | String         | See [key](#key)                                                       |
+| `required` | No       | Boolean        | Whether the property must be specified by the user, `true` by default |
 
 #### 3.2.2 Studio Pro UI
 
@@ -297,12 +297,12 @@ Some widgets are not yet supported inside pluggable widgets. Placing unsupported
 
 #### 3.3.1 XML Attributes
 
-| Attribute    | Required | Attribute Type | Description |
-| ------------ | -------- | -------------- | ----------- |
-| `type`       | Yes      | String         | Must be `widgets` |
-| `key`        | Yes      | String         | See [key](#key) |
-| `dataSource` | No       | Property Path  | Specifies path to a [`datasource`](#datasource) property linked to this widget's property |
-| `required`   | No       | Boolean        | Whether a user must provide at least one widget, `true` by default |
+| Attribute    | Required | Attribute Type | Description                                                                                    |
+| ------------ | -------- | -------------- |------------------------------------------------------------------------------------------------|
+| `type`       | Yes      | String         | Must be `widgets`                                                                              |
+| `key`        | Yes      | String         | See [key](#key)                                                                                |
+| `dataSource` | No       | Property Path  | Specifies the path to a [`datasource`](#datasource) property linked to this `widgets` property |
+| `required`   | No       | Boolean        | Whether a user must provide at least one widget, `true` by default                             |
 
 #### 3.3.2 Studio Pro UI
 
@@ -465,13 +465,13 @@ When a `dataSource` attribute is specified and configured by the user, it is pas
 
 #### 4.4.1 XML Attributes
 
-| Attribute    | Required | Attribute Type | Description                                                  |
-| ------------ | -------- | -------------- | ------------------------------------------------------------ |
-| `type`       | Yes      | String         | Must be `attribute`                                          |
-| `key`        | Yes      | String         | See [key](#key) |
-| `onChange`   | No       | Property Path  | The path to an Action property that will be executed by the Mendix Platform when the value is changed by the widget |
-| `required`   | No       | Boolean        | Decides if the property must be specified by the user, `true` by default |
-| `dataSource` | No       | Property Path  | Specifies the path to a [`datasource`](#datasource) property linked to this attribute property |
+| Attribute    | Required | Attribute Type | Description                                                                                                                      |
+| ------------ | -------- | -------------- |----------------------------------------------------------------------------------------------------------------------------------|
+| `type`       | Yes      | String         | Must be `attribute`                                                                                                              |
+| `key`        | Yes      | String         | See [key](#key)                                                                                                                  |
+| `onChange`   | No       | Property Path  | The path to an [`action`](#action) property that will be executed by the Mendix Platform when the value is changed by the widget |
+| `required`   | No       | Boolean        | Decides if the property must be specified by the user, `true` by default                                                         |
+| `dataSource` | No       | Property Path  | Specifies the path to a [`datasource`](#datasource) property linked to this attribute property                                   |
 
 #### 4.4.2 XML Elements
 
@@ -520,26 +520,35 @@ Then the Studio Pro UI for the property appears like this:
 
 The association property type allows a widget to work directly with both reading and writing associations between entities. Depending on the widget's purposes, a widget should define association types it supports.
 
-The client will receive an `ModifiableValue<T>` where `T` depends on the configured `<associationType>`. For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
+If a `dataSource` attribute is not specified, the client will receive a `ReferenceValue` for references (singular references) and/or `ReferenceSetValue` for reference sets (multiple references) or a union of them, if the widget is configured to allow both. For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
+
+When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListReferenceValue` or `ListReferenceSetValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listassociationvalue) depending on the configuration of the property. For more information, see the [Datasource](#datasource) section below.
 
 {{% alert color="info" %}}
 This property type was introduced in Mendix [9.13](/releasenotes/studio-pro/9.13/).
 {{% /alert %}}
 
+{{% alert color="info" %}}
+The ability to link association properties to a data source was introduced in Mendix [9.17](/releasenotes/studio-pro/9.17/).
+{{% /alert %}}
+
 #### 4.5.1 XML Attributes {#xml-attributes}
 
-| Attribute           | Required | Attribute Type | Description                                                                                                        |
-|---------------------| -------- | -------------- |--------------------------------------------------------------------------------------------------------------------|
-| `type`              | Yes      | String         | Must be `association`                                                                                              |
-| `key`               | Yes      | String         | See [key](#key)                                                                                                    |
-| `required`          | No       | Boolean        | Decides if the property must be specified by the user, `true` by default                                           |
-| `selectableObjects` | Yes      | Property Path  | The path to a Datasource property that will provide selectable objects for the association                         | 
+| Attribute           | Required | Attribute Type | Description                                                                                                                      |
+|---------------------| -------- | -------------- |----------------------------------------------------------------------------------------------------------------------------------|
+| `type`              | Yes      | String         | Must be `association`                                                                                                            |
+| `key`               | Yes      | String         | See [key](#key)                                                                                                                  |
+| `onChange`          | No       | Property Path  | The path to an [`action`](#action) property that will be executed by the Mendix Platform when the value is changed by the widget |
+| `required`          | No       | Boolean        | Decides if the property must be specified by the user, `true` by default                                                         |
+| `selectableObjects` | Yes      | Property Path  | Specifies the path to a [`datasource`](#datasource) property that will provide selectable objects for the association            |
+| `dataSource`        | No       | Property Path  | Specifies the path to a [`datasource`](#datasource) property linked to this association property                                 |
+
 
 #### 4.5.2 XML Elements
 
 `<associationTypes>` (required) — This element encapsulates `<associationType>` elements which declare supported association types available while configuring the association property in the Studios.
 
-`<associationType>` (required one or more) — this element defines the allowed attribute type in the `name` attribute.
+`<associationType>` (required one or more) — this element defines the allowed association type in the `name` attribute.
 
 | Supported Attribute Types | Corresponding Types Client Components Receive |
 |---------------------------|-----------------------------------------------|
@@ -643,7 +652,11 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.8 Datasource {#datasource}
 
-The datasource property allows widgets to work with object lists. The client component will receive value prop of type [`ListValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listvalue) and may be used with [`action`](#action), [`attribute`](#attribute), [`expression`](#expression), [`text template`](#texttemplate) and [`widgets`](#widgets) properties. See [Data Sources](/refguide/data-sources/#list-widgets) for available data source types.
+The datasource property allows widgets to work with object lists. The client component will receive value prop of type [`ListValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listvalue) and may be used with [`action`](#action), [`attribute`](#attribute), [`association`](#association), [`expression`](#expression), [`text template`](#texttemplate) and [`widgets`](#widgets) properties. See [Data Sources](/refguide/data-sources/#list-widgets) for available data source types.
+
+{{% alert color="info" %}}
+The ability to link association properties to a data source was introduced in Mendix [9.17](/releasenotes/studio-pro/9.17/).
+{{% /alert %}}
 
 If no data source has been configured by the user, any properties that are linked to the datasource property are automatically omitted from the props passed to the client component (even if they are marked as required).
 
@@ -653,12 +666,12 @@ Only list datasources are supported, therefore specifying `isList="true"` is req
 
 #### 4.8.1 XML Attributes
 
-| Attribute  | Required | Attribute Type | Description |
-| ---------- | -------- | -------------- | ----------- |
-| `type`     | Yes      | String         | Must be `datasource` |
-| `key`      | Yes      | String         | See [key](#key) |
-| `isList`   | Yes      | Boolean        | Must be `true` |
-| `required` | No       | Boolean        | This decides if the user is required to specify a datasource, `true` by default |
+| Attribute  | Required | Attribute Type | Description                                                                      |
+| ---------- | -------- | -------------- |----------------------------------------------------------------------------------|
+| `type`     | Yes      | String         | Must be `datasource`                                                             |
+| `key`      | Yes      | String         | See [key](#key)                                                                  |
+| `isList`   | Yes      | Boolean        | Must be `true`                                                                   |
+| `required` | No       | Boolean        | This decides if the user is required to specify a datasource, `true` by default  |
 
 #### 4.8.2 Studio Pro UI
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -520,7 +520,7 @@ Then the Studio Pro UI for the property appears like this:
 
 The association property type allows a widget to work directly with both reading and writing associations between entities. Depending on the widget's purposes, a widget should define association types it supports.
 
-If a `dataSource` attribute is not specified, the client will receive a `ReferenceValue` for references (singular references) and/or `ReferenceSetValue` for reference sets (multiple references) or a union of them, if the widget is configured to allow both. For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
+If a `dataSource` attribute is not specified the client will receive a `ReferenceValue` for references (singular references), possibly a `ReferenceSetValue` for reference sets (multiple references), or a union of them (if the widget is configured to allow both). For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
 
 When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListReferenceValue` or `ListReferenceSetValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listassociationvalue) depending on the configuration of the property. For more information, see the [Datasource](#datasource) section below.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -518,15 +518,15 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.5 Association {#association}
 
+{{% alert color="info" %}}
+This property type was introduced in Mendix [9.13](/releasenotes/studio-pro/9.13/).
+{{% /alert %}}
+
 The association property type allows a widget to work directly with both reading and writing associations between entities. Depending on the widget's purposes, a widget should define association types it supports.
 
 If a `dataSource` attribute is not specified the client will receive a `ReferenceValue` for references (singular references), possibly a `ReferenceSetValue` for reference sets (multiple references), or a union of them (if the widget is configured to allow both). For more information, see the [ModifiableValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#modifiable-value) section of *Client APIs Available to Pluggable Widgets*.
 
 When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListReferenceValue` or `ListReferenceSetValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listassociationvalue) depending on the configuration of the property. For more information, see the [Datasource](#datasource) section below.
-
-{{% alert color="info" %}}
-This property type was introduced in Mendix [9.13](/releasenotes/studio-pro/9.13/).
-{{% /alert %}}
 
 {{% alert color="info" %}}
 The ability to link association properties to a data source was introduced in Mendix [9.17](/releasenotes/studio-pro/9.17/).
@@ -652,7 +652,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.8 Datasource {#datasource}
 
-The datasource property allows widgets to work with object lists. The client component will receive value prop of type [`ListValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listvalue) and may be used with [`action`](#action), [`attribute`](#attribute), [`association`](#association), [`expression`](#expression), [`text template`](#texttemplate) and [`widgets`](#widgets) properties. See [Data Sources](/refguide/data-sources/#list-widgets) for available data source types.
+The datasource property allows widgets to work with object lists. The client component will receive value prop of type [`ListValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listvalue) and may be used with [`action`](#action), [`attribute`](#attribute), [`association`](#association), [`expression`](#expression), [`text template`](#texttemplate), and [`widgets`](#widgets) properties. See [Data Sources](/refguide/data-sources/#list-widgets) for available data source types.
 
 {{% alert color="info" %}}
 The ability to link association properties to a data source was introduced in Mendix [9.17](/releasenotes/studio-pro/9.17/).


### PR DESCRIPTION
As WTF we are introducing a new feature in 9.17 with which we are enabling data source linkable association properties for pluggable widgets. Meaning, association properties are now able to have their own data sources similar to attribute properties. This MR is for updating the pages and adding the related new sections in the Pluggable Widgets API part for the Mendix Docs.