### PR TITLE
Extend warning about usage of OpenSSL 3 on Windows

### DIFF
--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
@@ -65,7 +65,7 @@ Virtually all certificate formats can be converted to the PKCS12 format. For mor
 {{% alert color="warning" %}}
 **Do not use OpenSSL version 3.x on Windows**
 
-If you use OpenSSL on Windows and/or you get the error `Could not open certificate container. Wrong password or corrupted file. Please try again.`, please use the latest patch release of **version 1.x**, which can be downloaded here: [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html).
+If you use OpenSSL version 3.x on Windows and you get the error `Could not open certificate container. Wrong password or corrupted file. Please try again.`, please use the latest patch release of **version 1.x**, which can be downloaded here: [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html).
 
 Another option is to use OpenSSL from within the **Windows Subsystem for Linux** to generate the certificate. Use the instructions [Install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install) to set this up.
 {{% /alert %}}

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
@@ -65,9 +65,9 @@ Virtually all certificate formats can be converted to the PKCS12 format. For mor
 {{% alert color="warning" %}}
 **Do not use OpenSSL version 3.x on Windows**
 
-If you use OpenSSL on Windows and/or you get the error _'Could not open certificate container. Wrong password or corrupted file. Please try again.'_, please use the latest patch release of **version 1.x**, which can be downloaded here: [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html).
+If you use OpenSSL on Windows and/or you get the error `Could not open certificate container. Wrong password or corrupted file. Please try again.`, please use the latest patch release of **version 1.x**, which can be downloaded here: [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html).
 
-Another option is to use OpenSSL from within the **Windows Subsystem for Linux** to generate the certificate, which can be installed using the following instructions: [Install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+Another option is to use OpenSSL from within the **Windows Subsystem for Linux** to generate the certificate. Use the instructions [Install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install) to set this up.
 {{% /alert %}}
 
 You can upload a PKCS12 file by following these steps:

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/certificates.md
@@ -63,7 +63,11 @@ Virtually all certificate formats can be converted to the PKCS12 format. For mor
 * [openssl](https://www.openssl.org/docs/manmaster/man1/openssl.html)
 
 {{% alert color="warning" %}}
-If you use [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html), please use the latest patch release of **version 1.x**.
+**Do not use OpenSSL version 3.x on Windows**
+
+If you use OpenSSL on Windows and/or you get the error _'Could not open certificate container. Wrong password or corrupted file. Please try again.'_, please use the latest patch release of **version 1.x**, which can be downloaded here: [OpenSSL for Windows](https://slproweb.com/products/Win32OpenSSL.html).
+
+Another option is to use OpenSSL from within the **Windows Subsystem for Linux** to generate the certificate, which can be installed using the following instructions: [Install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 {{% /alert %}}
 
 You can upload a PKCS12 file by following these steps:


### PR DESCRIPTION
Extend warning about usage of OpenSSL 3 on Windows, include error message users might receive to increase chance of finding the suggestion when searching the Mendix Docs