### PR TITLE
Occurrence and Separated typos fixed.

### DIFF
--- a/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-css.md
+++ b/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-css.md
@@ -5,11 +5,11 @@ url: /appstore/partner-solutions/ats/rg-one-find-element-by-css/
 
 ## 1 Description
 
-Find a web element by CSS. Occurence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
+Find a web element by CSS. Occurrence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
 
 ## 2 Usage
 
-Provide the CSS selector which matches the elements you want to find. This action will find all matching elements from the DOM and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurence.  
+Provide the CSS selector which matches the elements you want to find. This action will find all matching elements from the DOM and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurrence.  
 Optionally restrict the search to a specified SearchContext element.
 
 ## 3 Input Parameters
@@ -18,7 +18,7 @@ Name | Datatype | Required | Description
 ---- | -------- | ------- |---------------
 CSS Selector | String | yes |  CSS selector which matches the elements you want to find
 Search Context | WebElement | no | Limit the search to the given WebElement
-Occurence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
+Occurrence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
 
 ## 4 Return Value
 

--- a/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-id.md
+++ b/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-id.md
@@ -5,11 +5,11 @@ url: /appstore/partner-solutions/ats/rg-one-find-element-by-id/
 
 ## 1 Description
 
-Find a web element by ID. Occurence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
+Find a web element by ID. Occurrence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
 
 ## 2 Usage
 
-Provide the ID of the element you want to find. This action will find all elements from the DOM with that ID and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurence.  
+Provide the ID of the element you want to find. This action will find all elements from the DOM with that ID and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurrence.  
 Optionally restrict the search to a specified SearchContext element.
 
 ## 3 Input Parameters
@@ -18,7 +18,7 @@ Name | Datatype | Required | Description
 ---- | -------- | ------- |---------------
 ID| String | yes |  The ID of the element you want to get  
 Search Context | WebElement | no | Limit the search to the given WebElement
-Occurence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
+Occurrence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
 
 ## 4 Return Value
 

--- a/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-sizzle.md
+++ b/content/en/docs/appstore/partner-solutions/ats/rg-ats/v1/test-dev/std-actions/selenium-actions/rg-one-find/rg-one-find-element-by-sizzle.md
@@ -5,11 +5,11 @@ url: /appstore/partner-solutions/ats/rg-one-find-element-by-sizzle/
 
 ## 1 Description
 
-Find a web element by Sizzle. Occurence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
+Find a web element by Sizzle. Occurrence lets you specify which element to fetch from the result-list, starting at 1 for the first element (defaults to the first element).
 
 ## 2 Usage
 
-Provide the Sizzle selector which matches the elements you want to find. This action will find all matching elements from the DOM and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurence.  
+Provide the Sizzle selector which matches the elements you want to find. This action will find all matching elements from the DOM and save them as a result-list. If you want, to get another element instead of the first element of the result-list, provide an index as input for the Occurrence.  
 Optionally restrict the search to a specified SearchContext element.
 
 ## 3 Input Parameters
@@ -18,7 +18,7 @@ Name | Datatype | Required | Description
 ---- | -------- | ------- |---------------
 Sizzle Selector | String | yes |  Sizzle selector which matches the elements you want to find
 Search Context | WebElement | no | Limit the search to the given WebElement
-Occurence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
+Occurrence | Integer | no | Index of the result-list value you want to get (defaults to the first element)
 
 ## 4 Return Value
 

