### PR TITLE
[MX10] Update mx check doc to mention the new -j option

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -129,9 +129,10 @@ The `OPTIONS` are described in the table below:
 | Option           | Shortcut | Result                                                       |
 | ---------------- | -------- | ------------------------------------------------------------ |
 | `--help`         | `-h`     | Displays the help text and exits.                            |
-| `--warnings`     | `-w`     | Include warnings in the output                               |
 | `--deprecations` | `-d`     | Include deprecations in the output                           |
+| `--json <path to new JSON file>`         | `-j <path to new JSON file>`     | Output the results to the specified file path, as JSON. |
 | `--performance`  | `-p`     | Include performance checks in the output (performance recommendations are only output if there are no errors) |
+| `--warnings`     | `-w`     | Include warnings in the output                               |
 
 {{% alert color="info" %}}
 Errors in the MPR are always reported.
@@ -150,6 +151,7 @@ Examples of commands are described in the table below:
 | `mx check --help`                                            | Displays the help text for the check command.                |
 | `mx check C:\MxProjects\App-main\App-main.mpr`               | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -p`            | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -p -j c:\temp\mx-result.json`            | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. Outputs the result as a JSON file at `c:\temp\mx-result.json`. |
 | `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. Suppressed warnings will be read from the *project-settings.user.json* file within the app directory. |
 | `mx check C:\MxProjects\App-main\App-main.mpr c:\MxFiles\my-exported-suppressed-warnings.json --warnings` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and warnings. Suppressed warnings will be read from the JSON file *my-exported-suppressed-warnings.json*. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p`      | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |


### PR DESCRIPTION
[MX10] Update mx check doc to mention the new -j option

note: I could not find the `mx-10-branch` branch - so this is forked from `development`.

Let me know if I should re-open this PR ?

thank you
Sean

MxAssist-Client ref = AA-4625
