### PR TITLE
Release notes for Mx4PC version 2.11.0 (planned release date May 3)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -1567,7 +1567,7 @@ Vertical pod autoscaling cannot be combined with horizontal pod autoscaling.
 
 ### 5.7 Log format
 
-#### 5.7.1 Runtime log format
+#### 5.7.1 Runtime log format{#runtime-log-format}
 
 Mendix Operator version 2.11.0 or above allows to specify the log format of Mendix apps.
 
@@ -1593,6 +1593,12 @@ You can set `runtimeLogFormatType` to one of the following values:
   ```json
   {"node":"M2EE","level":"INFO","message":"Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'","timestamp":1679409374607}
   ```
+
+{{% alert color="warning" %}}
+In the `json` format newline characters will be sent as `\n` (as specified in the [JSON spec](https://www.json.org/json-en.html)).
+You might need to configure you log viewer tool to display `\n` as line breaks.
+For example, to correctly display newline characters in Grafana, use the [Escape newlines](https://github.com/grafana/grafana/pull/31352) button.
+{{% /alert %}}
 
 ## 6 Cluster and Namespace Management
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -1569,9 +1569,9 @@ Vertical pod autoscaling cannot be combined with horizontal pod autoscaling.
 
 #### 5.7.1 Runtime log format{#runtime-log-format}
 
-Mendix Operator version 2.11.0 or above allows to specify the log format of Mendix apps.
+Mendix Operator version 2.11.0 or above allows you to specify the log format used by Mendix apps.
 
-To specify the log format, add a `runtimeLogFormatType` entry to OperatorConfiguration:
+To specify the log format, add a `runtimeLogFormatType` entry to `OperatorConfiguration`:
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
@@ -1586,17 +1586,16 @@ spec:
 You can set `runtimeLogFormatType` to one of the following values:
 
 * **plain**: – default option, produces plaintext logs in the following format:
-  ```
-  2023-03-21 14:36:14.607 INFO - M2EE: Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'
-  ```
+    ```
+    2023-03-21 14:36:14.607 INFO - M2EE: Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'
+    ```
 * **json**: – produces JSON logs in the following format:
-  ```json
-  {"node":"M2EE","level":"INFO","message":"Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'","timestamp":1679409374607}
-  ```
+    ```json
+    {"node":"M2EE","level":"INFO","message":"Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'","timestamp":1679409374607}
+    ```
 
 {{% alert color="warning" %}}
-In the `json` format newline characters will be sent as `\n` (as specified in the [JSON spec](https://www.json.org/json-en.html)).
-You might need to configure you log viewer tool to display `\n` as line breaks.
+In the `json` format, newline characters will be sent as `\n` (as specified in the [JSON spec](https://www.json.org/json-en.html)). You might need to configure your log viewer tool to display `\n` as line breaks.
 For example, to correctly display newline characters in Grafana, use the [Escape newlines](https://github.com/grafana/grafana/pull/31352) button.
 {{% /alert %}}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -1565,6 +1565,35 @@ We recommend using *horizontal* pod autoscaling to adjust environments to meet d
 Vertical pod autoscaling cannot be combined with horizontal pod autoscaling.
 {{% /alert %}}
 
+### 5.7 Log format
+
+#### 5.7.1 Runtime log format
+
+Mendix Operator version 2.11.0 or above allows to specify the log format of Mendix apps.
+
+To specify the log format, add a `runtimeLogFormatType` entry to OperatorConfiguration:
+
+```yaml
+apiVersion: privatecloud.mendix.com/v1alpha1
+kind: OperatorConfiguration
+spec:
+  # ...
+  # Other configuration options values
+  # Optional: log format type
+  runtimeLogFormatType: json
+```
+
+You can set `runtimeLogFormatType` to one of the following values:
+
+* **plain**: – default option, produces plaintext logs in the following format:
+  ```
+  2023-03-21 14:36:14.607 INFO - M2EE: Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'
+  ```
+* **json**: – produces JSON logs in the following format:
+  ```json
+  {"node":"M2EE","level":"INFO","message":"Added admin request handler '/prometheus' with servlet class 'com.mendix.metrics.prometheus.PrometheusServlet'","timestamp":1679409374607}
+  ```
+
 ## 6 Cluster and Namespace Management
 
 Once it is configured, you can manage your cluster and namespaces through the Developer Portal.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -111,6 +111,7 @@ spec:
     logLevels: # Optional, can be omitted : set custom log levels for specific nodes
       NodeOne: CRITICAL
       NodeTwo: DEBUG
+    logFormatType: json # Optional, can be omitted : specify the log format
     microflowConstants: # Optional, can be omitted : set values for microflow constants
       MyFirstModule.Constant: "1234"
       Atlas_UI_Resources.Atlas_UI_Resources_Version: "2.5.4"
@@ -199,6 +200,7 @@ You need to make the following changes:
     ```
 
 * **logLevels**: – set custom logging levels for specific log nodes in your app — valid values are: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`
+* **logFormatType**: – allows to specify the log format of Mendix apps - valid values are `plain` (default) and `json`; for more information, see the [runtime log format](/developerportal/deploy/private-cloud-cluster/#runtime-log-format) documentation.
 * **microflowConstants**: – set values for microflow constants
 * **scheduledEventExecution**: – choose which scheduled events should be enabled – valid values are: `ALL`, `NONE` and `SPECIFIED`
 * **myScheduledEvents**: – list scheduled events which should be enabled – can only be used when **scheduledEventExecution** is set to `SPECIFIED`
@@ -206,7 +208,7 @@ You need to make the following changes:
 * **environmentVariables**: – set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable
 * **clientCertificates**: – specify client certificates to be used for TLS calls to Web Services and REST services
 * **runtimeMetricsConfiguration**: – specify how metrics should be collected — any non-empty values will override [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration` — see [Monitoring Environments in Mendix for Private Cloud](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment
-* **runtimeLeaderSelection**: – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero)
+* **runtimeLeaderSelection**: – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
 
 #### 3.2.1 Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -155,6 +155,7 @@ spec:
       {
         …
       }
+  runtimeLeaderSelection: assigned # Optional, can be omitted : specify how the leader node will be selected
 ```
 
 You need to make the following changes:
@@ -205,6 +206,7 @@ You need to make the following changes:
 * **environmentVariables**: – set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable
 * **clientCertificates**: – specify client certificates to be used for TLS calls to Web Services and REST services
 * **runtimeMetricsConfiguration**: – specify how metrics should be collected — any non-empty values will override [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration` — see [Monitoring Environments in Mendix for Private Cloud](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment
+* **runtimeLeaderSelection**: – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero)
 
 #### 3.2.1 Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
@@ -37,7 +37,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
 * Kubernetes versions 1.19 through 1.26
-* OpenShift 4.6 through 4.11
+* OpenShift 4.6 through 4.12
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.

--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -14,7 +14,7 @@ Follow the links in the table below to see the release notes you want:
 | Type of Deployment | Last Updated |
 | --- | --- |
 | [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | April 20th, 2023 |
-| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 28th, 2023 |
+| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | May 3rd, 2023 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | November 17th, 2022 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | October 26th, 2020 |
 

--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -14,7 +14,7 @@ Follow the links in the table below to see the release notes you want:
 | Type of Deployment | Last Updated |
 | --- | --- |
 | [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | April 20th, 2023 |
-| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 25th, 2023 |
+| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 26th, 2023 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | November 17th, 2022 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | October 26th, 2020 |
 

--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -14,7 +14,7 @@ Follow the links in the table below to see the release notes you want:
 | Type of Deployment | Last Updated |
 | --- | --- |
 | [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | April 20th, 2023 |
-| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 26th, 2023 |
+| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 28th, 2023 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | November 17th, 2022 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | October 26th, 2020 |
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -19,11 +19,11 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 * We have updated components to use Go 1.19 and the latest dependency versions, in order to improve security score ratings for all container images.
 * We fixed an issue where applying a custom TLS trust config in [non-interactive mode](/developerportal/deploy/private-cloud-cli-non-interactive/) failed.
-* We added a `runtimeLeaderSelection` option that allows to run an environment without a leader replica - so that an app can be deployed into multiple regions.
+* We added a `runtimeLeaderSelection` option that allows you to run an environment without a leader replica - so that an app can be deployed into multiple regions.
 * We refactored the way the Mendix Runtime is launched. This removes the need to use Bash and Curl to start the Runtime.
-* It's now possible choose between plaintext and JSON formats for Mendix app logs.
+* It is now possible to choose between plaintext and JSON formats for Mendix app logs.
 * We have extended the options for configuring Ceph RADOS storage buckets. It is now possible to share a bucket between multiple environments.
-* We've updated the list of supported platforms to include OpenShift 4.12.
+* We have updated the list of supported platforms to include OpenShift 4.12.
 
 ### April 25th, 2023
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,7 +13,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
-### April 26th, 2023
+### April 28th, 2023
 
 #### Mendix Operator v2.11.0 {#2.11.0}
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,18 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### April 26th, 2023
+
+#### Mendix Operator v2.11.0 {#2.11.0}
+
+* We have updated components to use Go 1.19 and the latest dependency versions, in order to improve security score ratings for all container images.
+* We fixed an issue where applying a custom TLS trust config in [non-interactive mode](/developerportal/deploy/private-cloud-cli-non-interactive/) failed.
+* We added a `runtimeLeaderSelection` option that allows to run an environment without a leader replica - so that an app can be deployed into multiple regions.
+* We refactored the way the Mendix Runtime is launched. This removes the need to use Bash and Curl to start the Runtime.
+* It's now possible choose between plaintext and JSON formats for Mendix app logs.
+* We have extended the options for configuring Ceph RADOS storage buckets. It is now possible to share a bucket between multiple environments.
+* We've updated the list of supported platforms to include OpenShift 4.12.
+
 ### April 25th, 2023
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,7 +13,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
-### April 28th, 2023
+### May 3rd, 2023
 
 #### Mendix Operator v2.11.0 {#2.11.0}
 


### PR DESCRIPTION
We've prepared a new version of Mx4PC - containing a few new features and bugfixes.
We're planning to release this on May 3.