### PR TITLE
Swagger JSON location correction

### DIFF
--- a/content/en/docs/refguide/modeling/integration/published-rest-services/published-rest-service/_index.md
+++ b/content/en/docs/refguide/modeling/integration/published-rest-services/published-rest-service/_index.md
@@ -64,7 +64,7 @@ The public documentation is used in the service's [OpenAPI 2.0 (Swagger) Documen
 
 To save a service's [OpenAPI (Swagger) documentation](/refguide/open-api/) somewhere on your machine, simply right-click the service in the **App Explorer** and select **Export swagger.json** (or just click the **Export swagger.json** button, depending on your Studio Pro version). This is a machine-readable file in the [OpenAPI 2.0 file format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md). Most API tools support this format.
 
-When the app is running, this file is available under */rest-doc/rest/servicename/v1/swagger.json*.
+When the app is running, this file is available under */rest-doc/{location}/swagger.json*, where *{location}* is the location of the REST service, for instance *rest/myservice/v1*.
 
 ## 3 Security
 

--- a/content/en/docs/refguide/modeling/integration/published-rest-services/published-rest-technical-details/open-api.md
+++ b/content/en/docs/refguide/modeling/integration/published-rest-services/published-rest-technical-details/open-api.md
@@ -8,7 +8,7 @@ tags: ["swagger", "swagger.json", "OpenAPI 2.0", "documentation", "paths", "oper
 
 ## 1 Introduction
 
-Every [published REST service](/refguide/published-rest-service/) is automatically documented. The system generates a *swagger.json* file that conforms to the [OpenAPI 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) (formerly known as the "swagger specification"). This file can be [saved from Studio Pro](/refguide/published-rest-service/#export-swagger-json) or downloaded from */rest-doc/rest/servicename/v1/swagger.json*.
+Every [published REST service](/refguide/published-rest-service/) is automatically documented. The system generates a *swagger.json* file that conforms to the [OpenAPI 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) (formerly known as the "swagger specification"). This file can be [saved from Studio Pro](/refguide/published-rest-service/#export-swagger-json) or downloaded from */rest-doc/{location}/swagger.json*.
 
 If you need to communicate with the service from another app, you can use the *swagger.json* file to generate an API in many different systems, including Microsoft Visual Studio, React, Angular, and Java. This makes it easy to communicate between your different apps.
 


### PR DESCRIPTION
rest/servicename/v1 is the default location of a rest service, but this value can be changed.
This change clarifies that that choice of location affects the location of the swagger.json file as well.