### PR TITLE
Add optional timezone parameter to date functions

### DIFF
--- a/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datediff.md
+++ b/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datediff.md
@@ -13,7 +13,7 @@ The `DATEDIFF` function returns the difference between two given date/time value
 The syntax is as follows:
 
 ```sql
-DATEDIFF ( unit , startdate_expression, enddate_expression )
+DATEDIFF ( unit , startdate_expression, enddate_expression [, timezone ] )
 ```
 
 ### 2.1 unit
@@ -28,3 +28,10 @@ DATEDIFF ( unit , startdate_expression, enddate_expression )
 ### 2.3 enddate_expression
 
 `enddate_expression` specifies the end date of the period being calculated. This should be formatted in an expression which resolves to a date/time value.
+
+### 2.4 timezone
+
+`timezone` specifies the time zone to use for the retrieval.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone.
+GMT offset time zones are not supported.

--- a/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datediff.md
+++ b/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datediff.md
@@ -31,7 +31,4 @@ DATEDIFF ( unit , startdate_expression, enddate_expression [, timezone ] )
 
 ### 2.4 timezone
 
-`timezone` specifies the time zone to use for the retrieval.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the retrieval. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone. GMT offset time zones are not supported.

--- a/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datepart.md
+++ b/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datepart.md
@@ -13,7 +13,7 @@ The `DATEPART` function retrieves a specified element from a date/time values. T
 The syntax is as follows:
 
 ```sql
-DATEPART ( datepart , date_expression )
+DATEPART ( datepart , date_expression [, timezone ] )
 ```
 
 ### 2.1 datepart
@@ -22,7 +22,14 @@ DATEPART ( datepart , date_expression )
 
 ### 2.2 date_expression
 
-`date_expression` specifies the date to retrieve an element from. This should be formatted in an expression which resolves to a date/time value.
+`date_expression` specifies the date to retrieve an element from.This should be formatted in an expression which resolves to a date/time value.
+
+### 2.3 timezone
+
+`timezone` specifies the time zone to use for the retrieval.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone.
+GMT offset time zones are not supported.
 
 ## 3 Example{#oql-datepart-example}
 

--- a/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datepart.md
+++ b/content/en/docs/refguide/modeling/resources/data-sets/oql/oql-expressions/oql-functions/oql-datepart.md
@@ -22,14 +22,11 @@ DATEPART ( datepart , date_expression [, timezone ] )
 
 ### 2.2 date_expression
 
-`date_expression` specifies the date to retrieve an element from.This should be formatted in an expression which resolves to a date/time value.
+`date_expression` specifies the date to retrieve an element from. This should be formatted in an expression which resolves to a date/time value.
 
 ### 2.3 timezone
 
-`timezone` specifies the time zone to use for the retrieval.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the retrieval. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone. GMT offset time zones are not supported.
 
 ## 3 Example{#oql-datepart-example}
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-avg.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-avg.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Avg"
+title: "XPath avg"
 url: /refguide/xpath-avg/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-count.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-count.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Count"
+title: "XPath count"
 url: /refguide/xpath-count/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-max.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-max.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Max"
+title: "XPath max"
 url: /refguide/xpath-max/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-min.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-min.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Min"
+title: "XPath min"
 url: /refguide/xpath-min/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-sum.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-aggregate-functions/xpath-sum.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Sum"
+title: "XPath sum"
 url: /refguide/xpath-sum/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-contains.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-contains.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Contains"
+title: "XPath contains"
 url: /refguide/xpath-contains/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
@@ -18,7 +18,7 @@ day-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `day-from-dateTime()` function extracts the day of the month value from a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where `DateAttribute` is the 30th day of the month (for example, "2011-12-30"):
+The syntax is as follows:
+
+```
+day-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where `DateAttribute` is the 30th day of the month in the local time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[day-from-dateTime(DateAttribute) = 30]
 ```
