### PR TITLE
Hide feedback widget on old content

### DIFF
--- a/content/en/docs/howto7/_index.md
+++ b/content/en/docs/howto7/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Mendix 7 How-tos"
     - mendix_version: "7"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.2
 ---

--- a/content/en/docs/howto8/_index.md
+++ b/content/en/docs/howto8/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Studio Pro 8 How-tos"
     - mendix_version: "8"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.3
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/en/docs/refguide7/_index.md
+++ b/content/en/docs/refguide7/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Mendix 7 Reference Guide"
     - mendix_version: "7"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.3
 ---

--- a/content/en/docs/refguide8/_index.md
+++ b/content/en/docs/refguide8/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Studio Pro 8 Guide"
     - mendix_version: "8"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.4
 ---

--- a/content/en/docs/studio-how-to8/_index.md
+++ b/content/en/docs/studio-how-to8/_index.md
@@ -7,6 +7,7 @@ cascade:
     - space: "Studio 8 How-tos"
     - mendix_version: "8"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.3
 ---

--- a/content/en/docs/studio7/_index.md
+++ b/content/en/docs/studio7/_index.md
@@ -7,6 +7,7 @@ cascade:
     - space: "Mendix 7 Studio Guide"
     - mendix_version: "7"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.3
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.

--- a/content/en/docs/studio8/_index.md
+++ b/content/en/docs/studio8/_index.md
@@ -7,6 +7,7 @@ cascade:
     - space: "Studio 8 Guide"
     - mendix_version: "8"
     - old_content: true
+    - hide_feedback: true
     - sitemap:
         priority: 0.4
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.


### PR DESCRIPTION
Added `hide_feedback: true` to cascade through all older content spaces