### PR TITLE
Add new databases to system requirements

### DIFF
--- a/content/en/docs/refguide/general/system-requirements.md
+++ b/content/en/docs/refguide/general/system-requirements.md
@@ -189,12 +189,12 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
-* [MariaDB](/refguide/mysql/): 10.2, 10.3, 10.4, 10.5, 10.6 (please note that support for 10.2 is deprecated and will be removed in Studio Pro versions 9.22.0, 9.18.5, 9.12.11, and 9.6.17)
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019
+* [MariaDB](/refguide/mysql/): 10.2, 10.3, 10.4, 10.5, 10.6, 10.11 (please note that support for 10.2 is deprecated and will be removed in Studio Pro versions 9.22.0, 9.18.5, 9.12.11, and 9.6.17)
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
 * [MySQL](/refguide/mysql/): 8.0
-* [Oracle Database](/refguide/oracle/): 19
-* PostgreSQL: 11, 12, 13, 14
+* [Oracle Database](/refguide/oracle/): 19, 21c
+* PostgreSQL: 11, 12, 13, 14, 15
 * [SAP HANA](/refguide/saphana/): 2.00.040.00.1545918182
 * [IBM DB2](/refguide/db2/): 11.5 for Linux, Unix, and Windows (please note that support for DB2 is deprecated and will be removed in Studio Pro version 10)
 

--- a/content/en/docs/refguide7/general/system-requirements.md
+++ b/content/en/docs/refguide7/general/system-requirements.md
@@ -62,12 +62,12 @@ The browser you use needs to have JavaScript turned on.
 ### 5.3 Database Server
 
 * [IBM DB2](/refguide7/db2/) 11.5 for Linux, Unix, and Windows
-* [MariaDB](/refguide7/mysql/) 10.2, 10.3, 10.4, 10.5, 10.6
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/) 2017, 2019 (please note that support for 2017 is deprecated and will be removed in Studio Pro version 7.23.35)
+* [MariaDB](/refguide7/mysql/) 10.2, 10.3, 10.4, 10.5, 10.6, 10.11
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/) 2017, 2019, 2021 (please note that support for 2017 is deprecated and will be removed in Studio Pro version 7.23.35)
 * Azure SQL v12 (support is not independently verified and is available only through compatible versions of SQL Server)
 * [MySQL](/refguide7/mysql/) 8.0
-* [Oracle Database](/refguide7/oracle/) 19
-* PostgreSQL 10, 11, 12, 13, 14 (please note that support for 10 is deprecated and will be removed in Studio Pro version 7.23.35)
+* [Oracle Database](/refguide7/oracle/) 19, 21c
+* PostgreSQL 10, 11, 12, 13, 14, 15 (please note that support for 10 is deprecated and will be removed in Studio Pro version 7.23.35)
 * [SAP HANA](/refguide7/saphana/) 2.00.040.00.1545918182
 
 ### 5.4 Java

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -118,12 +118,12 @@ Mendix tries to support the most recent and patched database server versions fro
 Current support:
 
 * [IBM DB2](/refguide8/db2/) 11.5 for Linux, Unix, and Windows
-* [MariaDB](/refguide8/mysql/) 10.2, 10.3, 10.4, 10.5, 10.6
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/) 2019
+* [MariaDB](/refguide8/mysql/) 10.2, 10.3, 10.4, 10.5, 10.6, 10.11
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/) 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 140 or higher
 * [MySQL](/refguide8/mysql/) 8.0
-* [Oracle Database](/refguide8/oracle/) 19
-* PostgreSQL 11, 12, 13, 14
+* [Oracle Database](/refguide8/oracle/) 19, 21c
+* PostgreSQL 11, 12, 13, 14, 15
 * [SAP HANA](/refguide8/saphana/) 2.00.040.00.1545918182
 
 {{% alert color="warning" %}}


### PR DESCRIPTION
No need to wait for the next version because effectively the databases are already supported