### PR TITLE
Add Include metadata in response by default setting

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -95,6 +95,14 @@ You can choose between OData 4 (recommended) and OData 3. One of the main differ
 
 You can select how you want to represent associations. For more information, see the [Associations](/refguide/odata-representation/#associations) section of *OData Representation*.
 
+#### 3.1.3 Include metadata in response by default
+
+This checkbox allows you to change whether or not the service should include the metadata, such as the `@context` property, by default in the response. By default this is enabled, in order to conform to the OData specification. Disabling this has the same effect as including `metadata=none` in the `Accept` header of your HTTP request. Note that the value passed in the `Accept` header always takes precedences over this setting.
+
+{{% alert color="info" %}}
+Disabling this setting might break integrations with this service. Specifically for integrations with Microsoft Excel and PowerBI to work this setting must be left enabled.
+{{% /alert %}}
+
 ### 3.2 Export
 
 In this section, you can save the different representations of the service to file.

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -97,10 +97,10 @@ You can select how you want to represent associations. For more information, see
 
 #### 3.1.3 Include metadata in response by default
 
-This checkbox allows you to change whether or not the service should include the metadata, such as the `@context` property, by default in the response. By default this is enabled, in order to conform to the OData specification. Disabling this has the same effect as including `metadata=none` in the `Accept` header of your HTTP request. Note that the value passed in the `Accept` header always takes precedences over this setting.
+This checkbox allows you to choose if the service should include the metadata (for example, the `@context` property) in the response. This setting is enabled by default to conform to the OData specification. Disabling this setting has the same effect as including `metadata=none` in the `Accept` header of your HTTP request. Note that the value passed in the `Accept` header always takes precedences over this setting.
 
 {{% alert color="info" %}}
-Disabling this setting might break integrations with this service. Specifically for integrations with Microsoft Excel and PowerBI to work this setting must be left enabled.
+Disabling this setting could break integrations with this service, specifically integrations with Microsoft Excel and PowerBI. This setting must enabled to use these features.
 {{% /alert %}}
 
 ### 3.2 Export


### PR DESCRIPTION
We added a checkbox to disable OData services to include properties like `@context` in the response by default.
This is included in 10.8.