### PR TITLE
Clarified that the Oracle JDK will not be automatically installed

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -25,9 +25,7 @@ The following frameworks are required. They will be installed automatically by t
 * Microsoft .NET 6.0.x desktop runtime (x64) and all applicable Windows security patches
 * Redistributable Package (x64)
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
-* A Java Developer Kit (JDK) version 11 - the flavor which will be installed, if Java 11 is not already installed on your machine, you are installing:
-    * Eclipse Temurin JDK 11 (x64)
-    * Oracle JDK 11 can also be used if this is already installed
+* A Java Developer Kit (JDK) version 11 - If not yet installed on your machine, Mendix will install 'Eclipse Temurin JDK 11 (x64)'.
 * Git for Windows (x64)
 * Mendix Native Mobile Builder
 * Microsoft Edge WebView2 Evergreen Runtime (x64)

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -25,7 +25,7 @@ The following frameworks are automatically installed (if necessary):
 * Microsoft .NET Framework 4.7.2 and all applicable Windows security patches
 * Microsoft Visual C++ 2010 SP1 Redistributable Package
 * Microsoft Visual C++ 2015 Redistributable Package
-* AdoptOpenJDK 11 or Oracle JDK 11 (the former is installed automatically as of [Mendix 8.0.0](/releasenotes/studio-pro/8.0/#800) if you do not have any JDK 11 installed) 
+* AdoptOpenJDK 11 (installed automatically as of [Mendix 8.0.0](/releasenotes/studio-pro/8.0/#800) if you do not have any JDK 11 installed) 
 
 {{% alert color="info" %}}
 You can choose which JDK is used for building and running locally via the **Edit** > **Preferences** menu item in Studio Pro.

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -29,8 +29,6 @@ The following frameworks are required. They will be installed automatically by t
     * AdoptOpenJDK 11 (x64) – for Mendix 9.13 and below
     * Adoptium Temurin JDK 11 (x64) – for Mendix 9.14 to 9.17
     * Eclipse Temurin JDK 11 (x64)– for Mendix 9.18 and above
-    
-    Oracle JDK 11 can also be used if this is already installed.
 * Git for Windows (x64)
 * Mendix Native Mobile Builder
 * Microsoft Edge WebView2 Evergreen Runtime (x64)


### PR DESCRIPTION
The current text left some customers the impression we install the Oracle JDK