### PR TITLE
[RUN-3405] Clarify removal of variable in delete object activity

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/object-activities/deleting-objects.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/object-activities/deleting-objects.md
@@ -110,6 +110,10 @@ In detail, the following graph shows what happens during deletions:
 The **Committing** state of the **IMendixObject** is deprecated since Mendix Studio Pro 7.16.
 {{% /alert %}}
 
+{{% alert color="warning" %}}
+The **Delete object(s)** activity will also remove the variable from the Microflow. Take care to not use a variable anymore after using it in a **Delete object(s)** activity.
+{{% /alert %}}
+
 * Events:
     * All before and after events are executed, and if any before-delete event returns false, an exception can be thrown
     * If an exception occurs during an event, all the applied changes are reverted with the default error handling behavior

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/object-activities/deleting-objects.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/object-activities/deleting-objects.md
@@ -111,7 +111,7 @@ The **Committing** state of the **IMendixObject** is deprecated since Mendix Stu
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-The **Delete object(s)** activity will also remove the variable from the Microflow. Take care to not use a variable anymore after using it in a **Delete object(s)** activity.
+The **Delete object(s)** activity also removes the variable from the microflow. Be careful not to use the variable anymore after using it in a **Delete object(s)** activity.
 {{% /alert %}}
 
 * Events:


### PR DESCRIPTION
Mention that variables are removed when they are used in the "delete object(s)" activity. Needs review of placement and if it's clear enough.