### PR TITLE
Remove mention of fileID

### DIFF
--- a/content/en/docs/howto/security/set-up-anonymous-user-security.md
+++ b/content/en/docs/howto/security/set-up-anonymous-user-security.md
@@ -52,8 +52,6 @@ If you need to give an anonymous user access to change an object ALWAYS apply in
 
 Limiting the navigation or page display is not the same thing as security. All data can be accessed by talking directly to the Platform APIs, and anything that is visible according to the security model is accessible by sending the correct messages to the server. Limiting data in the UI does not mean that it cannot be accessed. Only instance access rules guarantee what you can and cannot do.
 
-For example, to download a file, it is possible to get the UR (for example, `https://myMendixApp.com/file?fileID=2804771`). All that is necessary is to try random numbers until a file is found that is accessible. Unless you specify instance or object access, in that case, the platform would always validate the request against your privileges before presenting the information.
-
 ## 7 Read More
 
 * [Creating a Secure App](/howto/security/create-a-secure-app/)

--- a/content/en/docs/howto7/security/set-up-anonymous-user-security.md
+++ b/content/en/docs/howto7/security/set-up-anonymous-user-security.md
@@ -51,7 +51,7 @@ If you need to give an anonymous user access to change an object ALWAYS apply in
 
 Limiting the navigation or page display is not the same thing as security. All data can be accessed by talking directly to the Platform APIs, and anything that is visible according to the security model is accessible by sending the correct messages to the server. Limiting data in the UI does not mean that it cannot be accessed. Only instance access rules guarantee what you can and cannot do.
 
-For example, to download a file, it is possible to get the UR (for example, `https://myMendixApp.com/file?fileID=2804771`). All that is necessary is to try random numbers until a file is found that is accessible. Unless you specify instance or object access, in that case, the platform would always validate the request against your privileges before presenting the information.
+For example, to download a file, it is possible to get the URL (for example, `https://myMendixApp.com/file?fileID=2804771`). All that is necessary is to try random numbers until a file is found that is accessible. Unless you specify instance or object access, in that case, the platform would always validate the request against your privileges before presenting the information.
 
 ## 7 Read More
 

--- a/content/en/docs/howto8/security/set-up-anonymous-user-security.md
+++ b/content/en/docs/howto8/security/set-up-anonymous-user-security.md
@@ -51,8 +51,6 @@ If you need to give an anonymous user access to change an object ALWAYS apply in
 
 Limiting the navigation or page display is not the same thing as security. All data can be accessed by talking directly to the Platform APIs, and anything that is visible according to the security model is accessible by sending the correct messages to the server. Limiting data in the UI does not mean that it cannot be accessed. Only instance access rules guarantee what you can and cannot do.
 
-For example, to download a file, it is possible to get the UR (for example, `https://myMendixApp.com/file?fileID=2804771`). All that is necessary is to try random numbers until a file is found that is accessible. Unless you specify instance or object access, in that case, the platform would always validate the request against your privileges before presenting the information.
-
 ## 7 Read More
 
 * [Creating a Secure App](/howto8/security/create-a-secure-app/)


### PR DESCRIPTION
This parameter will be removed in future Mendix versions of Mendix 8 and 9, so we should stop mentioning it in our documentation.