### PR TITLE
Update projects-api.md to reflect new deprecation date

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/projects-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/projects-api.md
@@ -7,7 +7,7 @@ weight: 85
 ---
 
 {{% alert color="warning" %}}
-The Projects API is deprecated. Mendix aims to remove the Project API on March 1, 2024.
+The Projects API is deprecated. Mendix aims to remove the Project API on March 31, 2024.
 {{% /alert %}}
 
 ## 1 Introduction


### PR DESCRIPTION
New deprecation date for Projects API moved from March 1 to March 31