### PR TITLE
Publishing OData 3 is deprecated

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -12,10 +12,9 @@ In Studio Pro, entities can be exposed as [OData resources](/refguide/published-
 
 A published OData service is a REST service with an OpenAPI contract, which means that OpenAPI compatible REST clients can easily interact with it. 
 
-The standards used for OData in Mendix are:
+The standard used for OData in Mendix is [OData version 4](http://www.odata.org/documentation), which returns data in JSON format.
 
-* [OData version 3](http://www.odata.org/documentation/odata-version-3-0), which returns data in Atom XML format.
-* [OData version 4](http://www.odata.org/documentation), which returns data in JSON format.
+The option to publish [OData version 3](http://www.odata.org/documentation/odata-version-3-0) services, which return data in Atom XML format, is deprecated and will be removed in a future version.
 
 Not all parts of the standard are implemented. If something is not documented here, it is has not yet been added.
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -30,7 +30,7 @@ For this example, imagine that you have four entities in your domain model: **Em
 * An association between **Employee** and **Address**
 * An association between **City** and **Address**
 
-Associated objects can be retrieved by passing the `$expand` query parameter. For example: `/odata/myservice/v1/Employees?$expand=Cars,Address($expand=City)` (OData 4) or `/odata/myservice/v1/Employees?$expand=Cars,Address/City` (OData 3).
+Associated objects can be retrieved by passing the `$expand` query parameter. For example: `/odata/myservice/v1/Employees?$expand=Cars,Address($expand=City)` (OData 4) or `/odata/myservice/v1/Employees?$expand=Cars,Address/City` (OData 3 (deprecated)).
 
 ## 3 Counting the Number of Objects
 
@@ -42,7 +42,7 @@ You can find out how many objects there are by passing the `$count` query option
 
 For OData 4, by setting the `$count` query option to `true`, a count of the number of items returned will be included in the result. For example: `?$count=true`.
 
-For OData 3, by setting the `$inlinecount` query option to `allpages`, a count of the number of items returned will be included in the result. For example: `?$inlinecount=allpages`.
+For OData 3 (deprecated), by setting the `$inlinecount` query option to `allpages`, a count of the number of items returned will be included in the result. For example: `?$inlinecount=allpages`.
 
 ## 4 Filtering
 
@@ -56,7 +56,7 @@ This table describes how to pass values for different attribute types:
 | --- | --- |
 | String | Enclosed in single quotes (for example, `'John'`) |
 | Enumeration | The enumeration member name between single quotes, prefixed with the enum type (for example, `DefaultNamespace.PrimaryColor'Red'`). OData v4.01 syntax without the qualified enum type name is not supported |
-| Datetime | For OData 4: a plain value (for example, `2021-12-31`). For OData 3: Preceded with `datetime` and enclosed in single quotes (for example, `datetime'2021-12-31'` or `datetime'<epoch value here>'`) |
+| Datetime | For OData 4: a plain value (for example, `2021-12-31`). For OData 3 (deprecated): Preceded with `datetime` and enclosed in single quotes (for example, `datetime'2021-12-31'` or `datetime'<epoch value here>'`) |
 | Other | Plain value (for example, 15) |
 
 ### 4.2 Comparison Operators
@@ -97,7 +97,7 @@ We support the following comparison operators:
 | minute       | `/Employees?$filter=minute(Registration) eq 55` | All employees registered on the 55th minute of any hour |
 | second       | `/Employees?$filter=second(Registration) eq 55` | All employees registered on the 55th second of any minute of any hour |
 
-<small><sup>1</sup> In OData 3, the `contains` function is called `substringof`, and its arguments are reversed For example, `/Employees?$filter=substringof('f', Name)`</small>
+<small><sup>1</sup> In OData 3 (deprecated), the `contains` function is called `substringof`, and its arguments are reversed For example, `/Employees?$filter=substringof('f', Name)`</small>
 
 ### 4.5 Combining Filters
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
@@ -40,8 +40,6 @@ The type of the attribute.
 
 This field is shown when the type is an enumeration that was previously exposed as a string, and only for OData version 4. Change the value to **Enumeration** to publish the enumeration. This informs clients of the possible values of this attribute.
 
-In Studio Pro 9.23 and below, enumeration attributes were published as strings.
-
 ### 2.7 Capabilities
 
 Select **Sortable** to allow clients to sort results based on this attribute.

--- a/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
@@ -116,10 +116,6 @@ When you use a microflow to provide data, any security constraints are applied t
 
         If the **ODataResponse** is present as a microflow parameter, then it will return the **Count** attribute value regardless of the result list of objects. Otherwise, it will return -1 for not defined, which is the default value. A **Count** value of 0 means that there no record.
 
-{{% alert color="info" %}}
-In Studio Pro [9.17](/releasenotes/studio-pro/9.17/) and above, the count value can be stored in the `ODataResponse` object.
-{{% /alert %}}
-
 ## 5 Key Selection When Exposing Entities as OData Resources {#select-key}
 
 Select which attribute(s) to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource so that clients will be able to identify objects returned by the service.


### PR DESCRIPTION
In Studio Pro 10, using OData version 3 in published OData services is deprecated. This change also removes two mentions of the history of Studio Pro 9.