### PR TITLE
Add note on attachments & comments in WFC 2.4.0

### DIFF
--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -22,7 +22,7 @@ This module allows Mendix developers with little or no experience in building wo
 * Attachments layer on top of workflows
 * Comments section to use with workflows
 
-{{% alert color="info" %}}For Workflow Commons version 2.4.0 and above, attachments are (an optional) part of comments. This means that the WorkflowAttachments entity is associated with the WorkflowComment entity. The WorkflowAttachments entity needs to be part of your own domain model and should be associated with the Workflow Context entity of the workflow. This allows you to configure the applicable security settings, since the context of a specific workflow is not known in advance in Workflow Commons.{{% /alert %}}
+{{% alert color="info" %}}For Workflow Commons version 2.4.0 and above, attachments are (an optional) part of comments. This means that the WorkflowAttachment entity is associated with the WorkflowComment entity. Security settings for the WorkflowAttachment entity are based on the workflows in which a user is involved, since the context of a specific workflow is not known in advance in Workflow Commons. If you would like to set custom security for attachments, you need to configure the attachment entity in your domain model and associate it with the Workflow Context entity of the workflow. {{% /alert %}}
 
 ### 1.3 Prerequisites
 

--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -22,6 +22,8 @@ This module allows Mendix developers with little or no experience in building wo
 * Attachments layer on top of workflows
 * Comments section to use with workflows
 
+{{% alert color="info" %}}For versions 2.4.0 and higher, attachments in Workflow Commons are now (an optional) part of comments. Attachments outside the scope of a comment need to be part of your own domain model, and should be associated to the context entity of the Workflow. This is required so you can configure the applicable security settings, since the context of a specific Workflow is not known in advance in Workflow Commons.{{% /alert %}}
+
 ### 1.3 Prerequisites
 
 As workflows are only available from Mendix 9 version, Workflow Commons requires Mendix 9.0.5 and above.

--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -22,7 +22,7 @@ This module allows Mendix developers with little or no experience in building wo
 * Attachments layer on top of workflows
 * Comments section to use with workflows
 
-{{% alert color="info" %}}For Workflow Commons version 2.4.0 and above, attachments in Workflow Commons are now (an optional) part of comments. This means that the WorkflowAttachments entity is associated with the WorkflowComment entity. The WorkflowAttachments entity needs to be part of your own domain model and should be associated to the Workflow Context entity of the workflow. This allows you to configure the applicable security settings, since the context of a specific workflow is not known in advance in Workflow Commons.{{% /alert %}}
+{{% alert color="info" %}}For Workflow Commons version 2.4.0 and above, attachments are (an optional) part of comments. This means that the WorkflowAttachments entity is associated with the WorkflowComment entity. The WorkflowAttachments entity needs to be part of your own domain model and should be associated with the Workflow Context entity of the workflow. This allows you to configure the applicable security settings, since the context of a specific workflow is not known in advance in Workflow Commons.{{% /alert %}}
 
 ### 1.3 Prerequisites
 

--- a/content/en/docs/appstore/modules/workflow-commons.md
+++ b/content/en/docs/appstore/modules/workflow-commons.md
@@ -22,7 +22,7 @@ This module allows Mendix developers with little or no experience in building wo
 * Attachments layer on top of workflows
 * Comments section to use with workflows
 
-{{% alert color="info" %}}For versions 2.4.0 and higher, attachments in Workflow Commons are now (an optional) part of comments. Attachments outside the scope of a comment need to be part of your own domain model, and should be associated to the context entity of the Workflow. This is required so you can configure the applicable security settings, since the context of a specific Workflow is not known in advance in Workflow Commons.{{% /alert %}}
+{{% alert color="info" %}}For Workflow Commons version 2.4.0 and above, attachments in Workflow Commons are now (an optional) part of comments. This means that the WorkflowAttachments entity is associated with the WorkflowComment entity. The WorkflowAttachments entity needs to be part of your own domain model and should be associated to the Workflow Context entity of the workflow. This allows you to configure the applicable security settings, since the context of a specific workflow is not known in advance in Workflow Commons.{{% /alert %}}
 
 ### 1.3 Prerequisites
 


### PR DESCRIPTION
In [version 2.4.0](https://github.com/mendix/WorkflowCommons/releases/tag/2.4.0) of Workflow Commons we repurposed the attachments and comments. As discussed with Paul, this PR adds a note on this change in the module documentation. More details are available in the release notes.