### PR TITLE
Update merge.md

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool/merge.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/merge.md
@@ -133,11 +133,9 @@ Normally, when you are merging branches with Git, it compares the changes in fil
 
 However, if the files in conflict are Mendix apps the conflict is in two *.mpr* files, both the files and the conflict are more complex, which is why we need Studio Pro to resolve the conflicts. For such cases, Git has an option to delegate conflict resolution for a certain file type to an external tool. The `mx merge` command is compatible with this mechanism and allows Git to try to merge the *.mpr* files as if Studio Pro did it. Then, if there are still conflicts, you can open Studio Pro and resolve those manually.
 
-
-
 ### 4.1 config File
 
-Add the lines below to the *config* file located in the *.git* folder of your app on disk.
+Add the lines below to the *config* file located in the **.git** folder of your app on disk.
 
 At the end of the file, add a `[merge "custom"]` block like this:
 
@@ -156,7 +154,8 @@ Under the `[core]` section, add the following:
 ```
 
 {{% alert color="info" %}}
-The *.git* folder is a hidden folder in a computer file management system. You can view it when hidden items are visible.{{% /alert %}}
+The **.git** folder is a hidden folder in a computer file management system. You can view it when hidden items are visible.
+{{% /alert %}}
 
 ### 4.2 .gitattributes File
 
@@ -203,4 +202,5 @@ Now, if you open you app on the **Main** branch, you should see the following:
 * A conflict on the **Home_Web** page concerning the renaming of home page caption (this is a conflicting change, as you changed the same caption to different values on both branches, so you can resolve this manually)
 
 {{% alert color="info" %}}
-Note that when you get a different output the custom merge drive is not configured correctly. Abort the merge using the command `$git merge --abort` and close the Git command line tool before making changes to the configuration. Changes made to the configuration *config* and *.gitattributes* files will  be picked up by reopening the Git command line tool.{{% /alert %}}
+When you get a different output, the custom merge drive is not configured correctly. Abort the merge using the command `$git merge --abort` and close the Git command line tool before making changes to the configuration. Changes made to the configuration *config* and *.gitattributes* files are picked up by reopening the Git command line tool.
+{{% /alert %}}

--- a/content/en/docs/refguide/general/mx-command-line-tool/merge.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/merge.md
@@ -133,9 +133,11 @@ Normally, when you are merging branches with Git, it compares the changes in fil
 
 However, if the files in conflict are Mendix apps the conflict is in two *.mpr* files, both the files and the conflict are more complex, which is why we need Studio Pro to resolve the conflicts. For such cases, Git has an option to delegate conflict resolution for a certain file type to an external tool. The `mx merge` command is compatible with this mechanism and allows Git to try to merge the *.mpr* files as if Studio Pro did it. Then, if there are still conflicts, you can open Studio Pro and resolve those manually.
 
-### 4.1 .gitconfig File
 
-Add the lines below to the *.gitconfig* file located in the *.git* folder of your app on disk.
+
+### 4.1 config File
+
+Add the lines below to the *config* file located in the *.git* folder of your app on disk.
 
 At the end of the file, add a `[merge "custom"]` block like this:
 
@@ -152,6 +154,9 @@ Under the `[core]` section, add the following:
 ```ini {linenos=false}
     attributesfile = .git/.gitattributes
 ```
+
+{{% alert color="info" %}}
+The *.git* folder is a hidden folder in a computer file management system. You can view it when hidden items are visible.{{% /alert %}}
 
 ### 4.2 .gitattributes File
 
@@ -196,3 +201,6 @@ Now, if you open you app on the **Main** branch, you should see the following:
 
 * Both the **branch** and **main** microflows ( this is a non-conflicting change, so `mx merge` sorted this out automatically, just like Studio Pro would do)
 * A conflict on the **Home_Web** page concerning the renaming of home page caption (this is a conflicting change, as you changed the same caption to different values on both branches, so you can resolve this manually)
+
+{{% alert color="info" %}}
+Note that when you get a different output the custom merge drive is not configured correctly. Abort the merge using the command `$git merge --abort` and close the Git command line tool before making changes to the configuration. Changes made to the configuration *config* and *.gitattributes* files will  be picked up by reopening the Git command line tool.{{% /alert %}}


### PR DESCRIPTION
Added some more information.

Updated named of the .gitconfig file to config file. The .gitconfig file is only part of the global configuration at c:/users/[name]/.gitconfig while git settings per app only have the config file.

Added info banner on the fact that the .git folder is a hidden folder

Added info banner on the fact that changes made to the config and .gitattributes files are only picked up when git command tool is reopened.


Discussed here: https://mendix.slack.com/archives/C04JZDSNPLP/p1696344393924479?thread_ts=1696325268.574399&cid=C04JZDSNPLP