### PR TITLE
[WOR-1285] Add Nanoflow Commons dependency

### DIFF
--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -31,6 +31,7 @@ As workflows are only available from Mendix 9 version, Workflow Commons requires
 * [Data Widgets](https://marketplace.mendix.com/link/component/116540)
 * [Atlas Core](https://marketplace.mendix.com/link/component/117187)
 * [Atlas Web Content](https://marketplace.mendix.com/link/component/117183)
+* [Nanoflow Commons](https://marketplace.mendix.com/link/component/109515)
 
 ## 2 Installation 
 
@@ -40,6 +41,7 @@ Download and install the following modules:
 * Data Widgets
 * Atlas Core
 * Atlas Web Content 
+* Nanoflow Commons
 
 ## 3 Components {#components}
 


### PR DESCRIPTION
Today we released Workflow Commons [v2.5.0](https://github.com/mendix/WorkflowCommons/releases/tag/2.5.0) to the marketplace. The v2.5.0 release adds a dependency on the [Nanoflow Commons](https://marketplace.mendix.com/link/component/109515) module. 

This PR contains a small update to add this dependency to the module documentation.