### PR TITLE
Add reference to React client setting in RN 10.7

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.7.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.7.md
@@ -33,6 +33,8 @@ In keeping with our commitment to delivering the best user experience possible, 
 
 The React client is available in [beta](/releasenotes/beta-features/) and will be generally available in Studio Pro 10.12.
 
+Enabling can be done with the [Use React Client](/refguide/app-settings/#react-client) configuration in the runtime settings.
+
 #### Studio Pro on Mac (Beta)
 
 Studio Pro on Mac is now in [public beta](/releasenotes/beta-features/). This allows you to run Studio Pro natively on Mac without Parallels. With the Mac version of Studio Pro, you can edit your apps in the same way as on Windows using the functionality you are used to. For more information, see the [Software Specifications](/refguide/system-requirements/#software) section in *System Requirements*. 

--- a/content/en/docs/releasenotes/studio-pro/10/10.7.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.7.md
@@ -33,7 +33,7 @@ In keeping with our commitment to delivering the best user experience possible, 
 
 The React client is available in [beta](/releasenotes/beta-features/) and will be generally available in Studio Pro 10.12.
 
-Enabling can be done with the [Use React Client](/refguide/app-settings/#react-client) configuration in the runtime settings.
+Enabling can be done with the [Use React Client](/refguide/app-settings/#react-client) configuration in the runtime settings. For more information, see [Mendix React Client](/refguide/mendix-client/react/).
 
 #### Studio Pro on Mac (Beta)
 


### PR DESCRIPTION
We had some questions about how to enable the React client, or vice-versa what the new setting in the runtime settings means because people couldn't find it in the release notes of 10.7. So I've hereby added a reference to the new setting.