### PR TITLE
[Mx4PC] - new release for the Data Transfer tool, planned for release on November 17

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -177,7 +177,7 @@ If you need to export or import data from an environment that uses AWS IRSA auth
    
     {{% alert color="info" %}}Use the environment internal name as the service account name.{{% /alert %}}
    
-2. In the IAM role, add an inline policy with the following JSON:
+2. In the IAM role, add an inline policy with the following JSON, where `<aws_region>` is the database's region, `<account_id>` is your AWS account number, `<database_id>` is the RDS database instance identifier, and `<bucket_name>` is the S3 bucket name:
 
     ```json
     {
@@ -209,11 +209,8 @@ If you need to export or import data from an environment that uses AWS IRSA auth
         ]
     }
     ```
-
-    (replace `<aws_region>` with the database’s region, `<account_id>` with your AWS account number, `<database_id>` with the RDS database instance identifier, `<bucket_name>` with the S3 bucket name).
-
-    {{% alert color="info" %}}The `<database_id>` parameter is not the database name (or ARN), but the uniquely generated AWS resource ID.
-    For more information and instructions how to write this policy, see the [IAM policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) document.{{% /alert %}}
+    
+    {{% alert color="info" %}}The `<database_id>` parameter is not the database name (or ARN), but the uniquely generated AWS resource ID. For more information and instructions how to write this policy, see the [IAM policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) document.{{% /alert %}}
 
 3. Allow a Kubernetes ServiceAccount (for example, `mendix-backup-restore`) to assume a role.
 

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -174,7 +174,9 @@ spec:
 If you need to export or import data from an environment that uses AWS IRSA authentication, you also need to do the following:
 
 1. Create an **IAM Role** without any attached policies for that environment in the AWS console.
+   
     {{% alert color="info" %}}Use the environment internal name as the service account name.{{% /alert %}}
+   
 2. In the IAM role, add an inline policy with the following JSON:
 
     ```json
@@ -228,7 +230,7 @@ If you need to export or import data from an environment that uses AWS IRSA auth
 
         After this, the specified serviceaccount in the specified namespace will be able to assume this role.
 
-3. Add the `eks.amazonaws.com/role-arn` annotation to the `mendix-backup-restore` ServiceAccount and set it to the role ARN value from the previous step.
+4. Add the `eks.amazonaws.com/role-arn` annotation to the `mendix-backup-restore` ServiceAccount and set it to the role ARN value from the previous step.
 
 This configuration creates a pod which includes `pgtools` (PostgreSQL tools such as `pg_dump` and `pg_restore`), and a Service Account that can get the database credentials from an environment.
 If your database is using another PostgreSQL version (for example, PostgreSQL 13), change the `image: docker.io/bitnami/postgresql:12` to match the target PostgreSQL version (for example, `docker.io/bitnami/postgresql:13`).

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -271,6 +271,11 @@ kubectl -n $NAMESPACE delete -f /tmp/mendix-backup-restore.yaml
 rm /tmp/mendix-backup-restore.yaml
 ```
 
+{{% alert color="warning" %}}
+The `kubectl cp` command can sometimes fail to copy files with a `.tar.gz` extension.
+In that case, changing the file extension can fix the issue, for example by changing the file extension from `.tar.gz` to `.tar.gz.backup`.
+{{% /alert %}}
+
 ## 3 Known Limitations
 
 * It is not possible to export/import only the database or only files. The import/export process will always export or import the database together with any files.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -294,6 +294,6 @@ In that case, changing the file extension can fix the issue, for example by chan
 * The export/import tool needs access to the Kubernetes API to get credentials for a specific environment.
 * If `pg_restore` fails for any reason, the data import process is terminated immediately with an error.
 * It is not possible to enforce TLS options.
-    * If _Strict TLS_ was disabled in the Postgres storage plan, the tool will try to use SSL, but will trust any server certificate. If the database doesn't support SSL, the tool will switch to an unencrypted connection.
-    * If the Postgres storage has the _Strict TLS_ option enabled, the tool will use SSL and validate the server certificate. If the certificate is not valid, or database doesn't support SSL, the connection will fail.
+    * If _Strict TLS_ was disabled in the Postgres storage plan, the tool will try to use SSL, but will trust any server certificate. If the database does not support SSL, the tool will switch to an unencrypted connection.
+    * If the Postgres storage has the _Strict TLS_ option enabled, the tool will use SSL and validate the server certificate. If the certificate is not valid, or database does not support SSL, the connection will fail.
     * For Minio and S3, TLS will be used if the environment's storage plan has an `https://` endpoint URL.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -220,13 +220,9 @@ If you need to export or import data from an environment that uses AWS IRSA auth
 
     2. For the second condition, copy and paste the `sts.amazonaws.com` line; replace `:aud` with `:sub` and set it to `system:serviceaccount:<Kubernetes namespace>:<Kubernetes serviceaccount name>`.
 
