### PR TITLE
Non-persistable external entities

### DIFF
--- a/content/en/docs/refguide/modeling/domain-model/entities/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/_index.md
@@ -35,7 +35,9 @@ The entity type defines how the data is handled and there are two types:
 {{< figure src="/attachments/refguide/modeling/domain-model/entities/type-of-entities.jpg" >}}
 
 {{% alert color="info" %}}
-You can also use data sources from other applications in your app through the [Integration pane](/refguide/integration-pane/). These data sources are represented in the domain model as *external entities* which are displayed as purple entity containers in the domain model.
+You can also use data sources from other applications in your app through the [Integration pane](/refguide/integration-pane/). These data sources are represented in the domain model as *external entities* which are displayed as purple entity containers in the domain model. 
+
+Data structures from other sources that have been imported through the Integration pane that cannot be retrieved are represented as *non-readable external entities* and behave similarly to non-persistable entities. Like non-persistable entities, these are displayed as yellow entity containers.
 
 For further information see [External Entities](/refguide/external-entities/).
 {{% /alert %}}

--- a/content/en/docs/refguide/modeling/domain-model/entities/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/_index.md
@@ -37,8 +37,6 @@ The entity type defines how the data is handled and there are two types:
 {{% alert color="info" %}}
 You can also use data sources from other applications in your app through the [Integration pane](/refguide/integration-pane/). These data sources are represented in the domain model as *external entities* which are displayed as purple entity containers in the domain model. 
 
-Data structures from other sources that have been imported through the Integration pane that cannot be retrieved are represented as *non-readable external entities* and behave similarly to non-persistable entities. Like non-persistable entities, these are displayed as yellow entity containers.
-
 For further information see [External Entities](/refguide/external-entities/).
 {{% /alert %}}
 

--- a/content/en/docs/refguide/modeling/domain-model/entities/_index.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/_index.md
@@ -35,7 +35,7 @@ The entity type defines how the data is handled and there are two types:
 {{< figure src="/attachments/refguide/modeling/domain-model/entities/type-of-entities.jpg" >}}
 
 {{% alert color="info" %}}
-You can also use data sources from other applications in your app through the [Integration pane](/refguide/integration-pane/). These data sources are represented in the domain model as *external entities* which are displayed as purple entity containers in the domain model. 
+You can also use data sources from other applications in your app through the [Integration pane](/refguide/integration-pane/). These data sources are represented in the domain model as *external entities* which are displayed as purple entity containers in the domain model.
 
 For further information see [External Entities](/refguide/external-entities/).
 {{% /alert %}}

--- a/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
@@ -47,7 +47,7 @@ When a new version of a consumed service becomes available in the Catalog, this 
 You can make local changes to the properties of external entities that only affect how the data is used and presented in the consuming app. All other properties are defined in the originating app and cannot be changed. When multiple external entities from the same OData service are used in a module or app, associations between the entities (made in the originating app) will automatically be made in the local module.
 
 {{% alert color="info" %}}
-If you delete an external entity from the domain model, the service documents remain in the App Explorer list and the service continues to be listed in the Integration pane. You can delete the two service documents if you are no longer going to use any entities from the consumed service.
+If you delete an external entity from the domain model, the service documents remain in the App Explorer list and the service remains listed in the Integration pane. You can delete the two service documents if you are no longer going to use any entities from the consumed service.
 {{% /alert %}}
 
 For more information on using published OData services and entities through the Catalog, see [Consume Registered Assets](/catalog/consume/consume-registered-assets/).

--- a/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
+++ b/content/en/docs/refguide/modeling/domain-model/entities/external-entities.md
@@ -47,7 +47,7 @@ When a new version of a consumed service becomes available in the Catalog, this 
 You can make local changes to the properties of external entities that only affect how the data is used and presented in the consuming app. All other properties are defined in the originating app and cannot be changed. When multiple external entities from the same OData service are used in a module or app, associations between the entities (made in the originating app) will automatically be made in the local module.
 
 {{% alert color="info" %}}
-If you delete an external entity from the domain model, the service documents remain in the App Explorer list and the service aryA listed in the Integration pane. You can delete the two service documents if you are no longer going to use any entities from the consumed service.
+If you delete an external entity from the domain model, the service documents remain in the App Explorer list and the service continues to be listed in the Integration pane. You can delete the two service documents if you are no longer going to use any entities from the consumed service.
 {{% /alert %}}
 
 For more information on using published OData services and entities through the Catalog, see [Consume Registered Assets](/catalog/consume/consume-registered-assets/).

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -24,7 +24,9 @@ The OData implementation in Mendix does not support all features in the OData sp
 
 ### 2.1 External Entities {#external-entities}
 
-When an external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
+#### 2.1.1 Readable External Entities
+
+When a readable external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
 
 External entities have some limitations compared to persistable entities:
 
