### PR TITLE
[UIA-360] Update dependencies for Unit Testing module

### DIFF
--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -27,14 +27,16 @@ For module versions below 9.1.0, use the [Object Handling](/appstore/modules/obj
 
 ## 2 Installation
 
-1. Import the Unit Testing module into your app.
+1.  Import the Unit Testing module into your app.
+
     For more information, see [Use Marketplace Content in Studio Pro](/appstore/general/app-store-content/).
+
 2. Download the latest Object Handling module into your app.
 3. Map the module role **TestRunner** to the applicable user roles in your app.
 4. Add the **UnitTestOverview** microflow to your navigation structure, or include the **UnitTestOverview** snippet on a custom page.
-5. The following steps are optional:
+5.  The following steps are optional:
     * For including JUnit tests – set the **UnitTesting.FindJUnitTests** constant to true (take the the app settings regarding cloud security into consideration)
-    * For running remote unit tests via API:
+    *  For running remote unit tests via API:
         * Add the **Startup** flow to your app model's startup sequence
         * Set the **UnitTesting.RemoteApiEnabled** constant to true and provide a password for **UnitTesting.RemoteApiPassword**
         * When hosting in a cloud node or on-premises. open a request handler on the **unittests/** path

--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -13,13 +13,17 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 
 ### 1.1 Dependencies
 
-* [Object Handling](/appstore/modules/object-handling/)
+* [Community Commons](/appstore/modules/community-commons-function-library/)
 * *junit-4.13.1.jar*
 * *commons-io-2.11.0.jar*
 * *commons-lang3-3.7.jar*
 * *httpclient5-5.0.3.jar*
 * *httpcore5-5.0.3.jar*
 * *hamcrest-2.2.jar*
+
+{{% alert color="info" %}}
+For module versions below 9.1.0, use the [Object Handling](/appstore/modules/object-handling/) module instead of Community Commons.
+{{% /alert %}}
 
 ## 2 Installation
 

--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -16,7 +16,7 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 * [Community Commons](/appstore/modules/community-commons-function-library/)
 * *junit-4.13.1.jar*
 * *commons-io-2.11.0.jar*
-* *commons-lang3-3.7.jar*
+* *commons-lang3-3.11.jar*
 * *httpclient5-5.0.3.jar*
 * *httpcore5-5.0.3.jar*
 * *hamcrest-2.2.jar*

--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -13,7 +13,7 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 
 ### 1.1 Dependencies
 
-* [Community Commons](/appstore/modules/community-commons-function-library/)
+* The [Community Commons](/appstore/modules/community-commons-function-library/) module
 * *junit-4.13.1.jar*
 * *commons-io-2.11.0.jar*
 * *commons-lang3-3.11.jar*
@@ -22,7 +22,7 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 * *hamcrest-2.2.jar*
 
 {{% alert color="info" %}}
-For module versions below 9.1.0, use the [Object Handling](/appstore/modules/object-handling/) module instead of Community Commons.
+For module versions below 9.1.0, use the [Object Handling](/appstore/modules/object-handling/) module instead of the Community Commons module.
 {{% /alert %}}
 
 ## 2 Installation

--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -15,7 +15,7 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 
 * [Object Handling](/appstore/modules/object-handling/)
 * *junit-4.13.1.jar*
-* *commons-io-2.8.0.jar*
+* *commons-io-2.11.0.jar*
 * *commons-lang3-3.7.jar*
 * *httpclient5-5.0.3.jar*
 * *httpcore5-5.0.3.jar*


### PR DESCRIPTION
Updated dependencies section in Unit Testing module documentation. The updates are based on changes introduced by two recent marketplace releases:
- [v9.0.5](https://github.com/mendix/UnitTesting/releases/tag/v9.0.5): We updated commons-io from v2.8.0 to 2.11.0
- [v9.1.0](https://github.com/mendix/UnitTesting/releases/tag/v9.1.0): We replaced the Object Handling dependency with Community Commons