### PR TITLE
Add release notes for Windows Service 4.7.1 and update requirements

### DIFF
--- a/content/en/docs/developerportal/deploy/on-premises-design/ms-windows/_index.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/ms-windows/_index.md
@@ -32,10 +32,10 @@ To set up an environment to run Mendix applications, you will need to install th
 
 Before starting this how-to, make sure you have the following prerequisites:
 
-* MS Windows Server 2008 SP2 or higher
-    * The Mendix Service Console will run and deploy a Mendix app on the [minimum hardware requirements for MS Windows Server 2008 SP2](https://learn.microsoft.com/en-us/iis/install/installing-iis-7/install-windows-server-2008-and-windows-server-2008-r2#hardware-requirements). However, you may need to increase the specifications depending on the functionality of your app. Although not directly comparable, see the [Cloud Resource Packs](/developerportal/deploy/mendix-cloud-deploy/#resource-pack) used when deploying to the Mendix Cloud for comparative information.
+* MS Windows Server 2012 or higher
+    * The Mendix Service Console will run and deploy a Mendix app on the [minimum hardware requirements for MS Windows Server 2012](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/jj134246(v=ws.11)#system-requirements). However, you may need to increase the specifications depending on the functionality of your app. Although not directly comparable, see the [Cloud Resource Packs](/developerportal/deploy/mendix-cloud-deploy/#resource-pack) used when deploying to the Mendix Cloud for comparative information.
 * .NET Framework 4.6.2 or higher
-* IIS 7 or higher with the following service roles enabled:
+* IIS 8 or higher with the following service roles enabled:
 
     * IIS Management console
     * Default Document

--- a/content/en/docs/releasenotes/studio-pro/windows-service.md
+++ b/content/en/docs/releasenotes/studio-pro/windows-service.md
@@ -19,7 +19,7 @@ To download the Windows Service, go to the [Get Studio Pro](https://marketplace.
 * Add possibility to add extra logsubscribers in the Settings.yaml file. See https://github.com/mendix/m2ee-tools/blob/v7.2.3/examples/full-documented-m2ee.yaml#L392 for more information. Compared to that information, the 'Logging' property has to start with an uppercase letter, so 'Logging:' instead of 'logging:'. The loglevel setting as described is not supported for the Windows Service.
 * We replaced the modified YAML parser YamlSerializer 0.9.0.2 by YamlDotNet 12.3.1.
 * We updated the Newtonsoft Json.NET library from version 13.0.1 to 13.0.2.
-* Add build number information to the version information of the executables and the subject field of the MSI installer file.
+* We have added build number information to the version information of the executables and the subject field of the MSI installer file.
 
 ### 4.7.0
 

--- a/content/en/docs/releasenotes/studio-pro/windows-service.md
+++ b/content/en/docs/releasenotes/studio-pro/windows-service.md
@@ -12,6 +12,17 @@ To download the Windows Service, go to the [Get Studio Pro](https://marketplace.
 
 ## 4.7
 
+### 4.7.1
+
+**Release date: February 24th, 2023**
+
+* Add possibility to add extra logsubscribers in the Settings.yaml file. See https://github.com/mendix/m2ee-tools/blob/v7.2.3/examples/full-documented-m2ee.yaml#L392 for more information. The 'Logging' property has to start with an uppercase letter, so 'Logging:' instead of 'logging:'. The loglevel node is not supported.
+* We replaced the modified YAML parser YamlSerializer 0.9.0.2 by YamlDotNet 12.3.1.
+* We updated the Newtonsoft Json.NET library from version 13.0.1 to 13.0.2.
+* Add build number information to the version information of the executables and the subject field of the MSI installer file.
+
+### 4.7.0
+
 **Release date: August 26th, 2022**
 
 * We fixed an exception which occurred when updating an app where files with a path exceeding 260 characters are overwritten. (Ticket 142021)

--- a/content/en/docs/releasenotes/studio-pro/windows-service.md
+++ b/content/en/docs/releasenotes/studio-pro/windows-service.md
@@ -16,7 +16,7 @@ To download the Windows Service, go to the [Get Studio Pro](https://marketplace.
 
 **Release date: February 24th, 2023**
 
-* Add possibility to add extra logsubscribers in the Settings.yaml file. See https://github.com/mendix/m2ee-tools/blob/v7.2.3/examples/full-documented-m2ee.yaml#L392 for more information. The 'Logging' property has to start with an uppercase letter, so 'Logging:' instead of 'logging:'. The loglevel node is not supported.
+* Add possibility to add extra logsubscribers in the Settings.yaml file. See https://github.com/mendix/m2ee-tools/blob/v7.2.3/examples/full-documented-m2ee.yaml#L392 for more information. Compared to that information, the 'Logging' property has to start with an uppercase letter, so 'Logging:' instead of 'logging:'. The loglevel setting as described is not supported for the Windows Service.
 * We replaced the modified YAML parser YamlSerializer 0.9.0.2 by YamlDotNet 12.3.1.
 * We updated the Newtonsoft Json.NET library from version 13.0.1 to 13.0.2.
 * Add build number information to the version information of the executables and the subject field of the MSI installer file.


### PR DESCRIPTION
Windows Server 2008 is not supported anymore by Microsoft, so we now require Windows Service 2012 with IIS 8.