@@ -36,6 +38,17 @@ External entities have some limitations compared to persistable entities:
 Associations between external entities (as defined in the originating app) are shown in the domain model. You can only use the associations where both sides are published.
 
 You can create associations between local [persistable entities](/refguide/persistability/#persistable) and external entities. For those associations, the persistable entities need to be the owner.
+
+#### 2.1.2 Non-Readable External Entities
+
+When an external entity is not readable, it can still be added to the domain model. It will behave like a non-persistable entity.
+
+Non-readable external entities have the following limitations:
+
+* You cannot add attributes
+* There is no possibility to enable **System members**  `createdDate`, `changedDate`, `owner`, and `changedBy`
+* These entities cannot be turned into persistable entities
+* Non-readable external entities cannot be the owner of an association
 
 ### 2.2 External Actions {#external-actions}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -39,8 +39,8 @@ You can create associations between local [persistable entities](/refguide/persi
 
 #### 2.1.1 External Non-Persistable Entities {#external-non-persistable-entities}
 
-When a service defines an entity without an entity set, it means that this entity is not persistable. It can be added to the domain model as a non-persistable entity.
-The definition of this entity is read-only and is controlled in the service that publishes it, meaning that you cannot change or add attributes.
+When a service defines an entity without an entity set, it means that this entity is not persistable. You can add it to the domain model as a non-persistable entity.
+The definition of this entity is read-only and is controlled in the service that publishes it. This means that you cannot add attributes or change them.
 
 {{% alert type="info" %}}
 Support for importing non-persistable entities from a consumed OData service was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -24,7 +24,7 @@ The OData implementation in Mendix does not support all features in the OData sp
 
 ### 2.1 External Entities {#external-entities}
 
-When a external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
+When an external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
 
 External entities have some limitations compared to persistable entities:
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -39,7 +39,7 @@ Associations between external entities (as defined in the originating app) are s
 
 You can create associations between local [persistable entities](/refguide/persistability/#persistable) and external entities. For those associations, the persistable entities need to be the owner.
 
-#### 2.1.2 Non-Readable External Entities
+#### 2.1.2 Non-Readable External Entities {#non-readable-external-entities}
 
 When an external entity is not readable, it can still be added to the domain model. It will behave like a non-persistable entity.
 
@@ -49,6 +49,10 @@ Non-readable external entities have the following limitations:
 * There is no possibility to enable **System members**  `createdDate`, `changedDate`, `owner`, and `changedBy`
 * These entities cannot be turned into persistable entities
 * Non-readable external entities cannot be the owner of an association
+
+{{% alert type="info" %}}
+Support for consuming non-readable external entities was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
+{{% /alert %}}
 
 ### 2.2 External Actions {#external-actions}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/_index.md
@@ -24,9 +24,7 @@ The OData implementation in Mendix does not support all features in the OData sp
 
 ### 2.1 External Entities {#external-entities}
 
-#### 2.1.1 Readable External Entities
-
-When a readable external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
+When a external entity is used in an app, the associated data for the entity is retrieved through the information in the consumed OData service contract and returned.
 
 External entities have some limitations compared to persistable entities:
 
@@ -39,19 +37,13 @@ Associations between external entities (as defined in the originating app) are s
 
 You can create associations between local [persistable entities](/refguide/persistability/#persistable) and external entities. For those associations, the persistable entities need to be the owner.
 
-#### 2.1.2 Non-Readable External Entities {#non-readable-external-entities}
+#### 2.1.1 External Non-Persistable Entities {#external-non-persistable-entities}
 
-When an external entity is not readable, it can still be added to the domain model. It will behave like a non-persistable entity.
-
-Non-readable external entities have the following limitations:
-
-* You cannot add attributes
-* There is no possibility to enable **System members**  `createdDate`, `changedDate`, `owner`, and `changedBy`
-* These entities cannot be turned into persistable entities
-* Non-readable external entities cannot be the owner of an association
+When a service defines an entity without an entity set, it means that this entity is not persistable. It can be added to the domain model as a non-persistable entity.
+The definition of this entity is read-only and is controlled in the service that publishes it, meaning that you cannot change or add attributes.
 
 {{% alert type="info" %}}
-Support for consuming non-readable external entities was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
+Support for importing non-persistable entities from a consumed OData service was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
 {{% /alert %}}
 
 ### 2.2 External Actions {#external-actions}

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
@@ -67,7 +67,7 @@ The key can consist of one or more properties, as long as the following conditio
 The list above for supported key fields does not include `Date` or `DateTime` data types.
 {{% /alert %}}
 
-Entities that are not accessible through an entity set can be imported as a [non-persistable entity](/refguide/consumed-odata-services/#external-non-persistable-entities).
+Entities that are not accessible through an entity set can be used as a [non-persistable entity](/refguide/consumed-odata-services/#external-non-persistable-entities).
 
 ### 3.2 Attributes
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
@@ -46,7 +46,7 @@ Vocabulary annotations can be used in a service to indicate features that are no
 * **Updatable** – an entity marked as `Updatable="true"` with `DeltaUpdateSupported="true"` and `UpdateMethod="2"` will make the entity updatable in the domain model. That means, for example, that you can model pages that change attributes values and associated objects, and that you can use the entity in the [Change Object](/refguide/change-object/) activity. For updatable entities, the annotations `NonUpdatableProperties` and `NonUpdatableNavigationProperties` list the (navigation) properties that cannot be updated.
 * **Deletable** - an entity marked as `Deletable="true"` can be used in the [Delete External Object](/refguide/delete-external-object/) activity.
 
-An entity can only be used as a readable external entity when it is accessible through an entity set, and when it is uniquely identifiable with a key. 
+An entity can only be used as an external entity when it is accessible through an entity set, and when it is uniquely identifiable with a key. 
 The key can consist of one or more properties, as long as the following conditions are met:
 
 * The properties cannot be nullable (so they must have `isNullable="false"` specified).
@@ -67,7 +67,7 @@ The key can consist of one or more properties, as long as the following conditio
 The list above for supported key fields does not include `Date` or `DateTime` data types.
 {{% /alert %}}
 
-Entities that are not accessible through an entity set can be imported as a [non-readable external entity](/refguide/consumed-odata-services/#non-readable-external-entities), which will behave similarly to a non-persistable local entity.
+Entities that are not accessible through an entity set can be imported as a [non-persistable entity](/refguide/consumed-odata-services/#external-non-persistable-entities).
 
 ### 3.2 Attributes
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
@@ -46,9 +46,8 @@ Vocabulary annotations can be used in a service to indicate features that are no
 * **Updatable** – an entity marked as `Updatable="true"` with `DeltaUpdateSupported="true"` and `UpdateMethod="2"` will make the entity updatable in the domain model. That means, for example, that you can model pages that change attributes values and associated objects, and that you can use the entity in the [Change Object](/refguide/change-object/) activity. For updatable entities, the annotations `NonUpdatableProperties` and `NonUpdatableNavigationProperties` list the (navigation) properties that cannot be updated.
 * **Deletable** - an entity marked as `Deletable="true"` can be used in the [Delete External Object](/refguide/delete-external-object/) activity.
 
-An entity can only be used when it is accessible through an entity set.
-
-Furthermore, an entity can only be used if it is uniquely identifiable with a key. The key can consist of one or more properties, as long as the following conditions are met:
+An entity can only be used as a readable external entity when it is accessible through an entity set, and when it is uniquely identifiable with a key. 
+The key can consist of one or more properties, as long as the following conditions are met:
 
 * The properties cannot be nullable (so they must have `isNullable="false"` specified).
 * Only the following types are allowed: 
@@ -67,6 +66,8 @@ Furthermore, an entity can only be used if it is uniquely identifiable with a ke
 {{% alert color="info" %}}
 The list above for supported key fields does not include `Date` or `DateTime` data types.
 {{% /alert %}}
+
+Entities that are not accessible through an entity set can be imported as a non-readable external entity, which will behave similarly to a non-persistable local entity.
 
 ### 3.2 Attributes
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/consumed-odata-services/consumed-odata-service-requirements.md
@@ -67,7 +67,7 @@ The key can consist of one or more properties, as long as the following conditio
 The list above for supported key fields does not include `Date` or `DateTime` data types.
 {{% /alert %}}
 
-Entities that are not accessible through an entity set can be imported as a non-readable external entity, which will behave similarly to a non-persistable local entity.
+Entities that are not accessible through an entity set can be imported as a [non-readable external entity](/refguide/consumed-odata-services/#non-readable-external-entities), which will behave similarly to a non-persistable local entity.
 
 ### 3.2 Attributes
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -18,7 +18,7 @@ The standard used for OData in Mendix is [OData v4](http://www.odata.org/documen
 he option to publish [OData v3](http://www.odata.org/documentation/odata-version-3-0) services, which return data in Atom XML format, is deprecated and will be removed in a future version.
 {{% /alert %}}
 
-Not all parts of the standard are implemented. If something is not documented here, it is has not yet been added.
+Not all parts of the standard are implemented. If something is not documented here, it has not yet been added.
 
 This document describes the options available to you when you create a published OData service and ends with some runtime considerations.
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -266,7 +266,7 @@ The request body is always a JSON object, with a property for each parameter tha
 
 If a parameter's data type is object, the value of the parameter's property is a JSON object. If a parameter's data type is list, the value of the parameter's property is a JSON array. This is similar to what is expected when [inserting objects](#inserting-objects) for that entity.
 
-For parameters whose type is an entity with the __Readable__ capability, you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
+For parameters whose type is an entity with the __Readable__ capability you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
 
 ```json
 {

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -266,7 +266,7 @@ The request body is always a JSON object, with a property for each parameter tha
 
 If a parameter's data type is object, the value of the parameter's property is a JSON object. If a parameter's data type is list, the value of the parameter's property is a JSON array. This is similar to what is expected when [inserting objects](#inserting-objects) for that entity.
 
-For parameters whose type is an entity with the __Readable__ capability you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
+For parameters whose type is an entity with the __Readable__ capability, you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
 
 ```json
 {

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -266,7 +266,7 @@ The request body is always a JSON object, with a property for each parameter tha
 
 If a parameter's data type is object, the value of the parameter's property is a JSON object. If a parameter's data type is list, the value of the parameter's property is a JSON array. This is similar to what is expected when [inserting objects](#inserting-objects) for that entity.
 
-To pass an existing object, use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
+For parameters whose type is a persistable entity, you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
 
 ```json
 {
@@ -290,4 +290,5 @@ An object passed to a microflow will not be committed automatically. If you want
 
 {{% alert type="info" %}}
 The functionality for [publishing microflows in your OData service](/refguide/published-odata-microflow/) was introduced in Studio Pro [10.2.0](/releasenotes/studio-pro/10.2/).
+Support for publishing entities without the __Readable__ capability was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
 {{% /alert %}}

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/odata-query-options.md
@@ -266,7 +266,7 @@ The request body is always a JSON object, with a property for each parameter tha
 
 If a parameter's data type is object, the value of the parameter's property is a JSON object. If a parameter's data type is list, the value of the parameter's property is a JSON array. This is similar to what is expected when [inserting objects](#inserting-objects) for that entity.
 
-For parameters whose type is a persistable entity, you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
+For parameters whose type is an entity with the __Readable__ capability, you can pass an existing object. Use the [`@id` syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_EntityReference) to reference the object. When you pass an object using the `@id` reference, you can also pass attributes of the object; this assigns the specified attribute values to the existing object. Here is an example that passes the `Employees(1783)` object while specifying a value for the `Email` attribute:
 
 ```json
 {

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-attribute.md
@@ -46,6 +46,8 @@ Select **Sortable** to allow clients to sort results based on this attribute.
 
 Select **Filter** to allow clients to filter results based on this attribute.
 
+Note that these capabilities are not shown for attributes of entities without the __Readable__ capability.
+
 ## 3 Public Documentation
 
 In the **Public documentation** tab, you can write a summary and description intended for people using the service.

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -72,31 +72,9 @@ When names have been customized in this way, the name of the entity, attribute, 
 
 These features make it easier to refactor the domain model without affecting external APIs.
 
-## 5 Exposed Set Name
+### 5 Key {#key}
 
-It is possible to customize the name of the entity set that is displayed in the **Exposed set name** field of the **Edit published entity** window. This forms the last part of the URL of the published entity as given in the **Example of location**.
-
-Default: {Entity name}s
-
-## 6 Use Paging {#paging}
-
-The **Use paging** option is used to set a maximum number of objects per response and includes a link to the next set of objects. A client such as [Tableau](https://www.tableau.com) is able use this to display progress and automatically continue to follow the links until all the data is retrieved. The memory usage of the clients can be improved if paging is set to a reasonable page size.
-
-Default: **No**
-
-When set to **Yes**, select **Top supported** and **Skip supported** [query options](#query-options).
-
-Setting **Use paging** to **Yes** may result in inconsistency in the retrieved data because the data will not be retrieved in a single transaction. As an example, sorting on the **Age** attribute in an entity called **Customer** and retrieving customers set to 1000 objects per page. If a customer is deleted between two calls, then the customer with **Age** 23 at position 1001 moves to position 1000. This means the object that would be the first item on the second page is moved to the first page and is no longer retrieved. Similarly, data inserted between calls can result in a duplication of the data. This option should only be used when this kind of inconsistency is acceptable.
-
-## 7 Page Size
-
-When **Use paging** is set to **Yes**, the number of objects per page can be set in **Page size**.
-
-Default: **10000**
-
-## 8 Key {#key}
-
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that it is not recommended to use the ID as a key. A published entity should have a combination of attributes that form a key instead. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
+Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that it is not recommended to use the ID as a key. A published entity should have a key attribute or a combination of attributes that form a key instead. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
 Select a combination of attributes with the following constraints:
 
@@ -108,15 +86,17 @@ Having an [index](/refguide/indexes/) for the key attribute (or attributes) make
 
 You can set unique and required constraints using [validation rules](/refguide/validation-rules/).
 
+Selecting a key is required when the __Readable__ capability is enabled.
+
 {{% alert color="info" %}}
 Selecting more than one attribute as the key is only available for published OData services that use OData v4.
 {{% /alert %}}
 
-## 9 Capabilities {#capabilities}
+## 6 Capabilities {#capabilities}
 
 The **Capabilities** section gives an overview of what operations the published entity supports.
 
-### 9.1 Insertable
+### 6.1 Insertable
 
 Select the checkbox for **Insertable** to indicate that clients can insert new objects.
 
@@ -133,9 +113,7 @@ You can also choose the **Call a microflow** action to use your own logic. Speci
 
 In the publishing app, you can use a validation message action to report a validation error. The client app can include a custom error handler on the [Send External Object](/refguide/send-external-object/) activity to handle the error. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed. For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
 
-### 9.2 Readable {#readable}
-
-A published OData entity is always readable.
+### 6.2 Readable {#readable}
 
 There are two options to handle an incoming GET request for a published entity:
 
@@ -144,7 +122,27 @@ There are two options to handle an incoming GET request for a published entity:
 
 You can also set the [query options](#query-options) for each request.
 
-### 9.3 Updatable {#updatable}
+A published OData entity is by default readable. It is possible to disable this capability, which means that the data of this entity will not be exposed; instead only the type and structure of the entity will be published. The entity can then still be used as a parameter or return type of a published microflow.
+
+When **Readable** is enabled you can configure how data can be queried in the [exposed data](#exposed-data) section. Note that **Readable** must be enabled in order to enable the other capabilities.
+
+{{% alert type="info" %}}
+Support for publishing entities without the __Readable__ capability was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
+{{% /alert %}}
+
+## 6.2.1 Query Options {#query-options}
+
+Select the options to include for the **Readable** OData capability.
+
+* **Countable** – This option is required for getting the total number of records.
+* **Top supported** – This option indicates whether clients can specify that they want to retrieve only a limited number of items. Enable this option when [Use paging](#paging) is selected.
+* **Skip supported** – This option indicates whether clients can specify the number of items in the queried collection that are to be skipped and not included in the result. Enable this option when [Use paging](#paging) is selected.
+
+The **Top supported** and **Skip supported** queries are required for pagination, when the server allows the client to request only a subset of the data and skips the first **n** objects. [Paging](#paging) occurs when the client requests a lot of data and the server returns a subset and a link to request the rest.
+
+For more information, see the [System Query Option $top and $skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) in the *Basic Tutorial* on OData.org
+
+### 6.3 Updatable {#updatable}
 
 Select the checkbox for **Updatable** to indicate that clients can update the values of attributes and associations.
 
@@ -160,7 +158,7 @@ You can also choose the **Call a microflow** action to use your own logic. Speci
 
 In the publishing app, you can use a validation message action to report a validation error. The client app can include a custom error handler on the [Send External Object](/refguide/send-external-object/) activity to handle the error. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed. For more information, see [OData query options](/refguide/odata-query-options/#updating-objects).
 
-### 9.4 Deletable {#deletable}
+### 6.4 Deletable {#deletable}
 
 Select the checkbox for **Deletable** to indicate that clients can delete the values of attributes and associations.
 
@@ -168,14 +166,26 @@ Choose whether the object should be deleted from the database directly, or wheth
 
 You can use a validation message to report a validation error if you are performing, for example, a soft delete. If the microflow reports [validation feedback](/refguide/validation-feedback/), the runtime informs the client that the request has failed.
 
-## 10 Query Options {#query-options}
+## 7 Exposed Data {#exposed-data}
 
-Select the options to include for the **Readable** OData capability.
+### 7.1 Exposed Set Name
 
-* **Countable** – This option is required for getting the total number of records.
-* **Top supported** – This option indicates whether clients can specify that they want to retrieve only a limited number of items. Enable this option when [Use paging](#paging) is selected.
-* **Skip supported** – This option indicates whether clients can specify the number of items in the queried collection that are to be skipped and not included in the result. Enable this option when [Use paging](#paging) is selected.
+It is possible to customize the name of the entity set that is displayed in the **Exposed set name** field of the **Edit published entity** window. This forms the last part of the URL of the published entity as given in the **Example of location**.
 
-The **Top supported** and **Skip supported** queries are required for pagination, when the server allows the client to request only a subset of the data and skips the first **n** objects. [Paging](#paging) occurs when the client requests a lot of data and the server returns a subset and a link to request the rest.
+Default: {Entity name}s
 
-For more information, see the [System Query Option $top and $skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) in the *Basic Tutorial* on OData.org
+### 7.2 Use Paging {#paging}
+
+The **Use paging** option is used to set a maximum number of objects per response and includes a link to the next set of objects. A client such as [Tableau](https://www.tableau.com) is able use this to display progress and automatically continue to follow the links until all the data is retrieved. The memory usage of the clients can be improved if paging is set to a reasonable page size.
+
+Default: **No**
+
+When set to **Yes**, select **Top supported** and **Skip supported** [query options](#query-options).
+
+Setting **Use paging** to **Yes** may result in inconsistency in the retrieved data because the data will not be retrieved in a single transaction. As an example, sorting on the **Age** attribute in an entity called **Customer** and retrieving customers set to 1000 objects per page. If a customer is deleted between two calls, then the customer with **Age** 23 at position 1001 moves to position 1000. This means the object that would be the first item on the second page is moved to the first page and is no longer retrieved. Similarly, data inserted between calls can result in a duplication of the data. This option should only be used when this kind of inconsistency is acceptable.
+
+#### 7.3 Page Size
+
+When **Use paging** is set to **Yes**, the number of objects per page can be set in **Page size**.
+
+Default: **10000**

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -124,7 +124,7 @@ There are two options to handle an incoming GET request for a published entity:
 
 You can also set the [query options](#query-options) for each request.
 
-A published OData entity is by default readable. It is possible to disable this capability, which means that the data of this entity will not be exposed; instead only the type and structure of the entity will be published. The entity can then still be used as a parameter or return type of a published microflow.
+A published OData entity is readable by default. It is possible to disable this capability, which means that the service only exposes the type and structure of the entity, but not the data. You can use the entity as a parameter or return type of a published microflow.
 
 When **Readable** is enabled you can configure how data can be queried in the [exposed data](#exposed-data) section. Note that **Readable** must be enabled in order to enable the other capabilities.
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -44,6 +44,8 @@ Attributes of type **Binary** cannot be exported through OData services except f
 
 {{% /alert %}}
 
+You cannot include associations to and from entities that are published without the __Readable__ capability. 
+
 ### 3.1 Required Validation Rules for Published Attributes
 
 For published OData services, the **Can be empty** checkbox appears when you edit a published attribute. 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -74,9 +74,9 @@ When names have been customized in this way, the name of the entity, attribute, 
 
 These features make it easier to refactor the domain model without affecting external APIs.
 
-### 5 Key {#key}
+## 5 Key {#key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, since it can change in certain scenarios (such as data migration). That means that it is not recommended to use the ID as a key. A published entity should have a key attribute or a combination of attributes that form a key instead. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
+Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, as it can change in certain scenarios (such as data migration). That means it is not recommended to use the ID as a key. A published entity should have a key attribute or a combination of attributes that form a key instead. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
 Select a combination of attributes with the following constraints:
 
@@ -124,9 +124,9 @@ There are two options to handle an incoming GET request for a published entity:
 
 You can also set the [query options](#query-options) for each request.
 
-A published OData entity is readable by default. It is possible to disable this capability, which means that the service only exposes the type and structure of the entity, but not the data. You can use the entity as a parameter or return type of a published microflow.
+A published OData entity is readable by default. It is possible to disable this capability, which means the service only exposes the type and structure of the entity, not the data. You can use the entity as a parameter or return type of a published microflow.
 
-When **Readable** is enabled you can configure how data can be queried in the [exposed data](#exposed-data) section. Note that **Readable** must be enabled in order to enable the other capabilities.
+When **Readable** is enabled, you can configure how data is queried in the [exposed data](#exposed-data) section. Note that **Readable** must be enabled in order to enable the other capabilities.
 
 {{% alert type="info" %}}
 Support for publishing entities without the __Readable__ capability was introduced in Studio Pro [10.8.0](/releasenotes/studio-pro/10.8/).
@@ -134,13 +134,13 @@ Support for publishing entities without the __Readable__ capability was introduc
 
 ## 6.2.1 Query Options {#query-options}
 
-Select the options to include for the **Readable** OData capability.
+Select the options to include for the **Readable** OData capability:
 
 * **Countable** – This option is required for getting the total number of records.
 * **Top supported** – This option indicates whether clients can specify that they want to retrieve only a limited number of items. Enable this option when [Use paging](#paging) is selected.
 * **Skip supported** – This option indicates whether clients can specify the number of items in the queried collection that are to be skipped and not included in the result. Enable this option when [Use paging](#paging) is selected.
 
-The **Top supported** and **Skip supported** queries are required for pagination, when the server allows the client to request only a subset of the data and skips the first **n** objects. [Paging](#paging) occurs when the client requests a lot of data and the server returns a subset and a link to request the rest.
+The **Top supported** and **Skip supported** queries are required for pagination, which is when the server allows the client to request only a subset of the data and skips the first **n** objects. [Paging](#paging) occurs when the client requests a lot of data and the server returns a subset and a link to request the rest.
 
 For more information, see the [System Query Option $top and $skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) in the *Basic Tutorial* on OData.org
 
@@ -178,13 +178,13 @@ Default: {Entity name}s
 
 ### 7.2 Use Paging {#paging}
 
-The **Use paging** option is used to set a maximum number of objects per response and includes a link to the next set of objects. A client such as [Tableau](https://www.tableau.com) is able use this to display progress and automatically continue to follow the links until all the data is retrieved. The memory usage of the clients can be improved if paging is set to a reasonable page size.
+The **Use paging** option is used to set a maximum number of objects per response and includes a link to the next set of objects. A client such as [Tableau](https://www.tableau.com) is able use this to display progress and automatically continues to follow the links until all the data is retrieved. The memory usage of the clients can be improved if paging is set to a reasonable page size.
 
 Default: **No**
 
 When set to **Yes**, select **Top supported** and **Skip supported** [query options](#query-options).
 
-Setting **Use paging** to **Yes** may result in inconsistency in the retrieved data because the data will not be retrieved in a single transaction. As an example, sorting on the **Age** attribute in an entity called **Customer** and retrieving customers set to 1000 objects per page. If a customer is deleted between two calls, then the customer with **Age** 23 at position 1001 moves to position 1000. This means the object that would be the first item on the second page is moved to the first page and is no longer retrieved. Similarly, data inserted between calls can result in a duplication of the data. This option should only be used when this kind of inconsistency is acceptable.
+Setting **Use paging** to **Yes** may result in inconsistency in the retrieved data because the data will not be retrieved in a single transaction. For example, sorting on the **Age** attribute in an entity called **Customer** and retrieving customers set to 1000 objects per page. If a customer is deleted between two calls, the customer with **Age** 23 at position 1001 moves to position 1000. This means the object that would be the first item on the second page is moved to the first page and is no longer retrieved. Similarly, data inserted between calls can result in a duplication of the data. This option should only be used when this kind of inconsistency is acceptable.
 
 #### 7.3 Page Size
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
@@ -14,7 +14,7 @@ Use the Integration pane in Studio Pro to use available data sources from the di
 
 You can search in the Catalog through the [Integration pane](/refguide/integration-pane/) to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
 
-Besides external entities, OData services can expose actions that can be called from within microflows, and can define non-persistable entities that can be used as parameters or return types of these actions. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable. If a parameter or result has a non-persistable entity as its type, it will add those to the domain model for you.
+Besides external entities, OData services can expose actions that can be called from within microflows, and can define non-persistable entities that can be used as parameters or return types of these actions. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable. If a parameter or result has an external or non-persistable entity as its type, it will add those to the domain model for you when you add the action to your microflow.
 
 To display the [Integration pane](/refguide/integration-pane/), click **View** > **Integration**.
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
@@ -14,7 +14,7 @@ Use the Integration pane in Studio Pro to use available data sources from the di
 
 You can search in the Catalog through the [Integration pane](/refguide/integration-pane/) to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
 
-Besides external entities, OData services can expose actions that can be called from within microflows. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable.
+Besides external entities, OData services can expose actions that can be called from within microflows, and can define non-persistable entities that can be used as parameters or return types of these actions. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable. If a parameter or result has a non-persistable entity as its type, it will add those to the domain model for you.
 
 To display the [Integration pane](/refguide/integration-pane/), click **View** > **Integration**.
 
@@ -138,6 +138,7 @@ Unsupported attributes are grayed out and are not included in your app.
 
 If the entity, association, or attribute supports **C**reate, **R**ead, **U**pdate, or **D**elete capabilities and it is also supported by Studio Pro, then it is displayed in the [Integration pane](/refguide/integration-pane/).
 Entities and associations can have any of the CRUD capabilities, while attributes can only have create and update. For more information on CRUD capabilities, see [Write Data to Another App](/catalog/write-data/).
+If an entity does not support any capability, it will be displayed with a yellow entity icon. Importing this will result in a non-persistable entity being added to your domain model.
 
 ### 4.3 Actions {#actions}
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
@@ -10,13 +10,13 @@ aliases:
 
 ## 1 Introduction
 
-Use the Integration pane in Studio Pro to use available data sources from the different applications in an organization into your Mendix apps. New apps can be created using shared datasets that are registered in the [Catalog](/catalog/). In Studio Pro, this is possible using the integrated functionality of Catalog through the [Integration pane](/refguide/integration-pane/).
+Use the Integration pane in Studio Pro to use available data sources from the different applications in an organization into your Mendix apps. New apps can be created using shared datasets that are registered in the [Catalog](/catalog/). In Studio Pro, this is possible using the integrated functionality of Catalog through the **Integration pane**.
 
-You can search in the Catalog through the [Integration pane](/refguide/integration-pane/) to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
+You can search in the Catalog through the Integration pane to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
 
 Besides external entities, OData services can expose actions that can be called from within microflows, and can define non-persistable entities that can be used as parameters or return types of these actions. From this pane you can drag these actions onto a microflow, where they will appear as a **Call external action** activity. In this activity you can configure the parameters and result variable. If a parameter or result has an external or non-persistable entity as its type, it will add those to the domain model for you when you add the action to your microflow.
 
-To display the [Integration pane](/refguide/integration-pane/), click **View** > **Integration**.
+To display the Integration pane, click **View** > **Integration**.
 
 {{% alert color="info" %}}
 In the Catalog, registered published services are referred to as *data sources*. Published entities will show the **Entity set** name and are called *datasets.*
@@ -35,7 +35,7 @@ The following functionality is available in the pane:
 
 ### 2.1 Used in Your App Section {#used-in-app}
 
-When you do not enter search text in the [Integration pane](/refguide/integration-pane/), then the **Used in your App** section is displayed. This shows the consumed services and the related external entities and actions used in the current app. The list of entities, associations, attributes, and actions for the consumed services are shown as for the search results:
+When you do not enter search text in the Integration pane, then the **Used in your App** section is displayed. This shows the consumed services and the related external entities and actions used in the current app. The list of entities, associations, attributes, and actions for the consumed services are shown as for the search results:
 
 {{< figure src="/attachments/refguide/modeling/menus/view-menu/data-hub-pane/used-in-your-app.png" alt="User in Your App Section" >}}
 
@@ -43,7 +43,7 @@ For more information on how to add entities and actions to your app, see [Adding
 
 ## 3 Searching Catalog Sources {#search}
 
-As you enter a search term, all the items in the Catalog satisfying the search string are listed in the search results. This includes words in the service, entity and attribute descriptions, which are not displayed in the [Integration pane](/refguide/integration-pane/). For more information, see the [Selected Asset Details](/catalog/manage/search/#search-details) section in *Search in the Catalog*.
+As you enter a search term, all the items in the Catalog satisfying the search string are listed in the search results. This includes words in the service, entity and attribute descriptions, which are not displayed in the Integration pane. For more information, see the [Selected Asset Details](/catalog/manage/search/#search-details) section in *Search in the Catalog*.
 
 You can drag the entity from the search results into your domain model and it will be added to your app and displayed as an [external entity](/refguide/external-entities/).
 
@@ -69,7 +69,7 @@ When the **Show development environments** is checked, all subsequent searches r
 
 ## 4 Integration Pane Information {#viewing}
 
-The information that is displayed in the [Integration pane](/refguide/integration-pane/) either when you enter a search term or when you open the **Used in your App** section is described in the sections below. 
+The information that is displayed in the [Integration pane](/refguide//) either when you enter a search term or when you open the **Used in your App** section is described in the sections below. 
 
 ### 4.1 Services
 
@@ -136,9 +136,9 @@ Unsupported attributes are grayed out and are not included in your app.
 
 #### 4.2.4 CRUD Capabilities
 
-If the entity, association, or attribute supports **C**reate, **R**ead, **U**pdate, or **D**elete capabilities and it is also supported by Studio Pro, then it is displayed in the [Integration pane](/refguide/integration-pane/).
+If the entity, association, or attribute supports **C**reate, **R**ead, **U**pdate, or **D**elete capabilities and it is also supported by Studio Pro, then it is displayed in the Integration pane.
 Entities and associations can have any of the CRUD capabilities, while attributes can only have create and update. For more information on CRUD capabilities, see [Write Data to Another App](/catalog/write-data/).
-If an entity does not support any capability, it will be displayed with a yellow entity icon. Importing this will result in a non-persistable entity being added to your domain model.
+If an entity does not support any capability, it will be displayed with a yellow entity icon. This results in a non-persistable entity in the domain model.
 
 ### 4.3 Actions {#actions}
 

--- a/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
+++ b/content/en/docs/refguide/modeling/menus/view-menu/integration-pane.md
@@ -10,7 +10,7 @@ aliases:
 
 ## 1 Introduction
 
-Use the Integration pane in Studio Pro to use available data sources from the different applications in an organization into your Mendix apps. New apps can be created using shared datasets that are registered in the [Catalog](/catalog/). In Studio Pro, this is possible using the integrated functionality of Catalog through the **Integration pane**.
+Use the Integration pane in Studio Pro to use available data sources from the different applications in an organization into your Mendix apps. New apps can be created using shared datasets that are registered in the [Catalog](/catalog/). In Studio Pro, this is possible using the integrated functionality of Catalog through the **Integration** pane.
 
 You can search in the Catalog through the Integration pane to discover data sources that you can use in your app. Via this pane you can add the entities that are published in the registered OData services into your app's domain model. These entities are called [external entities](/refguide/external-entities/) and are different because they enable the connection to the data associated with the entities in the originating app.
 
@@ -138,6 +138,7 @@ Unsupported attributes are grayed out and are not included in your app.
 
 If the entity, association, or attribute supports **C**reate, **R**ead, **U**pdate, or **D**elete capabilities and it is also supported by Studio Pro, then it is displayed in the Integration pane.
 Entities and associations can have any of the CRUD capabilities, while attributes can only have create and update. For more information on CRUD capabilities, see [Write Data to Another App](/catalog/write-data/).
+
 If an entity does not support any capability, it will be displayed with a yellow entity icon. This results in a non-persistable entity in the domain model.
 
 ### 4.3 Actions {#actions}


### PR DESCRIPTION
We've added the possibility to import NPEs from a consumed OData service in 10.8. These can be used as external action parameters / return types.