### PR TITLE
[UIA-408] Remove Community Commons dependency for Unit Testing module

### DIFF
--- a/content/en/docs/appstore/modules/unit-testing.md
+++ b/content/en/docs/appstore/modules/unit-testing.md
@@ -13,16 +13,19 @@ Use the [Unit Testing](https://marketplace.mendix.com/link/component/390/) modul
 
 ### 1.1 Dependencies
 
-* The [Community Commons](/appstore/modules/community-commons-function-library/) module
 * *junit-4.13.1.jar*
 * *commons-io-2.11.0.jar*
-* *commons-lang3-3.11.jar*
+* *commons-lang3-3.12.0.jar*
 * *httpclient5-5.0.3.jar*
 * *httpcore5-5.0.3.jar*
 * *hamcrest-2.2.jar*
 
 {{% alert color="info" %}}
-For module versions below 9.1.0, use the [Object Handling](/appstore/modules/object-handling/) module instead of the Community Commons module.
+For module version 9.1.0, the [Community Commons](/appstore/modules/community-commons-function-library/) module is required as a dependency. This dependency has been removed in module version 9.2.0.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+For module versions below 9.1.0, the [Object Handling](/appstore/modules/object-handling/) module is required as a dependency.
 {{% /alert %}}
 
 ## 2 Installation
@@ -31,10 +34,9 @@ For module versions below 9.1.0, use the [Object Handling](/appstore/modules/obj
 
     For more information, see [Use Marketplace Content in Studio Pro](/appstore/general/app-store-content/).
 
-2. Download the latest Community Commons module into your app.
-3. Map the module role **TestRunner** to the applicable user roles in your app.
-4. Add the **UnitTestOverview** microflow to your navigation structure, or include the **UnitTestOverview** snippet on a custom page.
-5. The following steps are optional:
+1. Map the module role **TestRunner** to the applicable user roles in your app.
+1. Add the **UnitTestOverview** microflow to your navigation structure, or include the **UnitTestOverview** snippet on a custom page.
+1. The following steps are optional:
     * For including JUnit tests – set the **UnitTesting.FindJUnitTests** constant to true (take the the app settings regarding cloud security into consideration)
     * For running remote unit tests via API:
         * Add the **Startup** flow to your app model's startup sequence

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/microflows/testing-microflows-with-unit-testing.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/microflows/testing-microflows-with-unit-testing.md
@@ -26,8 +26,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 
     | Component | Version Used in This How-to |
     | --- | --- |
-    | [Unit Testing](/appstore/modules/unit-testing/) | 9.1.0 |
-    | [Community Commons Function Library](/appstore/modules/community-commons-function-library/) | 9.0.2 |
+    | [Unit Testing](/appstore/modules/unit-testing/) | 9.2.0 |
 
     {{% alert color="info" %}}All the images, names, and steps in this how-to are based on the Marketplace component versions listed above. When using later versions of this content, images or names on your screen may be different than shown in this how-to.{{% /alert %}}
 
@@ -36,9 +35,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 To set up the unit testing module and run the example tests, follow these steps:
 
 1. Create a [new app](/refguide/new-app/).
-2. Download and install the following modules:
-    * [Unit Testing](/appstore/modules/unit-testing/)
-    * [Community Commons Function Library](/appstore/modules/community-commons-function-library/)
+2. Download and install the [Unit Testing](/appstore/modules/unit-testing/) module. 
 
     For more information, see [Use Marketplace Content in Studio Pro](/appstore/general/app-store-content/).
 


### PR DESCRIPTION
We have just released [version 9.2.0](https://github.com/mendix/UnitTesting/releases/tag/v9.2.0) of the Unit Testing module. In this release, we have removed the dependency on the Community Commons module, and updated the `commons-lang3` dependency from version 3.11 to 3.12.0.

This PR contains some small updates to the docs related to Unit Testing to reflect this.