### PR TITLE
Host OData service on any path

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -49,7 +49,7 @@ This is because changes to a particular version of a published OData service wil
 
 The location denotes where the service will be available. It is recommended to include the service name and the major version in the location, e.g. `svc/products/v1/`.
 
-The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved cannot be used at the start of the location. Other than that, you can change the location to any valid URL.
+The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved and cannot be used at the start of the location. Otherwise, you can change the location to any valid URL.
 
 ### 2.4 Namespace
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -47,7 +47,9 @@ This is because changes to a particular version of a published OData service wil
 
 ### 2.3 Location
 
-The location denotes where the service will be available. The part before `/odata/` may be different depending on where the app is running. You can specify the part after `/odata/` yourself. It is recommended to specify the service name and the major version in the location.
+The location denotes where the service will be available. It is recommended to include the service name and the major version in the location, e.g. `svc/products/v1/`.
+
+The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved cannot be used at the start of the location. Other than that, you can change the location to any valid URL.
 
 ### 2.4 Namespace
 

--- a/content/en/docs/refguide/modeling/integration/rest-services/published-rest-services/published-rest-service/_index.md
+++ b/content/en/docs/refguide/modeling/integration/rest-services/published-rest-services/published-rest-service/_index.md
@@ -38,7 +38,7 @@ Example:
 http://localhost:8080/rest/my_service_name/v1
 ```
 
-The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved cannot be used at the start of the location. Other than that, you can change the location to any valid URL.
+The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved and cannot be used at the start of the location. Otherwise, you can change the location to any valid URL.
 
 When your application is running, you can click the location to open the [interactive documentation page](/refguide/published-rest-services/#interactive-documentation).
 

--- a/content/en/docs/refguide/modeling/integration/rest-services/published-rest-services/published-rest-service/_index.md
+++ b/content/en/docs/refguide/modeling/integration/rest-services/published-rest-services/published-rest-service/_index.md
@@ -38,21 +38,7 @@ Example:
 http://localhost:8080/rest/my_service_name/v1
 ```
 
-You can change the default location to almost any valid URL.
-
-#### 2.3.1 Reserved Prefixes
-
-Following URL prefixes are reserved and are not allowed to be used in location:
-
-* `ws/`
-* `ws-doc/`
-* `rest-doc/`
-* `odata/`
-* `odata-doc/`
-* `api-doc/`
-* `xas/`
-* `p/`
-* `reload/`
+The URL prefixes `api-doc/`, `xas/`, `p/`, and `reload/` are reserved cannot be used at the start of the location. Other than that, you can change the location to any valid URL.
 
 When your application is running, you can click the location to open the [interactive documentation page](/refguide/published-rest-services/#interactive-documentation).
 


### PR DESCRIPTION
In Studio Pro 10.7.0, the location of a published OData service no longer has to start with `odata`. This change clarifies the details of the location of both published OData services and published REST services.