### PR TITLE
Added small note to object type decision for nanoflows

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/object-type-decision.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/object-type-decision.md
@@ -40,4 +40,8 @@ The input object contains an object of a generalized entity.
 
 For example, you have an entity **Student** and an entity **Professor** which have an entity **Member** as their generalization. You want to open a different page for **Professor** than for any other **Member**. The selected **Member** object is available in the parameter **SelectedMember** and is used as input to the object type decision. Note that there is no outgoing flow for **Student**. If an outgoing flow is missing, the closest generalization that has an outgoing flow is searched. In this case, this generalization is **Member**. The outgoing flow with the caption **(empty)** is followed when **SelectedMember** does not contain an object.
 
+{{% alert color="warning" %}}
+In a nanoflow, only generalizations that are accessible by the user can be searched.
+{{% /alert %}}
+
 {{< figure src="/attachments/refguide/modeling/application-logic/microflows-and-nanoflows/decisions/object-type-decision.png" >}}


### PR DESCRIPTION
Just to make people aware of this. Small note, object type decisions that make use of generalizations do not work at all in nanoflows at the moment and will be fixed in 10.9. (After which this can also be merged).