### PR TITLE
Mendix for Private Cloud 2.13.0 documentation updates (planned for release on September 19)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -874,8 +874,8 @@ The following fields can be configured:
 
 * `Liveness`, `readiness`, `startupProbe`, and `terminationGracePeriodSeconds` – these are used for all Mendix app deployments in the namespace — any changes made in the Deployments will be discarded and overwritten with values from the `OperatorConfiguration` resource
 * `sidecarResources` –  this is used for all m2ee-sidecar containers in the namespace
-* `metricsSidecarResources`: this is used for all m2ee-metrics containers in the namespace
-* `runtimeResources`: this is used for `mendix-runtime` containers in the namespace (but this is overwritten if the Mendix app CRD has a resources block)
+* `metricsSidecarResources` – this is used for all m2ee-metrics containers in the namespace
+* `runtimeResources` – this is used for `mendix-runtime` containers in the namespace (but this is overwritten if the Mendix app CRD has a resources block)
 * `buildResources`  – this is used for the main container in `*-build` pods
 
 ### 6.4 Customize Runtime Metrics {#customize-runtime-metrics}

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -306,17 +306,16 @@ List all local (including cluster-local) IP addresses and domains in the **No pr
 
 Hosts which should be excluded from proxying are specified as:
 
-* a string containing comma-separated values
-* each value is
-    * an IP address prefix (`1.2.3.4`)
-    * an IP address prefix in CIDR notation (`1.2.3.4/8`)
-    * a domain name
-    * if you use the special DNS label (`*`) this indicates that there are no exceptions and everything will be proxied
-* each IP address prefix or domain name can also include a literal port number (`1.2.3.4:80`)
-* a domain name matches that name and all subdomains
-* a domain name with a leading "." matches subdomains only
+* A string containing comma-separated values, where each value is one of the following:
+    * An IP address prefix (`1.2.3.4`)
+    * An IP address prefix in CIDR notation (`1.2.3.4/8`)
+    * A domain name
+    * If you use the special DNS label (`*`) this indicates that there are no exceptions and everything will be proxied
+* Each IP address prefix or domain name can also include a literal port number (`1.2.3.4:80`)
+* A domain name matches that name and all subdomains
+* A domain name with a leading "." matches subdomains only
 
