### PR TITLE
Clarify Use Docker with Minikube documentation

### DIFF
--- a/content/en/docs/developerportal/deploy/docker-deploy/_index.md
+++ b/content/en/docs/developerportal/deploy/docker-deploy/_index.md
@@ -4,16 +4,19 @@ url: /developerportal/deploy/docker-deploy/
 category: "Deployment"
 weight: 60
 description: "Describes how to deploy using a Docker image."
-tags: ["Docker", "Cloud", "container", "CI/CD"]
-#To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
+tags: ["Docker", "Cloud", "container", "push image", "build image"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
 ## 1 Introduction
 
-This page explains how to build a Docker image from your Mendix Project. Each release of a project will result in a unique Docker image that can be pushed through the different stages of your application pipeline.
+Docker is an open source container technology. With Mendix, you can use it for simple deployments, particularly when running local or development versions of your app. However, it lacks some scaling and integration features.
 
-**You will learn how to do the following:**
+We suggest that, if you are planning to deploy to your own cloud platform at scale, a better solution for production apps is to use [Mendix for Private Cloud](/developerportal/deploy/private-cloud/). This provides you with structured and tested solutions for integrating with your own cloud infrastructure using comprehensive, automated, native functions, avoiding the need to without create your own processes from scratch.
+
+This page explains how to build a Docker image from your Mendix App. Every time you make changes to your app, you must create a new  Docker image that can be pushed through the different stages of your application pipeline.
+
+This how-to will teach you how to do the following:
 
 * Build the image
 * Push the image

--- a/content/en/docs/developerportal/deploy/docker-deploy/run-mendix-docker-image.md
+++ b/content/en/docs/developerportal/deploy/docker-deploy/run-mendix-docker-image.md
@@ -1,5 +1,6 @@
 ---
 title: "Run a Mendix Docker Image"
+linktitle: "Run Docker Image"
 url: /developerportal/deploy/run-mendix-docker-image/
 weight: 10
 description: "Describes running a Mendix Docker image."

--- a/content/en/docs/developerportal/deploy/docker-deploy/run-mendix-on-kubernetes.md
+++ b/content/en/docs/developerportal/deploy/docker-deploy/run-mendix-on-kubernetes.md
@@ -1,34 +1,26 @@
 ---
-title: "Run Mendix on Kubernetes"
+title: "Use Docker with Minikube"
+linktitle: "Run with Minikube"
 url: /developerportal/deploy/run-mendix-on-kubernetes/
 weight: 20
-tags: ["Kubernetes", "cloud", "deployment"]
-#To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
+tags: ["Minikube", "Docker", "deployment"]
 ---
 
 ## 1 Introduction
 
-This how-to takes you through the process of deploying your Mendix app to [Kubernetes](https://kubernetes.io/).
+This how-to takes you through the process of deploying a Docker image of your Mendix app to [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), a local version of [Kubernetes](https://kubernetes.io/docs/home/) which runs in a Windows container or virtual machine. Many of the operations you perform on Minikube are the same as those on a hosted environment and it provides a low-level entry to Kubernetes. For more information, see [Installing Kubernetes with Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) on the Kubernetes documentation site.
 
-Kubernetes is the standard container orchestration platform supported by Mendix. For details on supported version of Kubernetes see [Mendix System Requirements](/refguide/system-requirements/). If possible, we suggest you use [Mendix for Private Cloud](/developerportal/deploy/private-cloud/) to deploy Mendix apps to Kubernetes as this provides you with integration with the Developer Portal and takes away some of the heavy lifting. 
-
-{{% alert color="warning" %}}
-Do not use these instructions if you are using Mendix for Private Cloud — many of the steps here are not needed. For deploying using Mendix for Private Cloud, follow the instructions in the [Mendix for Private Cloud](/developerportal/deploy/private-cloud/) documentation.
-{{% /alert %}}
-
-A Mendix application needs, as a minimum, a database to run. In this example you provision a PostgreSQL database within the Kubernetes cluster. In production scenarios, the database is usually provided as a service by the cloud provider, like AWS RDS or Azure SQL. For supported databases see [Mendix System Requirements](/refguide/system-requirements/). 
-
-If the application makes use of persistable FileDocument or FileImage entities, a persistent volume (PV) storage service needs to be attached as well. See [Mendix System Requirements](/refguide/system-requirements/) for supported external storage services. In this how-to you use a node-bound storage volume as an example. For more information, see [Architecture Overview](#architecture), below.
-
-This how-to uses [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), which is a way to run Kubernetes locally. Many of the operations you perform on Minikube are the same as those on a hosted environment and it provides a low-level entry to Kubernetes. For more information, see [Installing Kubernetes with Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) on the Kubernetes documentation site.
-
-For more details on Kubernetes, see the [Kubernetes Documentation](https://kubernetes.io/docs/home/) site.
+Kubernetes is a standard container orchestration platform supported by Mendix. For details on supported version of Kubernetes see [Mendix System Requirements](/refguide/system-requirements/). When publishing to your cloud infrastructure, we suggest you use [Mendix for Private Cloud](/developerportal/deploy/private-cloud/) to deploy Mendix apps to Kubernetes as this provides you with integration with the Developer Portal and takes away much of the heavy lifting. 
 
 This how-to will teach you how to do the following:
 
 * Deploy and run a Mendix app on Kubernetes using Minikube
 * Separate the database deployment from your app 
 * Attach persistence storage to the app container
+
+{{% alert color="warning" %}}
+Do not use these instructions if you are using Mendix for Private Cloud — Mendix for Private Cloud performs many of the steps here for you. If deploying using Mendix for Private Cloud, follow the instructions in the [Mendix for Private Cloud](/developerportal/deploy/private-cloud/) documentation.
+{{% /alert %}}
 
 ## 2 Prerequisites
 
@@ -47,6 +39,10 @@ This how-to uses commands for a Unix-like system. The commands for Windows may b
 ## 3 Architecture Overview{#architecture}
 
 Before you start, here is some background information on the components needed to deploy a Mendix app on Kubernetes.
+
+A Mendix application needs, as a minimum, a database to run. In this example you provision a PostgreSQL database within the Kubernetes cluster. In production scenarios, the database is usually provided as a service by the cloud provider, like AWS RDS or Azure SQL. For supported databases see [Mendix System Requirements](/refguide/system-requirements/). 
+
+If the application makes use of persistable FileDocument or FileImage entities, a persistent volume (PV) storage service needs to be attached as well. See [Mendix System Requirements](/refguide/system-requirements/) for supported external storage services. In this how-to you use a node-bound storage volume as an example. For more information, see [Architecture Overview](#architecture), below.
 
 This architecture overview shows all the components in the deployment:
 
@@ -77,6 +73,7 @@ Once Minikube is running you must configure your local environment to use the Do
 ```bash {linenos=false}
 minikube docker-env
 ```
+
 You must first deploy your database. Minikube uses an external folder to persist the data outside of the database pod.
 
 {{% alert color="info" %}}

--- a/content/en/docs/developerportal/deploy/general/licensing-apps-outside-mxcloud.md
+++ b/content/en/docs/developerportal/deploy/general/licensing-apps-outside-mxcloud.md
@@ -129,7 +129,7 @@ To activate a license on your app running on Kubernetes you need the license cre
 
 Two additional environment variables, `LICENSE_ID` and `LICENSE_KEY`, need to be set to the values of the *LicenseId* and *LicenseKey* provided by Mendix Support. This is done by adding them to the deployment command for your app.
 
-Full instructions on how to do this, and how to supply the keys using a *Secrets* file can be found in the [Deploying the Application](/developerportal/deploy/run-mendix-on-kubernetes/#deploy) section of *Run Mendix on Kubernetes*.
+Full instructions on how to do this, and how to supply the keys using a *Secrets* file can be found in the [Deploying the Application](/developerportal/deploy/run-mendix-on-kubernetes/#deploy) section of *Use Docker with Minikube*.
 
 ### 3.8 Windows Server
 

--- a/content/en/docs/refguide/general/system-requirements.md
+++ b/content/en/docs/refguide/general/system-requirements.md
@@ -205,7 +205,7 @@ For container-based deployments using Docker, Kubernetes, or Cloud Foundry, the 
 * SAP AWS S3 Object Storage
 * SAP Azure Blob Storage
 
-For container-mounted storage in Kubernetes, provided by an external storage class, see also [Run Mendix on Kubernetes](/developerportal/deploy/run-mendix-on-kubernetes/).
+For container-mounted storage in Kubernetes, provided by an external storage class, see also [Use Docker with Minikube](/developerportal/deploy/run-mendix-on-kubernetes/).
 
 ### 9.2 Storage Types for Servers
 

--- a/content/en/docs/refguide/runtime/clustered-mendix-runtime.md
+++ b/content/en/docs/refguide/runtime/clustered-mendix-runtime.md
@@ -16,7 +16,7 @@ The main feature enabling clustering is Mendix's stateless runtime architecture.
 
 Clustering support is built natively into our Cloud Foundry buildpack implementation. This means that you can simply scale up using Cloud Foundry. The buildpack ensures that your system automatically starts behaving as a cluster.
 
-Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the [Some Notes on Scaling](/developerportal/deploy/run-mendix-on-kubernetes/#scaling) section of *How to Run Mendix on Kubernetes*.
+Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the [Some Notes on Scaling](/developerportal/deploy/run-mendix-on-kubernetes/#scaling) section of *Use Docker with Minikube*.
 
 ## 3 Cluster Infrastructure
 

--- a/content/en/docs/refguide7/runtime/clustered-mendix-runtime.md
+++ b/content/en/docs/refguide7/runtime/clustered-mendix-runtime.md
@@ -16,7 +16,7 @@ Mendix 7 contains a completely new build approach for clustering. The main featu
 
 Clustering support is built natively into our Cloud Foundry buildpack implementation. This means that you can simply scale up using Cloud Foundry. The buildpack ensures that your system automatically starts behaving as a cluster.
 
-Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the *Some Notes on Scaling* section [How to Run Mendix on Kubernetes](/developerportal/deploy/run-mendix-on-kubernetes/#scaling).
+Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the *Some Notes on Scaling* section [Use Docker with Minikube](/developerportal/deploy/run-mendix-on-kubernetes/#scaling).
 
 ## 3 Cluster Infrastructure
 

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -142,7 +142,7 @@ For container-based deployments using Docker, Kubernetes, or Cloud Foundry, the 
 * SAP AWS S3 Object Storage
 * SAP Azure Blob Storage
 
-For container-mounted storage in Kubernetes, provided by an external storage class, see also [Run Mendix on Kubernetes](/developerportal/deploy/run-mendix-on-kubernetes/).
+For container-mounted storage in Kubernetes, provided by an external storage class, see also [Use Docker with Minikube](/developerportal/deploy/run-mendix-on-kubernetes/).
 
 ### 9.2 Storage types for Servers
 

--- a/content/en/docs/refguide8/runtime/clustered-mendix-runtime.md
+++ b/content/en/docs/refguide8/runtime/clustered-mendix-runtime.md
@@ -20,7 +20,7 @@ The main feature enabling clustering is Mendix's stateless runtime architecture.
 
 Clustering support is built natively into our Cloud Foundry buildpack implementation. This means that you can simply scale up using Cloud Foundry. The buildpack ensures that your system automatically starts behaving as a cluster.
 
-Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the [Some Notes on Scaling](/developerportal/deploy/run-mendix-on-kubernetes/#scaling) section of *How to Run Mendix on Kubernetes*.
+Clustering is also supported on Kubernetes, but you will have to use a *StatefulSet*. There is more information on this in the [Some Notes on Scaling](/developerportal/deploy/run-mendix-on-kubernetes/#scaling) section of *Use Docker with Minikube*.
 
 ## 3 Cluster Infrastructure
 


### PR DESCRIPTION
The current documentation gives an example of using Docker with Minikube. This is intended as a proof of concept explanation rather than a full-blown explanation of using Mendix on Kubernetes. However it appears above Mendix for Private Cloud, the fully supported offering for deploying to Kubernetes, in Google searches such as _Mendix Kubernetes_.

This PR highlights the use case for deploying on Minikube and clarifies the limitations compared to Mendix for Private Cloud.

**Publishing this will not immediately update Google search - we should force Google to re-index this manually so that we can review the impact on search results.**