### PR TITLE
Add descriptions to children docs-Studio Pro guide

### DIFF
--- a/content/en/docs/refguide/general/_index.md
+++ b/content/en/docs/refguide/general/_index.md
@@ -2,6 +2,7 @@
 title: "General Info"
 url: /refguide/general/
 weight: 10
+description: "Describes the system requirements and other important aspects of using Studio Pro 9."
 no_list: false
 description_list: true
 tags: ["studio pro", "system requirements", "install"]

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -3,7 +3,7 @@ title: "mx Command-Line Tool"
 url: /refguide/mx-command-line-tool/
 category: "General Info"
 weight: 50
-description: "Describes the options of the mx command-line tool"
+description: "Describes the options of the mx command-line tool."
 tags: ["mx", "command-line", "tool", "mx", "studio pro", "windows", "linux"]
 ---
 

--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -3,7 +3,7 @@ title: "MxBuild"
 url: /refguide/mxbuild/
 category: "General Info"
 weight: 50
-description: "Describes MxBuild which is a command-line tool for building and deploying Mendix Apps"
+description: "Describes MxBuild, which is a command-line tool for building and deploying Mendix Apps."
 tags: ["build", "deploy", "deployment package", "command-line", "studio pro"]
 ---
 

--- a/content/en/docs/refguide/general/third-party-licenses.md
+++ b/content/en/docs/refguide/general/third-party-licenses.md
@@ -3,7 +3,7 @@ title: "Third-Party Licenses"
 url: /refguide/third-party-licenses/
 category: "General Info"
 weight: 70
-description: "Describes where to find the available thrid-party licenses in Mendix."
+description: "Describes where to find the available third-party licenses in Mendix."
 tags: ["studio pro", "license", "library"]
 ---
 

--- a/content/en/docs/refguide/general/third-party-licenses.md
+++ b/content/en/docs/refguide/general/third-party-licenses.md
@@ -3,6 +3,7 @@ title: "Third-Party Licenses"
 url: /refguide/third-party-licenses/
 category: "General Info"
 weight: 70
+description: "Describes where to find the available thrid-party licenses in Mendix."
 tags: ["studio pro", "license", "library"]
 ---
 

--- a/content/en/docs/refguide/java-programming/troubleshooting.md
+++ b/content/en/docs/refguide/java-programming/troubleshooting.md
@@ -2,6 +2,7 @@
 title: "Troubleshooting"
 url: /refguide/troubleshooting/
 category: "Java Programming"
+description: "Lists the problematic JAR files and the known workarounds."
 tags: ["studio pro"]
 # See Jira issue IDS-807, compatibility list might need update
 ---

--- a/content/en/docs/refguide/java-programming/using-eclipse.md
+++ b/content/en/docs/refguide/java-programming/using-eclipse.md
@@ -2,6 +2,7 @@
 title: "Using Eclipse"
 url: /refguide/using-eclipse/
 category: "Java Programming"
+description: "Describes how to set up Eclipse, and how to add a Mendix application to Eclipse and launch it."
 tags: ["studio pro"]
 ---
 

--- a/content/en/docs/refguide/mobile/_index.md
+++ b/content/en/docs/refguide/mobile/_index.md
@@ -2,6 +2,7 @@
 title: "Mobile"
 url: /refguide/mobile/
 weight: 50
+description: "Gives an overview of mobile app development with Mendix."
 no_list: true
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.

--- a/content/en/docs/refguide/modeling/_index.md
+++ b/content/en/docs/refguide/modeling/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "App Modeling"
 url: /refguide/modeling/
-description: "Describes the various features used for modeling in Mendix Studio Pro, including document templates, the domain model, microflows, modules, pages, and security."
+description: "Describes the various features used for modeling in Studio Pro, including document templates, the domain model, microflows, modules, pages, and security."
 weight: 20
 no_list: false
 description_list: true

--- a/content/en/docs/refguide/modeling/data-types.md
+++ b/content/en/docs/refguide/modeling/data-types.md
@@ -3,6 +3,7 @@ title: "Data Types"
 url: /refguide/data-types/
 category: "App Modeling"
 weight: 60
