### PR TITLE
PDF Document Generation: Improvements for section on timeout errors

### DIFF
--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -334,6 +334,6 @@ In case you encounter the message "No configuration object available. For use in
 If you encounter the message "Failed to load page: TimeoutError: waiting for selector `#content .document-content` failed: timeout 30000ms exceeded" in your runtime logs, this means that a timeout occurred while the browser was waiting for the configured page to finish loading. This could be caused by the following reasons:
 
 * The required **Enable PDF export** design property is not set to **Yes** for the page you are trying to export to PDF.
-* Loading the page failed or took too much time. When this occurs, verify that the page loads successfully and does not trigger any client errors by temporarily adding the page to for example the app navigation.
+* Loading the page failed or took too much time. When this occurs, verify that the page loads successfully within the fixed timeout of 30 seconds and does not trigger any client errors. To verify this, we recommend to temporarily add the page to for example the app navigation.
 * A widget or add-on is being used in the `index.html` file that performs long polling network requests. This is not supported, since the document generation service waits until there are no more pending network requests.
 * The configured service user does not have the applicable access rights to run the page microflow. In this case, there should be a warning in the logs mentioning User `<username>` attempted to run the microflow with action name `<page microflow>`, but does not have the required permissions.

--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -210,7 +210,7 @@ For scenarios where you want to generate documents as a system task (for example
 6. In the microflow where you call the **Generate PDF from page** action, add a microflow call to the microflow you created in the previous step, and use the return value (the service user object) as input for the **Generate as user** parameter of the action.
 
 {{% alert color="info" %}}
-We recommend to try to log in as the service user at least once, to verify if the service user has the required module roles to log in. Depending on your app’s implementation, it might for example be required to assign the `Administration.Account` module role.
+We recommend trying to log in as the service user at least once, to verify if the service user has the required module roles to log in. Depending on your app’s implementation, it might for example be required to assign the `Administration.Account` module role.
 {{% /alert %}}
 
 ### 4.3 Language and Date/Time Handling
@@ -334,6 +334,6 @@ In case you encounter the message "No configuration object available. For use in
 If you encounter the message "Failed to load page: TimeoutError: waiting for selector `#content .document-content` failed: timeout 30000ms exceeded" in your runtime logs, this means that a timeout occurred while the browser was waiting for the configured page to finish loading. This could be caused by the following reasons:
 
 * The required **Enable PDF export** design property is not set to **Yes** for the page you are trying to export to PDF.
-* Loading the page failed or took too much time. When this occurs, verify that the page loads successfully within the fixed timeout of 30 seconds and does not trigger any client errors. To verify this, we recommend to temporarily add the page to for example the app navigation.
+* Loading the page failed or took too much time. When this occurs, verify that the page loads successfully within the fixed timeout of 30 seconds and does not trigger any client errors. To verify this, we recommend temporarily adding the page to, for example, the app navigation.
 * A widget or add-on is being used in the `index.html` file that performs long polling network requests. This is not supported, since the document generation service waits until there are no more pending network requests.
 * The configured service user does not have the applicable access rights to run the page microflow. In this case, there should be a warning in the logs mentioning User `<username>` attempted to run the microflow with action name `<page microflow>`, but does not have the required permissions.

--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -55,11 +55,11 @@ The PDF document generation service does not store pages or documents at any tim
 * The `System.Owner` association is currently not set to the user which has run the microflow. Instead, the user that is configured for the `Generate as user` property of the `Generate PDF from page` action is used to set the association.
 * For local development, we use the Chrome or Chromium executable that is available on the development machine. Even though we have not observed these yet, there might be minor differences in PDF output locally vs. when using the cloud service.
 * The access (and refresh) tokens used to secure requests to the cloud service are stored unencrypted in the app database. No user roles have read access to these tokens and all communication with the cloud service is encrypted by requiring HTTPS. However, do consider this when sharing a backup of the database with other developers. We will introduce encryption at a later stage.
+* If you have the [Application Performance Monitor (APM)](/appstore/partner-solutions/apd/) or [Application Performance Diagnostics (APD)](/appstore/partner-solutions/apd/) add-on enabled in your app, or set the log level of the **Services** log node to *Trace*, the PDF Document Generation module will not be able to generate documents when used in Mendix Cloud. Note: This is only applicable for apps built in Mendix 9.24.5 and below and Mendix 10.0.0.
 
 ### 1.4 Known Issues {#known-issues}
 
 * Some widgets, such as the [Charts](/appstore/widgets/charts/) widget, might not be fully loaded if they are rendered before all data is available. We check on pending network requests to prevent this, but this is not 100% reliable.
-* If you have the [Application Performance Monitor (APM)](/appstore/partner-solutions/apd/) or [Application Performance Diagnostics (APD)](/appstore/partner-solutions/apd/) add-on enabled in your app, or set the log level of the **Services** log node to *Trace*, the PDF Document Generation module will not be able to generate documents when used in Mendix Cloud. Note: This is only applicable for apps built in Mendix 9.24.5 and below and Mendix 10.0.0.
 
 ## 2 Installation {#installation}
 

--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -333,7 +333,7 @@ In case you encounter the message "No configuration object available. For use in
 
 If you encounter the message "Failed to load page: TimeoutError: waiting for selector `#content .document-content` failed: timeout 30000ms exceeded" in your runtime logs, this means that a timeout occurred while the browser was waiting for the configured page to finish loading. This could be caused by the following reasons:
 
+* The required **Enable PDF export** design property is not set to **Yes** for the page you are trying to export to PDF.
 * Loading the page failed or took too much time. When this occurs, verify that the page loads successfully and does not trigger any client errors by temporarily adding the page to for example the app navigation.
 * A widget or add-on is being used in the `index.html` file that performs long polling network requests. This is not supported, since the document generation service waits until there are no more pending network requests.
-* The required **Enable PDF export** design property is not set to **Yes** for the page you are trying to export to PDF.
 * The configured service user does not have the applicable access rights to run the page microflow. In this case, there should be a warning in the logs mentioning User `<username>` attempted to run the microflow with action name `<page microflow>`, but does not have the required permissions.

--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -263,16 +263,16 @@ The procedure uses the `Noto Sans SC` font as an example. You can visit [Google 
 1. Download the font [Noto Sans SC](https://fonts.google.com/noto/specimen/Noto+Sans+SC).
 2. Copy the font file *NotoSansSC-Regular.ttf* from the *static* folder of the downloaded font package into the *theme\web\fonts* folder of the app.
 3. In Studio Pro, go to **Styling** > **Web** > **main.scss** in **App Explorer**, and add the lines below to the *main.scss* file in the built-in styling editor:
- ```css
-    @font-face {
-        font-family: 'Noto Sans SC';
-        src: url(fonts/NotoSansSC-Regular.ttf);
-    }
+```css
+@font-face {
+    font-family: 'Noto Sans SC';
+    src: url(fonts/NotoSansSC-Regular.ttf);
+}
 
-    .font-noto-sans-sc {
-        font-family: 'Noto Sans SC', sans-serif;
-    }
- ```
+.font-noto-sans-sc {
+    font-family: 'Noto Sans SC', sans-serif;
+}
+```
 4. Add the class `font-noto-sans-sc` to all applicable text and widgets.
 
 #### 4.4.4 Advanced Styling


### PR DESCRIPTION
This PR contains two small improvements to [5.2.4 Timeout Errors](https://docs.mendix.com/appstore/modules/document-generation/#524-timeout-errors) of the troubleshooting section in the PDF Document Generation module docs.

Edit: also added a commit to remove the superfluous indentation in the CSS snippet in [4.4.3 Applying Custom Fonts](https://docs.mendix.com/appstore/modules/document-generation/#applying-custom-fonts)