### PR TITLE
Update string-function-calls.md

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -501,7 +501,7 @@ The output is:
 False
 ```
 
-In `isMatch()`, the regex is implicitly anchored at `^` and `$`, meaning that `isMatch()` will always match the entire input string instead of a substring.
+In `isMatch()`, the regex is implicitly anchored at `^` and `$`. This means that `isMatch()` will always match the entire input string instead of a substring.
 
 **Other Examples**
 

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -492,7 +492,7 @@ The output is described in the table below:
 This input below tests to see whether the string contains only numbers:
 
 ```java {linenos=false}
-isMatch('234hello6432', '^([0-9]+)$')
+isMatch('234hello6432', '([0-9]+)')
 ```
 
 The output is:
@@ -501,7 +501,7 @@ The output is:
 False
 ```
 
-In `isMatch()`, the regex is implicitly anchored at `^` and `$`.
+In `isMatch()`, the regex is implicitly anchored at `^` and `$`, meaning that `isMatch()` will always match the entire input string instead of a substring.
 
 **Other Examples**
 


### PR DESCRIPTION
Checked in Slack here: https://mendix.slack.com/archives/CJZ85RLTA/p1688659440472209 

Removed the ^and $ in the example based on this note https://mendix.atlassian.net/browse/WTF-1552?focusedCommentId=518230. Since they are implicit having them in the example is kinda confusing