+
+This query returns all the logs where `DateAttribute` is the 30th day of the month in the New York time zone (for example, "2011-12-30"):
+
+```java {linenos=false}
+//Logging.Log[day-from-dateTime(DateAttribute, 'America/New_York') = 30]
+```java {linenos=false}

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Day-from-DateTime"
+title: "XPath day-from-dateTime"
 url: /refguide/xpath-day-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
@@ -22,10 +22,7 @@ day-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 
@@ -39,4 +36,4 @@ This query returns all the logs where `DateAttribute` is the 30th day of the mon
 
 ```java {linenos=false}
 //Logging.Log[day-from-dateTime(DateAttribute, 'America/New_York') = 30]
-```java {linenos=false}
+```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -22,10 +22,7 @@ day-of-year-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -26,14 +26,14 @@ day-of-year-from-dateTime ( attribute [, timezone ] )
 
 ## 3 Examples
 
-This query returns all the logs where the day in the year in `DateAttribute` is 30 in the local time zone (for example, "2011-01-30" and "2012-01-30"):
+This query returns all the logs where the day in the year in `DateAttribute` is 40 in the local time zone (for example, "2011-02-09" and "2012-02-09"):
 
 ```java {linenos=false}
-//Logging.Log[day-of-year-from-dateTime(DateAttribute) = 30]
+//Logging.Log[day-of-year-from-dateTime(DateAttribute) = 40]
 ```
 
-This query returns all the logs where the day in the year in `DateAttribute` is 30 in the New York time zone (for example, "2011-01-30" and "2012-01-30"):
+This query returns all the logs where the day in the year in `DateAttribute` is 40 in the New York time zone (for example, "2011-02-09" and "2012-02-09"):
 
 ```java {linenos=false}
-//Logging.Log[day-of-year-from-dateTime(DateAttribute, 'America/New_York') = 30]
+//Logging.Log[day-of-year-from-dateTime(DateAttribute, 'America/New_York') = 40]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -18,7 +18,7 @@ day-of-year-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Day-of-Year-from-DateTime"
+title: "XPath day-of-year-from-dateTime"
 url: /refguide/xpath-day-of-year-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `day-of-year-from-dateTime()` function extracts the day in the year from a **Date and time** attribute so it can be used to compare to a value. Values range from 1 (January 1st) to 366 (due to leap years).
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the day in the year in `DateAttribute` is 30 (for example, "2011-01-30" and "2012-01-30"):
+The syntax is as follows:
+
+```
+day-of-year-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the day in the year in `DateAttribute` is 30 in the local time zone (for example, "2011-01-30" and "2012-01-30"):
 
 ```java {linenos=false}
 //Logging.Log[day-of-year-from-dateTime(DateAttribute) = 30]
+```
+
+This query returns all the logs where the day in the year in `DateAttribute` is 30 in the New York time zone (for example, "2011-01-30" and "2012-01-30"):
+
+```java {linenos=false}
+//Logging.Log[day-of-year-from-dateTime(DateAttribute, 'America/New_York') = 30]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-ends-with.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-ends-with.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Ends-With"
+title: "XPath ends-with"
 url: /refguide/xpath-ends-with/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-false.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-false.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath False"
+title: "XPath false"
 url: /refguide/xpath-false/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `hours-from-dateTime()` function extracts the hours value from a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the hours part of `DateAttribute` is 8 (for example, "2011-12-30 08:00:00"):
+The syntax is as follows:
+
+```
+hours-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the hours part of `DateAttribute` is 8 in the local time zone (for example, "2011-12-30 08:00:00"):
 
 ```java {linenos=false}
 //Logging.Log[hours-from-dateTime(DateAttribute) = 8]
+```
+
+This query returns all the logs where the hours part of `DateAttribute` is 8 in the New York time zone (for example, "2011-12-30 08:00:00"):
+
+```java {linenos=false}
+//Logging.Log[hours-from-dateTime(DateAttribute, 'America/New_York') = 8]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
@@ -18,7 +18,7 @@ hours-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Hours-from-DateTime"
+title: "XPath hours-from-dateTime"
 url: /refguide/xpath-hours-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
@@ -22,10 +22,7 @@ hours-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-length.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-length.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Length"
+title: "XPath length"
 url: /refguide/xpath-length/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Minutes-from-DateTime"
