### PR TITLE
Update send-external-object activity

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
@@ -9,11 +9,11 @@ These activities can only be used in **Microflows**.
 
 ## 1 Introduction
 
-The **Send external object** activity can be used to persist changes to an external object. It can be used to send objects that have been first retrieved and then changed, or to to send newly created objects.
+The **Send external object** activity can be used to persist changes to an external object. It can be used to send objects that have been first retrieved and then changed, or to send newly created objects.
 
-## 2 Using the **Send external object** Activity
+## 2 Using This Activity
 
-Use this activity with [updatable exernal entities](#updatable-entities) to send objects that have been first retrieved and then changed, or with [creatable external entities](#creatable-entities) to send newly created objects.
+Use this activity with [updatable external entities](#updatable-entities) to send objects that have been first retrieved and then changed, or with [creatable external entities](#creatable-entities) to send newly created objects.
 
 ### 2.1 Updatable External Entities {#updatable-entities}
 
@@ -37,7 +37,7 @@ This activity sends new objects and their attributes and owned associations to b
 
 ## 3 Activity Properties
 
-To manage the properties of the activity, double click the **Send external object** activity, or right-click the activity and select **Properties**. 
+To manage the properties of the activity, double-click the **Send external object** activity, or right-click the activity and select **Properties**. 
 
 Single-clicking on the activity displays the properties in the **Properties** pane.
 
@@ -53,7 +53,7 @@ This setting defines how changes are reflected in the pages presented to the end
 
 After this activity, the `$latestHttpResponse` variable (of the [HttpResponse](/refguide/http-request-and-response-entities/#http-response) type) is available to inspect the response returned by the service.
 
-After this activity, an external object would be update based on the received response.
+After this activity, an external object is updated based on the received response.
 
 {{% alert color="info" %}}
 The feature to update an external entity was introduced in Studio Pro [10.2.0](/releasenotes/studio-pro/10.2/).

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
@@ -53,6 +53,12 @@ This setting defines how changes are reflected in the pages presented to the end
 
 After this activity, the `$latestHttpResponse` variable (of the [HttpResponse](/refguide/http-request-and-response-entities/#http-response) type) is available to inspect the response returned by the service.
 
+After this activity, an external object would be update based on the received response.
+
+{{% alert color="info" %}}
+The feature to update an external entity was introduced in Studio Pro [10.2.0](/releasenotes/studio-pro/10.2/).
+{{% /alert %}}
+
 ## 5 Related
 
 Persistable objects are persisted by using the [commit](/refguide/committing-objects/) activity. External entities cannot be committed. Use this activity instead.

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/external-object-activities/send-external-object.md
@@ -56,7 +56,7 @@ After this activity, the `$latestHttpResponse` variable (of the [HttpResponse](/
 After this activity, an external object is updated based on the received response.
 
 {{% alert color="info" %}}
-The feature to update an external entity was introduced in Studio Pro [10.2.0](/releasenotes/studio-pro/10.2/).
+The feature to update an external entity was introduced in Studio Pro 10.3.0.
 {{% /alert %}}
 
 ## 5 Related


### PR DESCRIPTION
The update should be applied to version 10 docs, not 9 docs.

After verifying with @Ahmad-Elsayed, I copied the changes made in the PR (https://github.com/mendix/docs/pull/6416/files) to the current PR, with the update to the right doc version.