### PR TITLE
[RUN-3346] Default cost of BCrypt was changed to 12 in Mx10

### DIFF
--- a/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
+++ b/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
@@ -107,7 +107,7 @@ Mendix believes both algorithms are secure enough to store passwords within Mend
 
 #### 3.9.1 BCrypt Cost {#bcrypt-cost}
 
-**BCrypt cost** is used to specify the cost of the BCrypt algorithm. The default value is 10, and can go up to 30. The higher the value is, the slower the process of hashing values. For more information, see the subsections below.
+**BCrypt cost** is used to specify the cost of the BCrypt algorithm. The default value is 12, and can go up to 30. The higher the value is, the slower the process of hashing values. For more information, see the subsections below.
 
 #### 3.9.2 Performance
 


### PR DESCRIPTION
Default cost of BCrypt was changed to 12 in Mx10. There was still one reference in the docs that mentioned it as 10.