+title: "XPath minutes-from-dateTime"
 url: /refguide/xpath-minutes-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `minutes-from-dateTime()` function extracts the minutes value from a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the minutes part of `DateAttribute` is 30 (for example, "2011-12-30 08:30:00"):
+The syntax is as follows:
+
+```
+minutes-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the minutes part of `DateAttribute` is 30 in the local time zone (for example, "2011-12-30 08:30:00"):
 
 ```java {linenos=false}
 //Logging.Log[minutes-from-dateTime(DateAttribute) = 30]
+```
+
+This query returns all the logs where the minutes part of `DateAttribute` is 30 in the New York time zone (for example, "2011-12-30 08:30:00"):
+
+```java {linenos=false}
+//Logging.Log[minutes-from-dateTime(DateAttribute, 'America/New_York') = 30]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
@@ -22,10 +22,7 @@ minutes-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
@@ -18,7 +18,7 @@ minutes-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Month-From-DateTime"
+title: "XPath month-from-dateTime"
 url: /refguide/xpath-month-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
@@ -18,7 +18,7 @@ month-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `month-from-dateTime()` function extracts the month value from a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all logs where the month value `DateAttribute` is 12 (December). For example, "2011-12-30":
+The syntax is as follows:
+
+```
+month-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all logs where the month value `DateAttribute` is 12 (December) in the local time zone. For example, "2011-12-30":
 
 ```java {linenos=false}
 //Logging.Log[month-from-dateTime(DateAttribute) = 12]
+```
+
+This query returns all logs where the month value `DateAttribute` is 12 (December) in the New York timezone. For example, "2011-12-30":
+
+```java {linenos=false}
+//Logging.Log[month-from-dateTime(DateAttribute, 'America/New_York') = 12]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
@@ -22,20 +22,17 @@ month-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 
-This query returns all logs where the month value `DateAttribute` is 12 (December) in the local time zone. For example, "2011-12-30":
+This query returns all logs where the month value `DateAttribute` is 12 (December) in the local time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[month-from-dateTime(DateAttribute) = 12]
 ```
 
-This query returns all logs where the month value `DateAttribute` is 12 (December) in the New York timezone. For example, "2011-12-30":
+This query returns all logs where the month value `DateAttribute` is 12 (December) in the New York time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[month-from-dateTime(DateAttribute, 'America/New_York') = 12]

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-not.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-not.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Not"
+title: "XPath not"
 url: /refguide/xpath-not/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `quarter-from-dateTime()` function extracts the quarter corresponding to a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where `DateAttribute` is in quarter 4 (for example, "2011-12-30").
+The syntax is as follows:
+
+```
+quarter-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 2 Examples
+
+This query returns all the logs where `DateAttribute` is in quarter 4 in the local time zone (for example, "2011-12-30").
 
 ```java {linenos=false}
 //Logging.Log[quarter-from-dateTime(DateAttribute) = 4]
+```
+
+This query returns all the logs where `DateAttribute` is in quarter 4 in the New York time zone (for example, "2011-12-30").
+
+```java {linenos=false}
+//Logging.Log[quarter-from-dateTime(DateAttribute, 'America/New_York') = 4]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Quarter-from-DateTime"
+title: "XPath quarter-from-dateTime"
 url: /refguide/xpath-quarter-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
@@ -18,7 +18,7 @@ quarter-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 
@@ -26,13 +26,13 @@ quarter-from-dateTime ( attribute [, timezone ] )
 
 ## 3 Examples
 
-This query returns all the logs where `DateAttribute` is in quarter 4 in the local time zone (for example, "2011-12-30"):
+This query returns all the logs where `DateAttribute` is in the forth quarter in the local time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[quarter-from-dateTime(DateAttribute) = 4]
 ```
 
-This query returns all the logs where `DateAttribute` is in quarter 4 in the New York time zone (for example, "2011-12-30"):
+This query returns all the logs where `DateAttribute` is in the forth quarter in the New York time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[quarter-from-dateTime(DateAttribute, 'America/New_York') = 4]

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
@@ -22,20 +22,17 @@ quarter-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
-## 2 Examples
+## 3 Examples
 
