### PR TITLE
[MOO-1078] Update mobile ref guide

### DIFF
--- a/content/en/docs/refguide9/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide9/mobile/getting-started-with-mobile/prerequisites.md
@@ -98,23 +98,6 @@ If your company has strict network policies which do not allow you to open the p
 
 The latest version of Make It Native 9 is only compatible with versions of Mendix 9.24.0 and above. To develop with older versions of Mendix 9, you can create a custom developer app by following [this guide](/refguide9/mobile/distributing-mobile-apps/building-native-apps/how-to-devapps/). Note that a custom developer app can be used to develop multiple older Mendix apps as long as no custom dependencies are introduced.
 
-Until June 2023, Mendix is also providing a special version of the Make It Native 9 app that is compatible with older versions of Mendix 9. To install the special MIN 9 app, do the following:
-
-For iOS, do the following:
-
-1. Download and install the [TestFlight App from Apple](https://developer.apple.com/testflight/).
-1. Open the following URL on your phone: [https://testflight.apple.com/join/3tVndxSt](https://testflight.apple.com/join/3tVndxSt).
-1. Accept the invitation and install the Make It Native 9 app via TestFlight.
-
-For Android:
-
-1. Uninstall the Make It Native 9 app from your phone.
-1. Open the following URL in Chrome on your phone to download the *MakeItNative9.apk* file: [https://www.dropbox.com/s/9rvgnb87bofwyaj/MakeItNative9.apk?dl=1](https://www.dropbox.com/s/9rvgnb87bofwyaj/MakeItNative9.apk?dl=1).
-1. Access **Downloads** by tapping the three dots in the top-left corner.
-1. Tap on *MakeItNative9.apk* to install the app.
-1. If Chrome refuses to install the app, enable **Allow from this source** in Settings and try again.
-1. If a warning is shown, tap **Install anyway**.
-
 ### 3.2 Configure Parallels
 
 To use Studio Pro on a Mac device, you will first need to install and configure Parallels. For more information, see [Configuring Parallels](/refguide9/using-mendix-studio-pro-on-a-mac/).


### PR DESCRIPTION
Removing the Test Flight and the information about Android custom build for versions below 9.24