### PR TITLE
Add Swagger page types to Algolia index

### DIFF
--- a/layouts/_default/list.mxdocsalgolia.json
+++ b/layouts/_default/list.mxdocsalgolia.json
@@ -15,7 +15,7 @@ Define Global variables
 {{- /* range $i, $hit := .Site.AllPages */ -}}
 {{- $section := $.Site.GetPage "section" .Section }}
 {{- warnf "Algolia being generated" -}}
-    {{- range $pageDot := where .Site.Pages "Type" "in" (slice "docs") -}}
+    {{- range $pageDot := where .Site.Pages "Type" "in" (slice "docs" "swagger") -}}
     {{- if or (and ($pageDot.IsDescendant $section) (and (not $pageDot.Draft) (not $pageDot.Params.private))) $section.IsHome -}}
         {{- /* Make a slice of the page content */ -}}
         {{- $contentSlices := slice .Content -}}


### PR DESCRIPTION
The new API page was not being indexed for Algolia.
This is because it has a different page type ("swagger") so this needed to be added to the Hugo template for building the Algolia index.