### PR TITLE
[README.md] Added a note how to limit Hugo memory usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ See the [Hugo Server](https://gohugo.io/commands/hugo_server/) documentation for
 
 If you are using a Mac, you might get an error `too many open files` or `fatal error: pipe failed`. By default, your Mac is probably set to restrict the number of open files. You will need to override this, see [Docsy known issues](https://www.docsy.dev/docs/getting-started/#known-issues) for more information.
 
-If your system has a low memory limit, add the `--renderToDisk` parameter to the Hugo command, for example `hugo server --environment development`. With this option, Hugo will only load pages on demand; without the `--renderToDisk` option, Hugo will load all documentation into memory for faster access.
+If your system has a low memory limit, add the `--renderToDisk` parameter to the Hugo command, for example `hugo server --environment development --renderToDisk`. With this option, Hugo will only load pages on demand; without the `--renderToDisk` option, Hugo will load all documentation into memory for faster access.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ See the [Hugo Server](https://gohugo.io/commands/hugo_server/) documentation for
 #### Potential Issues
 
 If you are using a Mac, you might get an error `too many open files` or `fatal error: pipe failed`. By default, your Mac is probably set to restrict the number of open files. You will need to override this, see [Docsy known issues](https://www.docsy.dev/docs/getting-started/#known-issues) for more information.
+
+If your system has a low memory limit, add the `--renderToDisk` parameter to the Hugo command, for example `hugo server --environment development`. With this option, Hugo will only load pages on demand; without the `--renderToDisk` option, Hugo will load all documentation into memory for faster access.


### PR DESCRIPTION
When running Hugo in a container, or environment like Github Codespaces, Hugo will load all pages into memory by default.

At the moment, this requires 12+GB of available memory; with --renderToDisk, Hugo needs less than 4GB RAM. In my case, I didn't see any performance impact.