### PR TITLE
Mx4PC Operator 2.14.0 release notes (planned for December 8)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -103,6 +103,13 @@ spec:
   ingressClassName: alb # Optional, can be omitted : specify the Ingress class
   ingressPath: "/" # Optional, can be omitted : specify the Ingress path. Anything other than "/" or "/*" will be ignored as Mendix applications don't support path based routing
   ingressPathType: ImplementationSpecific # Optional, can be omitted : specify the Ingress pathType
+  topologySpreadConstraints: # Optional, can be omitted : specify Kubernetes topology spread constraints
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          privatecloud.mendix.com/app: example-mendixapp
   runtime: # Configuration of the Mendix Runtime
     logAutosubscribeLevel: INFO # Default logging level
     mxAdminPassword: V2VsYzBtZSE= # base64 encoded password for MendixAdmin user. In this example, 'Welc0me!'; can be left empty keep password unchanged
@@ -160,7 +167,7 @@ spec:
   customPodLabels: # Optional: custom pod labels
     general: # Optional: general pod labels (applied to all app-related pods)
       azure.workload.identity/use: "true" # Example: enable Azure Workload Identity
-  runtimeLicenseProduct: # Optional: Specify the type of product required for the Runtime License. This is applicable when PCLM is used for licensing. By default, the value is set to Standard, if left empty   
+  runtimeLicenseProduct: # Optional: Specify the type of product required for the Runtime License. This is applicable when PCLM is used for licensing. By default, the value is set to Standard, if left empty
 ```
 
 You need to make the following changes:
@@ -180,6 +187,7 @@ You need to make the following changes:
 * **endpointAnnotations** – set custom annotations for Ingress (or OpenShift Route) objects; these annotations are applied on top of [default annotations](/developerportal/deploy/private-cloud-cluster/#advanced-network-settings) from `OperatorConfiguration`
 * **ingressPath** – specify a custom Ingress path; this overrides the [default ingress path](/developerportal/deploy/private-cloud-cluster/#advanced-network-settings) from `OperatorConfiguration`
 * **ingressPathType** – specify a custom Ingress class name; this overrides the [default ingress pathType](/developerportal/deploy/private-cloud-cluster/#advanced-network-settings) from `OperatorConfiguration`
+* **topologySpreadConstraints** – specify Kubernetes [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for the app's runtime pods; please specify only constraints that are supported by your cluster
 * **logAutosubscribeLevel** – change the default logging level for your app, the standard level is INFO — possibilities are: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`
 * **mxAdminPassword** – here you can change the password for the MxAdmin user — if you leave this empty, the password will be the one set in the Mendix model
 * **debuggerPassword** – here you can provide the password for the debugger — this is optional. Setting an empty `debuggerPassword` will disable the debugging features. In order to connect to the debugger in Studio Pro, enter the debugger URL as `<AppURL>/debugger/`. You can find further information in [Debugging Microflows Remotely](/refguide/debug-microflows-remotely/)

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,14 +17,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.14.0 {#2.14.0}
 
-* We've added the following validation checks to the `mxpc-cli` installation and configuration tool
-  * When configuring a namespace, check to see that the database and blob file storage plans don't use the same name.
+* We have added the following validation checks to the `mxpc-cli` installation and configuration tool:
+  * When configuring a namespace, check to see that the database and blob file storage plans do not use the same name.
   * The registry name is validated to match the [OCI registry spec](https://github.com/opencontainers/distribution-spec/blob/v1.0.1/spec.md#pulling-manifests).
-* We're improved authentication security of the Mendix Gateway Agent connection by switching to Digest validation of the cluster ID and secret.
-* We've updated our AWS implementation to detect if a custom [AWS partition](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) should be used, and use that partition's ARN format. This should improve support for AWS China and GovCloud.
-* We've updated third-party component versions.
-* We’ve improved reliability of the code that processes statuses for resources such as Network, Build and Runtime. This will reduce the number of retries for _the object has been modified, please apply your changes to the latest version and try again errors_ and ensures that status icons are updated as soon as possible.
-* For standalone clusters, it's now possible to specify the Kubernetes [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) field.
+* We have improved the authentication security of the Mendix Gateway Agent connection by switching to digest validation of the cluster ID and secret.
+* We have updated our AWS implementation to detect if a custom [AWS partition](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) should be used, and use that partition's ARN format. This should improve support for AWS China and GovCloud.
+* We have updated third-party component versions.
+* We have improved the reliability of the code that processes statuses for resources such as Network, Build and Runtime. This reduces the number of retries for *the object has been modified, please apply your changes to the latest version and try again* errors, and ensures that status icons are updated as soon as possible.
+* For standalone clusters, it is now possible to specify the Kubernetes [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) field.
 * Upgrading to Mendix Operator v2.14.0 from a previous version will restart environments managed by that version of the Operator.
 
 ### November 23, 2023

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -23,6 +23,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We're improved authentication security of the Mendix Gateway Agent connection by switching to Digest validation of the cluster ID and secret.
 * We've updated our AWS implementation to detect if a custom [AWS partition](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) should be used, and use that partition's ARN format. This should improve support for AWS China and GovCloud.
 * We've updated third-party component versions.
+* We’ve improved reliability of the code that processes statuses for resources such as Network, Build and Runtime. This will reduce the number of retries for _the object has been modified, please apply your changes to the latest version and try again errors_ and ensures that status icons are updated as soon as possible.
 * For standalone clusters, it's now possible to specify the Kubernetes [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) field.
 * Upgrading to Mendix Operator v2.14.0 from a previous version will restart environments managed by that version of the Operator.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,19 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2023
 
+### December 8th, 2023
+
+#### Mendix Operator v2.14.0 {#2.14.0}
+
+* We've added the following validation checks to the `mxpc-cli` installation and configuration tool
+  * When configuring a namespace, check to see that the database and blob file storage plans don't use the same name.
+  * The registry name is validated to match the [OCI registry spec](https://github.com/opencontainers/distribution-spec/blob/v1.0.1/spec.md#pulling-manifests).
+* We're improved authentication security of the Mendix Gateway Agent connection by switching to Digest validation of the cluster ID and secret.
+* We've updated our AWS implementation to detect if a custom [AWS partition](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) should be used, and use that partition's ARN format. This should improve support for AWS China and GovCloud.
+* We've updated third-party component versions.
+* For standalone clusters, it's now possible to specify the Kubernetes [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) field.
+* Upgrading to Mendix Operator v2.14.0 from a previous version will restart environments managed by that version of the Operator.
+
 ### November 23, 2023
 
 #### Prometheus Metrics


### PR DESCRIPTION
Our team is planning to release the Mx4PC Operator this Friday; this PR contains release notes and documentation how to use the new `topologySpreadConstraints` parameter.