### PR TITLE
Improved documentation for published OData resource key

### DIFF
--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -112,9 +112,9 @@ Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representa
 
 Select a combination of attributes with the following constraints:
 
-* Unique – each key points to exactly one object
-* Required – ensures that no key attribute value is empty, which would mean you cannot find an object with it
-* Stable over time – the attribute values used for the key should not change so that you can find it again later
+* Unique – The combination of key attributes should be unique, so each key points to exactly one object.
+* Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
+* Stable over time – The attribute values used for the key should not change, so that you can find it again later.
 
 You can set unique and required constraints using [validation rules](/refguide/validation-rules/).
 

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -56,17 +56,7 @@ Attributes of type **Binary** cannot be exported through OData services except f
 
 {{% /alert %}}
 
-### 3.1 Selecting Attributes as the Key {#select-attributes}
-
-You can select which attributes you would like to use as a key. Choose a combination of attributes that are never empty, do not change, and together uniquely identify the object. An autonumber attribute is a good choice for a key.
-
-{{% alert color="info" %}}
-Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/).
-{{% /alert %}}
-
-To learn more about selecting attributes as keys, see the [Selecting an Attribute as a Key](/refguide/wrap-services-odata/#select-key) section of *Wrap Services, APIs, or Databases with OData*.
-
-### 3.2 Required Validation Rules for Published Attributes
+### 3.1 Required Validation Rules for Published Attributes
 
 For published OData services, the **Can be empty** check box appears when you edit a published attribute. 
 
@@ -118,14 +108,23 @@ Default: *10000*
 
 ## 8 Key {#key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select which attribute to use as a unique [key](/refguide/published-odata-resource/#key) when exposing an entity as a Published OData Resource. The attribute type can be one of the following: 
+Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that a published OData resource should not use the ID as a key, and needs to have a combination of attribute(s) that form a key instead. The attribute(s) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
-* **Integer**
-* **Long**
-* **String**
-* **AutoNumber** 
+Select a combination of attributes with the following constraints:
 
-To learn more about selecting a key, unique see the [Key Selection](/refguide/wrap-services-odata/#select-key) section of *Wrap Services, APIs, or Databases with OData*.
+* Unique – The combination of key attributes should be unique, so each key points to exactly one object.
+* Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
+* Stable over time – The attribute values used for the key should not change, so that you can find it again later.
+
+You can set unique and required constraints using [validation rules](/refguide/validation-rules/).
+
+{{% alert color="info" %}}
+Selecting a single attribute as a key was introduced in Studio Pro [9.17.0](/releasenotes/studio-pro/9.17/). Selecting multiple attributes as a key was introduced in Studio Pro [9.19.0](/releasenotes/studio-pro/9.19/).
+{{% /alert %}}
+
+{{% alert color="info" %}}
+Selecting more than one attribute as the key is only available for published OData services that use OData version 4.
+{{% /alert %}}
 
 ## 9 Capabilities {#capabilities}
 

--- a/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/published-odata-services/published-odata-resource.md
@@ -108,13 +108,13 @@ Default: *10000*
 
 ## 8 Key {#key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that a published OData resource should not use the ID as a key, and needs to have a combination of attribute(s) that form a key instead. The attribute(s) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
+Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that a published OData resource should not use the ID as a key, and needs to have a combination of attributes that form a key instead. The attribute(s) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
 Select a combination of attributes with the following constraints:
 
-* Unique – The combination of key attributes should be unique, so each key points to exactly one object.
-* Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
-* Stable over time – The attribute values used for the key should not change, so that you can find it again later.
+* Unique – each key points to exactly one object
+* Required – ensures that no key attribute value is empty, which would mean you cannot find an object with it
+* Stable over time – the attribute values used for the key should not change so that you can find it again later
 
 You can set unique and required constraints using [validation rules](/refguide/validation-rules/).
 

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -122,26 +122,9 @@ In Studio Pro [9.16](/releasenotes/studio-pro/9.16/) and below, the inline count
 
 ## 5 Key Selection When Exposing Entities as OData Resources {#select-key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration).
+Select which attribute(s) to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource so that clients will be able to identify objects returned by the service.
 
-Starting in Studio Pro [9.17](/releasenotes/studio-pro/9.17/), you can select which attribute to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource. The attribute type can be one of the following: 
-
-* **Integer**
-* **Long**
-* **String**
-* **AutoNumber**
-
-Select a combination of attributes with the following constraints: 
-
-* Unique – The combination of key attributes should be unique, so each key points to exactly one entity.
-* Required – If one of the key attribute values is empty, you cannot find an object with it anymore.
-* Stable over time – The attribute values used for the key should not change, so that you can find it again later.
-
-When exposing an entity as a published OData resource for the first time, Studio Pro chooses a unique and required attribute as the key. If there is no attribute that has a unique constraint or a required constraint, then it will select the first attribute with a supported type. You can set these constraints using [validation rules](/refguide/validation-rules/).
-
-{{% alert color="info" %}}
-Selecting more than one attribute as the key is only available for published OData services that use OData version 4.
-{{% /alert %}}
+To learn more about selecting a key, unique see the [Key](/refguide/published-odata-resource/#key) section of *Published OData Resource*.
 
 ### 5.1 Selecting Attributes as a Key {#select-key}
 

--- a/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/wrap-services-odata.md
@@ -124,7 +124,7 @@ In Studio Pro [9.16](/releasenotes/studio-pro/9.16/) and below, the inline count
 
 Select which attribute(s) to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource so that clients will be able to identify objects returned by the service.
 
-To learn more about selecting a key, unique see the [Key](/refguide/published-odata-resource/#key) section of *Published OData Resource*.
+To learn more about selecting a key, see the [Key](/refguide/published-odata-resource/#key) section of *Published OData Resource*.
 
 ### 5.1 Selecting Attributes as a Key {#select-key}
 

--- a/content/en/docs/releasenotes/studio-pro/9/9.19.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.19.md
@@ -44,7 +44,7 @@ For more information, see [How to Use Marketplace Content in Studio Pro](/appsto
 * We improved the way we handle the completion of workflow user tasks. The selection of a specific user task is no longer required when selecting an outcome. This way, both the microflow action and the client action **Complete user task** can be reused for different user tasks that share the same outcomes.
 * We improved the way published OData services return error messages. They now include a list with error details, which provides more information on which specific properties caused any errors.
 * We now show the consumed OData services on the **Data Hub** pane regardless of whether you are logged in.
-* You can now choose [more than one key attribute](/refguide/published-odata-resource/#select-attributes) for a published OData resource.
+* You can now choose [more than one key attribute](/refguide/published-odata-resource/#key) for a published OData resource.
 * In the list of attributes and associations for published OData resources, we removed the **Part of key** column and replaced it with a key icon.
 * We made it possible to configure the default editing mode for pages. You can now go to **Preferences** > **Work Environment** to choose whether the page editor should open in structure mode or design mode by default.
 * The MxAssist Performance Bot best practice [MXP014](/refguide/performance-best-practices/#mxp014) now presents recommendations grouped by microflow and by entity. This enables supressing by entity as opposed to suppressing the entire microflow.


### PR DESCRIPTION
Addressed a couple of things for choosing a good key for a published OData resource

wrap-services-odata
 * This is about Studio Pro 9.17 already, so that does not need to be mentioned in the key selection section -> deleted
 * This is about non-persistable entities, so talking about the Mendix ID and the database is not correct -> deleted
 * The documentation about what is a good key should not be in this guide, but rather in the documentation of the resource itself.  -> moved; The link for more information is now the other way around.

published-odata-resource
 * There were two sections about the key, with almost the same information. Removed one of them
