### PR TITLE
How-to: use password rotation and IRSA authentication in Mx4PC (no release date)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
@@ -75,14 +75,12 @@ The following table lists the properties used as keys for database and storage-r
 * `com.mendix.storage.azure` for Azure Blob Storage
 
 {{% alert color="info" %}}
-If your app is created in Mendix version 9.20 or above, and its Kubernetes service account is linked to an AWS IAM Role, you don't need to specify `storage-access-key-id` or `storage-secret-access-key` to access an S3 bucket.
-Instead, the same AWS IAM role can be used for S3 authentication.
+If your app is created in Mendix version 9.20 or above, and its Kubernetes service account is linked to an AWS IAM Role, you do not need to specify an `storage-access-key-id` or `storage-secret-access-key` to access an S3 bucket. Instead, you can use the same AWS IAM role for RDS authentication.
 For more information and a complete walkthrough example, see the [AWS Secrets Manager example](#configure-using-aws-secrets-manager).
 {{% /alert %}}
 
 {{% alert color="info" %}}
-If your app is created in Mendix version 9.22 or above, and its Kubernetes service account is linked to an AWS IAM Role, you don't need to specify `database-password` to access a Postgres RDS database.
-Instead, the same AWS IAM role can be used for RDS authentication.
+If your app is created in Mendix version 9.22 or above, and its Kubernetes service account is linked to an AWS IAM Role, you do not need to specify a `database-password` to access a Postgres RDS database. Instead, you can use the same AWS IAM role for RDS authentication.
 For more information and a complete walkthrough example, see the [AWS RDS IAM authentication example](#configure-using-rds-iam).
 {{% /alert %}}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
@@ -477,13 +477,13 @@ To use this feature, you need to:
 After completing the prerequisites, follow these steps to switch from password-based authentication to IAM authentication:
 
 1. Remove or comment out `database-password` from the SecretProviderClass and the associated AWS Secret.
-2. Enable [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html#UsingWithRDS.IAMDBAuth.DBAccounts.PostgreSQL) for the `database-user` role.
-   You will need to use the `psql` commandline and run the following commands (replacing `<database-user>` with the username specified in `database-user`):
+2. Enable [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html#UsingWithRDS.IAMDBAuth.DBAccounts.PostgreSQL) for the `database-username` role.
+   You will need to use the `psql` commandline and run the following commands (replacing `<database-username>` with the username specified in `database-username`):
    ```sql {linenos=false}
-   GRANT rds_iam TO <database-user>;
-   ALTER ROLE <database-user> WITH PASSWORD NULL;
+   GRANT rds_iam TO <database-username>;
+   ALTER ROLE <database-username> WITH PASSWORD NULL;
    ```
-   {{% alert color="info" %}}This step is not necessary if the RDS instance was created with only IAM authentication enabled, and if `database-user` is the default (master) user.{{% /alert %}}
+   {{% alert color="info" %}}This step is not necessary if the RDS instance was created with only IAM authentication enabled, and if `database-username` is the default (master) user.{{% /alert %}}
 3. Attach the following inline IAM policy to the environment's IAM role (created when configuring [AWS Secrets Manager](#configure-using-aws-secrets-manager)):
    ```json
    {
@@ -495,13 +495,13 @@ After completing the prerequisites, follow these steps to switch from password-b
            "rds-db:connect"
          ],
          "Resource": [
-           "arn:aws:rds-db:<db-region>:<account-id>:dbuser:<db-resource-id>/<database-user>"
+           "arn:aws:rds-db:<db-region>:<account-id>:dbuser:<db-resource-id>/<database-username>"
          ]
        }
      ]
    }
    ```
-   replacing `<db-region>` with the RDS database region, `<account-id>` with the AWS account ID, `<db-resource-id>` with the database Resource ID and `<database-user>` with the username specified in `database-user`.
+   replacing `<db-region>` with the RDS database region, `<account-id>` with the AWS account ID, `<db-resource-id>` with the database Resource ID and `<database-username>` with the username specified in `database-username`.
    
    For more information how to get the Resource ID and create an RDS IAM policy, see the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html).
 4. Restart the Mendix app environment.

--- a/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
@@ -478,10 +478,10 @@ After completing the prerequisites, follow these steps to switch from password-b
 
 1. Remove or comment out `database-password` from the SecretProviderClass and the associated AWS Secret.
 2. Enable [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html#UsingWithRDS.IAMDBAuth.DBAccounts.PostgreSQL) for the `database-user` role.
-   You will need to use the `psql` commandline and run the following commands (replacing `<role>` with the username specified in `database-user`):
+   You will need to use the `psql` commandline and run the following commands (replacing `<database-user>` with the username specified in `database-user`):
    ```sql {linenos=false}
-   GRANT rds_iam TO <role>;
-   ALTER ROLE <role> WITH PASSWORD NULL;
+   GRANT rds_iam TO <database-user>;
+   ALTER ROLE <database-user> WITH PASSWORD NULL;
    ```
    {{% alert color="info" %}}This step is not necessary if the RDS instance was created with only IAM authentication enabled, and if `database-user` is the default (master) user.{{% /alert %}}
 3. Attach the following inline IAM policy to the environment's IAM role (created when configuring [AWS Secrets Manager](#configure-using-aws-secrets-manager)):

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,12 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### February ???, 2023
+
+#### Documentation updates
+
+* We have updated [CSI Secrets Storage](/developerportal/deploy/secret-store-credentials/) documentation to clarify how database password rotation works, and how to use AWS RDS IAM authentication instead of passwords.
+
 ### February 2nd, 2023
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,11 +13,11 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
-### February ???, 2023
+### February 7th, 2023
 
 #### Documentation updates
 
-* We have updated [CSI Secrets Storage](/developerportal/deploy/secret-store-credentials/) documentation to clarify how database password rotation works, and how to use AWS RDS IAM authentication instead of passwords.
+* We have updated the [CSI Secrets Storage](/developerportal/deploy/secret-store-credentials/) documentation to clarify how database password rotation works, and how to use AWS RDS IAM authentication instead of passwords.
 
 ### February 2nd, 2023
 


### PR DESCRIPTION
This document is not linked with any upcoming release and can be published at any convenient moment.

These features require the app to use Mendix 9.22 (or higher), which was released last week:

* A customer using Mx4PC version 2.10.0 can now rotate database credentials in AWS Secrets Manager (or Hashicorp Vault) without having to restart the environment
* A customer using Mx4PC version 2.10.1 can switch from static passwords to IAM-based authentication