### PR TITLE
Exposing a resource terminology

### DIFF
--- a/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
@@ -19,7 +19,7 @@ To add an external entity to your app model, follow these steps:
 
 1. In the domain model of your app, use the Integration pane to search for the entity or data source you want to use. 
 
-    {{% alert color="info" %}}In the [Catalog](/catalog/search/), an OData service may be registered multiple times with different version numbers or deployed to different environments, all exposing the entity (dataset) that you may want to use. Search the Catalog first and find the one most relevant to the requirements for your app.{{% /alert %}}
+    {{% alert color="info" %}}In the [Catalog](/catalog/search/), an OData service may be registered multiple times with different version numbers or deployed to different environments, all publishing the entity (dataset) that you may want to use. Search the Catalog first and find the one most relevant to the requirements for your app.{{% /alert %}}
 
 2. Drag the entity into the domain model. 
 
@@ -74,13 +74,13 @@ This group displays the general properties of the external entity. These values 
 
 ### 3.2 Attributes {#attributes}
 
-The [attributes](/refguide/attributes/) that have been exposed in the OData service for the external entity are listed here. You can choose to remove attributes that the app does not need. All changes that are made to the attributes and the attribute list are applied to the local instance of the entity. As they are consumed, the changes will not affect the metadata of the consumed service that the entity is exposed in or the attributes of the entity in the originating app.
+The [attributes](/refguide/attributes/) that have been published in the OData service for the external entity are listed here. You can choose to remove attributes that the app does not need. All changes that are made to the attributes and the attribute list are applied to the local instance of the entity. As they are consumed, the changes will not affect the metadata of the consumed service that the entity is published in or the attributes of the entity in the originating app.
 
 {{% alert color="info" %}}In the Integration pane, the associations and attributes that are not supported in your Mendix model are shown as non-selectable (gray) and will not be included in the entity properties or when you drag them into the domain model. For more information, see [Integration Pane](/refguide/integration-pane/#association-attributes).{{% /alert %}}
 
 The following operations can be done on the attribute list:
 
-* **Add** – add attributes that were exposed in the OData service for the entity and were previously removed from this entity
+* **Add** – add attributes that were published in the OData service for the entity and were previously removed from this entity
 * **Edit** – edit the selected attribute from the [Edit Attribute](#edit-attribute) dialog
 * **Remove** – remove an attribute from the list
 
@@ -100,7 +100,7 @@ The **Edit Attribute** dialog can be used to specify a local name and add a loca
 
 ### 3.3 Associations {#associations}
 
-This tab displays the associations the external entity has with other entities that are exposed in the same service, and any associations that have been made with local entities. For more information on association properties in Studio Pro, see [Association Tab Properties](/refguide/association-member-properties/).
+This tab displays the associations the external entity has with other entities that are published in the same service, and any associations that have been made with local entities. For more information on association properties in Studio Pro, see [Association Tab Properties](/refguide/association-member-properties/).
 
 If the entity contains [one-way navigable associations](/refguide/association-properties/#one-way-navigable), there is a note at the top of the dialog box. 
 
@@ -184,4 +184,4 @@ External entities cannot be committed. Use the [Send External Object activity](/
 * The **Commit** activity does not work. Use **Send External Object** instead.
 * On pages, the [Save button](/refguide/button-widgets/) and the [Save Changes event](/refguide/on-click-event/#save-changes) do not work when the page contains widgets that update external entities. Call a microflow that persists the changes using **Send External Object** instead.
 
-For more details on consuming services and exposed entities, including operations that can be performed on external entities, see [Consume Registered Assets](/catalog/consume/) in the *Data Hub Guide*.
+For more details on consuming services and published entities, including operations that can be performed on external entities, see [Consume Registered Assets](/catalog/consume/) in the *Data Hub Guide*.

--- a/content/en/docs/refguide/modeling/integration/odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/_index.md
@@ -11,7 +11,7 @@ tags: ["odata services"]
 
 OData is a set of best practices for building REST APIs that standardizes many aspects of REST APIs. It describes how you should provide filtering, sorting, and pagination on your entities, as well as how you should provide nested data structures. Using OData best practices ensures that your APIs are compatible with tools like Excel and PowerBI out of the box (see [Expose Data to BI Tools Using OData](/howto/integration/exposing-data-to-bi-tools-using-odata/)), and also ensures that API clients can optimize payload size and minimize roundtrips for the best possible usage performance. 
 
-Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using them using [external entities](/refguide/external-entities/) is made easy for users deploying to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
+Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using them in [external entities](/refguide/external-entities/) is made easy for users deploying to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
 
 To publish OData services, see:
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/_index.md
@@ -9,9 +9,9 @@ tags: ["odata services"]
 
 ## 1 Introduction
 
-OData is a set of best practices for building REST APIs that standardizes many aspects of REST APIs. It describes how you should provide filtering, sorting, and pagination on your resources, as well as how you should provide nested data structures. Using OData best practices ensures that your APIs are compatible with tools like Excel and PowerBI out of the box (see [Expose Data to BI Tools Using OData](/howto/integration/exposing-data-to-bi-tools-using-odata/)), and also ensures that API clients can optimize payload size and minimize roundtrips for the best possible usage performance. 
+OData is a set of best practices for building REST APIs that standardizes many aspects of REST APIs. It describes how you should provide filtering, sorting, and pagination on your entities, as well as how you should provide nested data structures. Using OData best practices ensures that your APIs are compatible with tools like Excel and PowerBI out of the box (see [Expose Data to BI Tools Using OData](/howto/integration/exposing-data-to-bi-tools-using-odata/)), and also ensures that API clients can optimize payload size and minimize roundtrips for the best possible usage performance. 
 
-Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using OData resources in [external entities](/refguide/external-entities/) is made easy for users deploying to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
+Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using them using [external entities](/refguide/external-entities/) is made easy for users deploying to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
 
 To publish OData services, see:
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/build-odata-apis.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/build-odata-apis.md
@@ -37,7 +37,7 @@ REST APIs, and especially OData APIs, often provide access to data within the ap
 
 ## 2 Creating OData APIs {#creating-odata-apis}
 
-Create OData APIs by right clicking on an entity > **Expose as OData resource** or right clicking on a module > **Add other** > **Published OData service**. 
+Create OData APIs by right clicking on an entity > **Publish in OData service** or right clicking on a module > **Add other** > **Published OData service**. 
 
 ### 2.1 Published OData Service Document
 
@@ -45,7 +45,7 @@ In the [published OData service](/refguide/published-odata-services/) document, 
 
 {{< figure src="/attachments/refguide/modeling/integration/build-odata-apis/select-attributes-associations.png" >}} 
 
-For every published resource, you can define what functionality is available: 
+For every published entity, you can define what functionality is available: 
 
 * **Create** = `POST`
 * **Read** = `GET`
@@ -372,13 +372,13 @@ There are two ways to take an API-first approach, as explained in [API-First vs.
 
 ### 6.1 Defining a Resource Model
 
-Define a resource model using [non-persistable entities](/refguide/persistability/), expose these as OData resources, then model microflows to map these resources to the actual source data. This will require you to handle the OData query options in the microflow. Using custom Java actions can simplify this process, as explained in the [Combining Data from Two Entities](#two-entities) section below.
+Define a resource model using [non-persistable entities](/refguide/persistability/), published them in an OData service, then model microflows to map these resources to the actual source data. This will require you to handle the OData query options in the microflow. Using custom Java actions can simplify this process, as explained in the [Combining Data from Two Entities](#two-entities) section below.
 
 ### 6.2 Combining Data from Two Entities {#two-entities}
 
 Refer to the [example domain model](#starting-domain-model) for this section.
 
-In this example, you can expose a single REST resource that combines data from the **Customer** entity and the **Address** entity. It will join data from both entities and combine the **Firstname** and **Lastname** attributes into a single attribute, **Fullname**. Provide the home address information and exclude other address types:
+In this example, you can publish a single REST resource that combines data from the **Customer** entity and the **Address** entity. It will join data from both entities and combine the **Firstname** and **Lastname** attributes into a single attribute, **Fullname**. Provide the home address information and exclude other address types:
 
 {{< figure src="/attachments/refguide/modeling/integration/build-odata-apis/expose-single-resource-domain-model.png" width="300" >}} 
 
@@ -406,7 +406,7 @@ In this example, you can expose a single REST resource that combines data from t
 
      {{< figure src="/attachments/refguide/modeling/integration/build-odata-apis/get-call.png" >}} 
 
-5. You have decoupled your REST resource from your domain model persistent entities. You can change your entities and use the OQL query to ensure the exposed data remains backwards compatible.
+5. You have decoupled your REST resource from your domain model persistent entities. You can change your entities and use the OQL query to ensure the published data remains backwards compatible.
 
      The Java action used above adds the OData query to the original OQL query as follows:
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/build-odata-apis.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/build-odata-apis.md
@@ -372,7 +372,7 @@ There are two ways to take an API-first approach, as explained in [API-First vs.
 
 ### 6.1 Defining a Resource Model
 
-Define a resource model using [non-persistable entities](/refguide/persistability/), published them in an OData service, then model microflows to map these resources to the actual source data. This will require you to handle the OData query options in the microflow. Using custom Java actions can simplify this process, as explained in the [Combining Data from Two Entities](#two-entities) section below.
+Define a resource model using [non-persistable entities](/refguide/persistability/), publish them in an OData service, then model microflows to map these resources to the actual source data. This will require you to handle the OData query options in the microflow. Using custom Java actions can simplify this process, as explained in the [Combining Data from Two Entities](#two-entities) section below.
 
 ### 6.2 Combining Data from Two Entities {#two-entities}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -10,7 +10,7 @@ tags: ["studio pro"]
 
 Data can be published from an app for use by other apps through [published OData services](/refguide/published-odata-services/). Consumed OData services can be used to integrate external data sources and actions in apps through the [Integration Pane](/refguide/integration-pane/).
 
-OData services that are registered in the [Catalog](/catalog/) expose entities that can be dragged and dropped into your domain model through the [Integration Pane](/refguide/integration-pane/) as external entities. The OData service document that is added to your app provides the information for retrieving the metadata for the service and exposed entities.
+OData services that are registered in the [Catalog](/catalog/) publish entities that can be dragged and dropped into your domain model through the [Integration Pane](/refguide/integration-pane/) as external entities. The OData service document that is added to your app provides the information for retrieving the metadata for the service and published entities.
 
 For further details on the consumed OData service document and updating consumed OData services in your app, see [Consumed OData Service](/refguide/consumed-odata-service/).
 
@@ -33,13 +33,13 @@ External entities have some limitations compared to persistable entities:
 * External entities cannot be used in datasets
 * [XPath constraints](/refguide/xpath-constraints/) in the access rules of external entities cannot be set
 
-Associations between external entities (as defined in the originating app) are shown in the domain model. You can only use the associations where both sides are exposed.
+Associations between external entities (as defined in the originating app) are shown in the domain model. You can only use the associations where both sides are published.
 
 You can create associations between local [persistable entities](/refguide/persistability/#persistable) and external entities. For those associations, the persistable entities need to be the owner.
 
 ### 2.2 External Actions {#external-actions}
 
-External actions allow you to execute actions exposed by the OData service. An action can take parameters and may return a value. This is defined in the OData service contract.
+External actions allow you to execute actions published by the OData service. An action can take parameters and may return a value. This is defined in the OData service contract.
 
 There are some limitations on which actions can be consumed. These are described in the [Requirements on Actions](/refguide/consumed-odata-service-requirements/#actions) section of *Consumed OData Service Requirements*.
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
@@ -84,10 +84,10 @@ The consumed OData service does not support importing generalizations and specia
 
 This means that when you are consuming a Mendix OData endpoint, it is not necessary to consume both a generalization and its specialization. The specialization will now be an entity with all the attributes and associations of the generalization.
 
-Associations to the generalizations with other exposed entities in the published OData service will be included for the now discrete "specialized" entities.
+Associations to the generalizations with other published entities in the published OData service will be included for the now discrete "specialized" entities.
 
 {{% alert color="warning" %}}
-When a generalization and a specialized entity are exposed in the same service. Only the association for the generalization will be visible when both entities are consumed. The now discrete specialization will have the inherited association. A possible work-around for this is to publish a service with the specializations without the generalization. Alternatively, the association for the generalization should not be published, allowing for the inherited association in the specialization to be preserved.
+When a generalization and a specialized entity are published in the same service. Only the association for the generalization will be visible when both entities are consumed. The now discrete specialization will have the inherited association. A possible work-around for this is to publish a service with the specializations without the generalization. Alternatively, the association for the generalization should not be published, allowing for the inherited association in the specialization to be preserved.
 {{% /alert %}}
 
 ### 3.4 Binary Attributes {#binary-attributes}
@@ -102,7 +102,7 @@ An OData v3 association can only be used if it has two ends.
 
 An OData v4 navigation property can only be used as an association if it has a partner.
 
-When you publish a self-referencing association, you can only publish one side of it. This means that you cannot use the association when you consume the resource as an external entity.
+When you publish a self-referencing association, you can only publish one side of it. This means that you cannot use the association when you consume it as an external entity.
 
 ### 3.6 Enumerations
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -8,7 +8,7 @@ tags: ["studio pro","OData","publish"]
 
 ## 1 Introduction
 
-In Studio Pro, entities can be exposed as [OData resources](/refguide/published-odata-resource/) by adding them to a published OData service. You can expose any number of related resources in a published OData service. By default, the plural of the non-qualified names of entities are used in the URI to uniquely identify them, but you can override the name of the resource as well. 
+In Studio Pro, [entities can be published](/refguide/published-odata-entity/) by adding them to a published OData service. You can publish any number of related entities in a published OData service. By default, the plural of the non-qualified names of entities are used in the URI to uniquely identify them, but you can override the name of the published entity as well. 
 
 A published OData service is a REST service with an OpenAPI contract, which means that OpenAPI compatible REST clients can easily interact with it. 
 
@@ -55,7 +55,7 @@ In OData, the namespace is used to refer to data types. You can customize this n
 
 ### 2.5 Entities
 
-This list gives an overview of all entities published as [OData resources](/refguide/published-odata-resource/).
+This list gives an overview of all [published entities](/refguide/published-odata-entity/).
 
 #### 2.5.1 Entity Details
 
@@ -117,9 +117,9 @@ You can configure security for the OData service when [App Security](/refguide/a
 
 #### 3.3.1 Requires Authentication {#authentication}
 
-Select whether clients need to authenticate or not. Select **No** to allow access to the resources without restrictions. Select **Yes** to be able to select which authentication methods to support.
+Select whether clients need to authenticate or not. Select **No** to allow access to the service without restrictions. Select **Yes** to be able to select which authentication methods to support.
 
-Even when you choose **Yes**, you can still expose OData resources to anonymous users. For detailed information on allowing anonymous users, see [Anonymous User Role](/refguide/anonymous-users/).
+Even when you choose **Yes**, you can still expose the service to anonymous users. For detailed information on allowing anonymous users, see [Anonymous User Role](/refguide/anonymous-users/).
 
 {{% alert color="info" %}}
 The **Authentication** section of a published OData service is only visible when you have enabled [app security](/refguide/app-security/).
@@ -131,7 +131,7 @@ If authentication is required, you can select which authentication methods you w
 
 * Select **Username and password** to allow clients to authenticate themselves using a username and a password in the **Authorization** header (this is called "basic authentication")
 * Select **Active session** to allow access from JavaScript inside your current application
-* Select **Custom** to authenticate using a microflow (this microflow is called every time a user wants to access a resource)
+* Select **Custom** to authenticate using a microflow (this microflow is called every time a user wants to access a published entity)
 
 Check more than one authentication method to have the service try each of them. It will first try **Custom** authentication, then **Username and password**, and then **Active session**.
 
@@ -153,7 +153,7 @@ To prevent cross-site request forgery, the `X-Csrf-Token` header needs to be set
 
 ```js
 var xmlHttp = new XMLHttpRequest();
-xmlHttp.open("GET", "http://mysite/odata/myservice/myresource", false);
+xmlHttp.open("GET", "http://mysite/odata/myservice/myentity", false);
 xmlHttp.setRequestHeader("X-Csrf-Token", mx.session.getConfig("csrftoken"));
 xmlHttp.send(null);
 ```
@@ -225,14 +225,14 @@ Default value: *No*
 Once your app is published, a list of the published OData services will be available on the root URL of the app followed by `/odata-doc/`. For example, `http://localhost:8080/odata-doc/`. For each OData 4 service, there is a link to a Swagger UI page that shows an interactive documentation page on which users can interact with the service.
 
 {{% alert color="warning" %}}
-While the API documentation for OData resources is enabled by default, access to it may be restricted by the administrator for apps running in production.
+While the API documentation for published OData services is enabled by default, access to it may be restricted by the administrator for apps running in production.
 {{% /alert %}}
 
 For details on how to filter the OData response, refer to [OData Query Options](/refguide/odata-query-options/).
 
 For details on how Mendix attributes are represented in OData, refer to [OData Representation](/refguide/odata-representation/).
 
-When exposing entities through OData, the entities are retrieved from the Mendix database in a streaming fashion, to avoid out-of-memory errors in the Mendix Runtime.
+When publishing entities through OData, the entities are retrieved from the Mendix database in a streaming fashion, to avoid out-of-memory errors in the Mendix Runtime.
 
 ### 6.2 On-Premises Deployments
 
@@ -250,7 +250,7 @@ The Mendix runtime returns status codes for OData payloads. The possible status 
 
 ## 8 Publishing OData Services
 
-To publish an OData resource with full CRUD (Create, Read, Update, or Delete functionality, or in Studio Pro, **Insertable**, **Readable**, **Updateable**, and **Deletable**), select the relevant checkboxes in the [Capabilities](/refguide/published-odata-resource/#capabilities) section in the [Published OData Resource](/refguide/published-odata-resource/). You can then [Send](/refguide/send-external-object/) and [Delete](/refguide/delete-external-object/) these resources using [External Object activities](/refguide/external-object-activities/). 
+To publish an entity with full CRUD (Create, Read, Update, or Delete functionality, or in Studio Pro, **Insertable**, **Readable**, **Updateable**, and **Deletable**), select the relevant checkboxes in the [Capabilities](/refguide/published-odata-entity/#capabilities) section in [Published OData Entity](/refguide/published-odata-entity/). You can then [Send](/refguide/send-external-object/) and [Delete](/refguide/delete-external-object/) objects using [External Object activities](/refguide/external-object-activities/). 
 
 ## 9 Limitations
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -165,7 +165,7 @@ The request body must adhere to URL encoding principles; that means that everyth
 
 ### 10.1 Updating Attributes
 
-When a published resource has the [Updatable](/refguide/published-odata-resource/#updatable) capability, you can update the resource's attributes and associations by sending a `PATCH` request to the URL of the object. Here is an example: `PATCH /odata/myservice/v1/Employees(8444249301330581)`.
+When a published entity has the [Updatable](/refguide/published-odata-entity/#updatable) capability, you can update attributes and associations by sending a `PATCH` request to the URL of the object. Here is an example: `PATCH /odata/myservice/v1/Employees(8444249301330581)`.
 
 Specify new values for attributes in the body of the request. Here is an example:
 
@@ -228,7 +228,7 @@ You can update an association only from the entity that is the [owner](/refguide
 
 ## 11 Inserting Objects {#inserting-objects}
 
-When a published resource has the [Insertable](/refguide/published-odata-resource/#capabilities) capability, you can create new objects by sending a `POST` request to the URL of the entity set. Here is an example: `POST /odata/myservice/v1/Employees`.
+When a published entity has the [Insertable](/refguide/published-odata-entity/#capabilities) capability, you can create new objects by sending a `POST` request to the URL of the entity set. Here is an example: `POST /odata/myservice/v1/Employees`.
 
 The body of the request may specify attribute and association values, just as with updates. However, unlike with updates, the `@delta` syntax is not used to specify objects, even when the association refers to multiple objects. Here is an example:
 
@@ -245,7 +245,7 @@ You can set values for an association only from the entity that is the [owner](/
 
 ## 12 Deleting Objects {#deleting-objects}
 
-When a published resource has the [Deletable](/refguide/published-odata-resource/#deletable) capability, you can delete an object by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Employees(8444249301330581)`).
+When a published entity has the [Deletable](/refguide/published-odata-entity/#deletable) capability, you can delete an object by sending a `DELETE` request to the URL of the object (for example, `PATCH /odata/myservice/v1/Employees(8444249301330581)`).
 
 ## 13 Calling Microflows {#actions}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-representation.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-representation.md
@@ -29,7 +29,7 @@ This document describes how entities are represented in a published OData servic
 <sup>3</sup> When the string attribute has a limited length, the `MaxLength` attribute is specified. </small>
 <sup>4</sup> In Studio Pro 9.23 and below, all enumeration attributes were published as strings.
 
-Additionally, the `updated` field for an entry in OData comes from the system changedDate attribute of an entity. If this attribute is not available (because it is not exposed, the user does not have access rights, or it is empty in database), the default date (1-1-1970) will be used.
+Additionally, the `updated` field for an entry in OData comes from the system changedDate attribute of an entity. If this attribute is not available (because it is not published, the user does not have access rights, or it is empty in database), the default date (1-1-1970) will be used.
 
 ### 2.1 Representation of ID {#id-representation}
 
@@ -47,10 +47,10 @@ In the settings of the OData service, you can choose how associations are repres
 
 When you choose to represent associations as links, each object contains a link for each of its associations. The associated object(s) can be retrieved via those links.
 
-This means that you can only expose an association when the entity on the other side is a resource of this service as well. This also means that you cannot publish the same entity more than once in the same service (because in that case, it would not be clear where the link should point to).
+This means that you can only publish an association when the entity on the other side is published in this service as well. This also means that you cannot publish the same entity more than once in the same service (because in that case, it would not be clear where the link should point to).
 
-Using this method, you can expose both sides of the association and you can expose many-to-many associations.
+Using this method, you can publish both sides of the association and you can publish many-to-many associations.
 
 ### 3.2 As an Associated Object ID
 
-When you choose to represent assocations as an associated object ID, the ID of the associated object is represented as an `Edm.Int64` property. If the association refers to more than one object, you can not expose it from that side.
+When you choose to represent assocations as an associated object ID, the ID of the associated object is represented as an `Edm.Int64` property. If the association refers to more than one object, you can not publish it from that side.

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -2,6 +2,8 @@
 title: "Published OData Entity"
 url: /refguide/published-odata-entity/
 tags: ["studio pro", "OData"]
+alias:
+    - /refguide/published-odata-services/
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 
 ---

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -1,6 +1,6 @@
 ---
-title: "Published OData Resource"
-url: /refguide/published-odata-resource/
+title: "Published OData Entity"
+url: /refguide/published-odata-entity/
 tags: ["studio pro", "OData"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 
@@ -8,29 +8,29 @@ tags: ["studio pro", "OData"]
 
 ## 1 Introduction
 
-This document describes the properties of a published OData resource. 
+This document describes the properties of an entity published in an OData service. 
 
 For an overview of OData services, see [Published OData Services](/refguide/published-odata-services/).
 
-## 2 Adding or Editing a Resource
+## 2 Adding or Editing an Entity
 
-### 2.1 Add a Resource
+### 2.1 Add an Entity
 
-Click **Add** in the **Resources** pane of the **Published OData Service** window to open the **Select Entity** window. Select an entity to publish and click **Select**.
+Click **Add** in the **Entities** pane of the **Published OData Service** window to open the **Select Entity** window. Select an entity to publish and click **Select**.
 
-An alternative way to add a resource is by right-clicking an entity in the **Domain Model** and choosing **Expose as OData resource**. You will be asked to select a published OData service, or create a new one. 
+An alternative way to add an entity is by right-clicking an entity in the **Domain Model** and choosing **Publish in OData service**. You will be asked to select a published OData service, or create a new one. 
 
-### 2.2 Edit a Resource
+### 2.2 Edit a Published Entity
 
-In the **Entities** pane of the **Published OData Service** window, select a resource and click **Edit** to display the **Edit published resource** window. 
+In the **Entities** pane of the **Published OData Service** window, select an entity and click **Edit** to display the **Edit published entity** window. 
 
 It is possible to select another **Entity** or view the entity in the domain model by clicking **Show**.
 
-You can see the location where the resource will be published in **Example of location**.
+You can see the location where the entity is published in **Example of location**.
 
-In the **Public documentation** tab, you can provide a summary and a description of the exposed entity.
+In the **Public documentation** tab, you can provide a summary and a description of the published entity.
 
-## 3 Selecting Exposed Attributes and Associations {#exatass}
+## 3 Selecting Published Attributes and Associations {#exatass}
 
 When you have selected an entity in the list to the left, its published attributes and associations are shown in the list to the right. In this list, you can add, edit, delete and move these attributes and associations.
 
@@ -50,11 +50,11 @@ When the checkbox Can be empty is unselected, and there is no **Required** valid
 
 ## 4 Mapping from Internal Names to Exposed Names
 
-Use **Exposed entity name** in the **Edit published resource** window to customize the name of the resource that is exposed to the outside world. The default is the name of the exposed entity in the domain model. The **Exposed entity name** must start with a letter followed by letters or digits with a maximum length of 480 characters. 
+Use **Exposed entity name** in the **Edit published entity** window to customize the name of the entity that is exposed to the outside world. The default is the name of the published entity in the domain model. The **Exposed entity name** must start with a letter followed by letters or digits with a maximum length of 480 characters. 
 
 {{% alert color="info" %}}
 
-Location URIs must be unique. Exposing two different resources at the same location will result in a [consistency error](/refguide/consistency-errors/).
+Location URIs must be unique. Publishing two different entities at the same location will result in a [consistency error](/refguide/consistency-errors/).
 
 {{% /alert %}}
 
@@ -72,7 +72,7 @@ These features make it easier to refactor the domain model without affecting ext
 
 ## 5 Exposed Set Name
 
-It is possible to customize the name of the entity set that is displayed in the **Exposed set name** field of the **Edit published resource** window. This forms the last part of the URL of the resource as given in the **Example of location**.
+It is possible to customize the name of the entity set that is displayed in the **Exposed set name** field of the **Edit published entity** window. This forms the last part of the URL of the published entity as given in the **Example of location**.
 
 Default: *{Entity name}s*
 
@@ -94,7 +94,7 @@ Default: *10000*
 
 ## 8 Key {#key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that a published OData resource should not use the ID as a key, and needs to have a combination of attributes that form a key instead. The attribute(s) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
+Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that it is not recommended to use the ID as a key. A published entity should have a combination of attributes that form a key instead. The attribute(s) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
 Select a combination of attributes with the following constraints:
 
@@ -112,7 +112,7 @@ Selecting more than one attribute as the key is only available for published ODa
 
 ## 9 Capabilities {#capabilities}
 
-The **Capabilities** section gives an overview of what operations the resource supports.
+The **Capabilities** section gives an overview of what operations the published entity supports.
 
 ### 9.1 Insertable
 
@@ -133,9 +133,9 @@ In the publishing app, you can use a validation message action to report a valid
 
 ### 9.2 Readable {#readable}
 
-A published OData resource is always readable.
+A published OData entity is always readable.
 
-There are two options to handle an incoming GET request for an OData resource:
+There are two options to handle an incoming GET request for a published entity:
 
 1. **Read from database** – This action will parse the incoming OData query to a database query and retrieve the data from the database. This is the default action for *Readable* section. This action is not applicable to non-persistable entities, because non-persistable entities cannot be retrieved from the database.
 2. **Call a microflow** – This action will call a microflow. You can specify your custom logic in this microflow to return a list of objects that correspond to the incoming request. See the [Handle a GET Request with a Microflow](/refguide/wrap-services-odata/#handle-get-request) in *Wrap Services, APIs, or Databases with OData*.

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-microflow.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-microflow.md
@@ -9,7 +9,7 @@ aliases:
 
 ## 1 Introduction
 
-As of Mendix 10.2.0, Studio Pro allows you to publish microflows as part of an OData service. A published microflow will be exposed as an [external action](/refguide/call-external-action/) which can be called by an application consuming this service. This allows you to model and expose operations that are more complex than straightforward create, read, update, and delete operations on a single entity.
+As of Mendix 10.2.0, Studio Pro allows you to publish microflows as part of an OData service. A published microflow becomes an [external action](/refguide/call-external-action/) which can be called by an application consuming this service. This allows you to model and publish operations that are more complex than straightforward create, read, update, and delete operations on a single entity.
 
 ## 2 Adding or Editing a Published Microflow
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
@@ -14,9 +14,9 @@ You can also use these features to more easily [build connectors](/appstore/crea
 
 In this guide, you will learn about the following:
 
-* Exposing non-persistable entities as published OData resources 
-* Using a microflow to define how resources should be retrieved and stored, and to return values of published OData services
-* Selecting a key when exposing entities as OData resources
+* Exposing non-persistable entities as published OData entities 
+* Using a microflow to define how entities should be retrieved and stored, and to return values of published OData services
+* Selecting a key when publishing entities in an OData service
 
 ### 1.1 Prerequisites
 
@@ -30,30 +30,30 @@ Before you read this guide, do the following:
 
 ### 2.1 Best Practices and Performance
 
-OData is a set of best practices for building REST APIs that standardizes many aspects of REST APIs. It describes how you should provide filtering, sorting, and pagination on your resources, as well as how you should provide nested data structures. Using OData best practices ensures that your APIs are compatible with tools like Excel and PowerBI out of the box (see [Expose Data to BI Tools Using OData](/howto/integration/exposing-data-to-bi-tools-using-odata/)), and also ensures that API clients can optimize payload size and minimize roundtrips for the best possible usage performance. 
+OData is a set of best practices for building REST APIs that standardizes many aspects of REST APIs. It describes how you should provide filtering, sorting, and pagination on your published entities, as well as how you should provide nested data structures. Using OData best practices ensures that your APIs are compatible with tools like Excel and PowerBI out of the box (see [Expose Data to BI Tools Using OData](/howto/integration/exposing-data-to-bi-tools-using-odata/)), and also ensures that API clients can optimize payload size and minimize roundtrips for the best possible usage performance. 
 
 ### 2.2 Compatibility with the Catalog
 
-Wrapping a service, API, or database in OData ensures compatibility with the [Catalog](/catalog/). Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using OData resources in [external entities](/refguide/external-entities/) is made easy if you are using [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
+Wrapping a service, API, or database in OData ensures compatibility with the [Catalog](/catalog/). Published OData services are registered automatically in the [Catalog](/catalog/), making them easily usable in other Mendix apps. Discovering and using published entities in [external entities](/refguide/external-entities/) is made easy if you are using [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/), as [published OData Services](/refguide/published-odata-services/) are registered automatically in the [Catalog](/catalog/) and made available in the Studio Pro [Integration Pane](/refguide/integration-pane/).
   
-## 3 Non-Persistable Entities as Published OData Resources {#npe-published-odata}
+## 3 Publish Non-Persistable Entities in OData {#npe-published-odata}
 
-When building a connector or integration, you might only need to move data from back-end services to the client apps instead of storing the data in the database. To support this, you can expose [non-persistable entities](/refguide/entities/#non-persistable-entity) as [published OData resources](/refguide/published-odata-resource/). Previously, only persistable entities could be exposed as published OData resources.
+When building a connector or integration, you might only need to move data from back-end services to the client apps instead of storing the data in the database. To support this, you can expose [non-persistable entities](/refguide/entities/#non-persistable-entity) as [published OData entities](/refguide/published-odata-entity/). Previously, only persistable entities could published in OData services.
 
-### 3.1 Publishing a Non-Persistable Entity as a Published OData Resource
+### 3.1 Publishing a Non-Persistable Entity in an OData Service
 
-To expose a non-persistable entity as a published OData resource, do the following: 
+To expose a non-persistable entity in an OData service, do the following: 
 
 1. Right-click on the non-persistable entity you want to expose.
-2. Select **Expose as OData resource**.
+2. Select **Publish in OData service**.
 
-Publishing a non-persistable entity as a published OData resource is supported for all OData service versions.
+Publishing a non-persistable entity in an OData service is supported for all OData service versions.
 
-## 4 Data Sources for Published OData Resources {#odata-data-sources}
+## 4 Data Sources for Published OData Entities {#odata-data-sources}
 
-In Studio Pro, you can expose entities as OData resources by adding them to a published OData service. You can expose any number of related resources in a published OData service by using a microflow that determines the result of the incoming request. This is now possible for the [Readable](/refguide/published-odata-resource/#readable) capability of your service you can define how your resources should be retrieved and stored.
+In Studio Pro, you can publish entities in OData services. You can expose any number of related entities in a published OData service by using a microflow that determines the result of the incoming request. This is now possible for the [Readable](/refguide/published-odata-entity/#readable) capability of your service you can define how your entities should be retrieved and stored.
 
-When a consuming app reads your published OData service, it sends a GET request. You can handle an incoming GET request for an OData resource in the following ways:
+When a consuming app reads your published OData service, it sends a GET request. You can handle an incoming GET request for an published entity in the following ways:
 
 1. **Read from database** – This action passes the incoming OData query to a database query and retrieve the data from the database. This is the default action for *Readable* section. This action does not apply to non-persistable entities, because non-persistable entities cannot be retrieved from the database. For those, call a microflow.
 2. **Call a microflow** – This action calls a microflow defined in the *Readable* section. Specify your custom logic in this microflow to return a list of objects that correspond to the incoming request. See [Handle a GET Request with a Microflow](#handle-get-request).
@@ -66,7 +66,7 @@ The resulting list of objects from either will then be transformed into an OData
 This feature is only available for published OData services that use OData v4.
 {{% /alert %}}
 
-Inside a published OData service, you can expose entities as published resources and select how GET requests are handled. Do the following:
+Inside a published OData service, you can publish entities and select how GET requests are handled. Do the following:
 
 1. Open the published service, and in the **Entities** field, click **Add**.
 2. Choose an entity to add to to the published service and click **OK**.
@@ -116,17 +116,17 @@ When you use a microflow to provide data, any security constraints are applied t
 
         If the **ODataResponse** is present as a microflow parameter, then it will return the **Count** attribute value regardless of the result list of objects. Otherwise, it will return -1 for not defined, which is the default value. A **Count** value of 0 means that there no record.
 
-## 5 Key Selection When Exposing Entities as OData Resources {#select-key}
+## 5 Key Selection for Published Entities{#select-key}
 
-Select which attribute(s) to use as a [key](/refguide/published-odata-resource/#key) when exposing an entity as Published OData Resource so that clients will be able to identify objects returned by the service.
+Select which attribute(s) to use as a [key](/refguide/published-odata-entity/#key) when publishing an entity so that clients will be able to identify objects returned by the service.
 
-To learn more about selecting a key, see the [Key](/refguide/published-odata-resource/#key) section of *Published OData Resource*.
+To learn more about selecting a key, see the [Key](/refguide/published-odata-entity/#key) section of *Published OData Entity*.
 
 ### 5.1 Selecting Attributes as a Key {#select-key}
 
 To select different attributes as a key, do the following:
 
-1. Open the **Published OData Resource**. 
+1. Edit the published **Entity**. 
 2. In the **Key** section, click **Edit** located next to the **Key** property.
 3. In the **Key Selection** dialog box, move the key attributes to the right side. 
 
@@ -169,13 +169,13 @@ Set up a connector module that communicates to the Twitter API with OData by fol
 1. Use the Twitter API to find the JSON structures for the calls for users, tweets, and followers, and add the [JSON structure](/refguide/json-structures/) for each.
 2. Create [import mappings](/refguide/mapping-documents/#import-mappings) for each, which generates entities in your domain model.
     {{< figure src="/attachments/refguide/modeling/integration/wrap-services-odata/twitter-connector-domain-model.png" alt="Domain model for Twitter connector module." >}}
-3. Publish all three non-persistable entities as a published OData service (see [Non-Persistable Entities as Published OData Resources](#npe-published-odata)).
+3. Publish all three non-persistable entities as a published OData service (see [Publish Non-Persistable Entities in OData](#npe-published-odata)).
 4. Select a new [key](#select-key) to be used for each entity. For example, you can set the **UserId**, a **String** value, as a key for the **User** entity.
-5. For every exposed entity, specify the microflow that handles the count and query capabilities (for example, a QueryFollowers microflow). See [Data Sources for Published OData Resources](#odata-data-sources).
+5. For every exposed entity, specify the microflow that handles the count and query capabilities (for example, a QueryFollowers microflow). See [Data Sources for Published OData Entities](#odata-data-sources).
     {{< figure src="/attachments/refguide/modeling/integration/wrap-services-odata/query-followers-microflow.png" alt="Microflow for querying followers." >}}
 6. Export the metadata file of the published OData service to be used in the client module. To do so, open the service and go to **Settings**, and click **Export** next to the **Metadata** field.
 
-    Since you are working in local development environment and not deploying locally, your published resource will not automatically be available in the Catalog or the Integration Pane. See [Register Data Sources without the Mendix Cloud](/catalog/data-sources-without-mendix-cloud/) to understand how to work with external entities and the Catalog for local deployments.
+    Since you are working in local development environment and not deploying locally, your published entity will not automatically be available in the Catalog or the Integration Pane. See [Register Data Sources without the Mendix Cloud](/catalog/data-sources-without-mendix-cloud/) to understand how to work with external entities and the Catalog for local deployments.
 
 #### 7.1.3 Building the Client
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/wrap-services-odata.md
@@ -53,7 +53,7 @@ Publishing a non-persistable entity in an OData service is supported for all ODa
 
 In Studio Pro, you can publish entities in OData services. You can expose any number of related entities in a published OData service by using a microflow that determines the result of the incoming request. This is now possible for the [Readable](/refguide/published-odata-entity/#readable) capability of your service you can define how your entities should be retrieved and stored.
 
-When a consuming app reads your published OData service, it sends a GET request. You can handle an incoming GET request for an published entity in the following ways:
+When a consuming app reads your published OData service, it sends a GET request. You can handle an incoming GET request for a published entity in the following ways:
 
 1. **Read from database** – This action passes the incoming OData query to a database query and retrieve the data from the database. This is the default action for *Readable* section. This action does not apply to non-persistable entities, because non-persistable entities cannot be retrieved from the database. For those, call a microflow.
 2. **Call a microflow** – This action calls a microflow defined in the *Readable* section. Specify your custom logic in this microflow to return a list of objects that correspond to the incoming request. See [Handle a GET Request with a Microflow](#handle-get-request).

--- a/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
@@ -12,14 +12,14 @@ aliases:
 
 Use the Integration Pane in Studio Pro to use available data sources from the different applications in an organization into your Mendix apps. New apps can be created using shared datasets that are registered in the [Catalog](/catalog/). In Studio Pro, this is possible using the integrated functionality of Catalog through the [Integration Pane](/refguide/integration-pane/).
 
-You can search in the Catalog through the [Integration Pane](/refguide/integration-pane/) to discover data sources that you can use in your app. Via this pane you can add the entities that are exposed in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
+You can search in the Catalog through the [Integration Pane](/refguide/integration-pane/) to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
 
 Besides external entities, OData services can expose actions that can be called from within microflows. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable.
 
 To display the [Integration Pane](/refguide/integration-pane/), click **View** > **Integration**.
 
 {{% alert color="info" %}}
-In the Catalog, registered published services are referred to as *data sources*. Exposed entities will show the **Entity set** name and are called *datasets.*
+In the Catalog, registered published services are referred to as *data sources*. Published entities will show the **Entity set** name and are called *datasets.*
 {{% /alert %}}
 
 ## 2 Integration Pane Overview

--- a/content/en/docs/refguide/modeling/mx-assist-studio-pro/mx-assist-performance-bot/performance-best-practices.md
+++ b/content/en/docs/refguide/modeling/mx-assist-studio-pro/mx-assist-performance-bot/performance-best-practices.md
@@ -243,16 +243,16 @@ By "specific" we mean how many association steps are involved. For example, an X
 
 Rearrange the parts of the XPath, so that the cheapest and most-specific parts are to the left of each `and`. Similarly, if using separate predicates like `[part 1][part 2]`, you can rearrange the predicates to have optimal ordering.
 
-### 2.14 Entity Exposed as OData with Key That Uses Non-indexed Attribute [MXP016] {#mxp016}
+### 2.14 Entity Published in OData with Key That Uses Non-indexed Attribute [MXP016] {#mxp016}
 
-Entities can be exposed as OData services. Depending on how many records the underlying entities contain, loading the data from the database can take time. For read-intensive entities that are exposed with a single key, it makes sense to add an index on the attribute used as a key. For larger volumes of data, this can significantly improve performance of object retrieval from the database.
+Entities can be published as OData services. Depending on how many records the underlying entities contain, loading the data from the database can take time. For read-intensive entities that are published with a single key, it makes sense to add an index on the attribute used as a key. For larger volumes of data, this can significantly improve performance of object retrieval from the database.
 
 #### 2.14.1 Steps to Fix
 
 To fix the issue, do the following:
 
 1. Check if the underlying entity contains a substantial amount of records before adding an index (at least 10000 records).
-2. Add an index on the attribute that is used as a key for the exposed entity.
+2. Add an index on the attribute that is used as a key for the published entity.
 
 {{% alert color="info" %}}
 This optimization may not be very beneficial for data types like Boolean and enumerations due to a limited number of possible values of these types. It is not recommended to add indexes for such types.


### PR DESCRIPTION
Studio Pro 10.5.0 clarifies the terminology for publishing an entity in a published OData service.

This used to be "Exposing a resource", now it's "Publishing an entity". The former is not wrong, but outside-in, where we prefer inside-out when modeling. There are some exceptions:

* When comparing OData to REST it is clearer to keep referring to published entities as resources
* Attributes still have "exposed names" (not "published names")

Note that this involves a rename of a page that is references by Studio Pro, so it needs a redirect.