### PR TITLE
Update string-function-calls.md

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -131,13 +131,13 @@ The output is the following:
 If you use a third parameter that specifies the desired length of the output:
 
 ```java {linenos=false}
-substring('funwithmendixapps', 7,6)
+substring('thisismystring', 6, 2)
 ```
 
 The output is the following:
 
 ```java {linenos=false}
-'mendix'
+'my'
 ```
 
 You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -140,10 +140,10 @@ The output is the following:
 'my'
 ```
 
-You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+You can also specify the value of the third parameter using the `length` function:
 
 ```java {linenos=false}
-substring('thisismystring', 0, min(length('thisismystring'), 20))
+substring('thisismystring', 0, length('thisismystring'))
 ```
 
 ## 5 find

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -128,7 +128,7 @@ The output is the following:
 'mystring'
 ```
 
-If you use a third parameter that specifies the desired length of the output:
+If you use a third parameter to specify the desired length of the output:
 
 ```java {linenos=false}
 substring('thisismystring', 6, 2)
@@ -140,10 +140,10 @@ The output is the following:
 'my'
 ```
 
-You can also specify the value of the third parameter using the `length` function:
+To prevent the value of the third parameter from getting out of range, you can set a limit to the third parameter, for instance, using the `min` and `length` functions:
 
 ```java {linenos=false}
-substring('thisismystring', 0, length('thisismystring'))
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 5 find

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -128,7 +128,7 @@ The output is the following:
 'mystring'
 ```
 
-Another example of an input is:
+If you use a third parameter that specifies the desired length of the output:
 
 ```java {linenos=false}
 substring('funwithmendixapps', 7,6)
@@ -138,6 +138,12 @@ The output is the following:
 
 ```java {linenos=false}
 'mendix'
+```
+
+You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+
+```java {linenos=false}
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 5 find

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
@@ -122,10 +122,10 @@ returns:
 'my'
 ```
 
-If this third parameter is too big, the function will throw an error saying it is out of range, so make sure to limit it. This is an example with use of the length function:
+If this third parameter is too big, the function will throw an error saying it is out of range. You can specify the value of the third parameter using the `length` function:
 
 ```java
-substring('thisismystring', 0, min(length('thisismystring'), 20))
+substring('thisismystring', 0, length('thisismystring'))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
@@ -125,7 +125,7 @@ returns:
 If this third parameter is too big, the function will throw an error saying it is out of range, so make sure to limit it. This is an example with use of the length function:
 
 ```java
-'substring('thisismystring', 0, min(length('thisismystring'), 20))'
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
@@ -122,7 +122,7 @@ returns:
 'my'
 ```
 
-If this third parameter is too big, the function will throw an error saying it is out of range. You can specify the value of the third parameter using the `length` function:
+If this third parameter is too big, the function will throw an error saying it is out of range. To prevent the value of the third parameter from getting out of range, you can set a limit to the third parameter, for instance, using the `min` and `length` functions:
 
 ```java {linenos=false}
 substring('thisismystring', 0, min(length('thisismystring'), 20))

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
@@ -125,7 +125,7 @@ returns:
 If this third parameter is too big, the function will throw an error saying it is out of range, so make sure to limit it. This is an example with use of the length function:
 
 ```java
-'substring('thisismystring', 0, min(length('thisismystring') - 1, 20))'
+'substring('thisismystring', 0, min(length('thisismystring'), 20))'
 ```
 
 ## 6 find

--- a/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
+++ b/content/en/docs/refguide7/desktop-modeler/application-logic/common-elements/expressions/string-function-calls.md
@@ -124,8 +124,8 @@ returns:
 
 If this third parameter is too big, the function will throw an error saying it is out of range. You can specify the value of the third parameter using the `length` function:
 
-```java
-substring('thisismystring', 0, length('thisismystring'))
+```java {linenos=false}
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
@@ -159,16 +159,22 @@ The output is the following:
 'mystring'
 ```
 
-Another example of an input is:
+If you use a third parameter that specifies the desired length of the output:
 
-```java
-substring('mendixapp', 6,3)
+```java {linenos=false}
+substring('thisismystring', 6, 2)
 ```
 
 The output is the following:
 
-```java
-'app'
+```java {linenos=false}
+'my'
+```
+
+You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+
+```java {linenos=false}
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
@@ -159,7 +159,7 @@ The output is the following:
 'mystring'
 ```
 
-If you use a third parameter that specifies the desired length of the output:
+If you use a third parameter to specify the desired length of the output:
 
 ```java {linenos=false}
 substring('thisismystring', 6, 2)
@@ -171,10 +171,10 @@ The output is the following:
 'my'
 ```
 
-You can also specify the value of the third parameter using the `length` function:
+To prevent the value of the third parameter from getting out of range, you can set a limit to the third parameter, for instance, using the `min` and `length` functions:
 
 ```java {linenos=false}
-substring('thisismystring', 0, length('thisismystring'))
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide8/modeling/application-logic/expressions/string-function-calls.md
@@ -171,10 +171,10 @@ The output is the following:
 'my'
 ```
 
-You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+You can also specify the value of the third parameter using the `length` function:
 
 ```java {linenos=false}
-substring('thisismystring', 0, min(length('thisismystring'), 20))
+substring('thisismystring', 0, length('thisismystring'))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
@@ -168,10 +168,10 @@ The output is the following:
 'my'
 ```
 
-You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+You can also specify the value of the third parameter using the `length` function:
 
 ```java {linenos=false}
-substring('thisismystring', 0, min(length('thisismystring'), 20))
+substring('thisismystring', 0, length('thisismystring'))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
@@ -156,16 +156,22 @@ The output is the following:
 'mystring'
 ```
 
-Another example of an input is:
+If you use a third parameter that specifies the desired length of the output:
 
 ```java {linenos=false}
-substring('funwithmendixapps', 7,6)
+substring('thisismystring', 6, 2)
 ```
 
 The output is the following:
 
 ```java {linenos=false}
-'mendix'
+'my'
+```
+
+You can also limit the value of the third parameter to prevent it from specifying a desired length that is out of range:
+
+```java {linenos=false}
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find

--- a/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide9/modeling/application-logic/expressions/string-function-calls.md
@@ -156,7 +156,7 @@ The output is the following:
 'mystring'
 ```
 
-If you use a third parameter that specifies the desired length of the output:
+If you use a third parameter to specify the desired length of the output:
 
 ```java {linenos=false}
 substring('thisismystring', 6, 2)
@@ -168,10 +168,10 @@ The output is the following:
 'my'
 ```
 
-You can also specify the value of the third parameter using the `length` function:
+To prevent the value of the third parameter from getting out of range, you can set a limit to the third parameter, for instance, using the `min` and `length` functions:
 
 ```java {linenos=false}
-substring('thisismystring', 0, length('thisismystring'))
+substring('thisismystring', 0, min(length('thisismystring'), 20))
 ```
 
 ## 6 find


### PR DESCRIPTION
Example is incorrect.

Result from
'substring('thisismystring', 0, min(length('thisismystring') - 1, 20))' ->
thisismystrin

instead of thisismystring

P.S. Why is this useful example no longer included in refguide8, 9 and 10?