### PR TITLE
Remove Expectations for when Garbage Collector runs

### DIFF
--- a/content/en/docs/refguide/runtime/runtime-java/_index.md
+++ b/content/en/docs/refguide/runtime/runtime-java/_index.md
@@ -48,7 +48,7 @@ Back to the Heap. We can divide it into three parts:
 2. Survivor Space (young generation)
 3. Tenured Generation (old generation)
 
-When the GC executes a minor garbage collection it will try to clean up all the objects in the young generation only. If it fails to clean up an Eden Space object it will move it to the Survivor Space. If it fails to clean up a Survivor Space object enough times, it will move it to the Tenured Generation. If the Tenured Generation grows large enough (around 60% of the total space available to the Heap) it will execute a major garbage collection and try to clean up all the objects in both the young and the old generation. So a healthy JVM would have a Heap that goes up and down in relation to its memory usage in the various parts.
+When the GC executes a minor garbage collection it will try to clean up all the objects in the young generation only. If it fails to clean up an Eden Space object it will move it to the Survivor Space. If it fails to clean up a Survivor Space object enough times, it will move it to the Tenured Generation. At some time, the GC will decide to clean the Tenured Generation and will execute a major garbage collection to try to clean up all the objects in both the young and the old generation. So a healthy JVM would have a Heap that goes up and down in relation to its memory usage in the various parts.
 
 You can see this quite well in the following JVM Object Heap graph taken from the Mendix Cloud:
 

--- a/content/en/docs/refguide/runtime/runtime-java/java-memory-usage.md
+++ b/content/en/docs/refguide/runtime/runtime-java/java-memory-usage.md
@@ -5,6 +5,8 @@ weight: 2
 tags: ["runtime", "java", "memory usage", "memory", "studio pro"]
 ---
 
+## 1 Introduction
+
 The Java memory is divided in different Memory Usage blocks. Each of these blocks are a snapshot of the actual memory usage of that segment. Each of the memory usage blocks can be broken down into four different values
 
 | Memory block | Description |
@@ -16,11 +18,11 @@ The Java memory is divided in different Memory Usage blocks. Each of these block
 
 For all Mendix applications the value for init and max start with identical values. Immediately after startup the JVM can execute the garbage collection and correct the memory usage.
 
-## Memory Segments
+## 2 Memory Segments
 
-### **_Perm Gen and Code Cache    _**
+### 2.1 Permanent Generation and Code Cache
 
