### PR TITLE
Describe database-specific limitations on unlimited string uniqueness

### DIFF
--- a/content/en/docs/refguide/runtime/data-storage/case-sensitive-database-behavior.md
+++ b/content/en/docs/refguide/runtime/data-storage/case-sensitive-database-behavior.md
@@ -79,10 +79,10 @@ This table presents the default case sensitivity by different database types:
 |------------------:|:--------------:|:-----------:|:--------------------:|
 | HSQLDB            | I              | I           | I                    |
 | POSTGRESQL        | S              | S           | I                    |
-| DB2               | S              | S¹          | I³                    |
+| DB2               | S              | S¹          | I³                   |
 | MARIADB & MYSQL   | C              | C           | C                    |
 | ORACLE            | C¹             | C           | I                    |
-| SAP HANA          | S¹             | S¹          | I²                    |
+| SAP HANA          | S¹             | S¹          | I²                   |
 | SQL SERVER        | C              | C           | C                    |
 
 Where the letters have the following meaning:

--- a/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
+++ b/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
@@ -7,7 +7,7 @@ weight: 20
 
 ## 1 Introduction
 
-In the domain model, you can select attribute type String and set its length to **Unlimited**. Underlying implementation of such attribute differs per database.
+In the domain model, you can select the attribute type String and set its length to **Unlimited**. Underlying implementation of this attribute differs per database.
 
 ## 2 Behavior of Unlimited Strings by Database Type
 

--- a/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
+++ b/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
@@ -7,27 +7,27 @@ weight: 20
 
 ## 1 Introduction
 
-In the domain model, user can select attribute type String and set its length to "Unlimited". Underlying implementation of such attribute differs per database.
+In the domain model, you can select attribute type String and set its length to **Unlimited**. Underlying implementation of such attribute differs per database.
 
 ## 2 Behavior of Unlimited Strings by Database Type
 
 The following section describes the default behavior of the databases supported by Mendix.
 
-### 2.1 HSQLDB, PostgreSQL and MariaDB
+### 2.1 HSQLDB, PostgreSQL, and MariaDB
 
-User can sort by and compare unlimited strings. Unlimited strings can be used in uniqueness constraints.
+You can sort by and compare unlimited strings. Unlimited strings can be used in uniqueness constraints.
 
-### 2.2 SQL Server, MySQL
+### 2.2 SQL Server and MySQL
 
-User can sort by and compare unlimited strings. Uniqueness constraints on unlimited strings are not supported.
+You can sort by and compare unlimited strings. Uniqueness constraints on unlimited strings are not supported.
 
 ### 2.3  Oracle
 
-User can sort by unlimited strings. Uniqueness constraints on unlimited strings are not supported. Comparison of unlimited strings is not supported.
+You can sort by unlimited strings. Uniqueness constraints on unlimited strings are not supported. Comparison of unlimited strings is not supported.
 
 ### 2.4 DB2
 
-User can compare unlimited strings. Uniqueness constraints on unlimited strings are not supported. Sorting by unlimited strings is not supported.
+You can compare unlimited strings. Uniqueness constraints on unlimited strings are not supported. Sorting by unlimited strings is not supported.
 
 ### 2.5 SAP HANA
 

--- a/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
+++ b/content/en/docs/refguide/runtime/data-storage/unlimited-string-behavior.md
@@ -1,0 +1,47 @@
+---
+title: "Unlimited String Behavior"
+url: /refguide/unlimited-string-behavior/
+tags: ["studio pro", "strings", "sort", "case", "query", "constraint", "validation rule", "domain model"]
+weight: 20
+---
+
+## 1 Introduction
+
+In the domain model, user can select attribute type String and set its length to "Unlimited". Underlying implementation of such attribute differs per database.
+
+## 2 Behavior of Unlimited Strings by Database Type
+
+The following section describes the default behavior of the databases supported by Mendix.
+
+### 2.1 HSQLDB, PostgreSQL and MariaDB
+
+User can sort by and compare unlimited strings. Unlimited strings can be used in uniqueness constraints.
+
+### 2.2 SQL Server, MySQL
+
+User can sort by and compare unlimited strings. Uniqueness constraints on unlimited strings are not supported.
+
+### 2.3  Oracle
+
+User can sort by unlimited strings. Uniqueness constraints on unlimited strings are not supported. Comparison of unlimited strings is not supported.
+
+### 2.4 DB2
+
+User can compare unlimited strings. Uniqueness constraints on unlimited strings are not supported. Sorting by unlimited strings is not supported.
+
+### 2.5 SAP HANA
+
+Sorting by and comparison of unlimited strings is not supported. Uniqueness constraints on unlimited strings are not supported.
+
+## 3 Overview of Unlimited String Behavior
+
+| **Database Type** | **Comparison** | **Sorting**   | **Uniqueness constraint** |
+|------------------:|:--------------:|:-------------:|:-------------------------:|
+| HSQLDB            | **Supported**  | **Supported** | **Supported**             |
+| POSTGRESQL        | **Supported**  | **Supported** | **Supported**             |
+| DB2               | **Supported**  | Not supported | Not supported             |
+| MARIADB           | **Supported**  | **Supported** | **Supported**             |
+| MYSQL             | **Supported**  | **Supported** | Not supported             |
+| ORACLE            | Not supported  | **Supported** | Not supported             |
+| SAP HANA          | Not supported  | Not supported | Not supported             |
+| SQL SERVER        | **Supported**  | **Supported** | Not supported             |


### PR DESCRIPTION
Was not sure whether to describe the limitation here or in `case-sensitive-database-behavior`