### PR TITLE
Update nt-5.2-rn.md

### DIFF
--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/_index.md
@@ -11,6 +11,12 @@ These are the current Native Template versions for Studio Pro 8 in active develo
 * Native Template versions [5.1](/releasenotes/mobile/nt-5.1-rn/) are compatible with apps built using Studio Pro [8.15](/releasenotes/studio-pro/8.15/)-[8.18.8](/releasenotes/studio-pro/8.18/#8188).
 * Native Template versions of [5.0](/releasenotes/mobile/nt-5.0-rn/) are compatible with apps built using Studio Pro [8.12.1](/releasenotes/studio-pro/8.12/#8121)–[8.14.1](/releasenotes/studio-pro/8.14/). 
 
+{{% alert color="info" %}}
+The latest version of Native Template 5.2 targets Android 11 (API level 30). 
+
+To target Android 13 (API level 33 or higher), you can update the `compileSdkVersion` and `targetSdkVersion` to 33 in the **build.gradle** file and update your dependencies (as shown in the *Build a new version of your native mobile app* section of [this blog](https://www.mendix.com/blog/update-needed-for-android-native-mobile-apps/). 
+{{% /alert %}}
+
 {{% alert color="warning" %}}
 Native Template versions [5.0](/releasenotes/mobile/nt-5.0-rn/) and [5.1](/releasenotes/mobile/nt-5.1-rn/) are no longer receiving updates. Also, Native Template does not work for versions below 8.18.9. 
 

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/nt-5.2-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/nt-5.2-rn.md
@@ -4,8 +4,11 @@ url: /releasenotes/mobile/nt-5.2-rn/
 weight: 10
 description: "Native Template 5.2 release notes."
 ---
-{{% alert color="warning" %}}
-The latest version of Native Template 5.2 targets Android 11 (API level 30). To target Android 13 (API level 33) (or higher), you can update the compileSdkVersion en targetSdkVersion to 33 in the build.gradle file and update your dependencies (as is done in step 2 of [this document](https://www.mendix.com/blog/update-needed-for-android-native-mobile-apps/). 
+
+{{% alert color="info" %}}
+The latest version of Native Template 5.2 targets Android 11 (API level 30). 
+
+To target Android 13 (API level 33 or higher), you can update the `compileSdkVersion` and `targetSdkVersion` to 33 in the **build.gradle** file and update your dependencies (as shown in the *Build a new version of your native mobile app* section of [this blog](https://www.mendix.com/blog/update-needed-for-android-native-mobile-apps/). 
 {{% /alert %}}
 
 ## 5.2.18

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/nt-5.2-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-8-parent/nt-5.2-rn.md
@@ -4,6 +4,10 @@ url: /releasenotes/mobile/nt-5.2-rn/
 weight: 10
 description: "Native Template 5.2 release notes."
 ---
+{{% alert color="warning" %}}
+The latest version of Native Template 5.2 targets Android 11 (API level 30). To target Android 13 (API level 33) (or higher), you can update the compileSdkVersion en targetSdkVersion to 33 in the build.gradle file and update your dependencies (as is done in step 2 of [this document](https://www.mendix.com/blog/update-needed-for-android-native-mobile-apps/). 
+{{% /alert %}}
+
 ## 5.2.18
 
 **Release date: May 24, 2023**


### PR DESCRIPTION
adding warning due to this upcoming change: https://developer.android.com/google/play/requirements/target-sdk 

When we're satisfied with the text, we probably should add it here as well: https://docs.mendix.com/releasenotes/mobile/nt-studio-pro-8-parent/ 

FYI @hnejra @ConnorLand 