### PR TITLE
Clarify technology preview status of protected modules in Mendix 9 and availability in 10

### DIFF
--- a/content/en/docs/appstore/creating-content/sol-solutions-guide/sol-adapt/sol-ip-protection.md
+++ b/content/en/docs/appstore/creating-content/sol-solutions-guide/sol-adapt/sol-ip-protection.md
@@ -11,10 +11,6 @@ tags: ["adaptable solutions", "ip protection"]
 
 When selling solutions or components that are created in Mendix and the customer or partner will get access to the model, you as a publisher want to consider protecting the IP contained within the model that makes up the content you are selling. In addition, you want to ensure that developers use the implementation as intended and protect any custom usage metering so that customers cannot accidentally (or intentionally) disable usage metering. Therefore, it is a good idea to consider applying at least some intellectual property (IP) protection in your solutions and components.
 
-{{% alert color="info" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
-{{% /alert %}}
-
 ## 2 Why IP Protection?
 
 Reusable solutions, app services, connectors, and other modules contain IP in the form of app model content (for example, microflows) that is reusable and can be monetized. When you build a business around these types of sellable content, there is a risk associated with the loss of your IP. If customers copy your IP without compensating you as the publisher, then you lose out on part of your potential revenue.

--- a/content/en/docs/refguide/modeling/app-explorer/modules/_index.md
+++ b/content/en/docs/refguide/modeling/app-explorer/modules/_index.md
@@ -26,10 +26,6 @@ React Native modules expose native Java/Objective-C and C++ objects allowing for
 
 ## 2 Module Types {#module-types}
 
-{{% alert color="info" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
-{{% /alert %}}
-
 When you create a module, it has a default **app module** type. The type can be changed at any time in [Module Settings](/refguide/module-settings/). 
 
 There are the following type of modules:

--- a/content/en/docs/refguide/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
+++ b/content/en/docs/refguide/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
@@ -6,10 +6,6 @@ weight: 20
 tags: ["studio pro", "add-on", "solution", "module", "modules"]
 ---
 
-{{% alert color="warning" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
-{{% /alert %}}
-
 ## 1 Introduction
 
 Add-on and solution modules are special types of modules that are developed to add functionality to an app. They have Intellectual Property (IP) protection enabled and have the *.mxmodule* extension. For more information on IP protection, see [IP Protection](/appstore/creating-content/sol-ip-protection/). 

--- a/content/en/docs/refguide/modeling/app-explorer/modules/module-settings.md
+++ b/content/en/docs/refguide/modeling/app-explorer/modules/module-settings.md
@@ -30,10 +30,6 @@ You can add managed dependencies for each module on the **Java Dependencies** ta
 
 ## 3 Export
 
-{{% alert color="warning" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
-{{% /alert %}}
-
 Select the **Export** tab:
 
 {{< figure src="/attachments/refguide/modeling/app-explorer/modules/module-settings/module-settings-export.png" >}}

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
@@ -27,7 +27,7 @@ React Native modules expose native Java/Objective-C and C++ objects allowing for
 ## 2 Module Types {#module-types}
 
 {{% alert color="info" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
+In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
 {{% /alert %}}
 
 When you create a module, it has a default **app module** type. The type can be changed at any time in [Module Settings](/refguide9/module-settings/). 

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
@@ -17,17 +17,13 @@ Within a module you can define [module security](/refguide9/module-security/) vi
 Furthermore, a module can contain many different types of documents. Each type of document is described in its own domain-specific language (DSL). For example, user-interface forms are described by using a visual language with elements like text boxes, tables and grids. Below you see tables grouped by category of all the different kinds of documents you can create within a module.
 
 {{% alert color="info" %}}
-Mendix Modules are distinct from React Native modules. 
-
-Mendix modules are portions of your app which can include a data model, logic, and UI with a portable security model. 
-
-React Native modules expose native Java/Objective-C and C++ objects allowing for React Native apps (in Mendix apps you can leverage these modules via widgets or JavaScript actions to use device sensors or capabilities).
+Mendix Modules are distinct from React Native modules. Mendix modules are portions of your app which can include a data model, logic, and UI with a portable security model. React Native modules expose native Java/Objective-C and C++ objects allowing for React Native apps (in Mendix apps, you can leverage these modules via widgets or JavaScript actions to use device sensors or capabilities).
 {{% /alert %}}
 
 ## 2 Module Types {#module-types}
 
 {{% alert color="info" %}}
-In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
+In Studio Pro 9, add-on modules and solution modules were previously available in preview for select customers and partners as part of an early access program. In Studio Pro 10, this functionality is generally available for all users.
 {{% /alert %}}
 
 When you create a module, it has a default **app module** type. The type can be changed at any time in [Module Settings](/refguide9/module-settings/). 

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/_index.md
@@ -23,7 +23,7 @@ Mendix Modules are distinct from React Native modules. Mendix modules are portio
 ## 2 Module Types {#module-types}
 
 {{% alert color="info" %}}
-In Studio Pro 9, add-on modules and solution modules were previously available in preview for select customers and partners as part of an early access program. In Studio Pro 10, this functionality is generally available for all users.
+In Studio Pro 9, add-on modules and solution modules were previously available in preview for select customers and partners as part of an early access program. In Studio Pro 10, this functionality is generally available for all users. For more information, see this page in the [Studio Pro 10 Guide](/refguide/modules/).
 {{% /alert %}}
 
 When you create a module, it has a default **app module** type. The type can be changed at any time in [Module Settings](/refguide9/module-settings/). 

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
@@ -7,16 +7,16 @@ tags: ["studio pro", "add-on", "solution", "module", "modules"]
 ---
 
 {{% alert color="warning" %}}
-In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
+In Studio Pro 9, add-on modules and solution modules were previously available in preview for select customers and partners as part of an early access program. In Studio Pro 10, this functionality is generally available for all users. For more information, see this page in the [Studio Pro 10 Guide](/refguide/configure-add-on-and-solution-modules/).
 {{% /alert %}}
 
 ## 1 Introduction
 
-Add-on and solution modules are special types of modules that are developed to add functionality to an app. They have Intellectual Property (IP) protection enabled and have the *.mxmodule* extension. For more information on IP protection, see [IP Protection](/appstore/creating-content/sol-ip-protection/). 
+Add-on and solution modules are special types of modules that are developed to add functionality to an app. They have intellectual property (IP) protection enabled and have the *.mxmodule* extension. For more information on IP protection, see [IP Protection](/appstore/creating-content/sol-ip-protection/). 
 
-The main *difference* between an add-on and a solution module is their purpose. An add-on module is developed to be a *stand-alone functionality* that other users can consume in the their apps, for example, an add-on can be a connector. 
+The main difference between an add-on and a solution module is their purpose. An add-on module is developed to be a stand-alone functionality that other users can consume in the their apps, for example, an add-on can be a connector. 
 
-Solution modules are *always part of a solution* – any Mendix app that is suitable to be sold to multiple different customers. Solution modules are dependent on each other and are inseparable. Solutions modules form the **solution core** of the solution. 
+Solution modules are always part of a solution (any Mendix app that is suitable to be sold to multiple different customers). Solution modules are dependent on each other and are inseparable. Solutions modules form the solution core of the solution. 
 
 ## 2 Configuring Add-on and Solution Modules
 

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/configure-add-on-and-solution-modules.md
@@ -7,7 +7,7 @@ tags: ["studio pro", "add-on", "solution", "module", "modules"]
 ---
 
 {{% alert color="warning" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
+In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
 {{% /alert %}}
 
 ## 1 Introduction

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/module-settings.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/module-settings.md
@@ -7,7 +7,7 @@ tags: ["studio pro", "module settings", "module", "add-on", "solution"]
 ---
 
 {{% alert color="warning" %}}
-In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
+In Studio Pro 9, add-on modules and solution modules were previously available in preview for select customers and partners as part of an early access program. In Studio Pro 10, this functionality is generally available for all users. For more information, see this page in the [Studio Pro 10 Guide](/refguide/module-settings/).
 {{% /alert %}}
 
 ## 1 Introduction

--- a/content/en/docs/refguide9/modeling/app-explorer/modules/module-settings.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/modules/module-settings.md
@@ -7,7 +7,7 @@ tags: ["studio pro", "module settings", "module", "add-on", "solution"]
 ---
 
 {{% alert color="warning" %}}
-Access to this functionality is currently limited and can be gained through the [Mendix Component Partner Program](/appstore/creating-content/partner-program/) and the [Mendix Commercial Solution Partner Program](https://www.mendix.com/partners/become-a-partner/isv-program/).
+In Mendix 9, Add-on modules and Solution modules were previously available in preview for select customers and partners as part of an early access program. In Mendix 10, this functionality is generally available and ready for use by any customer or partner.
 {{% /alert %}}
 
 ## 1 Introduction


### PR DESCRIPTION
Mendix 9 contains an incomplete, unsupported version of protected modules, which was intentionally never released as generally available. Documentation has been clarified to point customers to Mendix 10, which contains a generally available and fully supported version of protected modules.

This has led to some unclarity with customers and this pull request intends to solve this problem.

Suggested text included in this pull request. Completeness should be verified, this PR might miss occurrences of the infobox that needs to be updated.