### PR TITLE
Update scheduled-events.md

### DIFF
--- a/content/en/docs/refguide/modeling/resources/scheduled-events.md
+++ b/content/en/docs/refguide/modeling/resources/scheduled-events.md
@@ -177,3 +177,7 @@ This limit cannot be overridden.
 ### 5.3 Unsupported Intervals
 
 Hour- and minute-based intervals can only be integer divisors of 24 or 60, respectively. For example you cannot schedule an event to run every seven minutes as this does not divide precisely into sixty minutes. If it is absolutely critical that an unsupported interval is used, you should schedule the event with interval value of one (every hour or every minute) and decide within the microflow whether it should continue executing at that particular time.
+
+### 5.4 Cleaning completed intervals of scheduled events
+
+Every run interval of a scheduled event produces an entry in the `System.ProcessedQueueTask` table in the database. Over time these accumulate and the table can grow large. Refer to the documentation on [Cleaning up old processed tasks](/refguide/task-queue/#cleanup) to learn how to remove processed entries.

--- a/content/en/docs/refguide/modeling/resources/scheduled-events.md
+++ b/content/en/docs/refguide/modeling/resources/scheduled-events.md
@@ -178,6 +178,6 @@ This limit cannot be overridden.
 
 Hour- and minute-based intervals can only be integer divisors of 24 or 60, respectively. For example you cannot schedule an event to run every seven minutes as this does not divide precisely into sixty minutes. If it is absolutely critical that an unsupported interval is used, you should schedule the event with interval value of one (every hour or every minute) and decide within the microflow whether it should continue executing at that particular time.
 
-### 5.4 Cleaning completed intervals of scheduled events
+### 5.4 Cleaning Up Completed Runs of Scheduled Events
 
-Every run interval of a scheduled event produces an entry in the `System.ProcessedQueueTask` table in the database. Over time these accumulate and the table can grow large. Refer to the documentation on [Cleaning up old processed tasks](/refguide/task-queue/#cleanup) to learn how to remove processed entries.
+Every time a scheduled event is run it produces an entry in the `System.ProcessedQueueTask` table in the database. Over time these accumulate and the table can grow large. Refer to the documentation on [Cleaning Up Old Processed Tasks](/refguide/task-queue/#cleanup) in *Task Queue* to learn how to remove processed entries.

--- a/content/en/docs/refguide/modeling/resources/task-queue.md
+++ b/content/en/docs/refguide/modeling/resources/task-queue.md
@@ -221,7 +221,7 @@ During shutdown, the `TaskQueueExecutors` will stop accepting new tasks. Running
 Interrupting task threads may cause them to fail. These tasks will be marked as `Aborted` and retried at a later time.
 {{% /alert %}}
 
-### 2.13 Cleaning up old processed tasks {#cleanup}
+### 2.13 Cleaning Up Old Processed Tasks {#cleanup}
 
 The execution of a task produces a `System.ProcessedQueueTask` row in the database. Over time these accumulate and the table can grow large.
 


### PR DESCRIPTION
I felt that it was not clear that a user should enable ProcessedTaskQueue runtime variables when an application utilizes scheduled events. 

Therefore, adding a section to the documentation of the scheduled event on this makes sense in my opinion.