### PR TITLE
Remove other outputs from pow function

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/mathematical-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/mathematical-function-calls.md
@@ -262,9 +262,9 @@ The input parameters are described in the table below:
 
 The output is described in the table below:
 
-| Value                                                        | Type                    |
-| ------------------------------------------------------------ | ----------------------- |
-| The number to the power, as in, n^p. The result will be of the most precise type necessary. | Integer/Long or Decimal |
+| Value                                | Type    |
+| ------------------------------------ | ------- |
+| The number to the power, as in, n^p. | Decimal |
 
 ### 8.3 Example
 
@@ -274,7 +274,7 @@ If you use the following input:
 pow(2, 3)
 ```
 
-The output is of type Integer/Long:
+The output is:
 
 ```java {linenos=false}
 8
@@ -286,7 +286,7 @@ Another example of an input is:
 pow(2.5, 3)
 ```
 
-The output is of type Decimal:
+The output is:
 
 ```java {linenos=false}
 15.625

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/mathematical-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/mathematical-function-calls.md
@@ -205,9 +205,9 @@ Calculates the exponent of a number to a certain power.
 
 ### Output
 
-The number to the power, as in, n^p. The result will be of the most precise type necessary.
+The number to the power, as in, n^p.
 
-Type: Integer/Long or Decimal
+Type: Decimal
 
 ```java
 pow(2, 3)
@@ -218,8 +218,6 @@ returns:
 ```java
 8
 ```
-
-of type "Integer/Long"
 
 and
 
@@ -232,8 +230,6 @@ returns:
 ```java
 15.625
 ```
-
-of type "Decimal"
 
 Calculation of 'pow' with a decimal exponent might be less accurate, as the standard Java libraries do not support these calculations with high precision. Use a specialized library in a custom Java action if high precision is required for this case.
 

--- a/content/en/docs/refguide8/modeling/application-logic/expressions/mathematical-function-calls.md
+++ b/content/en/docs/refguide8/modeling/application-logic/expressions/mathematical-function-calls.md
@@ -266,9 +266,9 @@ The input parameters are described in the table below:
 
 The output is described in the table below:
 
-| Value                                                        | Type                    |
-| ------------------------------------------------------------ | ----------------------- |
-| The number to the power, as in, n^p. The result will be of the most precise type necessary. | Integer/Long or Decimal |
+| Value                                | Type    |
+| ------------------------------------ | ------- |
+| The number to the power, as in, n^p. | Decimal |
 
 ### 8.3 Example
 
@@ -278,7 +278,7 @@ If you use the following input:
 pow(2, 3)
 ```
 
-The output is of type Integer/Long:
+The output is:
 
 ```java {linenos=false}
 8
@@ -290,7 +290,7 @@ Another example of an input is:
 pow(2.5, 3)
 ```
 
-The output is of type Decimal:
+The output is:
 
 ```java {linenos=false}
 15.625


### PR DESCRIPTION
Removed Integer/Long as possible output types of `pow()`, for SP 7, 8 & 9. The only possible output type of `pow()` is Decimal.

Waiting on verification that the same applies to `pow()` output in nanoflows.