### PR TITLE
Marketplace releasenotes header update

### DIFF
--- a/content/en/docs/releasenotes/app-store/_index.md
+++ b/content/en/docs/releasenotes/app-store/_index.md
@@ -9,7 +9,7 @@ weight: 35
 
 These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 
-## 2022
+## 2023
 
 ### March 23rd, 2023
 
@@ -21,6 +21,8 @@ On top of open-source community-supported content, we are introducing an additio
 * Partners commit to providing support to customers under an SLA (meaning, under terms specified by the partner). Customers can rely on this SLA for support if something goes wrong. A partner-supported [component details page](/appstore/general/app-store-overview/#details) contains a reference to the partner's support portal or the partner's support contact email.
 
 You can find and use partner-supported components on the [Marketplace homepage](https://marketplace.mendix.com/) under **From our partners** and by selecting the [Partner](/appstore/general/app-store-content-support/#category) **Support** level in the search box. A partner-supported component details page has an explicit indicator (a crown), which makes it easy to distinguish from community-supported content.
+
+## 2022
 
 ### October 25th, 2022
 


### PR DESCRIPTION
Made sure the 2022 H2 header is actually above the 2022 updates in the Marketplace releasenotes.