-        See [Amazon EKS Pod Identity Webhook – EKS Walkthrough](https://github.com/aws/amazon-eks-pod-identity-webhook#eks-walkthrough) for more details.
+        See [Amazon EKS Pod Identity Webhook – EKS Walkthrough](https://github.com/aws/amazon-eks-pod-identity-webhook#eks-walkthrough) for more details. The role ARN is required. You can use the **Copy** button next to the ARN name in the role details. After this, the specified service account in the specified namespace will be able to assume this role.
 
-        The role ARN is required, you can use the **Copy** button next to the ARN name in the role details.
-
-        After this, the specified serviceaccount in the specified namespace will be able to assume this role.
-
-4. Add the `eks.amazonaws.com/role-arn` annotation to the `mendix-backup-restore` ServiceAccount and set it to the role ARN value from the previous step.
+4. Add the `eks.amazonaws.com/role-arn` annotation to the `mendix-backup-restore` service account and set it to the role ARN value from the previous step.
 
 This configuration creates a pod which includes `pgtools` (PostgreSQL tools such as `pg_dump` and `pg_restore`), and a Service Account that can get the database credentials from an environment.
 If your database is using another PostgreSQL version (for example, PostgreSQL 13), change the `image: docker.io/bitnami/postgresql:12` to match the target PostgreSQL version (for example, `docker.io/bitnami/postgresql:13`).

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-data-transfer.md
@@ -208,7 +208,6 @@ If you need to export or import data from an environment that uses AWS IRSA auth
             }
         ]
     }
-
     ```
 
     (replace `<aws_region>` with the database’s region, `<account_id>` with your AWS account number, `<database_id>` with the RDS database instance identifier, `<bucket_name>` with the S3 bucket name).

--- a/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/secret-store-credentials.md
@@ -33,7 +33,7 @@ To implement an external secret store, you must configure the required settings 
     In most cases, this should only be done once for the entire cluster. For more information and support, contact the secret storage provider.
 2. Install and configure a [Kubernetes Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/#supported-providers), for example, [AWS Secrets Manager CSI Secrets Store](https://github.com/aws/secrets-store-csi-driver-provider-aws).
     This driver is installed globally for the entire cluster. For more information, refer to documentation supplied by the secret storage provider.
-3. Prepare a Kubernetes `ServiceAccount` to be used for authentication. 
+3. Prepare a Kubernetes `ServiceAccount` to be used for authentication.
     The `ServiceAccount` name must match the [Mendix App CR](/developerportal/deploy/private-cloud-technical-appendix-01/) name (that, is, the internal name of the app environment). In addition, the `ServiceAccount` needs to have a `privatecloud.mendix.com/environment-account: "true"` annotation.
     Your secret storage provider may have other requirements - for more information, refer to documentation supplied by the secret storage provider. Typically, the Kubernetes `ServiceAccount` requires vendor-specific annotations to link it with an account or role in the secret storage provider.
 4. Configure the [SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage.html#create-your-own-secretproviderclass-object)
@@ -265,7 +265,7 @@ To enable your environment to use Vault as external secret storage, follow these
 
 14. Create an app with the secret store enabled. If you are using the Portal, secret stores are enabled automatically if the **Enable Secrets Store** option is activated for the namespace where you create the app. For a standalone app, you must set the value of the `allowOverrideSecretsWithSecretStoreCSIDriver` setting to `true`in the Mendix app CRD.
     The following yaml shows an example Mendix app CRD:
-    
+
     ```yaml
     cat > mendixApp.yaml <<EOF
     apiVersion: privatecloud.mendix.com/v1alpha1
