### PR TITLE
Remove duplicated postgres 11 deprecation warning

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.4.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.4.md
@@ -109,10 +109,6 @@ We also made the **Delete** action configurable. You can now specify which objec
 * We fixed an issue with the creation of a new database from Studio Pro when using MySQL or MariaDB.
 * We fixed an issue where extraneous directories created by the Gradle build tool were included in an exported deployment package *.mda* file.
 
-### Deprecations
-
-* Starting with version 10.5, we will drop support for PostgreSQL 11, as it is no longer supported by the vendor.
-
 ### Known Issues
 
 * A finished parallel split branch that is removed from a running workflow instance wrongly leads to a versioning conflict.


### PR DESCRIPTION
It was already announced in 10.3.0