### PR TITLE
double "the"

### DIFF
--- a/content/en/docs/releasenotes/marketplace/_index.md
+++ b/content/en/docs/releasenotes/marketplace/_index.md
@@ -22,7 +22,7 @@ These release notes cover changes made to the [Mendix Marketplace](/appstore/).
 #### Improvements
 
 * MPK files are now uploaded asynchronously in the onboarding flow, which means that you can continue to go through the onboarding wizard while the upload is in progress.
-* We aligned the the Marketplace UI with the rest of the Mendix Platform.
+* We aligned the Marketplace UI with the rest of the Mendix Platform.
 
 #### Fixes
 


### PR DESCRIPTION
There is a double "the" in the Marketplace release notes