### PR TITLE
Remove git clone and git submodule output from log.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: xenial          # or bionic | xenial | trusty | precise with xenial as def
 
 git:
   depth: 20000 # We're cloning a max of xxx commits, so the author date is correct
+  quiet: true # prevent commit numbers appearing in the log and being flagged as potential security leaks.
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ dist: xenial          # or bionic | xenial | trusty | precise with xenial as def
 git:
   depth: 20000 # We're cloning a max of xxx commits, so the author date is correct
   quiet: true # prevent commit numbers appearing in the log and being flagged as potential security leaks.
+  submodules: false # turn off submodules and specifically update them in before_install - preventing the commit numbers appearing in the log
 
 env:
   global:
@@ -48,6 +49,8 @@ branches:
 
 before_install:
 ###############
+  # Added the submodule update here so that I can add the --quiet flag
+  - git submodule update --init --recursive --quiet
   #
   - npm install # use npm rather than yarn - HUGO doesn't have that many dependencies
   #


### PR DESCRIPTION
New Log Scan feature in Travis is flagging the commit numbers reported by the git process as potential security leaks.
Suppressing this output so we don't get false positives.