### PR TITLE
Multiple attributes can be the key

### DIFF
--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -57,7 +57,7 @@ Attributes of type **Binary** cannot be exported through OData services except f
 You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change and together uniquely identify the object. An autonumber attribute is a good choice for a key.
 
 {{% alert color="info" %}}
-Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/)
+Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/).
 {{% /alert %}}
 
 To learn more about selecting attributes as keys, see the [Selecting an Attribute as a Key](/refguide/wrap-services-odata/#select-key) section of *Wrap Services, APIs, or Databases with OData*.

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -52,9 +52,15 @@ Attributes of type **Binary** cannot be exported through OData services except f
 
 {{% /alert %}}
 
-### 3.1 Selecting an Attribute as Key
+### 3.1 Selecting Attributes as the Key
 
-In Studio Pro [9.17](/releasenotes/studio-pro/9.17/) and above, you can select which attributes you would like to use as a key. To learn more about selecting attributes as keys, see the [Selecting an Attribute as a Key](/refguide/wrap-services-odata/#select-key) section of *Wrap Services, APIs, or Databases with OData*.
+You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change and together uniquely identify the object. An autonumber attribute is a good choice for a key.
+
+{{% alert color="info" %}}
+Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/)
+{{% /alert %}}
+
+To learn more about selecting attributes as keys, see the [Selecting an Attribute as a Key](/refguide/wrap-services-odata/#select-key) section of *Wrap Services, APIs, or Databases with OData*.
 
 ### 3.2 Required Validation Rules for Published Attributes
 

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -54,7 +54,7 @@ Attributes of type **Binary** cannot be exported through OData services except f
 
 ### 3.1 Selecting Attributes as the Key
 
-You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change and together uniquely identify the object. An autonumber attribute is a good choice for a key.
+You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change, and together uniquely identify the object. An autonumber attribute is a good choice for a key.
 
 {{% alert color="info" %}}
 Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/).

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -52,7 +52,7 @@ Attributes of type **Binary** cannot be exported through OData services except f
 
 {{% /alert %}}
 
-### 3.1 Selecting Attributes as the Key
+### 3.1 Selecting Attributes as the Key {#select-attributes}
 
 You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change, and together uniquely identify the object. An autonumber attribute is a good choice for a key.
 

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -115,10 +115,6 @@ In Studio Pro [9.16](/releasenotes/studio-pro/9.16/) and below, the inline count
 
 ## 5 Key Selection When Exposing Entities as OData Resources {#select-key}
 
-{{% alert color="info" %}}
-Selecting a different key is only available for published OData services that use OData version 4.
-{{% /alert %}}
-
 Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration).
 
 Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select which attribute to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource. The attribute type can be one of the following: 
@@ -131,10 +127,14 @@ Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select wh
 Select a combination of attribute with the following constraints: 
 
 * Unique – The combination of key attributes should be unique, so each key points to exactly one entity.
-* Required – If one of the key attribute values is empty, you cannot find an entity with it anymore.
-* Stable over time – The attribute values used for the key should not change for an entity, so that you can find it again later.
+* Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
+* Stable over time – The attribute values used for the key should not change, so that you can find it again later.
 
-When exposing an entity as a published OData resource for the first time, Studio Pro chooses a unique and required attribute as the key. If there is no attribute that has a unique constraint or a required constraint, then it will select the first attribute with a supported type. You can set these constraints using [validation rules](/refguide/validation-rules/)
+When exposing an entity as a published OData resource for the first time, Studio Pro chooses a unique and required attribute as the key. If there is no attribute that has a unique constraint or a required constraint, then it will select the first attribute with a supported type. You can set these constraints using [validation rules](/refguide/validation-rules/).
+
+{{% alert color="info" %}}
+Selecting more than one attribute as the key is only available for published OData services that use OData version 4.
+{{% /alert %}}
 
 ### 5.1 Selecting an Attribute as a Key {#select-key}
 
@@ -142,7 +142,7 @@ To select a different attribute as a key, do the following:
 
 1. Open the **Published OData Resource**. 
 2. In the **Key** section, click **Edit** located next to the **Key** property.