-This query returns all the logs where `DateAttribute` is in quarter 4 in the local time zone (for example, "2011-12-30").
+This query returns all the logs where `DateAttribute` is in quarter 4 in the local time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[quarter-from-dateTime(DateAttribute) = 4]
 ```
 
-This query returns all the logs where `DateAttribute` is in quarter 4 in the New York time zone (for example, "2011-12-30").
+This query returns all the logs where `DateAttribute` is in quarter 4 in the New York time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[quarter-from-dateTime(DateAttribute, 'America/New_York') = 4]

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `seconds-from-dateTime()` function extracts the seconds part of a **Date and time** attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the seconds part of `DateAttribute` is 30 (for example, "2011-12-30 08:08:30"):
+The syntax is as follows:
+
+```
+seconds-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the seconds part of `DateAttribute` is 30 in the local time zone (for example, "2011-12-30 08:08:30"):
 
 ```java {linenos=false}
 //Logging.Log[seconds-from-dateTime(DateAttribute) = 30]
+```
+
+This query returns all the logs where the seconds part of `DateAttribute` is 30 in the New York time zone (for example, "2011-12-30 08:08:30"):
+
+```java {linenos=false}
+//Logging.Log[seconds-from-dateTime(DateAttribute, 'America/New_York') = 30]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Seconds-from-DateTime"
+title: "XPath seconds-from-dateTime"
 url: /refguide/xpath-seconds-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
@@ -18,7 +18,7 @@ seconds-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
@@ -22,10 +22,7 @@ seconds-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-starts-with.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-starts-with.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Starts-With"
+title: "XPath starts-with"
 url: /refguide/xpath-starts-with/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-string-length.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-string-length.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath String-Length"
+title: "XPath string-length"
 url: /refguide/xpath-string-length/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-true.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-true.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath True"
+title: "XPath true"
 url: /refguide/xpath-true/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
@@ -9,7 +9,7 @@ tags: ["studio pro"]
 The `week-from-dateTime()` function extracts the week number (in the year) from a **Date and time** attribute so it can be used to compare to a value. Values range from 1 to 53.
 
 {{% alert color="warning" %}}
-The value returned depends on which *database* is being used to support your Mendix app. It does *not* take into account the app runtime setting **First day of the week**.
+The value returned depends on which *database* is being used to support your Mendix app. It does NOT take into account the app runtime setting **First day of the week**.
 
 Many databases implement [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), but please refer to the documentation for the database you are using to find the exact details.
 {{% /alert %}}
@@ -28,10 +28,7 @@ week-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
@@ -24,7 +24,7 @@ week-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Week-from-DateTime"
+title: "XPath week-from-dateTime"
 url: /refguide/xpath-week-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
@@ -14,15 +14,40 @@ The value returned depends on which *database* is being used to support your Men
 Many databases implement [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), but please refer to the documentation for the database you are using to find the exact details.
 {{% /alert %}}
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the date `DateAttribute` falls in the second week of the year (for example, "2011-01-13"):
+The syntax is as follows:
+
+```
+week-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the date `DateAttribute` falls in the second week of the year in the local time zone (for example, "2011-01-13"):
 
 ```java {linenos=false}
 //Logging.Log[week-from-dateTime(DateAttribute) = 2]
 ```
 
