### PR TITLE
[WTF-1508] Add extra information on dynamic classes on grid columns

### DIFF
--- a/content/en/docs/refguide/modeling/pages/data-widgets/grids/data-grid/columns.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/grids/data-grid/columns.md
@@ -25,6 +25,10 @@ Grid column properties consist of the following sections:
 
 {{% snippet file="/static/_includes/refguide/common-section-link.md" %}}
 
+{{% alert color="info" %}}
+Dynamic classes specified on grid columns will only be applied on the table columns (the `col` elements) but not on individual table cells (the `td` elements).
+{{% /alert %}}
+
 ### 2.2 Data Source Section {#data-source}
 
 #### 2.2.1 Attribute (Path)

--- a/content/en/docs/refguide/modeling/pages/data-widgets/grids/data-grid/columns.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/grids/data-grid/columns.md
@@ -26,7 +26,7 @@ Grid column properties consist of the following sections:
 {{% snippet file="/static/_includes/refguide/common-section-link.md" %}}
 
 {{% alert color="info" %}}
-Dynamic classes specified on grid columns will only be applied on the table columns (the `col` elements) but not on individual table cells (the `td` elements).
+Dynamic classes specified on grid columns will only be applied on the table columns (`col` elements), not on individual table cells (`td` elements).
 {{% /alert %}}
 
 ### 2.2 Data Source Section {#data-source}

--- a/content/en/docs/refguide9/modeling/pages/data-widgets/grids/data-grid/columns.md
+++ b/content/en/docs/refguide9/modeling/pages/data-widgets/grids/data-grid/columns.md
@@ -25,6 +25,10 @@ Grid column properties consist of the following sections:
 
 {{% snippet file="/static/_includes/refguide9/common-section-link.md" %}}
 
+{{% alert color="info" %}}
+Dynamic classes specified on grid columns will only be applied on the table columns (the `col` elements) but not on individual table cells (the `td` elements). 
+{{% /alert %}}
+
 ### 2.2 Data Source Section {#data-source}
 
 #### 2.2.1 Attribute (Path)

--- a/content/en/docs/refguide9/modeling/pages/data-widgets/grids/data-grid/columns.md
+++ b/content/en/docs/refguide9/modeling/pages/data-widgets/grids/data-grid/columns.md
@@ -26,7 +26,7 @@ Grid column properties consist of the following sections:
 {{% snippet file="/static/_includes/refguide9/common-section-link.md" %}}
 
 {{% alert color="info" %}}
-Dynamic classes specified on grid columns will only be applied on the table columns (the `col` elements) but not on individual table cells (the `td` elements). 
+Dynamic classes specified on grid columns will only be applied on the table columns (`col` elements), not on individual table cells (`td` elements).
 {{% /alert %}}
 
 ### 2.2 Data Source Section {#data-source}


### PR DESCRIPTION
Dynamic classes for grid columns are only applied to the col element on not on the individual cells. This doc update is to make that more clear.