-    For example "foo.com" matches "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but not "y.com".
+    For example, "foo.com" matches "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but not "y.com".
 
 For more information about how to use this field, see the [http proxy documentation used by the Configuration Tool](https://pkg.go.dev/golang.org/x/net/http/httpproxy).
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -294,8 +294,7 @@ Additional network options such as Ingress/Service annotations and Service ports
 
 To run an app in Kubernetes, it needs to be converted (packaged) into a container image and pushed to an OCI registry.
 
-The Mendix Operator automatically builds and pushes images into a private OCI registry;
-to push an image to the target registry, the Operator needs to be configured.
+The Mendix Operator automatically builds and pushes images into a private OCI registry; to push an image to the target registry, the Mendix Operator needs to be configured.
 
 See the [Image registry](/developerportal/deploy/private-cloud-registry) document for a list of supported registries and instructions how to configure each one.
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -51,7 +51,7 @@ Should you consider using a connected environment, the following URLs should be 
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image3.png" >}}
 
 3. Click **Set up Mendix for Private Cloud**.
-   
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image4.png" >}}
 
 4. Open the [Switch to menu](/developerportal/#navigation) and select **Cloud**.
@@ -59,7 +59,7 @@ Should you consider using a connected environment, the following URLs should be 
 
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/cluster-manager.png" >}}
 
-6. Click **Register Cluster**. 
+6. Click **Register Cluster**.
 
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image6.png" >}}
 
@@ -153,17 +153,17 @@ You can do this as follows:
 1. Sign in to the OpenShift Console.
 
 2. Click **Copy Login Command** in the user drop-down.
-   
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image9.png" >}}
 
 3. Choose your IdP (Identity Provider).
-   
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image10.png" >}}
 
 4. Click **Display Token**.
 
 5. Copy the command under **Log in with this token**.
-   
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/image11.png" >}}
 
 6. Paste the command into your command line terminal and press Enter.
@@ -202,7 +202,7 @@ If the Mendix Operator and the Mendix Gateway Agent have not been installed in y
 
 4. Click **Run Installer** to install the Mendix Operator and Mendix Gateway Agent in your cluster.
     You will see the screen below.
-    
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/installer-options.png" >}}
 
     {{% alert color="info" %}}The installation is successful if the **Installer output** ends with **Done**.{{% /alert %}}
@@ -246,7 +246,7 @@ The options do the following:
 
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/installation-wizard.png" >}}
 
-3. Click the appropriate button at the bottom of the page to navigate to the setup page for each resource which you need to configure. Alternatively, use the allocated function keys (for example <kbd>F2</kbd> for the **Database Plan**). 
+3. Click the appropriate button at the bottom of the page to navigate to the setup page for each resource which you need to configure. Alternatively, use the allocated function keys (for example <kbd>F2</kbd> for the **Database Plan**).
 
 4. Each page will lead you through the information you need to supply.
 
@@ -312,7 +312,7 @@ Hosts which should be excluded from proxying are specified as:
     * an IP address prefix (`1.2.3.4`)
     * an IP address prefix in CIDR notation (`1.2.3.4/8`)
     * a domain name
-    * if you use the special DNS label (`*`) this indicates that there are no exceptions and everything will be proxied 
+    * if you use the special DNS label (`*`) this indicates that there are no exceptions and everything will be proxied
 * each IP address prefix or domain name can also include a literal port number (`1.2.3.4:80`)
 * a domain name matches that name and all subdomains
 * a domain name with a leading "." matches subdomains only
@@ -367,7 +367,7 @@ In order for the Mendix Operator to trust such certificates, you need to add the
         ```
 
 2. Paste the name of this `custom.crt` secret (the `{secret}` used in the commands above) into the **CA Certificates Secret Name** field (for example, `mendix-custom-ca`):
-   
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/custom-tls-config.png" alt="Custom TLS configuration" >}}
 
 These custom CAs will be trusted by:
@@ -430,7 +430,7 @@ You can license the Operator and Runtime of your application by configuring the 
 {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/PCLMDownload.png" >}}
 
 {{% alert color="info" %}}
-In order to configure PCLM, make sure that the Operator version is 2.11.0 and above. 
+In order to configure PCLM, make sure that the Operator version is 2.11.0 and above.
 {{% /alert %}}
 
 ## 6 Advanced Operator Configuration
@@ -602,7 +602,7 @@ spec:
 
 You can change the following options:
 
-* **runtimeAutomountServiceAccountToken**: – specify if Mendix app Pods should get a Kubernetes Service Account token; defaults to `false`; should be set to `true` when using Linkerd [Automatic Proxy Injection](https://linkerd.io/2.10/features/proxy-injection/) 
+* **runtimeAutomountServiceAccountToken**: – specify if Mendix app Pods should get a Kubernetes Service Account token; defaults to `false`; should be set to `true` when using Linkerd [Automatic Proxy Injection](https://linkerd.io/2.10/features/proxy-injection/)
 * **runtimeDeploymentPodAnnotations**: – specify default annotations for Mendix app Pods
 
 ### 6.3 Mendix App Resource Customization {#advanced-resource-customization}
@@ -689,7 +689,7 @@ spec:
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 4
-        terminationGracePeriodSeconds: 300      
+        terminationGracePeriodSeconds: 300
         resources:
           limits:
             cpu: 1
@@ -781,7 +781,7 @@ terminationGracePeriodSeconds: 300
 The `terminationGracePeriodSeconds` setting is available in the Mendix for Private Cloud Operator version 2.6.0 and above.
 {{% /alert %}}
 
-#### 5.3.4 Customize Container Resources: Memory and CPU
+#### 6.3.4 Customize Container Resources: Memory and CPU
 
 Let us now analyze the `resources` section from the example application deployment, above:
 
@@ -869,7 +869,7 @@ spec:
   runtimeStartupProbe:
     failureThreshold: 30
     periodSeconds: 10
-  runtimeTerminationGracePeriodSeconds: 300    
+  runtimeTerminationGracePeriodSeconds: 300
 ```
 
 The following fields can be configured:
@@ -1062,6 +1062,34 @@ In the `json` format, newline characters will be sent as `\n` (as specified in t
 For example, to correctly display newline characters in Grafana, use the [Escape newlines](https://github.com/grafana/grafana/pull/31352) button.
 {{% /alert %}}
 
+### 6.8 Pod labels
+
+#### 6.8.1 General pod labels
+
+Mendix Operator version 2.13.0 or above allows you to specify default pod labels for app-related pods: task pods (build and storage provisioners) and runtime (app) pods.
+
+To specify default pod labels for a namespace, specify them in `customPodLabels.general` in `OperatorConfiguration`:
+
+```yaml
+apiVersion: privatecloud.mendix.com/v1alpha1
+kind: OperatorConfiguration
+spec:
+  # ...
+  # Other configuration options values
+  # Optional: custom pod labels
+  customPodLabels:
+    # Optional: general pod labels (applied to all app-related pods)
+    general:
+      # Example: enable Azure Workload Identity
+      azure.workload.identity/use: "true"
+```
+
+Alternatively, for Standalone clusters, pod labels can be specified in the `MendixApp` CR for a specific app.
+
+{{% alert color="warning" %}}
+The Mendix Operator uses some labels for internal use. To avoid conflicts with these internal pod labels, please avoid using labels starting with the `privatecloud.mendix.com/` prefix.
+{{% /alert %}}
+
 ## 7 Cluster and Namespace Management
 
 Once it is configured, you can manage your cluster and namespaces through the Developer Portal.
@@ -1092,7 +1120,7 @@ Here you can perform the following actions on the entire cluster:
 {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-cluster/cluster-activity-logs.PNG" >}}
 
 {{% alert color="info" %}}
-When you add a cluster manager, the user will have most of the access which the original cluster manager had, such as the abilities to add a namespace, add a member, change the permissions of the cluster member, and delete another cluster manager. 
+When you add a cluster manager, the user will have most of the access which the original cluster manager had, such as the abilities to add a namespace, add a member, change the permissions of the cluster member, and delete another cluster manager.
 
 The only limitations are that:
 
@@ -1312,7 +1340,7 @@ This tab shows information on the versions of the various components installed i
 
 #### 7.2.7 Customization
 
-This tab allows the cluster manager to customize the enablement of the secret store and developer mode for the developers. 
+This tab allows the cluster manager to customize the enablement of the secret store and developer mode for the developers.
 
 Enabling the **External Secrets Store** option allows users to retrieve the following secrets from an external secrets store:
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/_index.md
@@ -296,7 +296,7 @@ To run an app in Kubernetes, it needs to be converted (packaged) into a containe
 
 The Mendix Operator automatically builds and pushes images into a private OCI registry; to push an image to the target registry, the Mendix Operator needs to be configured.
 
-See the [Image registry](/developerportal/deploy/private-cloud-registry) document for a list of supported registries and instructions how to configure each one.
+See the [Image registry](/developerportal/deploy/private-cloud-registry/) document for a list of supported registries and instructions how to configure each one.
 
 #### 4.3.3 Proxy {#proxy}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -2,7 +2,7 @@
 title: "Registry configuration"
 url: /developerportal/deploy/private-cloud-registry/
 description: "Describes how to configure the OCI image registry in Mendix for Private Cloud."
-weight: 10
+weight: 11
 tags: ["Private Cloud","Registry","Container","ACR","ECR","GCR","quay.io","OpenShift"]
 #To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
 ---
@@ -170,12 +170,39 @@ Only the `amazon-ecr` option is validated and supported when using the Elastic C
 
 ### 2.4 Azure Container Registry
 
-TODO
+To improve security, Azure Container Registry recommends using [workload identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) authentication instead of static credentials.
+
+To authenticate with ACR, the AKS cluster needs to be attached to ACR as described [in the Azure documentation](https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?toc=%2Fazure%2Fcontainer-registry%2Ftoc.json&bc=%2Fazure%2Fcontainer-registry%2Fbreadcrumb%2Ftoc.json&tabs=azure-cli#attach-an-acr-to-an-existing-aks-cluster).
+
+To access the ACR registry, the Mendix Operator will use its Kubernetes Service Account for authentication, using the [msal-go](https://github.com/AzureAD/microsoft-authentication-library-for-go) library.
+
+To use ACR with the Mendix Operator, you will need to:
+
+1. Create an ACR container registry. 
+2. Follow the [guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) to 
+    
+    * enable workload identity authentication in AKS
+    * create a managed identity for the Mendix Operator image builder
+    * establish the federated identity credential
+    
+    Other steps are provided as examples and can be skipped.
+    You'll need to specify the Kubernetes namespace and name - the namespace where the Mendix Operator is installed, and a Kubernetes service account name.
+    The Mendix Operator will use this Service Account to authenticate itself with ACR.
+
+    Write down the `USER_ASSIGNED_CLIENT_ID`, it will be needed later.
+
+3. Open the ACR Access Control (IAM) tab, and add an `AcrPush` role assigment to the Managed Identity created on step 2.
+
+Use the following configuration options:
+
+* **Registry Name** - Path in the Azure Container Registry — for example `mendix-apps/mynamespace`.
+* **Registry URL** - domain name (login name) of the ACR registry, for example `example.azurecr.io`
+* **Kubernetes Service Account** - the Kubernetes service account that was linked with the Azure workload identity step 2; the Kubernetes Service Account will be created automatically when you apply the changes.
+* **AZWI Client ID** - the workload identity `USER_ASSIGNED_CLIENT_ID` created on step 2, for example `00000000-0000-0000-0000-000000000000`.
 
 ### 2.5 Google Container Registry
 
-To improve security, Google Container Registry recommends using workload identities instead of static credentials.
-Instead, GCR recomments using [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) authentication.
+To improve security, Google Container Registry recommends using [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) authentication instead of static credentials.
 
 To access the GCR registry, the Mendix Operator will use its Kubernetes Service Account for authentication, using the [docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr) plugin.
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -27,7 +27,7 @@ Some examples of such container registries are:
 * Azure ACR [admin account](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
 * Self-hosted registries such as [Sonartype Nexus](https://www.sonatype.com/products/nexus-repository)
 
-However, static credentials are often considered insecure, and cloud providers offer alternative authentication methods based on short-lived tokens. For example, pushing an image to ECR requires getting a short-lived token from the AWS API. For more details about specific container registries, see the [Configure registry](#configure-registry) section.
+However, static credentials are often considered insecure, and cloud providers offer alternative authentication methods based on short-lived tokens. For example, pushing an image to ECR requires getting a short-lived token from the AWS API. For more details about specific container registries, see the [Configuring the Registry](#configure-registry) section.
 
 ### 1.2 Limitations
 
@@ -62,7 +62,7 @@ Kubernetes nodes need to pull images from the container registry:
 
 The Mendix Operator needs to push images to one URL (the push URL), but needs to tell Kubernetes to pull images from another URL (the pull URL).
 
-## 2 Configuring the Registry
+## 2 Configuring the Registry {#configure-registry}
 
 ### 2.1 OpenShift 3 Registry {#openshift-3-registry}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -1,0 +1,327 @@
+---
+title: "Registry configuration"
+url: /developerportal/deploy/private-cloud-registry/
+description: "Describes how to configure the OCI image registry in Mendix for Private Cloud."
+weight: 10
+tags: ["Private Cloud","Registry","Container","ACR","ECR","GCR","quay.io","OpenShift"]
+#To update these screenshots, you can log in with credentials detailed in How to Update Screenshots Using Team Apps.
+---
+
+
+## 1 Introduction
+
+To run an app, Kubernetes needs it to be available in an OCI image registry.
+
+When a new version of the app is deployed, the Mendix Operator will run a _build_ pod - to package an app into a container image and push it into your private OCI registry.
+
+To do this, the Operator needs to know which registry to use and how to authenticate with it.
+
+### 1.1 Supported container registries
+
+The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) documents the standards and APIs that a container registry needs to support in order to be compliant.
+
+The Mendix Operator uses [go-containerregistry](https://github.com/google/go-containerregistry) to build and push images to a container registry.
+
+This allows Mendix for Private Cloud to support most container registries.
+In most cases, if a container registry supports basic authentication (static username and password), the Mendix Operator supports it.
+
+Some examples of such container registries are:
+
+* quay.io
+* Docker Hub
+* Azure ACR [admin account](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
+* Self-hosted registries such as [Sonartype Nexus](https://www.sonatype.com/products/nexus-repository)
+
+However, static credentials are often considered insecure, and cloud providers offer alternative authentication methods based on short-lived tokens.
+For example, pushing an image to ECR requires getting a short-lived token from the AWS API.
+
+For more details about specific container registries see the [Configure registry](#configure-registry) section.
+
+### 1.2 Limitations
+
+Combining multiple registries is not possible at the moment.
+For example, if you'd like to host [air-gapped images](/developerportal/deploy/private-cloud-migrating/) of Mendix for Private Cloud in a Nexus repository, but use ECR as the destination registry for Mendix apps, this can only be don by using the [existing docker-registry secret](#existing-docker-registry) option and static credentials.
+
+The Docker image URL standard doesn't have an way to specify if a registry should be accessed over HTTP or HTTPS.
+Mendix for Private Cloud relies on heuristics from the [go-containerregistry](https://github.com/google/go-containerregistry/blob/a54d64203cffcbf94146e04069aae4a97f228ee2/pkg/name/registry.go#L81-L100) project:
+
+* Registries accessed by an private network RFC1918 IP address (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) will use unencrypted HTTP, as it's not possible to get a valid TLS certificate for those subnets.
+* Registries accessed by a `localhost` domain name will use unencrypted HTTP, as it's not possible to get a valid TLS certificate for the `localhost` domain.
+* Registries accessed by a `127.0.0.1` or `::1` IP address will use unencrypted HTTP, as it's not possible to get a valid TLS certificate for the `localhost` domain.
+* Registries which are subdomains of `.localhost` or `.local` will use unencrypted HTTP, as it's not possible to get a valid TLS certificate for the `localhost` domain.
+
+In all other cases, Mendix for Private Cloud will use HTTPS to access the registry.
+
+### 1.3 Push and pull URLs
+
+Mendix for Private Cloud builds images from inside the cluster.
+After an image is built, the Mendix Operator sets (updates) image URLs of the app's Kubernetes Deployment;
+to start a copy of the app, Kubernetes will pull the image directly from the registry, bypassing the Mendix Operator
+
+If the registry is hosted externally (outside the cluster), there's no difference between connecting to the registry from a pod in the cluster, or from the cluster node.
+
+However, if the registry is hosted in the cluster, there's a difference:
+
+Mendix Operator needs to push images to the container registry:
+
+* `localhost` would be the image builder's pod IP address
+* The registry service can be reached through a cluster-private DNS name, for example `docker-registry.default.svc.cluster.local:5000`
+
+Kubernetes nodes need to pull images from the container registry:
+
+* `localhost` is the node's own IP address
+* The registry can only be reached through a local address, for example `localhost:5000`
+
+The Mendix Operator needs to push images to one URL (the push URL), but needs to tell Kubernetes to pull images from another URL (the pull URL).
+
+## 2 Configure registry
+
+### 2.1 OpenShift 3 Registry {#openshift-3-registry}
+
+Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created.
+This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
+
+Before configuring the OpenShift 3 registry, run `oc get svc docker-registry -n default` to get the registry domain name and IP address.
+
+Use the following configuration options:
+
+* **Push URL** - specify the registry domain name, in most cases this would be `docker-registry.default.svc.cluster.local:5000`
+* **Pull URL** - specify the registry IP address returned by `oc get svc` earlier
+
+### 2.2 OpenShift 4 Registry {#openshift-4-registry}
+
+OpenShift 4 requires no configuration - all OpenShift 4 clusters use the same configuration.
+
+Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created.
+This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
+
+### 2.3 Amazon Elastic Container Registry
+
+In general, Elastic Container Registries can only be used with EKS clusters.
+
+To improve security, AWS ECR doesn't support static or basic credentials.
+Instead, ECR relies on time-limited tokens that can be generated by the [ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper).
+
+To access the ECR registry, the Mendix Operator will automatically request an authentication token from the AWS IAM API.
+To call the IAM API, the Operator can use [IRSA authentication](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or an AWS IAM access and secret key (not recommended by Amazon).
+
+To use ECR with the Mendix Operator, you will need to:
+
+1. Create an ECR repository, for example `mendixapps/mynamespace`.
+2. Allow EKS to pull images from ECR, as documented in https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_EKS.html
+3. Create an IAM role with the following policy (replace `<aws_region>` with the account's region, `<account_id>` with your AWS account number, `<repository>` with the repository name from Step 1):
+
+    ```json
+    {
+	"Version": "2012-10-17",
+	"Statement": [
+	    {
+		"Sid": "AllowImageBuilds",
+		"Effect": "Allow",
+		"Action": [
+		    "ecr:BatchGetImage",
+		    "ecr:BatchCheckLayerAvailability",
+		    "ecr:CompleteLayerUpload",
+		    "ecr:GetDownloadUrlForLayer",
+		    "ecr:InitiateLayerUpload",
+		    "ecr:PutImage",
+		    "ecr:UploadLayerPart"
+		],
+		"Resource": "arn:aws:ecr:<aws_region>:<account_id>:repository/<repository>"
+	    },
+	    {
+		"Sid": "AllowAuthentication",
+		"Effect": "Allow",
+		"Action": "ecr:GetAuthorizationToken",
+		"Resource": "*"
+	    }
+	]
+    }
+    ```
+4. Allow the Mendix Operator to assume this role by configuring the role's trust policy.
+
+    1. Open the role for editing and add an entry for the ServiceAccount(s) to the list of conditions:
+
+      {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-deploy/awsserviceaccountlinktorole.png" >}}
+
+    2. For the second condition, copy and paste the `sts.amazonaws.com` line; replace `:aud` with `:sub` and set it to `system:serviceaccount:<Kubernetes namespace>:<Kubernetes serviceaccount name>`. You can specify any serviceaccount name here (for simplicity, we recommend using `mendix-builder`). For example, if the Mendix Operator is installed into the `mynamespace` namespace, set the value to `system:serviceaccount:mynamespace:mendix-builder`.
+
+        See [Amazon EKS Pod Identity Webhook – EKS Walkthrough](https://github.com/aws/amazon-eks-pod-identity-webhook#eks-walkthrough) for more details.
+
+        The role ARN is required, you can use the **Copy** button next to the ARN name in the role details.
+
+Use the following configuration options:
+
+* **Host Name** - specify the ECR domain name in the following format: `<account_id>.dkr.ecr.<aws_region>.amazonaws.com` (replace `<aws_region>` with the account's region, `<account_id>` with your AWS account number)
+* **Pull URL** - specify the registry IP address returned by `oc get svc` earlier
+* **Registry name** - specify the repository name you created on step 1, for example: `mendixapps/mynamespace`
+* **Region** - specify the ECR region, for example `eu-west-1`
+* **Authentication** - choose the authentication mode, _Kubernetes Service Account_ (recommended) or _AWS Static Credentials_ (not recommented by AWS)
+   * **IAM Role ARN** - the role ARN you created on step 3
+   * **K8s Service Account** - the Kubernetes service account that the Mendix Operator should use for authentication; it should match the service account name specified on step 4; the account will be created automatically when you apply the changes
+   * **Access Key ID** - the IAM access key to use for static authentication (only when using the _AWS Static Credentials_ mode)
+   * **Access Secret Key** - the IAM secret key to use for static authentication (only when using the _AWS Static Credentials_ mode)
+
+{{% alert color="info" %}}
+ECR authentication will only work `amazon-ecr` option in the CLI.
+Other options (e.g. generic registry) will not enable the pod annotations required for the ECR authentication plugin to work correctly.
+Only the `amazon-ecr` option is validated and supported when using the Elastic Container Registry on AWS.
+{{% /alert %}}
+
+### 2.4 Azure Container Registry
+
+TODO
+
+### 2.5 Google Container Registry
+
+To improve security, Google Container Registry recommends using workload identities instead of static credentials.
+Instead, GCR recomments using [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) authentication.
+
+To access the GCR registry, the Mendix Operator will use its Kubernetes Service Account for authentication, using the [docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr) plugin.
+
+To use GCR with the Mendix Operator, you will need to:
+
+1. Create a GCP Service Account (⚠️  this is not the same as a Kubernetes Service Account).
+2. Assign the _Artifact Registry Writer_ (`roles/artifactregistry.writer`) role to the GCR Service Account.
+3. Allow the Mendix Operator to use the GCR Service Account by running:
+
+    ```shell
+    gcloud iam service-accounts add-iam-policy-binding \
+            --role roles/iam.workloadIdentityUser \
+            --member "serviceAccount:PROJECT_ID.svc.id.goog[K8S_NAMESPACE/KSA_NAME]" \
+            GSA_NAME@PROJECT_ID.iam.gserviceaccount.com
+    ```
+
+    (replace `PROJECT_ID` with the Google Cloud project ID, `K8S_NAMESPACE` with the Kubernetes namespace name where the Operator is installed, `KSA_NAME` with the Kubernetes Service Account name, and `GSA_NAME` with the GCP Service Account name from step 1).
+
+    On the Kubernetes side, the Mendix Operator will use a Kubernetes Service Account to authenticate. On the GCP side, there should be a matching GCP Service Account. For simplicity, we recommend using the `mendix-builder` for the service account name, on both GCP and Kubernetes sides.
+    For more details, see the Google documentation on [using workload identities](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+
+Use the following configuration options:
+
+* **Registry Name** - Google Container Registry full path name — for example `my-google-account-id/my-registry/dev-repo`.
+* **Registry URL** - container or artifact registry host — for example `us.gcr.io` or `europe-west4-docker.pkg.dev`.
+* **GCP Service Account** - the GCP account name created on step 1, for example `service-account-name@project-id.iam.gserviceaccount.com`.
+* **Kubernetes Service Account** - the Kubernetes service account that was linked with the GCP service account on step 3; the Kubernetes Service Account will be created automatically when you apply the changes.
+
+### 2.6 Generic registry with authentication
+
+This option works with most other registries - if the registry supports Basic authentication, this option should be compatible.
+
+Use the following configuration options:
+* **Push URL** - the registry domain name where the registry can be reached by pods inside the cluster.
+    * If the registry is running outside the cluster, this would be the registry domain name, such as `registry.example.com`.
+    * If the registry is hosted inside the cluster, this would be the internal Kubernetes domain name, for example `registry.namespace.svc` or `registry.container-registry.svc.cluster.local:5000` (for MicroK8s).
+* **Pull URL** - the registry domain name where the registry can be reached by Kubernetes nodes,
+    * If the registry is running outside the cluster, this would be the registry domain name, such as `registry.example.com`.
+    * If the registry is hosted inside the cluster, in most cases this would be a localhost domain name and port, for example for MicroK8s this is `localhost:32000`.
+* **Registry name** - the repository name, for example: `mendixapps/mynamespace`.
+    * For some registries, the repository might need to be created first.
+    * Registries could also have security or technical limitations on what can be specified as the repository name.
+* **With authentication** - allows to specify the username and password used to access the registry. This is required for almost all registries, the only exception is self-hosted registries in test envrionments such as MicroK8s, k3s or Minikube.
+* **Add credentials to pull secrets in default service account** - if your cluster is not using built-in authentication, checking this option will automatically image pull credentials to the `default` Kubernetes ServiceAccount. This would enable authentication when pulling app images.
+
+#### 2.6.1 Example configurations
+
+Here are a few example configurations for container registries:
+
+**Docker Hub**
+
+| Field               | Value           |
+| ------------------- | --------------- |
+| Push URL            | index.docker.io |
+| Pull URL            | index.docker.io |
+| Registry name       | `<username>/<repository>`, where `<username>` is a username for Docker Hub |
+| With authentication | ☑ checked       |
+| User                | A username for Docker Hub |
+| Password            | An access token for the Docker Hub user |
+
+The access token needs read and write permissions.
+Docker Hub will automatically create the repository when an image is pushed.
+
+**quay.io**
+
+| Field               | Value           |
+| ------------------- | --------------- |
+| Push URL            | quay.io         |
+| Pull URL            | quay.io         |
+| Registry name       | `<username>/<repository>`, where `<username>` is a username for Docker Hub |
+| With authentication | ☑ checked       |
+| User                | Username for a quay.io robot account |
+| Password            | Token (password) for the robot account | 
+
+Before pushing images to quay.io, you will need to create the repository first.
+To access quay.io, you will need to create a robot account, and give this account write permissions to the destination repository.
+
+**JFROG Artifactory**, **Sonatype Nexus**, **Harbor**, **Gitlab registry** and other on-premise registries
+
+| Field               | Value                  |
+| ------------------- | ---------------------- |
+| Push URL            | `<hostname>:<port>`    |
+| Pull URL            | `<hostname>:<port>`    |
+| Registry name       | `<path/to/repository>` |
+| With authentication | ☑ checked       |
+| User                | Username for a user or account with push and pull permissions |
+| Password            | Token (password) for a user or account with push and pull permissions |
+
+Check your image registry documentation to see if repositories can be created automatically (on push) or need to be pre-created.
+Some registries impose limitations on repository names, for example the repositiry path cannot have more than three parts.
+
+### 2.8 Existing docker-registry secret
+
+If you already have a existing `~/.docker/config.json` file, you can use it directly by choosing the `docker-secret` option.
+
+For more information on how create this type of secret, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
+After creating the `dockerconfigjson` secret, you can configure Mendix for Private Cloud to use it:
+
+* **Push URL** - the registry domain name where the registry can be reached by pods inside the cluster.
+    * If the registry is running outside the cluster, this would be the registry domain name, such as `registry.example.com`.
+    * If the registry is hosted inside the cluster, this would be the internal Kubernetes domain name, for example `registry.namespace.svc` or `registry.container-registry.svc.cluster.local:5000` (for MicroK8s).
+* **Pull URL** - the registry domain name where the registry can be reached by Kubernetes nodes,
+    * If the registry is running outside the cluster, this would be the registry domain name, such as `registry.example.com`.
+    * If the registry is hosted inside the cluster, in most cases this would be a localhost domain name and port, for example for MicroK8s this is `localhost:32000`.
+* **Registry name** - the repository name, for example: `mendixapps/mynamespace`.
+    * For some registries, the repository might need to be created first.
+    * Registries could also have security or technical limitations on what can be specified as the repository name.
+* **Secret name** - name of the Kubernetes secret you've created.
+
+You will need to add this secret to the `default` ServiceAccount manually, or provide registry authentication configuration in another way (depending on which registry authentication options the Kubernetes cluster vendor is offering).
+
+## 3 Advanced options
+
+You can host the default Mendix components in your own registry, for example if your cluster is firewalled and cannot open up a route to the Mendix registry. In this case you need to migrate some, or all, of the Mendix components to your cluster. See the instructions in [Migrating to Your Own Registry](/developerportal/deploy/private-cloud-migrating/) to find out how to do this.
+
+### 3.1 Customizing the image name template {#customize-registry-imagenametemplate}
+
+ImageNameTemplate allows you to specify how the image name and tag are generated. It allows both use of OpenShift-style "repository per app" and ECR-style "tag per app". For example, a value of imageNameTemplate may be `registry.example.com/mendix-apps/{{.Name}}-{{.Version}}-{{.UnixTimestamp}}` which would generate an image for the build like `registry.example.com/mendix-apps/pgv9gw71-0.0.1.2-1640699175.392`
+
+The imageNameTemplate is generated by mxpc-cli when you update the registry configuration.
+
+{{% alert color="warning" %}}
+Any manual changes you make to the imageNameTemplate in the manifest are overwritten when you update the registry configuration using mxpc-cli.
+{{% /alert %}}
+
+An example of the imageNameTemplate in the operator configuration manifest is given below.
+
+```yaml
+apiVersion: privatecloud.mendix.com/v1alpha1
+kind: OperatorConfiguration
+    # …
+spec:
+  registry:
+    imageNameTemplate: 'my-registry/{{.Name}}-{{.Version}}-{{.UnixTimestamp}}'
+    pullURL: 'image-registry.openshift-image-registry.svc:5000'
+    pushURL: 'image-registry.openshift-image-registry.svc:5000'
+    type: openshift
+  # …
+```
+
+You can customize the registry imageNameTemplate in OperatorConfiguration with these available variables:
+
+* `{{.Name}}`: internal environment name.
+* `{{.Generation}}`: value of the Build CR’s [Generation](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace#generation) attribute.
+* `{{.Version}}`: value of sourceVersion in MendixApp CR. The value will be automatically set to the MDA version if an MDA is deployed from the Private Cloud Portal.
+* `{{.UnixTimestamp}}`: current UNIX timestamp with at least millisecond precision e.g. 1640615972.897.
+* `{{.Timestamp}}`: current timestamp in the following format 20211231.081224.789 for 2021-12-31 08:12:24.789.
+

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -200,6 +200,11 @@ Use the following configuration options:
 * **Kubernetes Service Account** - the Kubernetes service account that was linked with the Azure workload identity step 2; the Kubernetes Service Account will be created automatically when you apply the changes.
 * **AZWI Client ID** - the workload identity `USER_ASSIGNED_CLIENT_ID` created on step 2, for example `00000000-0000-0000-0000-000000000000`.
 
+{{% alert color="warning" %}}
+Azure Workload Identity authentication is supported in Mendix Operator 2.13.0 and later versions.
+Older versions can only authenticate with ACR using static credentials; upgrading to Mendix Operator and switching to workload identity authentication is highly recommended.
+{{% /alert %}}
+
 ### 2.5 Google Container Registry
 
 To improve security, Google Container Registry recommends using [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) authentication instead of static credentials.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -115,31 +115,39 @@ To use ECR with the Mendix Operator, you will need to:
 
     ```json
     {
-	"Version": "2012-10-17",
-	"Statement": [
-	    {
-		"Sid": "AllowImageBuilds",
-		"Effect": "Allow",
-		"Action": [
-		    "ecr:BatchGetImage",
-		    "ecr:BatchCheckLayerAvailability",
-		    "ecr:CompleteLayerUpload",
-		    "ecr:GetDownloadUrlForLayer",
-		    "ecr:InitiateLayerUpload",
-		    "ecr:PutImage",
-		    "ecr:UploadLayerPart"
-		],
-		"Resource": "arn:aws:ecr:<aws_region>:<account_id>:repository/<repository>"
-	    },
-	    {
-		"Sid": "AllowAuthentication",
-		"Effect": "Allow",
-		"Action": "ecr:GetAuthorizationToken",
-		"Resource": "*"
-	    }
-	]
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowImageBuilds",
+                "Effect": "Allow",
+                "Action": [
+                    "ecr:BatchGetImage",
+                    "ecr:BatchCheckLayerAvailability",
+                    "ecr:CompleteLayerUpload",
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:InitiateLayerUpload",
+                    "ecr:PutImage",
+                    "ecr:List",
+                    "ecr:UploadLayerPart",
+                    "ecr:DescribeRepositories",
+                    "ecr:CreateRepository"
+                ],
+                "Resource": "arn:aws:ecr:<aws_region>:<account_id>:repository/<repository>"
+            },
+            {
+                "Sid": "AllowAuthentication",
+                "Effect": "Allow",
+                "Action": "ecr:GetAuthorizationToken",
+                "Resource": "*"
+            }
+        ]
     }
     ```
+
+    {{% alert color="info" %}}The `DescribeRepositories` and `CreateRepository` actions are optional.
+    They allow the Mendix Operator to check if the ECR repository exists, and create the repository if it doesn't exist.
+    If the repository already exists, these actions can be removed.{{% /alert %}}
+
 4. Allow the Mendix Operator to assume this role by configuring the role's trust policy.
 
     1. Open the role for editing and add an entry for the ServiceAccount(s) to the list of conditions:
@@ -180,13 +188,13 @@ To access the ACR registry, the Mendix Operator will use its Kubernetes Service 
 
 To use ACR with the Mendix Operator, you will need to:
 
-1. Create an ACR container registry. 
-2. Follow the [guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) to 
-    
+1. Create an ACR container registry.
+2. Follow the [guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) to
+
     * enable workload identity authentication in AKS
     * create a managed identity for the Mendix Operator image builder
     * establish the federated identity credential
-    
+
     Other steps are provided as examples and can be skipped.
     You'll need to specify the Kubernetes namespace and name - the namespace where the Mendix Operator is installed, and a Kubernetes service account name.
     The Mendix Operator will use this Service Account to authenticate itself with ACR.
@@ -282,7 +290,7 @@ Docker Hub will automatically create the repository when an image is pushed.
 | Registry name       | `<username>/<repository>`, where `<username>` is a username for Docker Hub |
 | With authentication | ☑ checked       |
 | User                | Username for a quay.io robot account |
-| Password            | Token (password) for the robot account | 
+| Password            | Token (password) for the robot account |
 
 Before pushing images to quay.io, you will need to create the repository first.
 To access quay.io, you will need to create a robot account, and give this account write permissions to the destination repository.
@@ -358,4 +366,3 @@ You can customize the registry imageNameTemplate in OperatorConfiguration with t
 * `{{.Version}}`: value of sourceVersion in MendixApp CR. The value will be automatically set to the MDA version if an MDA is deployed from the Private Cloud Portal.
 * `{{.UnixTimestamp}}`: current UNIX timestamp with at least millisecond precision e.g. 1640615972.897.
 * `{{.Timestamp}}`: current timestamp in the following format 20211231.081224.789 for 2021-12-31 08:12:24.789.
-

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -1,5 +1,5 @@
 ---
-title: "Registry configuration"
+title: "Registry Configuration"
 url: /developerportal/deploy/private-cloud-registry/
 description: "Describes how to configure the OCI image registry in Mendix for Private Cloud."
 weight: 11
@@ -12,40 +12,29 @@ tags: ["Private Cloud","Registry","Container","ACR","ECR","GCR","quay.io","OpenS
 
 To run an app, Kubernetes needs it to be available in an OCI image registry.
 
-When a new version of the app is deployed, the Mendix Operator will run a _build_ pod - to package an app into a container image and push it into your private OCI registry.
+When a new version of the app is deployed, the Mendix Operator will run a *build* pod - to package an app into a container image and push it into your private OCI registry.
 
-To do this, the Operator needs to know which registry to use and how to authenticate with it.
+To do this, the Mendix Operator needs to know which registry to use and how to authenticate with it.
 
-### 1.1 Supported container registries
+### 1.1 Supported Container Registries
 
-The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) documents the standards and APIs that a container registry needs to support in order to be compliant.
-
-The Mendix Operator uses [go-containerregistry](https://github.com/google/go-containerregistry) to build and push images to a container registry.
-
-This allows Mendix for Private Cloud to support most container registries.
-In most cases, if a container registry supports basic authentication (static username and password), the Mendix Operator supports it.
+The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) documents the standards and APIs that a container registry needs to support in order to be compliant. The Mendix Operator uses [go-containerregistry](https://github.com/google/go-containerregistry) to build and push images to a container registry. This allows Mendix for Private Cloud to support most container registries. In most cases, if a container registry supports basic authentication (static username and password), the Mendix Operator supports it.
 
 Some examples of such container registries are:
 
-* quay.io
+* Quay.io
 * Docker Hub
 * Azure ACR [admin account](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
 * Self-hosted registries such as [Sonartype Nexus](https://www.sonatype.com/products/nexus-repository)
 
-However, static credentials are often considered insecure, and cloud providers offer alternative authentication methods based on short-lived tokens.
-For example, pushing an image to ECR requires getting a short-lived token from the AWS API.
-
-For more details about specific container registries see the [Configure registry](#configure-registry) section.
+However, static credentials are often considered insecure, and cloud providers offer alternative authentication methods based on short-lived tokens. For example, pushing an image to ECR requires getting a short-lived token from the AWS API. For more details about specific container registries, see the [Configure registry](#configure-registry) section.
 
 ### 1.2 Limitations
 
-Combining multiple authentication methods is not possible at the moment.
-For example, Nexus uses static username/password credentials, while ECR requires using an authentication plugin that integrates with AWS IAM; if you'd like to host [air-gapped images](/developerportal/deploy/private-cloud-migrating/) of Mendix for Private Cloud in a Nexus repository, you will need to use Nexus (or another registry supporting static credentials) - using ECR or ACR as the target registry will not be possible.
+Combining multiple authentication methods is not possible at the moment. For example, Nexus uses static username/password credentials, while ECR requires using an authentication plugin that integrates with AWS IAM; if you'd like to host [air-gapped images](/developerportal/deploy/private-cloud-migrating/) of Mendix for Private Cloud in a Nexus repository, you will need to use Nexus (or another registry supporting static credentials). Using ECR or ACR as the target registry will not be possible.
 
-The Docker image URL standard doesn't have an way to specify if a registry should be accessed over HTTP or HTTPS.
-Mendix for Private Cloud relies on heuristics from the [go-containerregistry](https://github.com/google/go-containerregistry/blob/a54d64203cffcbf94146e04069aae4a97f228ee2/pkg/name/registry.go#L81-L100) project.
-These heuristics are based on an assumption that it's not possible to get a valid TLS certificate for "local" addresses.
-If the registry domain name matches any of these rules, TLS will be disabled and all communication with the registry will happen over unencrypted HTTP:
+The Docker image URL standard does not have an way to specify if a registry should be accessed over HTTP or HTTPS. Mendix for Private Cloud relies on heuristics from the [go-containerregistry](https://github.com/google/go-containerregistry/blob/a54d64203cffcbf94146e04069aae4a97f228ee2/pkg/name/registry.go#L81-L100) project.
+These heuristics are based on an assumption that it's not possible to get a valid TLS certificate for local addresses. If the registry domain name matches any of these rules, TLS will be disabled and all communication with the registry will happen over unencrypted HTTP:
 
 * A private network RFC1918 IP address (`10.0.0.0/8`, `172.16.0.0/12` or `192.168.0.0/16`).
 * A `localhost` domain name.
@@ -54,15 +43,12 @@ If the registry domain name matches any of these rules, TLS will be disabled and
 
 In all other cases, Mendix for Private Cloud will use HTTPS to access the registry.
 
-### 1.3 Push and pull URLs
+### 1.3 Push and Pull URLs
 
-Mendix for Private Cloud builds images from inside the cluster.
-After an image is built, the Mendix Operator sets (updates) image URLs of the app's Kubernetes Deployment resouce;
+Mendix for Private Cloud builds images from inside the cluster. After an image is built, the Mendix Operator sets (updates) image URLs of the app's Kubernetes Deployment resouce;
 to start a copy of the app, Kubernetes will pull the image directly from the registry.
 
-If the registry is hosted externally (outside the cluster), there's no difference between connecting to the registry from a pod in the cluster, or from the cluster node.
-
-However, if the registry is hosted in the cluster, there's a difference:
+If the registry is hosted externally (outside the cluster), there is no difference between connecting to the registry from a pod in the cluster, or from the cluster node. However, if the registry is hosted in the cluster, there are the following differences:
 
 Mendix Operator needs to push images to the container registry:
 
@@ -76,12 +62,11 @@ Kubernetes nodes need to pull images from the container registry:
 
 The Mendix Operator needs to push images to one URL (the push URL), but needs to tell Kubernetes to pull images from another URL (the pull URL).
 
-## 2 Configure registry
+## 2 Configuring the Registry
 
 ### 2.1 OpenShift 3 Registry {#openshift-3-registry}
 
-Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created.
-This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
+Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created. This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
 
 Before configuring the OpenShift 3 registry, run `oc get svc docker-registry -n default` to get the registry domain name and IP address.
 
@@ -94,24 +79,19 @@ Use the following configuration options:
 
 OpenShift 4 requires no configuration - all OpenShift 4 clusters use the same configuration.
 
-Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created.
-This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
+Mendix for Private Cloud will use the standard `builder` ServiceAccount, which is automatically created when a new OpenShift Project is created. This `builder` ServiceAccount has permissions to push to the Project's ImageStreams (OpenShift's built-in registry).
 
 ### 2.3 Amazon Elastic Container Registry
 
-In general, Elastic Container Registries can only be used with EKS clusters.
+In general, Elastic Container Registries can only be used with EKS clusters. To improve security, AWS ECR doesn't support static or basic credentials. Instead, ECR relies on time-limited tokens that can be generated by the [ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper).
 
-To improve security, AWS ECR doesn't support static or basic credentials.
-Instead, ECR relies on time-limited tokens that can be generated by the [ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper).
+To access the ECR registry, the Mendix Operator will automatically request an authentication token from the AWS IAM API. To call the IAM API, the Mendix Operator can use [IRSA authentication](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or an AWS IAM access and secret key (not recommended by Amazon).
 
-To access the ECR registry, the Mendix Operator will automatically request an authentication token from the AWS IAM API.
-To call the IAM API, the Operator can use [IRSA authentication](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or an AWS IAM access and secret key (not recommended by Amazon).
-
-To use ECR with the Mendix Operator, you will need to:
+To use ECR with the Mendix Operator, you must do the following steps:
 
 1. Create an ECR repository, for example `mendixapps/mynamespace`.
 2. Allow EKS to pull images from ECR, as documented in https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_EKS.html
-3. Create an IAM role with the following policy (replace `<aws_region>` with the account's region, `<account_id>` with your AWS account number, `<repository>` with the repository name from Step 1):
+3. Create an IAM role with the following policy (replace `<aws_region>` with the account's region, `<account_id>` with your AWS account number, `<repository>` with the repository name from step 1):
 
     ```json
     {
@@ -144,9 +124,7 @@ To use ECR with the Mendix Operator, you will need to:
     }
     ```
 
-    {{% alert color="info" %}}The `DescribeRepositories` and `CreateRepository` actions are optional.
-    They allow the Mendix Operator to check if the ECR repository exists, and create the repository if it doesn't exist.
-    If the repository already exists, these actions can be removed.{{% /alert %}}
+    {{% alert color="info" %}}The `DescribeRepositories` and `CreateRepository` actions are optional. They allow the Mendix Operator to check if the ECR repository exists, and create the repository if it does not exist. If the repository already exists, these actions can be removed.{{% /alert %}}
 
 4. Allow the Mendix Operator to assume this role by configuring the role's trust policy.
 
@@ -166,16 +144,14 @@ Use the following configuration options:
 * **Pull URL** - specify the registry IP address returned by `oc get svc` earlier
 * **Registry name** - specify the repository name you created on step 1, for example: `mendixapps/mynamespace`
 * **Region** - specify the ECR region, for example `eu-west-1`
-* **Authentication** - choose the authentication mode, _Kubernetes Service Account_ (recommended) or _AWS Static Credentials_ (not recommented by AWS)
+* **Authentication** - choose the authentication mode, *Kubernetes Service Account* (recommended) or *AWS Static Credentials* (not recommented by AWS)
    * **IAM Role ARN** - the role ARN you created on step 3
    * **K8s Service Account** - the Kubernetes service account that the Mendix Operator should use for authentication; it should match the service account name specified on step 4; the account will be created automatically when you apply the changes
    * **Access Key ID** - the IAM access key to use for static authentication (only when using the _AWS Static Credentials_ mode)
    * **Access Secret Key** - the IAM secret key to use for static authentication (only when using the _AWS Static Credentials_ mode)
 
 {{% alert color="info" %}}
-ECR authentication will only work `amazon-ecr` option in the CLI.
-Other options (e.g. generic registry) will not enable the pod annotations required for the ECR authentication plugin to work correctly.
-Only the `amazon-ecr` option is validated and supported when using the Elastic Container Registry on AWS.
+ECR authentication will only work `amazon-ecr` option in the CLI. Other options (for example, generic registry) will not enable the pod annotations required for the ECR authentication plugin to work correctly. Only the `amazon-ecr` option is validated and supported when using the Elastic Container Registry on AWS.
 {{% /alert %}}
 
 ### 2.4 Azure Container Registry
@@ -195,9 +171,7 @@ To use ACR with the Mendix Operator, you will need to:
     * create a managed identity for the Mendix Operator image builder
     * establish the federated identity credential
 
-    Other steps are provided as examples and can be skipped.
-    You'll need to specify the Kubernetes namespace and name - the namespace where the Mendix Operator is installed, and a Kubernetes service account name.
-    The Mendix Operator will use this Service Account to authenticate itself with ACR.
+    Other steps are provided as examples and can be skipped. You must specify the Kubernetes namespace and name - the namespace where the Mendix Operator is installed, and a Kubernetes service account name. The Mendix Operator will use this Service Account to authenticate itself with ACR.
 
     Write down the `USER_ASSIGNED_CLIENT_ID`, it will be needed later.
 
@@ -211,8 +185,7 @@ Use the following configuration options:
 * **AZWI Client ID** - the workload identity `USER_ASSIGNED_CLIENT_ID` created on step 2, for example `00000000-0000-0000-0000-000000000000`.
 
 {{% alert color="warning" %}}
-Azure Workload Identity authentication is supported in Mendix Operator 2.13.0 and later versions.
-Older versions can only authenticate with ACR using static credentials; upgrading to Mendix Operator and switching to workload identity authentication is highly recommended.
+Azure Workload Identity authentication is supported in Mendix Operator 2.13.0 and later versions. Older versions can only authenticate with ACR using static credentials; upgrading to Mendix Operator and switching to workload identity authentication is highly recommended.
 {{% /alert %}}
 
 ### 2.5 Google Container Registry
@@ -223,7 +196,7 @@ To access the GCR registry, the Mendix Operator will use its Kubernetes Service 
 
 To use GCR with the Mendix Operator, you will need to:
 
-1. Create a GCP Service Account (⚠️  this is not the same as a Kubernetes Service Account).
+1. Create a GCP Service Account (note that this is not the same as a Kubernetes Service Account).
 2. Assign the _Artifact Registry Writer_ (`roles/artifactregistry.writer`) role to the GCR Service Account.
 3. Allow the Mendix Operator to use the GCR Service Account by running:
 
@@ -246,7 +219,7 @@ Use the following configuration options:
 * **GCP Service Account** - the GCP account name created on step 1, for example `service-account-name@project-id.iam.gserviceaccount.com`.
 * **Kubernetes Service Account** - the Kubernetes service account that was linked with the GCP service account on step 3; the Kubernetes Service Account will be created automatically when you apply the changes.
 
-### 2.6 Generic registry with authentication
+### 2.6 Generic Registry with Authentication
 
 This option works with most other registries - if the registry supports Basic authentication, this option should be compatible.
 
@@ -263,7 +236,7 @@ Use the following configuration options:
 * **With authentication** - allows to specify the username and password used to access the registry. This is required for almost all registries, the only exception is self-hosted registries in test envrionments such as MicroK8s, k3s or Minikube.
 * **Add credentials to pull secrets in default service account** - if your cluster is not using built-in authentication, checking this option will automatically image pull credentials to the `default` Kubernetes ServiceAccount. This would enable authentication when pulling app images.
 
-#### 2.6.1 Example configurations
+#### 2.6.1 Example Configurations
 
 Here are a few example configurations for container registries:
 
@@ -274,7 +247,7 @@ Here are a few example configurations for container registries:
 | Push URL            | index.docker.io |
 | Pull URL            | index.docker.io |
 | Registry name       | `<username>/<repository>`, where `<username>` is a username for Docker Hub |
-| With authentication | ☑ checked       |
+| With authentication | enabled       |
 | User                | A username for Docker Hub |
 | Password            | An access token for the Docker Hub user |
 
@@ -288,7 +261,7 @@ Docker Hub will automatically create the repository when an image is pushed.
 | Push URL            | quay.io         |
 | Pull URL            | quay.io         |
 | Registry name       | `<username>/<repository>`, where `<username>` is a username for Docker Hub |
-| With authentication | ☑ checked       |
+| With authentication | enabled       |
 | User                | Username for a quay.io robot account |
 | Password            | Token (password) for the robot account |
 
@@ -302,14 +275,14 @@ To access quay.io, you will need to create a robot account, and give this accoun
 | Push URL            | `<hostname>:<port>`    |
 | Pull URL            | `<hostname>:<port>`    |
 | Registry name       | `<path/to/repository>` |
-| With authentication | ☑ checked       |
+| With authentication | enabled      |
 | User                | Username for a user or account with push and pull permissions |
 | Password            | Token (password) for a user or account with push and pull permissions |
 
 Check your image registry documentation to see if repositories can be created automatically (on push) or need to be pre-created.
 Some registries impose limitations on repository names, for example the repositiry path cannot have more than three parts.
 
-### 2.8 Existing docker-registry secret
+### 2.8 Existing Docker Registry Secret
 
 If you already have a existing `~/.docker/config.json` file, you can use it directly by choosing the `docker-secret` option.
 
@@ -328,23 +301,23 @@ After creating the `dockerconfigjson` secret, you can configure Mendix for Priva
     * Registries could also have security or technical limitations on what can be specified as the repository name.
 * **Secret name** - name of the Kubernetes secret you've created.
 
-You will need to add this secret to the `default` ServiceAccount manually, or provide registry authentication configuration in another way (depending on which registry authentication options the Kubernetes cluster vendor is offering).
+You must add this secret to the `default` ServiceAccount manually, or provide registry authentication configuration in another way (depending on which registry authentication options the Kubernetes cluster vendor is offering).
 
-## 3 Advanced options
+## 3 Advanced Options
 
 You can host the default Mendix components in your own registry, for example if your cluster is firewalled and cannot open up a route to the Mendix registry. In this case you need to migrate some, or all, of the Mendix components to your cluster. See the instructions in [Migrating to Your Own Registry](/developerportal/deploy/private-cloud-migrating/) to find out how to do this.
 
 ### 3.1 Customizing the image name template {#customize-registry-imagenametemplate}
 
-ImageNameTemplate allows you to specify how the image name and tag are generated. It allows both use of OpenShift-style "repository per app" and ECR-style "tag per app". For example, a value of imageNameTemplate may be `registry.example.com/mendix-apps/{{.Name}}-{{.Version}}-{{.UnixTimestamp}}` which would generate an image for the build like `registry.example.com/mendix-apps/pgv9gw71-0.0.1.2-1640699175.392`
+**ImageNameTemplate** allows you to specify how the image name and tag are generated. It allows both use of OpenShift-style "repository per app" and ECR-style "tag per app". For example, a value of **imageNameTemplate** may be `registry.example.com/mendix-apps/{{.Name}}-{{.Version}}-{{.UnixTimestamp}}` which would generate an image for the build like `registry.example.com/mendix-apps/pgv9gw71-0.0.1.2-1640699175.392`
 
-The imageNameTemplate is generated by mxpc-cli when you update the registry configuration.
+The **imageNameTemplate** is generated by mxpc-cli when you update the registry configuration.
 
 {{% alert color="warning" %}}
 Any manual changes you make to the imageNameTemplate in the manifest are overwritten when you update the registry configuration using mxpc-cli.
 {{% /alert %}}
 
-An example of the imageNameTemplate in the operator configuration manifest is given below.
+An example of the **imageNameTemplate** in the Mendix Operator configuration manifest is given below.
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
@@ -359,7 +332,7 @@ spec:
   # …
 ```
 
-You can customize the registry imageNameTemplate in OperatorConfiguration with these available variables:
+You can customize the registry **imageNameTemplate** in **OperatorConfiguration** with these available variables:
 
 * `{{.Name}}`: internal environment name.
 * `{{.Generation}}`: value of the Build CR’s [Generation](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace#generation) attribute.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -202,18 +202,18 @@ You need to make the following changes:
           key: LicenseKey # Offline LicenseKey value provided by Mendix Support
     ```
 
-* **logLevels**: – set custom logging levels for specific log nodes in your app — valid values are: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`
-* **logFormatType**: – allows to specify the log format of Mendix apps - valid values are `plain` (default) and `json`; for more information, see the [runtime log format](/developerportal/deploy/private-cloud-cluster/#runtime-log-format) documentation.
-* **microflowConstants**: – set values for microflow constants
-* **scheduledEventExecution**: – choose which scheduled events should be enabled – valid values are: `ALL`, `NONE` and `SPECIFIED`
-* **myScheduledEvents**: – list scheduled events which should be enabled – can only be used when **scheduledEventExecution** is set to `SPECIFIED`
-* **jettyOptions** and **customConfiguration**: – if you have any custom Mendix Runtime parameters, they need to be added to this section — options for the Mendix runtime have to be provided in JSON format — see the examples in the CR for the correct format and the information below for more information on [setting app constants](#set-app-constants) and [configuring scheduled events](#configure-scheduled-events)
-* **environmentVariables**: – set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable
-* **clientCertificates**: – specify client certificates to be used for TLS calls to Web Services and REST services
-* **runtimeMetricsConfiguration**: – specify how metrics should be collected — any non-empty values will override [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration` — see [Monitoring Environments in Mendix for Private Cloud](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment
-* **runtimeLeaderSelection**: – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
-* **customPodLabels**: - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
-   * **general**: - specify additional labels for all pods of the app
+* **logLevels** – set custom logging levels for specific log nodes in your app; valid values are: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`
+* **logFormatType** – allows to specify the log format of Mendix apps; valid values are `plain` (default) and `json`; for more information, see the [runtime log format](/developerportal/deploy/private-cloud-cluster/#runtime-log-format) documentation.
+* **microflowConstants** – set values for microflow constants
+* **scheduledEventExecution** – choose which scheduled events should be enabled; valid values are: `ALL`, `NONE` and `SPECIFIED`
+* **myScheduledEvents** – list scheduled events which should be enabled – can only be used when **scheduledEventExecution** is set to `SPECIFIED`
+* **jettyOptions** and **customConfiguration** – if you have any custom Mendix Runtime parameters, they need to be added to this section; options for the Mendix runtime have to be provided in JSON format; see the examples in the CR for the correct format and the information below for more information on [setting app constants](#set-app-constants) and [configuring scheduled events](#configure-scheduled-events)
+* **environmentVariables** – set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable
+* **clientCertificates** – specify client certificates to be used for TLS calls to Web Services and REST services
+* **runtimeMetricsConfiguration** – specify how metrics should be collected; any non-empty values will override [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration`; see [Monitoring Environments in Mendix for Private Cloud](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment
+* **runtimeLeaderSelection** – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
+* **customPodLabels** - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
+   * **general** - specify additional labels for all pods of the app
 
 #### 3.2.1 Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -76,7 +76,7 @@ spec:
       [...]
       -----END PRIVATE KEY-----
   replicas: 1 # Number of replicas, set to 0 to stop all replicas
-  resources: # Optional, can be omitted : set resources for Mendix Runtime container 
+  resources: # Optional, can be omitted : set resources for Mendix Runtime container
     limits: # Upper limit - process will be stopped if it tries to use more
       cpu: 500m # 500 millicores - half of a vCPU
       memory: 512Mi # 512 megabytes - suitable for small-scale non-production apps
@@ -157,6 +157,9 @@ spec:
         …
       }
   runtimeLeaderSelection: assigned # Optional, can be omitted : specify how the leader node will be selected
+  customPodLabels: # Optional: custom pod labels
+    general: # Optional: general pod labels (applied to all app-related pods)
+      azure.workload.identity/use: "true" # Example: enable Azure Workload Identity
 ```
 
 You need to make the following changes:
@@ -209,6 +212,8 @@ You need to make the following changes:
 * **clientCertificates**: – specify client certificates to be used for TLS calls to Web Services and REST services
 * **runtimeMetricsConfiguration**: – specify how metrics should be collected — any non-empty values will override [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration` — see [Monitoring Environments in Mendix for Private Cloud](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment
 * **runtimeLeaderSelection**: – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
+* **customPodLabels**: - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
+   * **general**: - specify additional labels for all pods of the app
 
 #### 3.2.1 Setting App Constants{#set-app-constants}
 
@@ -303,7 +308,7 @@ To build and deploy your app using the OpenShift Console, do the following:
 
 4. In the **Import YAML** page, enter/paste the YML you prepared in [Editing the CR}(#edit-cr), above.
 5. Click the **Create** button.
-    
+
     {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-operator/image2.png" >}}
 
 Mendix Operator will now pick up the YAML and deploy your app.
@@ -346,7 +351,7 @@ All names beginning **openshift-** are reserved for use by OpenShift if you are 
 
 In some cases, your Mendix app will need to know its own URL – for example when using SSO or sending emails.
 
-For this to work properly, you need to set the [ApplicationRootUrl variable](/refguide/custom-settings/#general) in `customConfiguration` to the app's URL. For example: 
+For this to work properly, you need to set the [ApplicationRootUrl variable](/refguide/custom-settings/#general) in `customConfiguration` to the app's URL. For example:
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-supported-environments.md
@@ -36,8 +36,8 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.27
-* OpenShift 4.6 through 4.12
+* Kubernetes versions 1.19 through 1.28
+* OpenShift 4.6 through 4.19
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
@@ -90,7 +90,7 @@ The image builder doesn't build multiple architecture images at the moment.
 
 It is not possible to use Mendix for Private Cloud in [OpenShift Online](https://www.openshift.com/products/online/) (all editions, including Starter and Pro) or [OpenShift Developer Sandbox](https://developers.redhat.com/developer-sandbox) because they don't allow the installation of Custom Resource Definitions.
 
-Kubernetes included with [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) is not officially supported. 
+Kubernetes included with [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) is not officially supported.
 
 ## 3 Container Registries
 
@@ -140,7 +140,7 @@ The OpenShift registry must be installed and enabled for use.
 
 ### 3.4 Amazon Elastic Container Registry (ECR)
 
-[Amazon ECR](https://aws.amazon.com/ecr/) can only be used together with EKS clusters. 
+[Amazon ECR](https://aws.amazon.com/ecr/) can only be used together with EKS clusters.
 
 To use an ECR registry, the Mendix Operator will need an AWS Identity and Access Management (IAM) account with permissions to push and pull images.
 
@@ -186,6 +186,7 @@ The following standard PostgreSQL databases are supported:
 * PostgreSQL 12
 * PostgreSQL 13
 * PostgreSQL 14
+* PostgreSQL 15
 
 {{% alert color="info" %}}
 While Mendix for Private Cloud supports all Postgres versions listed above, the Mendix Runtime might require a more specific Postgres version.
@@ -197,7 +198,7 @@ A standard PostgreSQL database is an unmodified PostgreSQL database installed fr
 
 The following managed PostgreSQL databases are supported:
 
-* [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) 
+* [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/)
 * [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/).
 * [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres).
 
@@ -217,7 +218,7 @@ For every Mendix app environment, a new database schema and user (role) will be 
 By default, the Mendix Operator will first connect to the database server with TLS enabled; if the database server doesn't support TLS, the Mendix Operator will reconnect without TLS.
 To ensure compatibility with all PostgreSQL databases (including ones with self-signed certificates), all TLS CAs are trusted by default.
 
-If Strict TLS is enabled, Mendix for Private Cloud will connect to the PostgreSQL server with TLS and validate the PostgreSQL server's TLS certificate. In this case, the connection will fail if: 
+If Strict TLS is enabled, Mendix for Private Cloud will connect to the PostgreSQL server with TLS and validate the PostgreSQL server's TLS certificate. In this case, the connection will fail if:
 
 * the PostgreSQL server has an invalid certificate
 * or its certificate is signed by an unknown certificate authority
@@ -256,7 +257,7 @@ For every Mendix app environment, a new database, user and login will be created
 {{% alert color="info" %}}
 By default, Mendix for Private Cloud will not enforce encryption. Encryption can be enforced in SQL Server if required.
 
-If Strict TLS is enabled, the Mendix Operator will connect to SQL server with TLS and validate the SQL Server's TLS certificate. In this case, the connection will fail if 
+If Strict TLS is enabled, the Mendix Operator will connect to SQL server with TLS and validate the SQL Server's TLS certificate. In this case, the connection will fail if
 
 * SQL Server doesn't support encryption
 * the SQL Server server has an invalid certificate
@@ -319,7 +320,7 @@ Unlike MinIO and S3, Mendix for Private Cloud doesn't manage Azure Blob Storage 
 
 [Google Cloud Storage](https://cloud.google.com/storage) is supported with [Cloud Storage Interoperability](https://cloud.google.com/storage/docs/interoperability) mode.
 
-Mendix Operator will need the endpoint, access key, and secret key to access the storage that can be configured in the interoperability setting. 
+Mendix Operator will need the endpoint, access key, and secret key to access the storage that can be configured in the interoperability setting.
 
 ### 5.6 Ceph
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,7 +17,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.13.0 {#2.13.0}
 
-* We've added support for Azure Workload Identity authentication when pushing images to Azure Container Registry.
+* We've added support for Azure Workload Identity authentication when pushing images to Azure Container Registry. To use this option, the `mxpc-cli` installation and configuration tool now has a dedicated `microsoft-acr` registry type.
 * We've added an option to specify additional custom pod labels for an environment (or all environments in the namespace).
 * To improve security, ECR will use IRSA authentication by default instead of static credentials.
 * We've updated documentation on configuring and using container registries.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,20 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### September ???th, 2023
+
+#### Mendix Operator v2.13.0 {#2.13.0}
+
+* We've added support for Azure Workload Identity authentication when pushing images to Azure Container Registry.
+* We've added an option to specify additional custom pod labels for an environment (or all environments in the namespace).
+* To improve security, ECR will use IRSA authentication by default instead of static credentials.
+* We've updated documentation on configuring and using container registries.
+* When pushing an image to a non-existing ECR repository, the Operator will attempt to create it by calling the ECR API.
+* We've added support for Postgres 15.
+* We refactored registry authentication code to use library authentication instead of binary plugins; this allows to keep dependencies up to date, improves reliability of builds and allows to have improved logging of the authentication process.
+* When deploying an image to an environment, the Mendix Operator will now use the built image's sha256 digest to ensure that what was built will be deployed.
+* We have updated the list of supported platforms to include Kubernetes 1.28 and OpenShift 4.13.
+
 ### August 17, 2023
 
 #### Portal Improvements
@@ -160,8 +174,8 @@ This feature is currently in a Beta release.
 #### Deploy API Improvements
 
 * We have added a new API endpoint for updating the namespaces. This will allow cluster managers to do the following tasks:
-    * Add, edit or remove member permissions and members in a namespace. 
-    * Enable or disable the external secret store and development mode configurations. 
+    * Add, edit or remove member permissions and members in a namespace.
+    * Enable or disable the external secret store and development mode configurations.
     * Add, update, or clear the operational URLs.
     * Activate or deactivate database and storage plans.
 * We have improved the Update Cluster API endpoint by allowing cluster managers to add new cluster managers.
@@ -224,7 +238,7 @@ Your build may fail if you try to deploy the same deployment package more than o
 
 #### Portal Improvements
 
-* When using Mendix Operator version 2.10.0, it is now possible to load MxApp constants and custom runtime settings from the Kubernetes CSI Secrets Store. This allows you to store configuration in a secure credential storage system (such as Hashcorp Vault or AWS Secrets Manager) instead of the Cloud Portal and Kubernetes secrets. 
+* When using Mendix Operator version 2.10.0, it is now possible to load MxApp constants and custom runtime settings from the Kubernetes CSI Secrets Store. This allows you to store configuration in a secure credential storage system (such as Hashcorp Vault or AWS Secrets Manager) instead of the Cloud Portal and Kubernetes secrets.
 * We have added a new status field indicating whether custom runtime setting and MxApp constants were loaded from CSI Secrets Storage.
 * We have added a notification on top of the Model Options and Runtime Settings page to indicate whether CSI Secrets Storage is enabled for a namespace.
 * We have removed the limit of eight characters for the MxAdmin password. You should set the password based on the policy set in Studio Pro.
@@ -339,7 +353,7 @@ Your build may fail if you try to deploy the same deployment package more than o
 
 * We fixed an issue where users were unable to see all the environments on the environment details page. (Ticket 151698)
 
-### June 2, 2022 
+### June 2, 2022
 
 #### Portal Improvements
 
@@ -423,7 +437,7 @@ This issue is fixed in Mendix Operator [version 2.5.1](#2.5.1).
 
 * We have improved the UX, and added a new button, **Save and Apply** to directly apply changes made in an environment. This button restarts the environment.
 * We have added the ability to add metrics configuration to an environment.
-  
+
 ### January 13, 2022
 
 #### Mendix Operator v2.3.0 and Mendix Gateway Agent v2.3.0
@@ -702,7 +716,7 @@ After upgrading the Mendix Operator, we recommend downloading the latest version
 
 * We have added support in the Developer Portal to configure custom Certificate Authorities which should be trusted by the Mendix Operator and app environments.
 * We now add an environment UUID to environments deployed to Private Cloud namespaces so environment names no longer need to be unique.
-* As part of a Developer Portal clean up, we removed the *Model* option from the *DEVELOP* section of the Developer Portal menu when you are looking at environments on Mendix for Private Cloud. The functions of this page are still available via the **Edit in Studio Pro** button on the environments page. 
+* As part of a Developer Portal clean up, we removed the *Model* option from the *DEVELOP* section of the Developer Portal menu when you are looking at environments on Mendix for Private Cloud. The functions of this page are still available via the **Edit in Studio Pro** button on the environments page.
 
 #### Fixes
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -27,6 +27,8 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * When deploying an image to an environment, the Mendix Operator will now use the built image's sha256 digest to ensure that what was built will be deployed.
 * We have updated the list of supported platforms to include Kubernetes 1.28 and OpenShift 4.13.
 
+Upgrading to Mendix Operator v2.13.0 from a previous version will restart environments managed by that version of the Operator.
+
 ### August 17, 2023
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,17 +17,16 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.13.0 {#2.13.0}
 
-* We've added support for Azure Workload Identity authentication when pushing images to Azure Container Registry. To use this option, the `mxpc-cli` installation and configuration tool now has a dedicated `microsoft-acr` registry type.
-* We've added an option to specify additional custom pod labels for an environment (or all environments in the namespace).
+* We have added support for Azure Workload Identity authentication when pushing images to Azure Container Registry. To use this option, the `mxpc-cli` installation and configuration tool now has a dedicated `microsoft-acr` registry type.
+* We have added an option to specify additional custom pod labels for an environment (or all environments in the namespace).
 * To improve security, ECR will use IRSA authentication by default instead of static credentials.
-* We've updated documentation on configuring and using container registries.
+* We have updated documentation on configuring and using container registries.
 * When pushing an image to a non-existing ECR repository, the Operator will attempt to create it by calling the ECR API.
-* We've added support for Postgres 15.
-* We refactored registry authentication code to use library authentication instead of binary plugins; this allows to keep dependencies up to date, improves reliability of builds and allows to have improved logging of the authentication process.
+* We have added support for Postgres 15.
+* We refactored registry authentication code to use library authentication instead of binary plugins. This allows the dependencies to be kept up to date, improves reliability of builds and allows improved logging of the authentication process.
 * When deploying an image to an environment, the Mendix Operator will now use the built image's sha256 digest to ensure that what was built will be deployed.
 * We have updated the list of supported platforms to include Kubernetes 1.28 and OpenShift 4.13.
-
-Upgrading to Mendix Operator v2.13.0 from a previous version will restart environments managed by that version of the Operator.
+* Upgrading to Mendix Operator v2.13.0 from a previous version will restart environments managed by that version of the Operator.
 
 ### August 17, 2023
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -429,7 +429,7 @@ This issue is fixed in Mendix Operator [version 2.5.1](#2.5.1).
 #### Mendix Operator v2.3.0 and Mendix Gateway Agent v2.3.0
 
 * We have added a new field to set the Kubernetes ingress class as an annotation in the installer.
-* We have added a new feature to customize your image names in the registry using a [custom imageNameTemplate](/developerportal/deploy/private-cloud-cluster/#customize-registry-imagenametemplate).
+* We have added a new feature to customize your image names in the registry using a [custom imageNameTemplate](/developerportal/deploy/private-cloud-registry/#customize-registry-imagenametemplate).
 
 #### Portal Improvements
 


### PR DESCRIPTION
Updated documentation and release notes for an upcoming Mendix for Private Cloud release:
* Release notes for new features
* Documentation how to use use the new pod labels
* Refactored documentation how to use and configure registries
* Fixed numbering for some document sections