-3. In the **Key Selection** dialog box, move the desired key attributes to the right side. 
+3. In the **Key Selection** dialog box, move the key attributes to the right side. 
 
 ## 6 Testing {#testing}
 

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -124,7 +124,7 @@ Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select wh
 * **String**
 * **AutoNumber** 
 
-Select a combination of attribute with the following constraints: 
+Select a combination of attributes with the following constraints: 
 
 * Unique – The combination of key attributes should be unique, so each key points to exactly one entity.
 * Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
@@ -136,9 +136,9 @@ When exposing an entity as a published OData resource for the first time, Studio
 Selecting more than one attribute as the key is only available for published OData services that use OData version 4.
 {{% /alert %}}
 
-### 5.1 Selecting an Attribute as a Key {#select-key}
+### 5.1 Selecting Attributes as a Key {#select-key}
 
-To select a different attribute as a key, do the following:
+To select different attributes as a key, do the following:
 
 1. Open the **Published OData Resource**. 
 2. In the **Key** section, click **Edit** located next to the **Key** property.

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -16,7 +16,7 @@ In this guide, you will learn about the following:
 
 * Exposing non-persistable entities as published OData resources 
 * Using a microflow to define how resources should be retrieved and stored, and to return values of published OData services
-* Selecting a key (other than the object ID) when exposing entities as OData resources
+* Selecting a key when exposing entities as OData resources
 
 ### 1.2 Prerequisites
 
@@ -116,7 +116,7 @@ In Studio Pro [9.16](/releasenotes/studio-pro/9.16/) and below, the inline count
 ## 5 Key Selection When Exposing Entities as OData Resources {#select-key}
 
 {{% alert color="info" %}}
-Selecting a different key is only available for published OData services that use OData v3 and v4.
+Selecting a different key is only available for published OData services that use OData version 4.
 {{% /alert %}}
 
 Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration).
@@ -128,13 +128,13 @@ Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select wh
 * **String**
 * **AutoNumber** 
 
-Select an attribute with the following constraints: 
+Select a combination of attribute with the following constraints: 
 
-* Unique – Every entity should have a unique value, so any one key points to exactly one entity.
-* Required – If the attribute value is empty, you cannot find an entity with it anymore.
-* Stable over time – The attribute value used for the key should not change for an entity, so that you can find it again later.
+* Unique – The combination of key attributes should be unique, so each key points to exactly one entity.
+* Required – If one of the key attribute values is empty, you cannot find an entity with it anymore.
+* Stable over time – The attribute values used for the key should not change for an entity, so that you can find it again later.
 
-A unique and required attribute is automatically selected when such an attribute is available, and when exposing an entity as a Published OData Resource for the first time. You can set these constraints using [validation rules](/refguide/validation-rules/). If there is no attribute that has a unique constraint or a required constraint, then it will select the first attribute with a supported type.
+When exposing an entity as a published OData resource for the first time, Studio Pro chooses a unique and required attribute as the key. If there is no attribute that has a unique constraint or a required constraint, then it will select the first attribute with a supported type. You can set these constraints using [validation rules](/refguide/validation-rules/)
 
 ### 5.1 Selecting an Attribute as a Key {#select-key}
 
@@ -142,9 +142,7 @@ To select a different attribute as a key, do the following:
 
 1. Open the **Published OData Resource**. 
 2. In the **Key** section, click **Edit** located next to the **Key** property.
-3. In the **Key Selection** dialog box, move the desired key attribute to the right side and move the old key attribute to the left side. 
-
-Currently, you can only set only a single attribute as a key. 
+3. In the **Key Selection** dialog box, move the desired key attributes to the right side. 
 
 ## 6 Testing {#testing}
 

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -144,6 +144,8 @@ To select different attributes as a key, do the following:
 2. In the **Key** section, click **Edit** located next to the **Key** property.
 3. In the **Key Selection** dialog box, move the key attributes to the right side. 
 
+A key icon represents attributes that are part of the key.
+
 ## 6 Testing {#testing}
 
 You can use tools like Postman or Visual Studio Code to test your published OData services. These tools can help you call the OData service and validate its output.


### PR DESCRIPTION
In Studio Pro 9.19.0, multiple attributes can be the key of a published OData resource (OData version 4 services only)