### PR TITLE
Update string-function-calls.md

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -411,10 +411,6 @@ The output is described in the table below:
 | -------------------------------------------------------- | ------ |
 | Same string, but without spaces at the beginning and end. | String |
 
-{{% alert color="info" %}}
-If you pass an empty string to this function, it returns an empty string.
-{{% /alert %}}
-
 ### 10.3 Example
 
 If you use the following input:
@@ -429,10 +425,10 @@ The output is:
 'this is my string'
 ```
 
-If you use the following input:
+If the input string is empty, it returns an empty string. So, if you use the following input and `MyString` is empty:
 
 ```java {linenos=false}
-trim('')
+trim($MyString)
 ```
 
 The output is:

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -393,7 +393,7 @@ true
 
 ## 10 trim {#trim}
 
-Removes all the whitespace at the beginning and end of a string; if the input string was empty, returns an empty string ''.
+Removes all the whitespace at the beginning and end of a string.
 
 ### 10.1 Input Parameters
 
@@ -411,7 +411,11 @@ The output is described in the table below:
 | -------------------------------------------------------- | ------ |
 | Same string, but without spaces at the beginning and end. | String |
 
-### 10.3.1 Example 1 - trimming behaviour
+{{% alert color="info" %}}
+If you pass an empty string to this function, it returns an empty string.
+{{% /alert %}}
+
+### 10.3 Example
 
 If you use the following input:
 
@@ -425,12 +429,10 @@ The output is:
 'this is my string'
 ```
 
-### 10.3.2 Example 2  - empty
-
 If you use the following input:
 
 ```java {linenos=false}
-trim(empty)
+trim('')
 ```
 
 The output is:

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -393,7 +393,7 @@ true
 
 ## 10 trim {#trim}
 
-Removes all the whitespace at the beginning and end of a string.
+Removes all the whitespace at the beginning and end of a string; if the input string was empty, returns an empty string ''.
 
 ### 10.1 Input Parameters
 
@@ -411,7 +411,7 @@ The output is described in the table below:
 | -------------------------------------------------------- | ------ |
 | Same string, but without spaces at the beginning and end. | String |
 
-### 10.3 Example
+### 10.3.1 Example 1 - trimming behaviour
 
 If you use the following input:
 
@@ -423,6 +423,20 @@ The output is:
 
 ```java {linenos=false}
 'this is my string'
+```
+
+### 10.3.2 Example 2  - empty
+
+If you use the following input:
+
+```java {linenos=false}
+trim(empty)
+```
+
+The output is:
+
+```java {linenos=false}
+''
 ```
 
 ## 11 isMatch

--- a/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/string-function-calls.md
@@ -425,7 +425,7 @@ The output is:
 'this is my string'
 ```
 
-If the input string is empty, it returns an empty string. So, if you use the following input and `MyString` is empty:
+If the input string is empty, it returns an empty string. So, if you use the following input and `MyString` in the input is empty:
 
 ```java {linenos=false}
 trim($MyString)


### PR DESCRIPTION
Adding a key principle to the functioning of trim(), which also auto-initialises. Also added an example. Please contact me if there are questions. The proof of this addition can be found here https://medium.com/@wpenris/empty-strings-in-mendix-61be3ce3b7a6