### PR TITLE
Update mxbuild documentation and requirements to latest specification

### DIFF
--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -50,7 +50,7 @@ In Windows, use the following format for the command line:
 
 You can also run MxBuild under Linux using the the following command line format:
 
-`mono mxbuild.exe --java-home="JDKDirectory" --java-exe-path="javaExecutable" [options] projectFile`
+`mxbuild --java-home="JDKDirectory" --java-exe-path="javaExecutable" [options] projectFile`
 
 After creating the deployment package, the MxBuild process quits.
 

--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -238,7 +238,7 @@ Depending on your app's complexity, these minimum hardware requirements might no
 
 MxBuild is a Windows and Linux command-line tool that can be used to build a Mendix Deployment Package. For more information, see [MxBuild](/refguide/mxbuild/).
 
-* Mono v5.20.x or .NET v4.7.2
+* .NET 6.0
 * JDK 11
 
 ## 12 mx Command-Line Tool {#mxtool}


### PR DESCRIPTION
change mxbuild documentation to call native linux binaries correctly.
update mxbuild system requirements to use .net 6 instead of mono and .net framework
