### PR TITLE
Add buttons to widget docs

### DIFF
--- a/content/en/docs/appstore/widgets/accessibility-helper.md
+++ b/content/en/docs/appstore/widgets/accessibility-helper.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "accessibility helper",
 
 The [Accessibility Helper](https://marketplace.mendix.com/link/component/114803/) widget allows a user to add a list of HTML properties to elements in the HTML `page.carousel`.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/114803/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Target elements via CSS selectors for easy usage

--- a/content/en/docs/appstore/widgets/accordion.md
+++ b/content/en/docs/appstore/widgets/accordion.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "accordion", "group box
 
 The [Accordion](https://marketplace.mendix.com/link/component/117895) widget enables to group and collapse content within your [progressive web apps](/refguide/progressive-web-app/) and [web apps](https://www.mendix.com/evaluation-guide/app-capabilities/web-apps/).
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/117895" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Display groups consisting of a header and content

--- a/content/en/docs/appstore/widgets/auto-load-more.md
+++ b/content/en/docs/appstore/widgets/auto-load-more.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "auto-load more", "load
 
 The [Auto-Load More](https://marketplace.mendix.com/link/component/50323/) widget loads more items on the list view as the end-user scrolls.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/50323/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ## 2 Usage
 
 1. Place the widget in the same page or snippet as the target list view (as in, right below it).

--- a/content/en/docs/appstore/widgets/badge-button.md
+++ b/content/en/docs/appstore/widgets/badge-button.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "badge button", "token"
 
 The [Badge Button](https://marketplace.mendix.com/link/component/52705/) widget can function as a special distinctive mark or token put on any display as a button.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/52705/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Display a badge on a button

--- a/content/en/docs/appstore/widgets/badge.md
+++ b/content/en/docs/appstore/widgets/badge.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "app store", "marketplace component", "app store component
 
 The [Badge](https://marketplace.mendix.com/link/component/50325/) widget shows a value inside a colored badge or label.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/50325/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 The widget does the following:
 
 * Displays a value based on a configured text template

--- a/content/en/docs/appstore/widgets/barcode-scanner.md
+++ b/content/en/docs/appstore/widgets/barcode-scanner.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "barcode scanner", "pla
 
 The [Barcode Scanner](https://marketplace.mendix.com/link/component/117627) widget enables a barcode scanning functionality within your Mendix web application.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/117627" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 The widget does the following:
 
 * Displays a full-screen canvas overlay that allows the end-user to scan a barcode

--- a/content/en/docs/appstore/widgets/bootstrap-tooltip.md
+++ b/content/en/docs/appstore/widgets/bootstrap-tooltip.md
@@ -14,6 +14,10 @@ This widget is deprecated. For an alternative, see [Tooltip](/appstore/widgets/t
 
 The [Bootstrap Tooltip](https://marketplace.mendix.com/link/component/1939/) widget adds a tooltip to a user-defined field that contains help text or extra information.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/1939/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Usage Scenario
 
 * Add help text to an input field that is visible upon focus

--- a/content/en/docs/appstore/widgets/calendar.md
+++ b/content/en/docs/appstore/widgets/calendar.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "calendar", "platform s
 
 The [Calendar](https://marketplace.mendix.com/link/component/107954/) widget can be used to display and manage calendar events.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/107954/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Add and edit calendar events

--- a/content/en/docs/appstore/widgets/carousel.md
+++ b/content/en/docs/appstore/widgets/carousel.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "carousel", "image", "p
 
 The [Carousel](https://marketplace.mendix.com/link/component/47784/) widget displays images in a carousel.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/47784/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Allows you to use the widget as a composable region for your image widgets, text widgets, and more

--- a/content/en/docs/appstore/widgets/charts/_index.md
+++ b/content/en/docs/appstore/widgets/charts/_index.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "chart", "line chart", 
 
 The [Charts](https://marketplace.mendix.com/link/component/105695/) widget enables plotting and comparing your data across different charts.
 
+To see the component in the Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/105695/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 For more examples of what Charts widgets can do, see the following documents:
 
 * [Create a Basic Chart](/appstore/widgets/charts-basic-create/)

--- a/content/en/docs/appstore/widgets/charts/_index.md
+++ b/content/en/docs/appstore/widgets/charts/_index.md
@@ -11,7 +11,7 @@ tags: ["marketplace", "marketplace component", "widget", "chart", "line chart", 
 
 The [Charts](https://marketplace.mendix.com/link/component/105695/) widget enables plotting and comparing your data across different charts.
 
-To see the component in the Marketplace, click here:
+To see the component in the Mendix Marketplace, click here:
 
 {{% button color="dark" href="https://marketplace.mendix.com/link/component/105695/" text="See component in Marketplace" title="See component in Marketplace" %}}
 

--- a/content/en/docs/appstore/widgets/check-box-set-selector.md
+++ b/content/en/docs/appstore/widgets/check-box-set-selector.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "check box set selector
 
 The [Check Box Set Selector](https://marketplace.mendix.com/link/component/121/) widget lets you use a list of check boxes for your reference set. It supports multiple display attributes and looks the same as a [reference set selector](/refguide/reference-set-selector/).
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/121/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Usage Scenario
 
 * Quickly set or adjust a reference set without having to go through pop-up windows and buttons

--- a/content/en/docs/appstore/widgets/color-picker.md
+++ b/content/en/docs/appstore/widgets/color-picker.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "color picker", "react"
 
 The [Color Picker](https://marketplace.mendix.com/link/component/107044/) enables selecting and adjusting a color value that is stored in a string attribute
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/107044/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Render using the button, input box, and inline modes

--- a/content/en/docs/appstore/widgets/fieldset.md
+++ b/content/en/docs/appstore/widgets/fieldset.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "fieldset", "token", "p
 
 The [Fieldset](https://marketplace.mendix.com/link/component/113922/Mendix/Fieldset) widget is a container which groups widgets within a form. Structuring a form helps end-users fill it out, especially when they rely on accessibility tools like a screen reader. For example, you could use this widget to group input widgets that belong to the same address when a form requires multiple addresses.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/113922/Mendix/Fieldset" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ## 2 Features
 
 * Group widgets in a form

--- a/content/en/docs/appstore/widgets/format-string.md
+++ b/content/en/docs/appstore/widgets/format-string.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "format string", "platf
 
 The [Format String](https://marketplace.mendix.com/link/component/264/) widget adds a user-defined string to your page, taking object attributes as input parameters.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/264/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Use Cases
 
 Use this widget to display multiple attributes as a single string.

--- a/content/en/docs/appstore/widgets/google-analytics.md
+++ b/content/en/docs/appstore/widgets/google-analytics.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "google analytics", "ev
 
 The [Google Analytics](https://marketplace.mendix.com/link/component/105/) widget enables tracking page views and custom events with Google Analytics. If you have an e-commerce application, you can also use this widget to keep track of your transactions.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/105/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Usage Scenario
 
 With this widget, you can track custom events, page views, and transactions. For example, you want to track how often a product is viewed and inspect it in Google Analytics, and you want a detailed overview of all transactions.

--- a/content/en/docs/appstore/widgets/google-maps.md
+++ b/content/en/docs/appstore/widgets/google-maps.md
@@ -19,6 +19,10 @@ The [Google Maps](https://marketplace.mendix.com/link/component/48911/) widget c
 
 For information on styling your Google Maps widget, see the [Style Google Maps](#style-google-maps) section below.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/48911/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Show the location on a map based on an address or a coordinate

--- a/content/en/docs/appstore/widgets/html-javascript-snippet.md
+++ b/content/en/docs/appstore/widgets/html-javascript-snippet.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "html", "javascript", "
 
 The [HTML/JavaScript Snippet](https://marketplace.mendix.com/link/component/56/) widget is useful for adding a piece of HTML or JavaScript to a page (for example, to embed a YouTube or Flash object). In addition, it can be used to enhance styling by adding arbitrary HTML elements.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/56/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Use Cases
 
 * Display a predefined HTML document

--- a/content/en/docs/appstore/widgets/htmlelement.md
+++ b/content/en/docs/appstore/widgets/htmlelement.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "htmlelement", "platfor
 
 The [HTML Element](https://marketplace.mendix.com/link/component/204843) widget allows a developer to create custom HTML elements to build custom structures, visualizations, or interactions. The widget can also execute advanced text formatting, build custom UI components, and embed HTML.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/204843" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 The HTML Element widget contains settings to define the HTML tag, HTML attributes, events, and repeat elements. This widget can be nested and combined with other widgets.
 
 ### 1.1 Features

--- a/content/en/docs/appstore/widgets/image.md
+++ b/content/en/docs/appstore/widgets/image.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "image", "platform supp
 
 The [Image](https://marketplace.mendix.com/link/component/118579) widget displays an image and optionally performs an on-click action like enlarging to mobile-friendly, opening a page, calling a mircoflow, and more.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/118579" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Supports different data sources

--- a/content/en/docs/appstore/widgets/label-selector.md
+++ b/content/en/docs/appstore/widgets/label-selector.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "label selector", "plat
 
 The [Label Selector](https://marketplace.mendix.com/link/component/292/) widget enables easily creating objects, assigning objects to other objects, and removing objects (for example, labels) from other objects.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/292/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 It features both an input box for searching and creating objects and a drop-down menu for selecting objects that already exist . The implementation is based on the [Tag-it library](https://aehlke.github.io/tag-it/).
 
 You configure background colors for labels and how the text contrasts with a label background via the `text-normal` or `text-contrast` class.

--- a/content/en/docs/appstore/widgets/language-selector.md
+++ b/content/en/docs/appstore/widgets/language-selector.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "languageSelector", "gr
 
 The [Language Selector](https://marketplace.mendix.com/link/component/202738/) widget allows the end-user to easily switch the language of your application.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/202738/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Displays a list of app languages available to the end-user determined by the developer.

--- a/content/en/docs/appstore/widgets/list-view-controls.md
+++ b/content/en/docs/appstore/widgets/list-view-controls.md
@@ -15,6 +15,10 @@ This widget is deprecated. You can use the [Data Widgets](/appstore/modules/data
 
 The [List View Controls](https://marketplace.mendix.com/link/component/105694/) enable filtering and searching a list view with the database and XPath data sources.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/105694/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 These are the available list view widgets:
 
 * [Check box filter](#check-box-filter) – filters a list view with various constraints when checked or unchecked

--- a/content/en/docs/appstore/widgets/list-view-swipe.md
+++ b/content/en/docs/appstore/widgets/list-view-swipe.md
@@ -15,6 +15,10 @@ This widget is deprecated.
 
 The [List View Swipe](https://marketplace.mendix.com/link/component/47781/) widget makes it possible for the app end-user to perform a swipe action on a list view.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/47781/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Open a page after an item is swiped

--- a/content/en/docs/appstore/widgets/maps.md
+++ b/content/en/docs/appstore/widgets/maps.md
@@ -9,7 +9,13 @@ tags: ["marketplace", "marketplace component", "widget", "maps", "google maps", 
 
 ## 1 Introduction {#introduction}
 
-The [Maps](https://marketplace.mendix.com/link/component/108261/) widget enables showing locations on maps. It supports the following map providers:
+The [Maps](https://marketplace.mendix.com/link/component/108261/) widget enables showing locations on maps. 
+
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/108261/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
+The widget supports the following map providers:
 
 * [Google Maps](https://www.google.com/maps/)
 * [OpenStreetMap](https://www.openstreetmap.org)

--- a/content/en/docs/appstore/widgets/mendix-feedback.md
+++ b/content/en/docs/appstore/widgets/mendix-feedback.md
@@ -21,6 +21,10 @@ In case of any questions, contact [Mendix Support](https://support.mendix.com/hc
 
 The [Mendix Feedback](https://marketplace.mendix.com/link/component/199/) widget allows end-users of your application to directly submit feedback into your app. The feedback widget is fully integrated with the [Feedback](/developerportal/collaborate/feedback/) page in the Developer Portal, where you can review feedback and convert it into [user stories](/developerportal/collaborate/stories/) to improve your app.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/199/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{< figure src="/attachments/appstore/widgets/mendix-feedback/feedback-in-app.png" >}}
 
 The Mendix Feedback widget is easy to set up and automatically attaches additional information to each submitted issue such as the user’s name, role, active form, browser version, and screen resolution.

--- a/content/en/docs/appstore/widgets/microflow-timer.md
+++ b/content/en/docs/appstore/widgets/microflow-timer.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "microflow timer", "pla
 
 The [Microflow Timer](https://marketplace.mendix.com/link/component/27/) widget can be used to time and execute a microflow or nanoflow as long as a certain page is open. The microflow or nanoflow can be executed once or repeatedly, in which case it will not stop until it returns false or until the page is closed. 
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/27/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{% alert color="warning" %}}
 In offline apps, you cannot use microflows, but you can use nanoflows.
 {{% /alert %}}

--- a/content/en/docs/appstore/widgets/mobile-device.md
+++ b/content/en/docs/appstore/widgets/mobile-device.md
@@ -13,7 +13,13 @@ This widget is deprecated.
 
 ## 1 Introduction
 
-The [Mobile Device](https://marketplace.mendix.com/link/component/65139/) widget retrieves information about your device and mobile app. It can retrieve the following data:
+The [Mobile Device](https://marketplace.mendix.com/link/component/65139/) widget retrieves information about your device and mobile app. 
+
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/65139/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
+The widget can retrieve the following data:
 
 * **Device ID** – the unique ID of the device
 * **Device platform** – the platform on which the app runs (for example, Android, iOS, or web)

--- a/content/en/docs/appstore/widgets/mobile-features.md
+++ b/content/en/docs/appstore/widgets/mobile-features.md
@@ -15,6 +15,10 @@ This widget is deprecated.
 
 The [Mobile Features](https://marketplace.mendix.com/link/component/48902/) widget can be placed in a page layout and used in [hybrid mobile](/refguide/hybrid-mobile/) applications.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/48902/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Use Cases
 
 The widget is designed to be dropped on your master mobile page template. It overrides functions in the Mendix UI code to hook into Cordova plugins. The features below (with the exception of custom body classes) can be switched on and off.

--- a/content/en/docs/appstore/widgets/popup-menu.md
+++ b/content/en/docs/appstore/widgets/popup-menu.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "popup", "pop-up", "pop
 
 The [Pop-Up Menu](https://marketplace.mendix.com/link/component/115826/) widget shows a floating menu with items. The widget allows users to create their own items in "custom" mode.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/115826/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Allows you to configure widgets that trigger the menu visibility

--- a/content/en/docs/appstore/widgets/progress-bar.md
+++ b/content/en/docs/appstore/widgets/progress-bar.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "progress bar", "bootst
 
 The [Progress Bar](https://marketplace.mendix.com/link/component/48910/) widget displays a progress bar.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/48910/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 The widget does the following:
 
 * Displays a progress percentage in the form of a bar based on a configurable range

--- a/content/en/docs/appstore/widgets/progress-circle.md
+++ b/content/en/docs/appstore/widgets/progress-circle.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "progress circle", "pla
 
 The [Progress Circle](https://marketplace.mendix.com/link/component/47783/) widget displays a progress in a circle.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/47783/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 The widget does the following:
 
 * Displays a progress percentage in the form of a circle based on a configurable range

--- a/content/en/docs/appstore/widgets/pull-to-refresh.md
+++ b/content/en/docs/appstore/widgets/pull-to-refresh.md
@@ -15,6 +15,10 @@ This widget is deprecated.
 
 The [Pull to Refresh](https://marketplace.mendix.com/link/component/47782/) widget enables the end-user to pull down on mobile apps to trigger a page refresh or a synchronization for offline apps.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/47782/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Overlay with icon and message shown when pulling down

--- a/content/en/docs/appstore/widgets/radio-button-list.md
+++ b/content/en/docs/appstore/widgets/radio-button-list.md
@@ -15,6 +15,10 @@ This widget is deprecated. For more information, see the [Deprecated Support Cat
 
 The [Radio Button List](https://marketplace.mendix.com/link/component/20/) widget enables rendering an attribute or association as a radio button list. The widget is used with enumeration values, Boolean values, and references, and it is a useful replacement for the default drop-down menu or reference selector widget.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/20/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Use Cases
 
 Visualize all the possible options in your user interface, instead of just forcing your end-user to open a drop-down menu to view all available options.

--- a/content/en/docs/appstore/widgets/range-slider.md
+++ b/content/en/docs/appstore/widgets/range-slider.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "range slider", "platfo
 
 The [Range Slider](https://marketplace.mendix.com/link/component/52704/) allows the user to set a range using a slider. You need to configure a minimum value and a maximum value for the slider, which define the limits of the slider's track. The user can set a range within these limits by defining the lower bound value and the upper bound value of the range.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/52704/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{% alert color="info" %}}
 If the user needs to set one value, instead of a range, you should use the [Slider](/appstore/widgets/slider/) widget instead.
 {{% /alert %}}

--- a/content/en/docs/appstore/widgets/rating.md
+++ b/content/en/docs/appstore/widgets/rating.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "star rating", "rating"
 
 The [Rating](https://marketplace.mendix.com/link/component/54611) widget enables rating from 0 to a defined maximum amount using an attribute.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/54611" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{< figure src="/attachments/appstore/widgets/rating/example.gif" alt="Example" >}}
 
 ## 2 Usage

--- a/content/en/docs/appstore/widgets/rich-text.md
+++ b/content/en/docs/appstore/widgets/rich-text.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "rich text", "platform 
 
 The [Rich Text](https://marketplace.mendix.com/link/component/74889/) widget provides the user with an WYSIWYG editor, where the user can enter and edit rich-text content. The widget automatically converts the rich-text content into a string in HTML format, which can be stored in an attribute of an entity.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/74889/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{< figure src="/attachments/appstore/widgets/rich-text/example.jpg" alt="Example" >}}
 
 ### 1.1 Features

--- a/content/en/docs/appstore/widgets/signature.md
+++ b/content/en/docs/appstore/widgets/signature.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "signature", "platform 
 
 The [Signature](https://marketplace.mendix.com/link/component/107984/) widget is a signature pad for capturing signatures in your app. The widget implements bezier curves and velocity for the smooth drawing of the signature.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/107984/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Record a signature

--- a/content/en/docs/appstore/widgets/simple-check-box-set-selector.md
+++ b/content/en/docs/appstore/widgets/simple-check-box-set-selector.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "simple check box set s
 
 The [Simple Check Box Set Selector](https://marketplace.mendix.com/link/component/2349/) enables rending a reference set association as a check box list. It is a useful replacement for the default [reference set selector](/refguide/reference-set-selector/).
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/2349/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Typical Usage Scenario
 
 * Visualizing all possible options in your UI, instead of forcing your user to open a pop-up window to reference available options

--- a/content/en/docs/appstore/widgets/slider.md
+++ b/content/en/docs/appstore/widgets/slider.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "slider", "bound", "pla
 
 The [Slider](https://marketplace.mendix.com/link/component/48786/) widget allows the user to set a value using a slider. You need to configure a minimum value and a maximum value for the slider, which define the limits of the slider's track. The user can adjust the value within these limits.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/48786/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 {{% alert color="info" %}}
 If the user needs to set a range, instead of one value, you should use the [Range Slider](/appstore/widgets/range-slider/) widget instead.
 {{% /alert %}}

--- a/content/en/docs/appstore/widgets/switch.md
+++ b/content/en/docs/appstore/widgets/switch.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "switch", "platform sup
 
 The [Switch](https://marketplace.mendix.com/link/component/50324/) widget enables toggling a Boolean attribute.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/50324/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ## 2 Usage
 
 To use this widget, place it in a [data container](/refguide/data-sources/) that has a Boolean attribute.

--- a/content/en/docs/appstore/widgets/tab-swipe.md
+++ b/content/en/docs/appstore/widgets/tab-swipe.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "tab swipe", "platform 
 
 The [Tab Swipe](https://marketplace.mendix.com/link/component/78620/) widget can be used for navigating between tabs.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/78620/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ## 2 Usage
 
 To use this widget, follow these steps:

--- a/content/en/docs/appstore/widgets/timeline.md
+++ b/content/en/docs/appstore/widgets/timeline.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "timeline", "platform s
 
 You can use the [Timeline](https://marketplace.mendix.com/link/component/115852/) widget to create a vertical list of events with descriptions.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/115852/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ## 2 Configuration
 
 ### 2.1 Choosing the Render Type

--- a/content/en/docs/appstore/widgets/tooltip.md
+++ b/content/en/docs/appstore/widgets/tooltip.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "widget", "tooltip", "platform su
 
 You can use the [Tooltip](https://marketplace.mendix.com/link/component/119160) widget to add tooltip texts to any widget available in Mendix.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/119160" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Trigger
 
 When placing the new Tooltip widget onto a page, use the composable region to place the content which will trigger the tooltip. You can freely model and combine widgets per your use case.

--- a/content/en/docs/appstore/widgets/video-player.md
+++ b/content/en/docs/appstore/widgets/video-player.md
@@ -11,6 +11,10 @@ tags: ["marketplace", "marketplace component", "platform support", "widget", "vi
 
 The [Video Player](https://marketplace.mendix.com/link/component/110700/) widget enables playing videos from Youtube, Vimeo, Dailymotion, and external MP4 files.
 
+To see the component in the Mendix Marketplace, click here:
+
+{{% button color="dark" href="https://marketplace.mendix.com/link/component/110700/" text="See component in Marketplace" title="See component in Marketplace" %}}
+
 ### 1.1 Features
 
 * Identify the provider and auto-load the right player


### PR DESCRIPTION
I'm adding buttons at the top of widget docs which take users to the component's Marketplace page. The button pops a bit more than a link, and can let our users navigate to Marketplace faster.

If I have any shortcode issues, I'll work them out with @NatasaKralj when she's back from sick leave.