### PR TITLE
Inline date format tokens (1)

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
@@ -10,9 +10,29 @@ tags: ["studio pro", "expressions", "parsing", "formatting"]
 
 This document describes functions that are used to parse Date and time values from strings using a specified pattern, or to produce a string from a Date and time value.
 
-{{% alert color="info" %}}
-For details on all pattern possibilities, see the Java class [SimpleDateFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html). 
-{{% /alert %}}
+The following pattern letters can be used in functions which accept format:
+
+| Letter | Date or Time Component                    | Examples         |
+| ------ | ----------------------------------------- | ---------------- |
+| L      | Month in year                             | July; Jul; 07    |
+| y      | Year                                      | 1996; 96         |
+| G      | Era designator                            | AD               |
+| E      | Day name in week                          | Tuesday; Tue     |
+| u      | Day of week (1 = Monday, ..., 7 = Sunday) | 1                |
+| Y      | Week year                                 | 2009; 09         |
+| w      | Week in year                              | 27               |
+| W      | Week in month                             | 2                |
+| D      | Day in year                               | 189              |
+| d      | Day in month                              | 10               |
+| F      | Day of week in month                      | 2                |
+| a      | Am/pm marker                              | PM               |
+| H      | Hour in day (0-23)                        | 0                |
+| k      | Hour in day (1-24)                        | 24               |
+| K      | Hour in am/pm (0-11)                      | 0                |
+| h      | Hour in am/pm (1-12)                      | 12               |
+| m      | Minute in hour                            | 30               |
+| s      | Second in minute                          | 55               |
+| S      | Millisecond                               | 978              |
 
 ## 2 parseDateTime[UTC] {#parsedatetime-utc}
 

--- a/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
@@ -12,27 +12,27 @@ This document describes functions that are used to parse Date and time values fr
 
 The following pattern letters can be used in functions which accept format:
 
-| Letter | Date or Time Component                    | Examples         |
-| ------ | ----------------------------------------- | ---------------- |
-| L      | Month in year                             | July; Jul; 07    |
-| y      | Year                                      | 1996; 96         |
-| G      | Era designator                            | AD               |
-| E      | Day name in week                          | Tuesday; Tue     |
-| u      | Day of week (1 = Monday, ..., 7 = Sunday) | 1                |
-| Y      | Week year                                 | 2009; 09         |
-| w      | Week in year                              | 27               |
-| W      | Week in month                             | 2                |
-| D      | Day in year                               | 189              |
-| d      | Day in month                              | 10               |
-| F      | Day of week in month                      | 2                |
-| a      | Am/pm marker                              | PM               |
-| H      | Hour in day (0-23)                        | 0                |
-| k      | Hour in day (1-24)                        | 24               |
-| K      | Hour in am/pm (0-11)                      | 0                |
-| h      | Hour in am/pm (1-12)                      | 12               |
-| m      | Minute in hour                            | 30               |
-| s      | Second in minute                          | 55               |
-| S      | Millisecond                               | 978              |
+| Letter | Date or Time Component                    | Examples               |
+| ------ | ----------------------------------------- | ---------------------- |
+| L      | Month in year                             | November; Nov; 11      |
+| y      | Year                                      | 2001; 01               |
+| G      | Era designator                            | AD                     |
+| E      | Day name in week                          | Tuesday; Tue           |
+| u      | Day of week (1 = Monday, ..., 7 = Sunday) | 5                      |
+| Y      | Week year                                 | 2009; 09               |
+| w      | Week in year                              | 11                     |
+| W      | Week in month                             | 2                      |
+| D      | Day in year                               | 133                    |
+| d      | Day in month                              | 7                      |
+| F      | Day of week in month                      | 1                      |
+| a      | Am/pm marker                              | PM                     |
+| H      | Hour in day (0-23)                        | 0                      |
+| k      | Hour in day (1-24)                        | 24                     |
+| K      | Hour in am/pm (0-11)                      | 0                      |
+| h      | Hour in am/pm (1-12)                      | 12                     |
+| m      | Minute in hour                            | 24                     |
+| s      | Second in minute                          | 50                     |
+| S      | Millisecond                               | 201                    |
 
 ## 2 parseDateTime[UTC] {#parsedatetime-utc}
 


### PR DESCRIPTION
Currently, we link Oracle doc on SimpleDateFormat. This doc covers formatting options in Microflows but doesn't take into account that Nanoflows does not support all of these tokens. This MR removes the link and inlines all officially supported date tokens into our documentation.