### PR TITLE
Rename Webhooks and Deployment Webhooks

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/build-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/build-api.md
@@ -15,7 +15,7 @@ The Build API only works for apps which are deployed to the Mendix Cloud.
 
 The Build API allows you to manage deployment packages and create new deployment packages using our build server. You will need the information from the [Teamserver API](/apidocs-mxsdk/apidocs/team-server-api/) as input for these API calls. You will also need to provide authentication for each call; this is described in [Authentication](/apidocs-mxsdk/apidocs/authentication/).
 
-You can use deployment webhooks to trigger CI/CD pipelines which use this API. These are described in [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/).
+You can use webhooks to trigger CI/CD pipelines which use this API. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 
 The image below provides a domain model representation of the concepts discussed below and how these are related:
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/deploy-api/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deploy-api/_index.md
@@ -16,7 +16,7 @@ The Deploy API only works for apps which are deployed to the Mendix Cloud.
 
 The Deploy API allows you to manage application environments in the Mendix Cloud. You can retrieve the status of, and start and stop, applications. You can also configure new model versions and deploy them to application environments. To create and manage deployment packages you also need the [Build API](/apidocs-mxsdk/apidocs/build-api/). For backup-related actions refer to [Backups API](/apidocs-mxsdk/apidocs/backups-api/).
 
-You can use deployment webhooks to trigger CI/CD pipelines which use this API. These are described in [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/).
+You can use webhooks to trigger CI/CD pipelines which use this API. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 
 This image provides a domain model representation of the concepts discussed below and how these are related:
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/webhooks-sprints.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/webhooks-sprints.md
@@ -9,14 +9,16 @@ weight: 75
 ## 1 Introduction
 
 {{% alert color="warning" %}}
