### PR TITLE
Add reference to new React Client API docs

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/client-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/client-api.md
@@ -13,6 +13,7 @@ Enrich the user interface of your applications by building on top of our web cli
 
 ## 2 Client APIs
 
+* [Mendix 10 React Client API](https://apidocs.rnd.mendix.com/10/client-react/index.html)
 * [Mendix 10 Client API](https://apidocs.rnd.mendix.com/10/client/index.html)
 * [Mendix 9 Client API](https://apidocs.rnd.mendix.com/9/client/index.html)
 * [Mendix 8 Client API](https://apidocs.rnd.mendix.com/8/client/index.html)


### PR DESCRIPTION
For the React Client we will publish separate API docs.

These will be published during the release of 10.8