### PR TITLE
Added documentation for subpath support

### DIFF
--- a/content/en/docs/developerportal/deploy/general/deployment-location.md
+++ b/content/en/docs/developerportal/deploy/general/deployment-location.md
@@ -17,10 +17,13 @@ In this document, `domain` is used to identify the domain registered to you thro
 For apps deployed to the Mendix Cloud, you can customize a URL by adding [custom domains](/developerportal/deploy/custom-domains/).
 
 ## 2 Paths
+If you specify an app URL location on a (sub)path, it is necessary for the Mendix runtime to know the public URL of your application. This can be done by setting the customer [runtime setting](/refguide/custom-settings/#applicationrooturl) `ApplicationRootUrl`. 
 
-Do not use a path to your app. Your app should always be at the root of your subdomain. In other words at a location `https://subdomain.domain/`.
+{{% alert color="info" %}}
+For Mendix version 9 or lower it is not possible to a use a path to your app. Your app should always be at the root of your subdomain. In other words at a location `https://subdomain.domain/`.
 
 If you want to deploy several apps on the same domain, you should use different subdomains to identify the app. For example, use `https://appA.apps.mydomain.com/` and not `https://mydomain.com/apps/appA`.
+{{% /alert %}}
 
 ## 3 Main Domain Name
 

--- a/content/en/docs/developerportal/deploy/general/deployment-location.md
+++ b/content/en/docs/developerportal/deploy/general/deployment-location.md
@@ -17,10 +17,11 @@ In this document, `domain` is used to identify the domain registered to you thro
 For apps deployed to the Mendix Cloud, you can customize a URL by adding [custom domains](/developerportal/deploy/custom-domains/).
 
 ## 2 Paths
-If you specify an app URL location on a (sub)path, it is necessary for the Mendix runtime to know the public URL of your application. This can be done by setting the customer [runtime setting](/refguide/custom-settings/#applicationrooturl) `ApplicationRootUrl`. 
+
+If you specify an app URL location on a (sub)path, the Mendix runtime needs to know the public URL of your application. This can be done by setting the [custom runtime setting](/refguide/custom-settings/#applicationrooturl) `ApplicationRootUrl`. 
 
 {{% alert color="info" %}}
-For Mendix version 9 or lower it is not possible to a use a path to your app. Your app should always be at the root of your subdomain. In other words at a location `https://subdomain.domain/`.
+For Mendix version 9 or below, it is not possible to a use a path to your app. Your app should always be at the root of your subdomain. In other words at a location `https://subdomain.domain/`.
 
 If you want to deploy several apps on the same domain, you should use different subdomains to identify the app. For example, use `https://appA.apps.mydomain.com/` and not `https://mydomain.com/apps/appA`.
 {{% /alert %}}

--- a/content/en/docs/refguide/runtime/custom-settings/_index.md
+++ b/content/en/docs/refguide/runtime/custom-settings/_index.md
@@ -40,7 +40,7 @@ The following custom settings can be configured:
 
 | Name | Description | Default Value |
 | --- | --- | --- |
-| <a id="ApplicationRootUrl" href="#ApplicationRootUrl">ApplicationRootUrl</a> | Can be used within Java actions to get the public location of the application. Useful when the HOST header is not available, for example when including a URL to the application when sending e-mails from a scheduled event. | In Mendix Cloud, https://\[domain\].<wbr>mendixcloud.<wbr>com |
+| <a id="ApplicationRootUrl" href="#ApplicationRootUrl">ApplicationRootUrl</a> | see [subsection](#applicationrooturl) | In Mendix Cloud, https://\[domain\].<wbr>mendixcloud.<wbr>com |
 | <a id="CACertificates" href="#CACertificates">CACertificates</a> | A comma-separated list of paths to CA certificates. Example: `D:\App\CA1.pem, D:\App\CA2.pem, D:\App\CA3.pem, D:\App\CA4.pem` |   |
 | <a id="ClientCertificatePasswords" href="#ClientCertificatePasswords">ClientCertificatePasswords</a> | Comma-separated list of passwords for Client Certificates (should match the **ClientCertificates** order). Example: `pwd1, pwd2, pwd3, pwd4` |   |
 | <a id="ClientCertificates" href="#ClientCertificates">ClientCertificates</a> | Comma-separated list of paths to Client Certificates. Example: `D:\App\Mx1.pfx, D:\App\Mx2.pfx, D:\App\Mx3.pfx, D:\App\Mx4.pfx` |   |
@@ -72,6 +72,27 @@ The following custom settings can be configured:
 | <a id="UploadedFilesPath" href="#UploadedFilesPath">UploadedFilesPath</a> | The location of the uploaded files. A valid path can be: `\\FileServer\CustomerPortalFiles`. | [deployment folder]\data\files |
 | <a id="EnableFileDocumentCaching" href="#EnableFileDocumentCaching">EnableFileDocumentCaching</a> | Defines whether file documents should be cached. Only enable this if you are sure that the file documents will not contain sensitive information. Images are always cached. | false |
 | <a id="ObjectManagementStrictChangeBehavior" href="#ObjectManagementStrictChangeBehavior">ObjectManagement.<wbr>StrictChangeBehavior</a> | Defines the behavior when changing values of Enums and Calculated attributes.<br/>When set to true, setting an invalid value for an Enum attribute and/or setting a value for a Calculated attribute will result in an InvalidEnumerationValueException and/or ReadOnlyAttributeException respectively.<br/>When set to false, changes to the values of Enums and/or Calculated attributes will be allowed.<br/>We plan to remove this setting in Mendix version 11, after which, an exception will always be raised when setting an invalid value. | true |
+
+### 2.1 ApplicationRootUrl {#applicationrooturl}
+
+Used to specify the domain and path to your application. This can be used within Java actions to get the public location of the application, for example when including a URL to the application when sending e-mails from a scheduled event. 
+
+There are two main ways that you might use to host multiple applications.
+- Routing based on a (sub)domain
+- Routing based on a subpath (supported since Mendix 10.3.0)
+
+Say we are hosting two apps, namely App1 and App2. In domain based routing, every app gets it's own domain (e.g. `app1.domain.com` and `app2.domain.com`) In subpath based routing, this would be for instance: `domain.com/app1` and `domain.com/app2`.
+
+When setting up either variant of this routing, most content is served automatically in a correct fashion due it being relative to the path in which it is being served. Exceptions to this can be:
+
+- Client components that automatically forward/route you to a top-level domain
+- Content that specifies a full path to your public domain/path.
+
+For the first case, domain based routing generally works more stable, and path based routing is possible with the platform components of Mendix version 10.3.0 or higher. Examples of the second case are OData contracts, sending mails to your organization, and any place you want to render a static URL in your application. For this case it is possible to specify the ApplicationRootURL.
+
+#### 2.1.1 Multiple external domains
+Mendix systems like OData that generate content based on a http request to the server, will use the headers passed (e.g. by a proxy) to generate content. These headers are `X-Forwarded-Proto`, `X-Forwarded-Scheme`, `X-Forwarded-Host`, `X-Forwarded-Port` ,  `X-Forwarded-Prefix` and `Host`. From Mendix 10 and onwards, `ApplicationRootURL` will take precedence over the headers. If you host a single application on two or more domains, you will have to choose one of the domains to represent the public facing URL.
+
 
 ## 3 Log File Settings
 

--- a/content/en/docs/refguide/runtime/custom-settings/_index.md
+++ b/content/en/docs/refguide/runtime/custom-settings/_index.md
@@ -40,7 +40,7 @@ The following custom settings can be configured:
 
 | Name | Description | Default Value |
 | --- | --- | --- |
-| <a id="ApplicationRootUrl" href="#ApplicationRootUrl">ApplicationRootUrl</a> | see [subsection](#applicationrooturl) | In Mendix Cloud, https://\[domain\].<wbr>mendixcloud.<wbr>com |
+| <a id="ApplicationRootUrl" href="#ApplicationRootUrl">ApplicationRootUrl</a> | see [ApplicationRootUrl](#applicationrooturl-section), below | In Mendix Cloud, https://\[domain\].<wbr>mendixcloud.<wbr>com |
 | <a id="CACertificates" href="#CACertificates">CACertificates</a> | A comma-separated list of paths to CA certificates. Example: `D:\App\CA1.pem, D:\App\CA2.pem, D:\App\CA3.pem, D:\App\CA4.pem` |   |
 | <a id="ClientCertificatePasswords" href="#ClientCertificatePasswords">ClientCertificatePasswords</a> | Comma-separated list of passwords for Client Certificates (should match the **ClientCertificates** order). Example: `pwd1, pwd2, pwd3, pwd4` |   |
 | <a id="ClientCertificates" href="#ClientCertificates">ClientCertificates</a> | Comma-separated list of paths to Client Certificates. Example: `D:\App\Mx1.pfx, D:\App\Mx2.pfx, D:\App\Mx3.pfx, D:\App\Mx4.pfx` |   |
@@ -73,26 +73,29 @@ The following custom settings can be configured:
 | <a id="EnableFileDocumentCaching" href="#EnableFileDocumentCaching">EnableFileDocumentCaching</a> | Defines whether file documents should be cached. Only enable this if you are sure that the file documents will not contain sensitive information. Images are always cached. | false |
 | <a id="ObjectManagementStrictChangeBehavior" href="#ObjectManagementStrictChangeBehavior">ObjectManagement.<wbr>StrictChangeBehavior</a> | Defines the behavior when changing values of Enums and Calculated attributes.<br/>When set to true, setting an invalid value for an Enum attribute and/or setting a value for a Calculated attribute will result in an InvalidEnumerationValueException and/or ReadOnlyAttributeException respectively.<br/>When set to false, changes to the values of Enums and/or Calculated attributes will be allowed.<br/>We plan to remove this setting in Mendix version 11, after which, an exception will always be raised when setting an invalid value. | true |
 
-### 2.1 ApplicationRootUrl {#applicationrooturl}
+### 2.1 ApplicationRootUrl {#applicationrooturl-section}
 
-Used to specify the domain and path to your application. This can be used within Java actions to get the public location of the application, for example when including a URL to the application when sending e-mails from a scheduled event. 
+The ApplicationRootUrl setting is used to specify the domain and path to your application. This can be used within Java actions to get the public location of the application, for example when including a URL to the application when sending e-mails from a scheduled event. 
 
 There are two main ways that you might use to host multiple applications.
-- Routing based on a (sub)domain
-- Routing based on a subpath (supported since Mendix 10.3.0)
 
-Say we are hosting two apps, namely App1 and App2. In domain based routing, every app gets it's own domain (e.g. `app1.domain.com` and `app2.domain.com`) In subpath based routing, this would be for instance: `domain.com/app1` and `domain.com/app2`.
+* Routing based on a (sub)domain
+* Routing based on a subpath (supported since Mendix 10.3.0)
 
-When setting up either variant of this routing, most content is served automatically in a correct fashion due it being relative to the path in which it is being served. Exceptions to this can be:
+Say we are hosting two apps, App1 and App2. In domain-based routing, every app gets its own domain (for example. `app1.domain.com` and `app2.domain.com`). In subpath-based routing, this would be on a subpath, for example `domain.com/app1` and `domain.com/app2`.
 
-- Client components that automatically forward/route you to a top-level domain
-- Content that specifies a full path to your public domain/path.
+When setting up either routing variant, most content is correctly served automatically as it is relative to the path in which it is being served. Exceptions to this include:
 
-For the first case, domain based routing generally works more stable, and path based routing is possible with the platform components of Mendix version 10.3.0 or higher. Examples of the second case are OData contracts, sending mails to your organization, and any place you want to render a static URL in your application. For this case it is possible to specify the ApplicationRootURL.
+1. Client components that automatically forward/route you to a top-level domain
+1. Content that specifies a full path to your public domain/path
 
-#### 2.1.1 Multiple external domains
-Mendix systems like OData that generate content based on a http request to the server, will use the headers passed (e.g. by a proxy) to generate content. These headers are `X-Forwarded-Proto`, `X-Forwarded-Scheme`, `X-Forwarded-Host`, `X-Forwarded-Port` ,  `X-Forwarded-Prefix` and `Host`. From Mendix 10 and onwards, `ApplicationRootURL` will take precedence over the headers. If you host a single application on two or more domains, you will have to choose one of the domains to represent the public facing URL.
+For the first case, domain-based routing is generally more stable, although path-based routing is possible with Mendix version 10.3.0 or above.
 
+Examples of the second case are OData contracts, sending mails to your organization, and any place you want to render a static URL in your application. For this case it is possible to specify the ApplicationRootURL.
+
+#### 2.1.1 Multiple External Domains
+
+Mendix systems like OData that generate content based on a http request to the server, will use the headers passed (e.g. by a proxy) to generate content. These headers are `X-Forwarded-Proto`, `X-Forwarded-Scheme`, `X-Forwarded-Host`, `X-Forwarded-Port` ,  `X-Forwarded-Prefix` and `Host`. For Mendix 10 and above, `ApplicationRootURL` will take precedence over these headers. If you host a single application on two or more domains, you will have to choose one of the domains to represent the public-facing URL.
 
 ## 3 Log File Settings
 


### PR DESCRIPTION
Adapted the documentation to reflect the following:
- Since 10.3 it is possible to use the Runtime on a Subpath, given the right settings
- Since Mx10 the HTTP headers (host, etc) no longer take precedence of ApplicationRootUrl

Added a longer description on the use cases, update the docs stating that subpaths are not supported.