-The webhook payloads described in this document are for app Sprints and stories. These webhooks were enabled via **General Settings** > **Webhooks** or via your app. These webhooks have been deprecated. For more information, see the deprecation note in [Webhooks](/developerportal/collaborate/general-settings/#webhooks).
+The webhook payloads described in this document are for app stories and Sprints. These webhooks were enabled via **General Settings** > **Webhooks** or via your app.
+
+The webhooks for stories and Sprints have been deprecated. For more information, see the deprecation note in the [Webhooks](/developerportal/collaborate/general-settings/#webhooks) section of *General Settings*.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-You can now set deployment webhooks for your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
+You can also set deployment webhooks for your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 {{% /alert %}}
 
-Webhooks allow you to build or set up Mendix Platform connectors that subscribe to certain events on the Developer Portal. When one of those events is triggered, Mendix sends an HTTP POST payload to the webhook's configured URL. Webhooks can be used to update an external application to keep it up-to-date with the changes happening in the Developer Portal.
+Webhooks for stories and Sprints allow you to build or set up Mendix Platform connectors that subscribe to certain events on the Developer Portal. When one of those events is triggered, Mendix sends an HTTP POST payload to the webhook's configured URL. Webhooks for stories and Sprints can be used to update an external application to keep it up-to-date with the changes happening in the Developer Portal.
 
 Every POST payload contains the following delivery information as part of the header:
 
@@ -24,7 +26,7 @@ Every POST payload contains the following delivery information as part of the he
 * `MxAPI-Projects-Delivery` – a random UUID
 * `MxAPI-Signature` –  the HMAC hex digest (asymmetric hash using the *HMAC_SHA256* hash algorithm) of the response body, which is calculated using the hash (the hashes secret provided in the webhooks setting using the *SHA-256* hash algorithm with the length as 50)
     * For example, `(gNh407kBD1wkpHfwIrjWcTMjw4rKxIKX0s5b48FYOys=)`
-* `MxAPI-Webhooks-Version` – the version of the webhooks payload (for example, 1)
+* `MxAPI-Webhooks-Version` – the version of the webhooks for stories and Sprints payload (for example, 1)
 * `MxAPI-Webhooks-Version-Expiry` – the expiry date for this version (empty if it is the latest version)
 * `User-Agent` – `Mx-Platform`
 
@@ -36,7 +38,7 @@ The required event category subscription is **Sprints**.
 
 ## 3 Stories
 
-Webhooks event are generated when a [story](/developerportal/collaborate/stories/) is created or updated.
+Webhooks for stories and Sprints event are generated when a [story](/developerportal/collaborate/stories/) is created or updated.
 
 The required event category subscription is **Stories**.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/webhooks-sprints.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/webhooks-sprints.md
@@ -1,5 +1,6 @@
 ---
-title: "Webhooks"
+title: "Webhooks for Stories and Sprints"
+linktitle: "Webhooks for Stories/Sprints"
 url: /apidocs-mxsdk/apidocs/webhooks-sprints/
 category: "API Documentation"
 weight: 75
@@ -12,7 +13,7 @@ The webhook payloads described in this document are for app Sprints and stories.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-You can now set deployment webhooks for your app. These are described in [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/).
+You can now set deployment webhooks for your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 {{% /alert %}}
 
 Webhooks allow you to build or set up Mendix Platform connectors that subscribe to certain events on the Developer Portal. When one of those events is triggered, Mendix sends an HTTP POST payload to the webhook's configured URL. Webhooks can be used to update an external application to keep it up-to-date with the changes happening in the Developer Portal.

--- a/content/en/docs/developerportal/collaborate/general-settings/_index.md
+++ b/content/en/docs/developerportal/collaborate/general-settings/_index.md
@@ -153,37 +153,37 @@ It is possible to migrate all or part of your content from [Stories](/developerp
 ## 7 Webhooks {#webhooks}
 
 {{% alert color="warning" %}}
-This tab is for webhooks for app Sprints and stories, and it is deprecated. This tab will be removed and these webhooks will be discontinued later in 2023. It is no longer possible to add new webhook configurations for app Sprints and stories to your apps, but existing configurations will remain active and can still be edited. 
+This tab is for webhooks for stories and Sprints, and it is deprecated. This tab will be removed and these webhooks will be discontinued later in 2023. It is no longer possible to add new webhook configurations for stories and Sprints to your apps, but existing configurations will remain active and can still be edited. 
 {{% /alert %}}
 
 {{% alert color="info" %}}
-You can now set deployment webhooks for your app. For details, see [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/).
+You can also set webhooks for your app to trigger endpoints when changes are made to deployment packages or models held in the git Team Server. For details, see [Webhooks](/developerportal/deploy/webhooks/).
 {{% /alert %}}
 
 {{% alert color="info" %}}
-This tab is only visible if you already have webhooks created, you are a **Scrum Master**, and you have **Mendix Stories** turned on in the [Project Management](#project-management) tab.
+This tab is only visible if you already have webhooks for stories and Sprints created, you are a **Scrum Master**, and you have **Mendix Stories** turned on in the [Project Management](#project-management) tab.
 {{% /alert %}}
 
-Open the **Webhooks** tab to manage your app's webhooks. A webhook enables the Developer Portal to talk to another website and post updated Developer Portal content (for example, Sprint updates and new stories) to that website. For example, if you want to follow the changes in your app, you can create a service with a certain [URL](#url) that keeps track of the data, and then changes in the app in the Developer Portal are sent to that URL.
+Open the **Webhooks** tab to manage your app's webhooks for stories and Sprints. A webhook enables the Developer Portal to talk to another website and post updated Developer Portal content (for example, Sprint updates and new stories) to that website. For example, if you want to follow the changes in your app, you can create a service with a certain [URL](#url) that keeps track of the data, and then changes in the app in the Developer Portal are sent to that URL.
 
 {{< figure src="/attachments/developerportal/collaborate/general-settings/webhooks-list.png" width="800"  >}}
 
-After clicking **New Webhook** to create a new webhook, fill in the following details:
+After clicking **New Webhook** to create a new webhook for stories and sprints, fill in the following details:
 
-* **Name** – the name of the webhook
-* <a id="url"></a>**URL** – the URL to which the webhook will connect 
-* **Secret** – the secret used by the Developer Portal to sign the data payload in order to identify the source of the data to the receiving URL (this appears when creating and editing a webhook, but it will not be displayed on the **Webhooks settings** page)
+* **Name** – the name of the webhook for stories and Sprints
+* <a id="url"></a>**URL** – the URL to which the webhook for stories and Sprints will connect 
+* **Secret** – the secret used by the Developer Portal to sign the data payload in order to identify the source of the data to the receiving URL (this appears when creating and editing a webhook for stories and Sprints, but it will not be displayed on the **Webhooks settings** page)
 * **Version** – the version of the webhooks feature to be used
-* **Events** – what types of data will be sent via the webhook (you must select at least one; this appears when creating and editing a webhook, but it will not be displayed on the **Webhooks settings** page)
+* **Events** – what types of data will be sent via the webhook for stories and Sprints (you must select at least one; this appears when creating and editing a webhook for stories and Sprints, but it will not be displayed on the **Webhooks settings** page)
     * [Sprints](/developerportal/collaborate/stories/#story-actions)
     * [Stories](/developerportal/collaborate/stories/)
 
-To edit the above details for an existing webhook, click **Edit**.
+To edit the above details for an existing webhook for stories and Sprints, click **Edit**.
 
-To delete an existing webhook, click **Delete**.
+To delete an existing webhook for stories and Sprints, click **Delete**.
 
 {{% alert color="info" %}}
-For details on the technical configuration of webhooks, see [Webhooks](/apidocs-mxsdk/apidocs/webhooks-sprints/) in the *API Documentation*.
+For details on the technical configuration of webhooks for stories and sprints, see [Webhooks for Stories and Sprints](/apidocs-mxsdk/apidocs/webhooks-sprints/) in the *API Documentation*.
 {{% /alert %}}
 
 ## 8 History {#history}

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/webhooks.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/webhooks.md
@@ -25,7 +25,7 @@ The webhooks contain a retry mechanism if an error response is received from the
 {{% alert color="info" %}}
 Webhooks are only available for licensed Mendix apps which are deployed to the Mendix Cloud.
 
-They are set up and work independently of the [webhooks used for Sprints and stories](/developerportal/collaborate/general-settings/#webhooks), which are deprecated.
+They are set up and work independently of the deprecated [webhooks for Sprints and Stories](/developerportal/collaborate/general-settings/#webhooks).
 {{% /alert %}}
 
 ## 2 Configuring a Webhook{#setting-up}

--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/webhooks.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/webhooks.md
@@ -1,6 +1,6 @@
 ---
-title: "Mendix Deployment Webhooks"
-linktitle: "Deployment Webhooks"
+title: "Webhooks"
+linktitle: "Webhooks"
 url: /developerportal/deploy/webhooks/
 weight: 75
 description: "Creating a Webhook to trigger actions from the Mendix cloud"
@@ -13,7 +13,7 @@ This feature is in Beta. For more information on Beta products, see [Beta Releas
 
 ## 1 Introduction
 
-Mendix deployment webhooks allow you to send information about your licensed Mendix app deployed to the Mendix Cloud to an external app or workflow. This can be used, for example, to trigger an automated CI/CD workflow when a new change is committed to the Team Server.
+Webhooks allow you to send information about your licensed Mendix app deployed to the Mendix Cloud to an external app or workflow. This can be used, for example, to trigger an automated CI/CD workflow when a new change is committed to the Team Server.
 
 Mendix provides webhooks to send project information when the following events happen to your app:
 
@@ -23,7 +23,7 @@ Mendix provides webhooks to send project information when the following events h
 The webhooks contain a retry mechanism if an error response is received from the endpoint to ensure that the trigger reaches the endpoint.
 
 {{% alert color="info" %}}
-Mendix deployment webhooks are only available for licensed Mendix apps which are deployed to the Mendix Cloud.
+Webhooks are only available for licensed Mendix apps which are deployed to the Mendix Cloud.
 
 They are set up and work independently of the [webhooks used for Sprints and stories](/developerportal/collaborate/general-settings/#webhooks), which are deprecated.
 {{% /alert %}}

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -21,7 +21,7 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 #### Improvements
 
-* We have added webhooks which can trigger endpoints when changes are committed to a Team Server Git repository, or a new deployment package is available for deployment to the Mendix Cloud. See [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/) for more information.
+* We have added webhooks which can trigger endpoints when changes are committed to a Team Server Git repository, or a new deployment package is available for deployment to the Mendix Cloud. See [Webhooks](/developerportal/deploy/webhooks/) for more information.
 
     {{% alert color="info" %}}This feature is currently in a [Beta Release](/releasenotes/beta-features/).{{% /alert %}}
 

--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -26,7 +26,7 @@ To see the current status of the Mendix Developer Portal and Control Center, see
 
 #### Deprecations
 
-* We have deprecated **General Settings** > **Webhooks** for app Sprints and stories. For more information, see the deprecation note in [Webhooks](/developerportal/collaborate/general-settings/#webhooks). You can now set deployment webhooks for your app. These are described in [Mendix Deployment Webhooks](/developerportal/deploy/webhooks/).
+* We have deprecated **General Settings** > **Webhooks** for app Sprints and stories. For more information, see the deprecation note in [Webhooks](/developerportal/collaborate/general-settings/#webhooks). You can now set webhooks for your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 
 ### March 9th, 2023
 

--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -26,7 +26,7 @@ To see the current status of the Mendix Developer Portal and Control Center, see
 
 #### Deprecations
 
-* We have deprecated **General Settings** > **Webhooks** for app Sprints and stories. For more information, see the deprecation note in [Webhooks](/developerportal/collaborate/general-settings/#webhooks). You can now set webhooks for your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
+* We have deprecated **General Settings** > **Webhooks** for stories and Sprints. For more information, see the deprecation note in the [Webhooks](/developerportal/collaborate/general-settings/#webhooks) section of *General Settings*. You can now set webhooks for building and deploying your app. These are described in [Webhooks](/developerportal/deploy/webhooks/).
 
 ### March 9th, 2023
 
@@ -963,7 +963,7 @@ In Portfolio Management, you can do the following
 
 #### Webhooks Available
 
-* We have added the ability to create webhooks for your apps. These webhooks can be configured to send information when Sprints change and/or stories change.
+* We have added the ability to create webhooks for stories and Sprints for your apps. These webhooks can be configured to send information when Sprints change and/or stories change.
 
 ### April 5th, 2019
 


### PR DESCRIPTION
Since the deployment webhooks will be the default webhooks, reverse this current naming to avoid any confusion for users:

"webhooks" --> webhooks for stories & Sprints
"Mendix deployment webhooks" --> webhooks
