### PR TITLE
Add backup and restore information for Private Cloud

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/_index.md
@@ -70,10 +70,14 @@ The table below shows the differences between the capabilities for apps deployed
 | Environment provisioning | Fully automated | Provisioned with database and blob storage provided by the customer | Provisioned with database and blob storage provided by the customer|
 | Environment configuration<br/>*For example, constants and scheduled event* | Mendix Developer Portal | Mendix Developer Portal | Custom Resources via Mendix Operator |
 | Mendix app/deployment package deployment | Mendix Developer Portal, Studio Pro, and Studio | Mendix Developer Portal and Studio Pro | Custom Resources via Mendix Operator<br/>*normally combined in a CI/CD pipeline* |
-| Backup and restore | Mendix Developer Portal | Services supplied by the database server and file storage used | Services supplied by the database server and file storage used |
+| Backup and restore | Mendix Developer Portal | Services supplied by the database server and file storage used¹ | Services supplied by the database server and file storage used¹ |
 | Monitoring | Mendix Developer Portal | App metrics sent to a Prometheus-compatible monitoring tool | App metrics sent to a Prometheus-compatible monitoring tool |
 | App logs | Mendix Developer Portal | Prints app logs to `stdout` | Prints app logs to `stdout` |
 | Remote debugging | Mendix Developer Portal + Studio Pro | Mendix Developer Portal + Studio Pro | Not supported |
+
+{{% alert color="info" %}}
+¹ No backup or restore functionality is installed automatically with Mendix for Private Cloud. You will need to choose and deploy your own  solution, dependent on your choice of database, file storage, and cloud platform.
+{{% /alert %}}
 
 ## 4 Licensing Mendix for Private Cloud{#licensing}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -268,6 +268,10 @@ The options do the following:
 
 A database plan tells the Operator how the Mendix app needs to connect to a database when it is deployed. Although the database plan might be valid, there also has to be a database instance for it to connect to. This database instance may be created when the database plan is applied, or it may be an existing database instance which the database plan identifies.
 
+{{% alert color="warning" %}}
+The database plan does not include any functionality for backing up or restoring data on your database. It is your responsibility to ensure that appropriate provision is made for backing up and restoring your database using the tools provided by your database management system and/or cloud provider.
+{{% /alert %}}
+
 Give your plan a **Name** and choose the **Database Type**. See the information below for more help in setting up plans for the different types of database which are supported by Mendix for Private Cloud.
 
 Once you have entered the details you can apply two validation checks by clicking the **Validate** and **Connection Validation** buttons:
@@ -354,6 +358,10 @@ To use this plan, [upgrade](/developerportal/deploy/private-cloud-upgrade-guide/
 
 {{% alert color="info" %}}
 Storage plans are “blueprints” that specify how to request/decommission a new database or blob storage and pass its credentials to an environment.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+The storage plan does not include any functionality for backing up or restoring files used by your app. It is your responsibility to ensure that appropriate provision is made for backing up and restoring these files using the tools provided by your storage and/or cloud provider.
 {{% /alert %}}
 
 {{% alert color="info" %}}

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -16,8 +16,11 @@ The Private Cloud data migration tool allows you to:
 * export the database and files from a Private Cloud environment into a backup file
 * import the database and files from a previously exported backup file into an environment
 
-The Private Cloud data migration tool is compatible with [backup files](/developerportal/operate/restore-backup/#format-of-backup-file) from Mendix Cloud V4,
-allowing you to transfer application data between Mendix Cloud V4 and Mendix for Private Cloud.
+The Private Cloud data migration tool is compatible with [backup files](/developerportal/operate/restore-backup/#format-of-backup-file) from Mendix Cloud V4, allowing you to transfer application data between Mendix Cloud V4 and Mendix for Private Cloud.
+
+{{% alert color="info" %}}
+Although this tool can also be used to backup and restore your Mendix for Private Cloud databases and files regularly, we recommend that you implement your own backup and restore processes which take advantage of the tools provided by your database vendor or cloud provider.
+{{% /alert %}}
 
 ## 2 Prerequisites
 


### PR DESCRIPTION
The customer's role in providing backup and restore functionality for data held in the private cloud was not clear enough.