+description: "Presents an overview of the data types that Studio Pro supports."
 tags: ["studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide/modeling/domain-model/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/_index.md
@@ -3,6 +3,7 @@ title: "Domain Model"
 url: /refguide/domain-model/
 category: "App Modeling"
 weight: 30
+description: "Introduces the domain model in Studio Pro."
 tags: ["domain model", "entity", "association", "annotation", "studio pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide/modeling/images.md
+++ b/content/en/docs/refguide/modeling/images.md
@@ -3,6 +3,7 @@ title: "Images"
 url: /refguide/images/
 category: "App Modeling"
 weight: 70
+description: "Introduces the image functionality in Studio Pro."
 tags: ["Images", "Image Collections", "png", "Studio Pro"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide/modeling/import-and-export/_index.md
+++ b/content/en/docs/refguide/modeling/import-and-export/_index.md
@@ -4,6 +4,7 @@ linktitle: "Importing & Exporting Elements"
 url: /refguide/import-and-export/
 category: "App Modeling"
 weight: 12
+description: "Gives an overview of the import and export functions in Studio Pro."
 tags: ["mpk", "import", "export", "document", "module", "widget", "app package"]
 ---
 

--- a/content/en/docs/refguide/modeling/integration/_index.md
+++ b/content/en/docs/refguide/modeling/integration/_index.md
@@ -3,6 +3,7 @@ title: "Integration"
 url: /refguide/integration/
 category: "App Modeling"
 weight: 110
+description: "Introduces the services that Mendix uses for application integration, for instance, OData, REST, and SOAP/Web Services. Mendix can also import and export data from XML and JSON."
 tags: ["studio pro"]
 ---
 

--- a/content/en/docs/refguide/modeling/mx-assist-studio-pro/_index.md
+++ b/content/en/docs/refguide/modeling/mx-assist-studio-pro/_index.md
@@ -3,7 +3,7 @@ title: "Mendix Assist"
 url: /refguide/mx-assist-studio-pro/
 category: "App Modeling"
 weight: 120
-description: "Describes Mendix Assist in Mendix Studio Pro."
+description: "Describes Mendix Assist in Studio Pro."
 tags: ["studio pro", "mendix assist", "AI", "assistant"]
 ---
 

--- a/content/en/docs/refguide/modeling/pages/_index.md
+++ b/content/en/docs/refguide/modeling/pages/_index.md
@@ -3,6 +3,7 @@ title: "Pages"
 url: /refguide/pages/
 category: "App Modeling"
 weight: 30
+description: "Presents an overvies of the features of pages and relevant page resources in Studio Pro."
 tags: ["Pages", "Widgets", "Studio Pro", "page structure"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document also has a redirect from opening-pages (which has been deleted)

--- a/content/en/docs/refguide/modeling/pages/_index.md
+++ b/content/en/docs/refguide/modeling/pages/_index.md
@@ -3,7 +3,7 @@ title: "Pages"
 url: /refguide/pages/
 category: "App Modeling"
 weight: 30
-description: "Presents an overvies of the features of pages and relevant page resources in Studio Pro."
+description: "Presents an overview of the features of pages and relevant page resources in Studio Pro."
 tags: ["Pages", "Widgets", "Studio Pro", "page structure"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 #This document also has a redirect from opening-pages (which has been deleted)

--- a/content/en/docs/refguide/modeling/resources/_index.md
+++ b/content/en/docs/refguide/modeling/resources/_index.md
@@ -3,6 +3,7 @@ title: "Resources"
 url: /refguide/resources/
 category: "App Modeling"
 weight: 50
+description: "Introduces the helping documents (resources) that can be used in Studio Pro."
 tags: ["studio pro", "resources"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---

--- a/content/en/docs/refguide/modeling/studio-pro-overview/_index.md
+++ b/content/en/docs/refguide/modeling/studio-pro-overview/_index.md
@@ -2,7 +2,7 @@
 title: "Studio Pro Overview"
 url: /refguide/studio-pro-overview/
 category: "App Modeling"
-description: "Describes Studio Pro in general: tabs, menus, shortcut keys."
+description: "Describes Studio Pro in general, for example, tabs, menus, and shortcut keys."
 weight: 10
 tags: ["Studio Pro"]
 aliases:

--- a/content/en/docs/refguide/quickstart-guide/_index.md
+++ b/content/en/docs/refguide/quickstart-guide/_index.md
@@ -2,7 +2,7 @@
 title: "Quickstart"
 url: /refguide/quickstart-guide/
 weight: 9
-description: "Learn how to build an app in Studio Pro quickly and easily."
+description: "Presents tutorials on how to build an app in Studio Pro quickly and easily."
 tags: ["microflows", "widgets", "app", "nanoflow", "app development"]
 ---
 

--- a/content/en/docs/refguide/runtime/_index.md
+++ b/content/en/docs/refguide/runtime/_index.md
@@ -2,6 +2,7 @@
 title: "Mendix Runtime"
 url: /refguide/runtime/
 weight: 40
+description: "Gives an overview of the Mendix Runtime."
 no_list: false
 description_list: true
 tags: ["runtime", "runtime server", "mendix client", "cluster leader"]

--- a/content/en/docs/refguide/runtime/clustered-mendix-runtime.md
+++ b/content/en/docs/refguide/runtime/clustered-mendix-runtime.md
@@ -2,7 +2,7 @@
 title: "Clustered Mendix Runtime"
 url: /refguide/clustered-mendix-runtime/
 category: "Mendix Runtime"
-description: "Using the cluster functionality, you can set up your Mendix application to run behind a load balancer to enable a failover and/or high availability architecture."
+description: "Introduces the cluster functionality of the Mendix Runtime, which allows you to set up your Mendix application to run behind a load balancer to enable a failover and/or high availability architecture."
 tags: ["runtime", "cluster", "load balancer", "failover", "studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -3,6 +3,7 @@ title: "Communication Patterns in the Mendix Runtime"
 linktitle: "Communication Patterns"
 url: /refguide/communication-patterns/
 category: "Mendix Runtime"
+description: "Outlines the communication patterns used by the Mendix Runtime environment for some typical application use cases."
 tags: ["studio pro", "Mendix Runtime", "Communications", "Runtime Server", "Mendix Client"]
 ---
 

--- a/content/en/docs/refguide/runtime/data-storage/_index.md
+++ b/content/en/docs/refguide/runtime/data-storage/_index.md
@@ -2,6 +2,7 @@
 title: "Data Storage"
 url: /refguide/data-storage/
 category: "Mendix Runtime"
+description: "Introduces data storage, which is the data foundation of the Mendix Runtime."
 tags: ["studio pro", "Databases"]
 ---
 

--- a/content/en/docs/refguide/runtime/date-and-time-handling/_index.md
+++ b/content/en/docs/refguide/runtime/date-and-time-handling/_index.md
@@ -2,6 +2,7 @@
 title: "Date & Time Handling"
 url: /refguide/date-and-time-handling/
 category: "Mendix Runtime"
+description: "Describes date and time handling for a Mendix application."
 tags: ["studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/logging.md
+++ b/content/en/docs/refguide/runtime/logging.md
@@ -2,6 +2,7 @@
 title: "Logging"
 url: /refguide/logging/
 category: "Mendix Runtime"
+description: "Describes what the various log levels of the runtime will show as output."
 tags: ["studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/login-behavior.md
+++ b/content/en/docs/refguide/runtime/login-behavior.md
@@ -2,7 +2,7 @@
 title: "Login Behavior"
 url: /refguide/login-behavior/
 category: "Mendix Runtime"
-description: "Describes default and customized login behavior in Runtime."
+description: "Describes default and customized login behavior in the Mendix Runtime."
 tags: ["Runtime", "login", "studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/mendix-client.md
+++ b/content/en/docs/refguide/runtime/mendix-client.md
@@ -2,7 +2,7 @@
 title: "Mendix Client"
 url: /refguide/mendix-client/
 category: "Mendix Runtime"
-description: "A description of the Mendix Client part of the runtime and how it functions"
+description: "Describes the Mendix Client part of the Mendix Runtime and how it functions."
 weight: 20
 tags: ["runtime", "mendix client", "offline-first", "browser", "javascript", "nanoflows", "widgets", "launch"]
 ---

--- a/content/en/docs/refguide/runtime/metrics.md
+++ b/content/en/docs/refguide/runtime/metrics.md
@@ -2,7 +2,7 @@
 title: "Metrics"
 url: /refguide/metrics/
 category: "Mendix Runtime"
-description: "Describes how to congifure and report metrics in Mendix."
+description: "Describes how to configure and report metrics in Mendix."
 tags: ["studio pro", "metrics", "micrometer"]
 ---
 

--- a/content/en/docs/refguide/runtime/metrics.md
+++ b/content/en/docs/refguide/runtime/metrics.md
@@ -2,6 +2,7 @@
 title: "Metrics"
 url: /refguide/metrics/
 category: "Mendix Runtime"
+description: "Describes how to congifure and report metrics in Mendix."
 tags: ["studio pro", "metrics", "micrometer"]
 ---
 

--- a/content/en/docs/refguide/runtime/monitoring-client-state.md
+++ b/content/en/docs/refguide/runtime/monitoring-client-state.md
@@ -2,6 +2,7 @@
 title: "Monitoring Client State"
 url: /refguide/monitoring-client-state/
 category: "Mendix Runtime"
+description: "Describes the supported client state monitoring actions."
 tags: ["studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/objects-and-caching.md
+++ b/content/en/docs/refguide/runtime/objects-and-caching.md
@@ -2,7 +2,7 @@
 title: "Objects & Caching"
 url: /refguide/objects-and-caching/
 category: "Mendix Runtime"
-description: "This page describes how objects interact with each other within a runtime request."
+description: "Describes how objects interact with each other within a runtime request."
 tags: ["runtime", "MendixObject", "caching", "context", "session", "request", "microflow", "studio pro"]
 ---
 

--- a/content/en/docs/refguide/runtime/runtime-deployment.md
+++ b/content/en/docs/refguide/runtime/runtime-deployment.md
@@ -2,7 +2,7 @@
 title: "Runtime Deployment"
 url: /refguide/runtime-deployment/
 category: "Mendix Runtime"
-description: "A description of how the Mendix Runtime is deployed"
+description: "Describes how the Mendix Runtime is deployed."
 weight: 30
 tags: ["runtime", "deploy", "mxbuild", "runtime server", "m2ee"]
 ---

--- a/content/en/docs/refguide/runtime/runtime-java/_index.md
+++ b/content/en/docs/refguide/runtime/runtime-java/_index.md
@@ -2,6 +2,7 @@
 title: "Mendix Runtime & Java"
 url: /refguide/runtime-java/
 category: "Mendix Runtime"
+description: "Explains some of the basic concepts of Java in Mendix."
 tags: ["runtime", "java"]
 ---
 

--- a/content/en/docs/refguide/runtime/runtime-server.md
+++ b/content/en/docs/refguide/runtime/runtime-server.md
@@ -2,7 +2,7 @@
 title: "Runtime Server"
 url: /refguide/runtime-server/
 category: "Mendix Runtime"
-description: "A description of the Runtime Server and how it functions"
+description: "Describes the Runtime Server and how it functions."
 weight: 10
 tags: ["runtime", "runtime server", "stateless", "database", "java", "microflows"]
 ---

--- a/content/en/docs/refguide/runtime/websockets-in-runtime.md
+++ b/content/en/docs/refguide/runtime/websockets-in-runtime.md
@@ -2,7 +2,7 @@
 title: "WebSockets"
 url: /refguide/websockets-in-runtime/
 category: "Mendix Runtime"
-description: "A description of how to use websockets in the Mendix Runtime"
+description: "Describes how to use websockets in the Mendix Runtime."
 tags: ["runtime", "web socket", "endpoint", "java"]
 ---
 

--- a/content/en/docs/refguide/version-control/_index.md
+++ b/content/en/docs/refguide/version-control/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Version Control"
 url: /refguide/version-control/
-description: "This document gives definitions and explains the version control  process"
+description: "Gives definitions and explains the version control process."
 weight: 30
 no_list: false
 description_list: true

--- a/content/en/docs/refguide/version-control/collaborative-development/_index.md
+++ b/content/en/docs/refguide/version-control/collaborative-development/_index.md
@@ -3,7 +3,7 @@ title: "Collaborative Development"
 url: /refguide/collaborative-development/
 category: "Version Control"
 weight: 40
-description: "Describes the process of collaborative development between the Mendix Studio Pro and the Mendix Studio"
+description: "Describes the process of collaborative development between Mendix Studio Pro and Mendix Studio."
 tags: ["studio pro", "studio", "collaborative development", "sync"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide/version-control/collaborative-development/collaborative-development-troubleshooting.md
+++ b/content/en/docs/refguide/version-control/collaborative-development/collaborative-development-troubleshooting.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting Collaborative Development"
 url: /refguide/collaborative-development-troubleshooting/
 linktitle: "Troubleshoot Collaborative Development"
-description: "Describes troubleshooting for collaborative development between the Mendix Studio Pro and the Mendix Studio"
+description: "Describes troubleshooting for collaborative development between Mendix Studio Pro and Mendix Studio."
 tags: ["studio pro", "studio", "collaborative development", "troubleshooting", "troubleshoot"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---

--- a/content/en/docs/refguide/version-control/new-merge-algorithm.md
+++ b/content/en/docs/refguide/version-control/new-merge-algorithm.md
@@ -4,7 +4,7 @@ linktitle: "Merge Algorithm & Conflict Resolution"
 url: /refguide/new-merge-algorithm/
 category: "Version Control"
 weight: 30
-description: "Introduces a new merge algorithm and how to enable it to resolve conflicts."
+description: "Introduces a new merge algorithm and describes how to enable it to resolve conflicts."
 tags: ["merge", "algorithm", "conflict", "resolution"]
 ---
 

--- a/content/en/docs/refguide/version-control/new-merge-algorithm.md
+++ b/content/en/docs/refguide/version-control/new-merge-algorithm.md
@@ -4,6 +4,7 @@ linktitle: "Merge Algorithm & Conflict Resolution"
 url: /refguide/new-merge-algorithm/
 category: "Version Control"
 weight: 30
+description: "Introduces a new merge algorithm and how to enable it to resolve conflicts."
 tags: ["merge", "algorithm", "conflict", "resolution"]
 ---
 

--- a/content/en/docs/refguide/version-control/on-premises-git.md
+++ b/content/en/docs/refguide/version-control/on-premises-git.md
@@ -3,6 +3,7 @@ title: "Working with Git On-Premises Version Control Server"
 linktitle: "Git On-Premises Version Control Server"
 url: /refguide/on-premises-git/
 weight: 60
+description: "Introduces how to work with Git on-premises version control server."
 tags: ["on-premises", "git", "version control"]
 aliases:
     - /howto/collaboration-requirements-management/on-premises-git-howto/

--- a/content/en/docs/refguide/version-control/on-premises-svn.md
+++ b/content/en/docs/refguide/version-control/on-premises-svn.md
@@ -3,6 +3,7 @@ title: "Working with SVN On-Premises Version Control Server"
 linktitle: "SVN On-Premises Version Control Server"
 url: /refguide/on-premises-svn/
 weight: 50
+description: "Introduces how to work with SVN on-premises version control server."
 tags: ["on-premises", "svn", "version control"]
 aliases:
     - /howto/collaboration-requirements-management/on-premises-svn-howto/

--- a/content/en/docs/refguide/version-control/troubleshoot-git-issues.md
+++ b/content/en/docs/refguide/version-control/troubleshoot-git-issues.md
@@ -2,7 +2,7 @@
 title: "Solve Known Git Issues"
 url: /howto/collaboration-requirements-management/troubleshoot-git-issues/
 weight: 70
-description: "This document describes a list of problems and fixes for Git version control issues."
+description: "Describes a list of problems and fixes for Git version control issues."
 tags: ["version control", "troubleshoot", "Studio Pro", "Git"]
 ---
 

--- a/content/en/docs/refguide/version-control/troubleshoot-version-control-issues.md
+++ b/content/en/docs/refguide/version-control/troubleshoot-version-control-issues.md
@@ -4,7 +4,7 @@ url: /refguide/troubleshoot-version-control-issues/
 linktitle: "Troubleshoot Version Control & Team Server Issues"
 category: "Collaboration"
 weight: 18
-description: "This document presents a list of problems and fixes for version control issues."
+description: "Presents a list of problems and fixes for version control issues."
 tags: ["version control", "troubleshoot", "Studio Pro", "Subversion", "TortoiseSVN"]
 aliases:
     - /howto/collaboration-requirements-management/troubleshoot-version-control-issues/

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro.md
@@ -3,7 +3,7 @@ title: "Using Version Control in Studio Pro"
 url: /refguide/using-version-control-in-studio-pro/
 category: "Version Control"
 weight: 10
-description: "How to work with version control and how to resolve some issues which may arise"
+description: "Describes how to work with version control and how to resolve some issues which may arise."
 tags: ["Version Control", "Conflicts", "Resolve", "Merge", "Patch", "Branch", "Development"]
 # Renamed from version-control-scenarios
 ---

--- a/content/en/docs/refguide/version-control/version-control-faq.md
+++ b/content/en/docs/refguide/version-control/version-control-faq.md
@@ -3,6 +3,7 @@ title: "Version Control FAQ"
 url: /refguide/version-control-faq/
 category: "Version Control"
 weight: 15
+description: "Presents and explains several frequently asked questions about version control."
 tags: ["git", "svn", "subversion", "teamserver", "byo-git", "byo-svn" ]
 ---
 


### PR DESCRIPTION
Commit part of the changes for Studio Pro Guide