### PR TITLE
Document the requirement for Atlas 2 or for PWAs

### DIFF
--- a/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
+++ b/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
@@ -21,6 +21,10 @@ Progressive web apps have three main characteristics:
 As PWAs are basically web apps with additional features, Mendix offers these features as a part of web navigation profiles. Based on what is needed, you can create a fully offline-capable PWA, or a web application that requires an internet connection but still uses PWA features.
 
 {{% alert color="warning" %}}
+PWAs require the app to use a recent version of Atlas 2 or Atlas 3.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
 PWAs have the following limitations on iOS:
 
 * Push notifications are not supported for PWAs on iOS

--- a/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
+++ b/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
@@ -21,7 +21,7 @@ Progressive web apps have three main characteristics:
 As PWAs are basically web apps with additional features, Mendix offers these features as a part of web navigation profiles. Based on what is needed, you can create a fully offline-capable PWA, or a web application that requires an internet connection but still uses PWA features.
 
 {{% alert color="warning" %}}
-PWAs require the app to use a recent version of Atlas 2 or Atlas 3.
+PWAs require the app to use a recent version of Atlas 2 or newer.
 {{% /alert %}}
 
 {{% alert color="warning" %}}

--- a/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
+++ b/content/en/docs/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app.md
@@ -18,10 +18,10 @@ Progressive web apps have three main characteristics:
 
 ## 2 Enabling PWA Features
 
-As PWAs are basically web apps with additional features, Mendix offers these features as a part of web navigation profiles. Based on what is needed, you can create a fully offline-capable PWA, or a web application that requires an internet connection but still uses PWA features.
+As PWAs are basically web apps with additional features, Mendix offers these features as a part of web navigation profiles. Depending on your needs, you can create either a fully offline-capable PWA or a web application that requires an internet connection but still uses PWA features.
 
-{{% alert color="warning" %}}
-PWAs require the app to use a recent version of Atlas 2 or newer.
+{{% alert color="info" %}}
+PWAs require a version of Atlas 2 or above.
 {{% /alert %}}
 
 {{% alert color="warning" %}}


### PR DESCRIPTION
This PR documents the requirement for a recent version of Atlas 2 or 3 when using the PWA features.