### PR TITLE
The Events properties needs to be adjusted because the options Close …

### DIFF
--- a/content/en/docs/refguide/modeling/pages/input-widgets/text-area.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/text-area.md
@@ -100,6 +100,14 @@ This differs from the [on change](#on-change) property in that the event will al
 
 {{% snippet file="/static/_includes/refguide/events-section-link.md" %}}
 
+#### 2.5.5 Close page
+
+The close page property will close the page after the event is triggered.
+
+#### 2.5.6 Auto-synchronize
+
+?????
+
 ### 2.6 General Section{#general}
 
 #### 2.6.1 Grow Automatically


### PR DESCRIPTION
…page and Auto-synchronize are not explained

Now the close page option is obvious it will close the page after an event. But what does the Auto-synchronize option do? Is that for mobile? All the options needs to be explained in the documentation imho.  Regards,
Ronald