### PR TITLE
Generated code breaking changes

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.0.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.0.md
@@ -82,6 +82,8 @@ For more information on upgrading to Studio Pro 10, see [Upgrading from Mendix S
 
 ### Breaking Changes {#breaking-changes}
 
+#### Various Breaking Changes
+
 * The `parseDateTime\[UTC\]` microflow functions now use [strict parsing](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/DateFormat.html#setLenient(boolean)) by default. To revert to lenient parsing, set the `com.mendix.core.LenientDateTimeParsing` custom Mendix Runtime setting to `true`. (Ticket 169612)
 * Legacy scheduled events (meaning, those that are non-repeating or have a start time) are no longer supported. Mendix Runtime will fail to start if legacy scheduled events exist.
 * In Mendix [9.0](/releasenotes/studio-pro/9.0/), we removed support for Mendix Runtime uniqueness validation in preference of database uniqueness validation. There was still a custom setting to use the old behavior. This setting has now been removed.
@@ -98,9 +100,9 @@ For more information on upgrading to Studio Pro 10, see [Upgrading from Mendix S
 * We removed the deprecated `IActionRegistrator#bundleComponentLoaded` method.
 * We no longer support using DB2 as the database for applications.
 
-#### Generated code changes {#generated-code-changes}
-* The public constructors of generated Constant and Microflow proxy classes are now private and the classes are marked final to prevent instantiation and derivation.
-* The fields in Java Actions are now generated as final fields.
-* Entity and List of Entity parameters in Java Actions are now initialized in the constructor and the accompanying `__[FieldName]` field will be generated as deprecated. To get access to the `IMendixObject` variant, call the `getMendixObject()` method on the field (or items in the list in case of a list).
-* The methods `initialize(IContext, IMendixIdentifier)` and `getGUID()` on generated entity proxies are no longer generated.
+#### Generated Code Changes {#generated-code-changes}
 
+* The public constructors of generated `Constant` and `Microflow` proxy classes are now private, and the classes are marked final to prevent instantiation and derivation.
+* The fields in Java actions are now generated as final fields.
+* The `Entity` and `List of Entity` parameters in Java actions are now initialized in the constructor, and the accompanying `__[FieldName]` field will be generated as deprecated. To get access to the `IMendixObject` variant, call the `getMendixObject()` method on the field (or items in the list, in case of a list).
+* The `initialize(IContext, IMendixIdentifier)` and `getGUID()` methods on generated entity proxies are no longer generated.

--- a/content/en/docs/releasenotes/studio-pro/10/10.0.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.0.md
@@ -97,3 +97,10 @@ For more information on upgrading to Studio Pro 10, see [Upgrading from Mendix S
 * We removed the deprecated error constants from `AdminException` and `IMxRuntime`.
 * We removed the deprecated `IActionRegistrator#bundleComponentLoaded` method.
 * We no longer support using DB2 as the database for applications.
+
+#### Generated code changes {#generated-code-changes}
+* The public constructors of generated Constant and Microflow proxy classes are now private and the classes are marked final to prevent instantiation and derivation.
+* The fields in Java Actions are now generated as final fields.
+* Entity and List of Entity parameters in Java Actions are now initialized in the constructor and the accompanying `__[FieldName]` field will be generated as deprecated. To get access to the `IMendixObject` variant, call the `getMendixObject()` method on the field (or items in the list in case of a list).
+* The methods `initialize(IContext, IMendixIdentifier)` and `getGUID()` on generated entity proxies are no longer generated.
+


### PR DESCRIPTION
There were some feature changes to generated code that were added to the beta 1, but were missed in the initial generation of the notes.