-## 3 Read More
+This query returns all the logs where the date `DateAttribute` falls in the second week of the year in the New York time zone (for example, "2011-01-13"):
+
+```java {linenos=false}
+//Logging.Log[week-from-dateTime(DateAttribute, 'America/New_York') = 2]
+```
+
+## 4 Read More
 
 The following links are for the relevant documentation on how week number is calculated for a specific date for many of the databases used with Mendix.
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
@@ -22,7 +22,7 @@ weekday-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
@@ -12,10 +12,35 @@ The `weekday-from-dateTime()` function extracts the day of the week (as a number
 The range of values returned, and the day of the week corresponding to the lowest value returned depend on which database you are using.
 {{% /alert %}}
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the day of the week in `DateAttribute` is 6 (Friday, for locally run apps or apps using a PostgreSQL database):
+The syntax is as follows:
+
+```
+weekday-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the day of the week in `DateAttribute` is 6 in the local time zone (Friday, for locally run apps or apps using a PostgreSQL database):
 
 ```java {linenos=false}
 //Logging.Log[weekday-from-dateTime(DateAttribute) = 6]
+```
+
+This query returns all the logs where the day of the week in `DateAttribute` is 6 in the New York time zone (Friday, for locally run apps or apps using a PostgreSQL database):
+
+```java {linenos=false}
+//Logging.Log[weekday-from-dateTime(DateAttribute, 'America/New_York') = 6]
 ```

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
@@ -26,10 +26,7 @@ weekday-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Weekday-from-DateTime"
+title: "XPath weekday-from-dateTime"
 url: /refguide/xpath-weekday-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
@@ -18,7 +18,7 @@ year-from-dateTime ( attribute [, timezone ] )
 
 ### 2.1 attribute
 
-`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+`attribute` specifies the attribute to extract the day from. Attribute must be of the **Date and time** type.
 
 ### 2.2 timezone
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
@@ -1,5 +1,5 @@
 ---
-title: "XPath Year-from-DateTime"
+title: "XPath year-from-dateTime"
 url: /refguide/xpath-year-from-datetime/
 tags: ["studio pro"]
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
@@ -22,10 +22,7 @@ year-from-dateTime ( attribute [, timezone ] )
 
 ### 2.2 timezone
 
-`timezone` specifies the time zone to use for the extraction.
-This parameter is optional and defaults to the local time zone.
-It should be a string literal containing an IANA time zone or `'UTC'`.
-GMT offset time zones are not supported.
+`timezone` specifies the time zone to use for the extraction. This parameter is optional and defaults to the local time zone. It should be a string literal containing an IANA time zone or `'UTC'`. GMT offset time zones are not supported.
 
 ## 3 Examples
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
@@ -8,10 +8,35 @@ tags: ["studio pro"]
 
 The `year-from-dateTime()` function extracts the amount of years from a `Date and time` attribute so it can be used to compare to a value.
 
-## 2 Example
+## 2 Syntax
 
-This query returns all the logs where the amount of years in `DateAttribute` is "2011" (for example, "2011-12-30"):
+The syntax is as follows:
+
+```
+year-from-dateTime ( attribute [, timezone ] )
+```
+
+### 2.1 attribute
+
+`attribute` specifies the attribute to extract the day from. It must have the **Date and time** type.
+
+### 2.2 timezone
+
+`timezone` specifies the time zone to use for the extraction.
+This parameter is optional and defaults to the local time zone.
+It should be a string literal containing an IANA time zone or `'UTC'`.
+GMT offset time zones are not supported.
+
+## 3 Examples
+
+This query returns all the logs where the amount of years in `DateAttribute` is "2011" in the local time zone (for example, "2011-12-30"):
 
 ```java {linenos=false}
 //Logging.Log[year-from-dateTime(DateAttribute) = 2011]
+```
+
+This query returns all the logs where the amount of years in `DateAttribute` is "2011" in the New York time zone (for example, "2011-12-30"):
+
+```java {linenos=false}
+//Logging.Log[year-from-dateTime(DateAttribute, 'America/New_York') = 2011]
 ```


### PR DESCRIPTION
We've added an (optional) timezone parameter to all XPath and OQL date/time functions:
- seconds-from-dateTime (XPath)
- minutes-from-dateTime (XPath)
- hours-from-dateTime (XPath)
- day-from-dateTime (XPath)
- day-of-year-from-dateTime (XPath)
- week-from-dateTime (XPath)
- weekday-from-dateTime (XPath)
- month-from-dateTime (XPath)
- quarter-from-dateTime (XPath)
- year-from-dateTime (XPath)
- DATEPART (OQL)
- DATEDIFF (OQL)

This change is planned for Mendix 9.22.0.