### PR TITLE
Release notes for Mx4PC version 2.10.1 (patch update, planned for January 26th)

### DIFF
--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -14,7 +14,7 @@ Follow the links in the table below to see the release notes you want:
 | Type of Deployment | Last Updated |
 | --- | --- |
 | [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | January 18th, 2023 |
-| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | January 5th, 2023 |
+| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | January 26th, 2023 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | November 17th, 2022 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | October 26th, 2020 |
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,9 +17,9 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.10.1{#2.10.1}
 
-* We’ve updated components to use the latest dependency versions. This update addresses CVE-2021-31525, CVE-2021-33194, CVE-2021-41092, CVE-2021-44716,   CVE-2022-32149, CVE-2022-41717 and CVE-2022-41721. These CVEs are unlikely to put Mendix for Private Cloud environments at risk and are mitigated by design.
-* We switched from UBI 8 Minimal base images to [UBI 8 Micro](https://www.redhat.com/en/blog/introduction-ubi-micro) to reduce the image size and the number of CVEs.
-* We’ve implemented a feature to use [IAM role authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) when connecting to RDS Postgres databases. This feature depends on an upcoming release of Mendix, and additional documentation will be provided later.
+* We have updated components to use the latest dependency versions, in order to improve security score ratings for all container images.
+* We have switched from UBI 8 Minimal base images to [UBI 8 Micro](https://www.redhat.com/en/blog/introduction-ubi-micro).
+* We have implemented a feature to use [IAM role authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) when connecting to RDS Postgres databases. This feature depends on an upcoming release of Mendix, and additional documentation will be provided later.
 
 ### January 19th, 2023
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### January 26th, 2023
+
+#### Mendix Operator v2.10.1{#2.10.1}
+
+* We’ve updated components to use the latest dependency versions. This update addresses CVE-2021-31525, CVE-2021-33194, CVE-2021-41092, CVE-2021-44716,   CVE-2022-32149, CVE-2022-41717 and CVE-2022-41721. These CVEs are unlikely to put Mendix for Private Cloud environments at risk and are mitigated by design.
+* We switched from UBI 8 Minimal base images to [UBI 8 Micro](https://www.redhat.com/en/blog/introduction-ubi-micro) to reduce the image size and the number of CVEs.
+* We’ve implemented a feature to use [IAM role authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) when connecting to RDS Postgres databases. This feature depends on an upcoming release of Mendix, and additional documentation will be provided later.
+
 ### January 19th, 2023
 
 #### Portal Improvements


### PR DESCRIPTION
We've prepared a patch version of Mx4PC - mostly focusing on CVE fixes. We're planning to release this on January 26th or 27th, depending on the test results.

There's also a new feature to use built-in AWS authentication to connect to the database instead of passwords. This feature was tested to work correctly, but depends on an upcoming Mendix Runtime feature to work correctly. We'll provide additional documentation later, after we have confirmation that everything works correctly.