### PR TITLE
Remove webhooks, the tab has been deprecated

### DIFF
--- a/content/en/docs/developerportal/collaborate/general-settings/_index.md
+++ b/content/en/docs/developerportal/collaborate/general-settings/_index.md
@@ -35,7 +35,6 @@ These tabs are only available for users with the **App Settings** permission:
 * **Cloud Settings**
 * **API Keys**
 * **Project Management**
-* **Webhooks**
 * **History**
 * **Story Archive**
 


### PR DESCRIPTION
The tab is only available to customers who are using it