@@ -301,12 +301,12 @@ To enable your environment to use Vault as external secret storage, follow these
 To enable your environment to use [AWS Secrets Manager](https://aws.amazon.com/blogs/security/how-to-use-aws-secrets-configuration-provider-with-kubernetes-secrets-store-csi-driver/) as external secret storage, follow these steps:
 
 1. In AWS Secrets Manager, create a new secret of the type **Other**.
-2. Define the keys as described in the [SecretProviderClass Keys](#keys) section above, and then click **Next**. 
+2. Define the keys as described in the [SecretProviderClass Keys](#keys) section above, and then click **Next**.
 3. Enter the secret name, for example, `<namespace>/<Kubernetes environment name>`.
 4. Follow the wizard to complete the secret creation process.
 5. Open the secret and copy the **Secret name** and **Secret ARN**.
 6. In the Cloud Portal, create an environment using secrets storage, with no database or storage plan.
-7. Create an **IAM Role** without any attached policies for that environment in the AWS console. 
+7. Create an **IAM Role** without any attached policies for that environment in the AWS console.
     {{% alert color="info" %}}Use the environment internal name as the service account name.{{% /alert %}}
 8. In the IAM role, add an inline policy with the following JSON:
 
@@ -341,7 +341,7 @@ To enable your environment to use [AWS Secrets Manager](https://aws.amazon.com/b
         The role ARN is required, you can use the **Copy** button next to the ARN name in the role details.
 
         After this, the specified serviceaccount in the specified namespace will be able to assume this role.
-       
+
 10. Create a Kubernetes `ServiceAccount` for your environment:
 
     ```shell
@@ -353,7 +353,7 @@ To enable your environment to use [AWS Secrets Manager](https://aws.amazon.com/b
 11. Create an app with the secret store enabled. If you are using connected mode, secret stores are enabled automatically if the **Enable Secrets Store** option is activated for the namespace where you create the app. For a standalone app, you must set the value of the setting `allowOverrideSecretsWithSecretStoreCSIDriver` to `true`in the Mendix app CRD.
 
     The following yaml shows an example Mendix app CRD:
-    
+
     ```yaml
     cat > mendixApp.yaml <<EOF
     apiVersion: privatecloud.mendix.com/v1alpha1
@@ -503,7 +503,7 @@ After completing the prerequisites, follow these steps to switch from password-b
    ```
 
    replacing `<db-region>` with the RDS database region, `<account-id>` with the AWS account ID, `<db-resource-id>` with the database Resource ID and `<database-username>` with the username specified in `database-username`.
-   
+
    For more information on how to get the Resource ID and create an RDS IAM policy, see the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html).
 4. Restart the Mendix app environment.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,16 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### November 17, 2023
+
+#### Data Migration Tool (Preview) v0.0.4
+
+* We added support for backing up and restoring data in environments using [AWS IRSA](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) authentication.
+
+{{% alert color="info" %}}
+The data migration tool is available as a technical preview. For documentation and download links, see [Private Cloud Data Transfer](/developerportal/deploy/private-cloud-data-transfer/).
+{{% /alert %}}
+
 ### November 3, 2023
 
 #### Portal Fixes
@@ -34,7 +44,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Deploy API Improvements
 
-* We have recently decoupled the **Modify MxAdmin Password** and **Manage Environment** permissions for cases where member permissions are customized. 
+* We have recently decoupled the **Modify MxAdmin Password** and **Manage Environment** permissions for cases where member permissions are customized.
 
 ### October 30, 2023
 
@@ -52,7 +62,7 @@ The data migration tool is available as a technical preview. For documentation a
 
 * We have added an option to specify additional custom pod labels for an environment from the portal.
 * We have added an option to configure the ephemeral storage in the core resources selection flow.
-* In order to be consistent with the Mendix Public Cloud portal, the number of constants visible per page has been increased from 5 to 10. A similar change has also been made for scheduled events, custom runtime settings, custom environment variables, and client certificates. For log levels, the number of items visible per page has been increased to 20. (Ticket 196963) 
+* In order to be consistent with the Mendix Public Cloud portal, the number of constants visible per page has been increased from 5 to 10. A similar change has also been made for scheduled events, custom runtime settings, custom environment variables, and client certificates. For log levels, the number of items visible per page has been increased to 20. (Ticket 196963)
 * We have fixed the issue where a user was able to select custom plans created for other namespaces.
 * We have added an extra warning message when a user tries to switch from default to custom core resource plans.
 


### PR DESCRIPTION
We've prepared a new release of the Private Cloud data transfer tool and are planning to release it tomorrow, on November 17. It's not time-sensitive and ahead of schedule, so it's OK to review and publish it at any convenient time, next week is OK as well :)

This MR includes release notes and updated documentation (how to use IRSA authentication).