--- a/content/en/docs/howto/front-end/styles.md
+++ b/content/en/docs/howto/front-end/styles.md
@@ -129,7 +129,7 @@ For more information on grid options, including suggestions and examples, see [B
 Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
-* `listview-striped`: list view widget with striped listview items
+* `listview-striped`: list view widget with striped list view items
 * `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 

--- a/content/en/docs/howto/front-end/styles.md
+++ b/content/en/docs/howto/front-end/styles.md
@@ -130,7 +130,7 @@ Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
 * `listview-striped`: list view widget with striped listview items
-* `listview-seperated`: list view widget with list view items seperated
+* `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 
 ## 8 Alerts

--- a/content/en/docs/howto7/front-end/styles.md
+++ b/content/en/docs/howto7/front-end/styles.md
@@ -129,7 +129,7 @@ For more information on grid options, including suggestions and examples, see [B
 Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
-* `listview-striped`: list view widget with striped listview items
+* `listview-striped`: list view widget with striped list view items
 * `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 

--- a/content/en/docs/howto7/front-end/styles.md
+++ b/content/en/docs/howto7/front-end/styles.md
@@ -130,7 +130,7 @@ Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
 * `listview-striped`: list view widget with striped listview items
-* `listview-seperated`: list view widget with list view items seperated
+* `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 
 ## 8 Alerts

--- a/content/en/docs/howto8/front-end/styles.md
+++ b/content/en/docs/howto8/front-end/styles.md
@@ -129,7 +129,7 @@ For more information on grid options, including suggestions and examples, see [B
 Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
-* `listview-striped`: list view widget with striped listview items
+* `listview-striped`: list view widget with striped list view items
 * `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 

--- a/content/en/docs/howto8/front-end/styles.md
+++ b/content/en/docs/howto8/front-end/styles.md
@@ -130,7 +130,7 @@ Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
 * `listview-striped`: list view widget with striped listview items
-* `listview-seperated`: list view widget with list view items seperated
+* `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 
 ## 8 Alerts

--- a/content/en/docs/howto9/front-end/styles.md
+++ b/content/en/docs/howto9/front-end/styles.md
@@ -129,7 +129,7 @@ For more information on grid options, including suggestions and examples, see [B
 Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
-* `listview-striped`: list view widget with striped listview items
+* `listview-striped`: list view widget with striped list view items
 * `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 

--- a/content/en/docs/howto9/front-end/styles.md
+++ b/content/en/docs/howto9/front-end/styles.md
@@ -130,7 +130,7 @@ Change the way items appear in a list:
 
 * `listview-lined`: list view widget with only a bordered bottom in a list view item
 * `listview-striped`: list view widget with striped listview items
-* `listview-seperated`: list view widget with list view items seperated
+* `listview-seperated`: list view widget with list view items separated
 * `listview-stylingless`: list view widget without spacing and background
 
 ## 8 Alerts

--- a/content/en/docs/refguide/modeling/pages/data-widgets/data-sources/xpath-source.md
+++ b/content/en/docs/refguide/modeling/pages/data-widgets/data-sources/xpath-source.md
@@ -75,7 +75,7 @@ The feature to use objects and attributes can be used for [List view](/refguide/
 
 #### 2.4.1 Known Errors
 
-Currently, Studio Pro does not support database retreivals using XPath constraints that walk through both regular databases and [external entities](/refguide/external-entities/). This results in the `Mixed source retrieval is currently not supported` error. If you experience this error, use Data Grid 2 instead of Data Grid, then disable sorting and remove the option to search on external entity attributes.
+Currently, Studio Pro does not support database retrievals using XPath constraints that walk through both regular databases and [external entities](/refguide/external-entities/). This results in the `Mixed source retrieval is currently not supported` error. If you experience this error, use Data Grid 2 instead of Data Grid, then disable sorting and remove the option to search on external entity attributes.
 
 ## 3 Read More
 

--- a/content/en/docs/refguide9/general/moving-from-8-to-9/moving-from-atlas-2-to-3/_index.md
+++ b/content/en/docs/refguide9/general/moving-from-8-to-9/moving-from-atlas-2-to-3/_index.md
@@ -45,7 +45,7 @@ To upgrade your theme directory to Atlas 3 specifications, please complete the f
 
 ### 2.2  Migrating UI Content {#upgrade-ui-content}
 
-**Atlas 3** distributes the UI content previously found in the Atlas_UI_Resources, in 3 seperate modules: **Atlas Core**, **Atlas Web Content** and **Atlas Native Content**. 
+**Atlas 3** distributes the UI content previously found in the Atlas_UI_Resources, in 3 separate modules: **Atlas Core**, **Atlas Web Content** and **Atlas Native Content**. 
 
 * [Atlas Core](https://marketplace.mendix.com/link/component/117187) - Contains Atlas core styling and layouts
 * [Atlas Web Content](https://marketplace.mendix.com/link/component/117183) - Contains Atlas's web page templates and building blocks


### PR DESCRIPTION
- Changed where Occurrence and Separated were written like Occurence and Seperated to the correct spelling
- The css class "listview-seperated" is still misspelled, but it's probably not a good idea to rename as that will break some applications that make use of that class.