### PR TITLE
Exposed name clash

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
@@ -16,7 +16,7 @@ The **Edit published attribute** dialog allows you to edit the properties of an 
 
 ### 2.1 Exposed Name
 
-The exposed name is the name of the attribute as it appears to clients of the service.
+The exposed name is the name of the attribute as it appears to clients of the service. This cannot be the same as the exposed name of the entity.
 
 ### 2.2 Can Be Empty
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-resource.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-resource.md
@@ -2,8 +2,6 @@
 title: "Published OData Resource"
 url: /refguide/published-odata-resource/
 tags: ["studio pro", "OData"]
-aliases:
-    - /refguide/published-odata-attribute
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 
 ---


### PR DESCRIPTION
In published OData services in Studio Pro 10, the exposed names of attributes, associations and system id cannot be the same as the exposed name of the entity, because that results in an invalid OData contract.