### PR TITLE
refguide: update debian and nginx supported versions

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -146,7 +146,7 @@ The Mendix Docker buildpack supports the following Kubernetes versions:
 
 * Microsoft Windows Server 2012 and above
 * The following Unix-like operating systems:
-    * Debian OldOldStable (LTS), Debian OldStable, Debian Stable
+    * [Debian OldOldStable (LTS)](https://wiki.debian.org/DebianOldOldStable), [Debian OldStable, Debian Stable](https://wiki.debian.org/DebianReleases#Current_Releases.2FRepositories)
     * Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7, and Red Hat Enterprise Linux 8
     * CentOS 6, CentOS 7
 

--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -146,14 +146,14 @@ The Mendix Docker buildpack supports the following Kubernetes versions:
 
 * Microsoft Windows Server 2012 and above
 * The following Unix-like operating systems:
-    * Debian 8 (Jessie) and above
+    * Debian OldOldStable (LTS), Debian OldStable, Debian Stable
     * Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7, and Red Hat Enterprise Linux 8
     * CentOS 6, CentOS 7
 
 ### 6.2 Web Server
 
 * Microsoft Internet Information Services 8 and above
-* Nginx (tested with versions included in Debian Jessie and Debian Jessie Backports)
+* Nginx
 * Apache
 
 ### 6.3 Java {#java}

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -85,14 +85,14 @@ The Mendix Docker buildpack supports the following Kubernetes versions:
 ### 6.1 Operating System
 
 * Microsoft Windows Server 2008 SP2 and above
-* Debian 8 (Jessie) and above
+* Debian OldOldStable (LTS), Debian OldStable, Debian Stable
 * Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7
 * CentOS 6, CentOS 7
 
 ### 6.2 Web Server
 
 * Microsoft Internet Information Services 7 and above
-* Nginx (tested with versions included in Debian Jessie and Debian Jessie Backports)
+* Nginx
 * Apache
 
 ### 6.3 Java

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -170,14 +170,14 @@ The Mendix Docker buildpack supports the following Kubernetes versions:
 
 * Microsoft Windows Server 2008 SP2 and above
 * The following Unix-like operating systems:
-    * Debian 8 (Jessie) and above
+    * Debian OldOldStable (LTS), Debian OldStable, Debian Stable
     * Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7, and Red Hat Enterprise Linux 8
     * CentOS 6, CentOS 7
 
 ### 6.2 Web Server
 
 * Microsoft Internet Information Services 7 and above
-* Nginx (tested with versions included in Debian Jessie and Debian Jessie Backports)
+* Nginx
 * Apache
 
 ### 6.3 Java {#java}


### PR DESCRIPTION
This has been out-of-date for a while. Instead of referring to specific versions, refer to [OldOldStable](https://wiki.debian.org/DebianOldOldStable) ([LTS](https://wiki.debian.org/LTS)), [OldStable](https://wiki.debian.org/DebianOldStable) and [Stable](https://wiki.debian.org/DebianStable).