### PR TITLE
Update rg-two-app.md

### DIFF
--- a/content/en/docs/appstore/partner-solutions/ats/rg-ats/v2/rg-two-app.md
+++ b/content/en/docs/appstore/partner-solutions/ats/rg-ats/v2/rg-two-app.md
@@ -116,9 +116,9 @@ Starting with ATS version 2.0, ATS capabilities override custom capabilities.
 
 Under **App Team**, you can specify which app members have what type of access rights for an app.
 
-By default, app members with the Scrum Master role in the Developer Portal will have administrative rights. All other members of the app will get No access for that app. Please keep in mind that users still need to be a member of an app in the Developer Portal for them to be eligible to be app administrators for the corresponding app in ATS.
+By default, app members with the Scrum Master role in the Developer Portal will have administrative rights. All other members of the app will get **No access** for that app. Please keep in mind that users still need to be a member of an app in the Developer Portal for them to be eligible to be app administrators for the corresponding app in ATS.
 
-App member that the have a No access role will not see the app in their **My apps** page and will not be able to open or edit or run any test cases for this app.
+App members that have a **No access** role will not see the app in their **My apps** page and will not be able to open or edit or run any test cases for this app.
 
 {{% alert color="info" %}}
 For on-premises instances of ATS, all accounts created manually by the tenant administrator will be members of each project.

--- a/content/en/docs/appstore/partner-solutions/ats/rg-ats/v2/rg-two-app.md
+++ b/content/en/docs/appstore/partner-solutions/ats/rg-ats/v2/rg-two-app.md
@@ -116,7 +116,7 @@ Starting with ATS version 2.0, ATS capabilities override custom capabilities.
 
 Under **App Team**, you can specify which app members have what type of access rights for an app.
 
-By default, app members with the Scrum Master role in the Developer Portal will have administrative rights. All other members of the app will get the default role configured for that app. Please keep in mind that users still need to be a member of an app in the Developer Portal for them to be eligible to be app administrators for the corresponding app in ATS.
+By default, app members with the Scrum Master role in the Developer Portal will have administrative rights. All other members of the app will get No access for that app. Please keep in mind that users still need to be a member of an app in the Developer Portal for them to be eligible to be app administrators for the corresponding app in ATS.
 
 App member that the have a No access role will not see the app in their **My apps** page and will not be able to open or edit or run any test cases for this app.
 


### PR DESCRIPTION
Discussed the user role behavior with CLEVR (who own ATS) in the support ticket that I will mention to you in Slack. 

New non-SCRUM master will get no access to apps in ATS. It is also not possible to change the default role of the app so updated the docs here