-The Permanent Generation space is allocated to all classes and libraries. The allocated memory to the Perm Gen stays fairly static and only increases when new libraries or classes are loaded into the application. The Perm Gen is not part of the Java Heap, it is added on top of the assigned heap. For more details, see [Presenting the Permanent Generation](https://blogs.oracle.com/jonthecollector/presenting-the-permanent-generation).
+The Permanent Generation (Perm Gen) space is allocated to all classes and libraries. The allocated memory to the Perm Gen stays fairly static and only increases when new libraries or classes are loaded into the application. The Perm Gen is not part of the Java Heap, it is added on top of the assigned heap. For more details, see [Presenting the Permanent Generation](https://blogs.oracle.com/jonthecollector/presenting-the-permanent-generation).
 
 This image on the right shows shows in detail how data moves through the memory. The Stack is made up out of all threads, classes and in case of Mendix also contains all information about microflows domain model and all other Mendix specific information.
 
@@ -46,9 +48,9 @@ When the **Young Generation** reaches its capacity the Major Garbage collection 
 
 The Major Garbage Collection process is optimized for speedy garbage collection without wasting a lot of memory.
 
-The **Old / Tenured Generation** won’t cleaned frequently by the garbage collector. The Tenured Generation space either keeps on increasing until it reaches +/- 70% of its capacity, or after several days. The tenured space will steadily increase and should drop close to 0% after garbage collection.
+The **Old / Tenured Generation** will be cleaned less frequently by the garbage collector. The Tenured Generation space will, generally, steadily increase until the GC is triggered and will usually drop considerably after garbage collection.
 
-### Examples
+### 2.2 Examples
 
 {{< figure src="/attachments/refguide/runtime/runtime-java/java-memory-usage/16844068.png" >}}
 
@@ -58,4 +60,4 @@ A healthy Mendix application that consumes a small amount of memory will show a 
 
 The graph on the right shows an unhealthy application. As can be seen here, the memory usage steadily increases throughout the span of one week. This can only be caused by a process that keeps consuming memory.
 
-It is acceptable for an application to consume a lot of memory in the tenured generation space, the JVM should run the major garbage collection and reduce the tenured generation to zero.
+It is acceptable for an application to consume a lot of memory in the tenured generation space, the JVM should run the major garbage collection and reduce the tenured generation to zero. 

--- a/content/en/docs/refguide/runtime/runtime-java/java-memory-usage.md
+++ b/content/en/docs/refguide/runtime/runtime-java/java-memory-usage.md
@@ -11,20 +11,22 @@ The Java memory is divided in different Memory Usage blocks. Each of these block
 
 | Memory block | Description |
 | --- | --- |
-| ***init*** | Represents the initial amount of memory (in bytes) that the Java virtual machine requests from the operating system for memory management of this segment during startup. The Java virtual machine may request additional memory from the operating system and may also release memory to the system over time. |
+| ***init*** | Represents the initial amount of memory (in bytes) that the Java virtual machine (JVM) requests from the operating system for memory management of this segment during startup. The JVM may request additional memory from the operating system and may also release memory to the system over time. |
 | ***used*** | represents the amount of memory that is actively used (in bytes). |
-| ***committed*** | Represents the amount of memory (in bytes) that is guaranteed to be available for use by the Java virtual machine. The amount of committed memory may change over time (increase or decrease). |
+| ***committed*** | Represents the amount of memory (in bytes) that is guaranteed to be available for use by the JVM. The amount of committed memory may change over time (increase or decrease). |
 | ***max*** | Represents the maximum amount of memory (in bytes) that can be used for memory management. The maximum amount of memory may change over time if defined. The amount of used and committed memory will always be less than or equal to max if max is defined. |
 
 For all Mendix applications the value for init and max start with identical values. Immediately after startup the JVM can execute the garbage collection and correct the memory usage.
 
 ## 2 Memory Segments
 
-### 2.1 Permanent Generation and Code Cache
+### 2.1 Metaspace and Code Cache
 
-The Permanent Generation (Perm Gen) space is allocated to all classes and libraries. The allocated memory to the Perm Gen stays fairly static and only increases when new libraries or classes are loaded into the application. The Perm Gen is not part of the Java Heap, it is added on top of the assigned heap. For more details, see [Presenting the Permanent Generation](https://blogs.oracle.com/jonthecollector/presenting-the-permanent-generation).
+Classes and libraries within the JVM are allocated in metaspace. This is a separate part of native memory. The memory allocated to metaspace stays fairly static and only increases when new libraries or classes are loaded into the application. Metaspace is not part of the heap, but is kept in the native OS memory.
 
-This image on the right shows shows in detail how data moves through the memory. The Stack is made up out of all threads, classes and in case of Mendix also contains all information about microflows domain model and all other Mendix specific information.
+In JVM version 7 and before, this data was stored in what was called the permanent generation (perm gen). In contrast to the perm gen, metaspace is able to collect classes that are no longer used and thus reduce memory impact.
+
+The image below shows in detail how data moves through the memory. The Stack is made up of all threads and classes and, in case of Mendix,  information about microflows, the domain model, and all other Mendix-specific information.
 
 {{< figure src="/attachments/refguide/runtime/runtime-java/java-memory-usage/16844065.png" >}}
 


### PR DESCRIPTION
The Java garbage collector works differently depending on the version of Java, and many factors influence when it runs and what it does.
This PR removes any expectation of when the GC might run, as it is not possible to predict with any certainty.