### PR TITLE
Revert "Remove App Switcher documentation"

### DIFF
--- a/content/en/docs/appstore/modules/_index.md
+++ b/content/en/docs/appstore/modules/_index.md
@@ -151,6 +151,7 @@ To check out which modules a category contains, click the category in the list b
 ### 2.14 Utility {#utility}
 
 * [Administration](/appstore/modules/administration/)
+* [App Switcher](/appstore/modules/app-switcher/)
 * [Community Commons](/appstore/modules/community-commons-function-library/)
 * [Encryption](/appstore/modules/encryption/)
 * [Mendix Feedback](/appstore/modules/mendix-feedback/)

--- a/content/en/docs/appstore/modules/app-switcher.md
+++ b/content/en/docs/appstore/modules/app-switcher.md
@@ -1,0 +1,43 @@
+---
+title: "App Switcher"
+url: /appstore/modules/app-switcher/
+category: "Modules"
+description: "Describes the configuration and troubleshooting of the App Switcher module, which is available in the Mendix Marketplace."
+tags: ["marketplace", "marketplace component", "app switcher", "platform support"]
+#If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
+---
+
+## 1 Introduction
+
+The [App Switcher](https://marketplace.mendix.com/link/component/119451) is a module that allows the end-user to see and switch between all the Mendix apps they have access to that are connected through Mendix SSO.
+
+## 2 Prerequisites
+
+* Use Mendix Studio Pro [9.6.1](/releasenotes/studio-pro/9.1/) or higher
+* Install [Mendix SSO module](/appstore/modules/mendix-sso/) (Mendix recommends having this module updated to the latest version)
+
+## 3 Configuration
+
+1. [Install](/appstore/overview/use-content/) the App Switcher module.
+2. Configure the [user roles](/refguide/user-roles/) to have access to the user AppSwitcherModule module role.
+3. Add the App Switcher widget to the desired page or layout. You can find the widget in the **Add-ons** category in the **Toolbar**.
+4. Make sure the end-user has to log in to Mendix SSO before accessing the page with the App Switcher widget.
+
+## 4 Troubleshooting
+
+* Failed to get an access token for user x
+    * The token cannot be retrieved
+    * Make sure Mendix SSO is correctly implemented and the user is logged into the application before accessing
+  
+* Failed to get custom authentication token for user x
+    * This can happen for various reasons – check the `HTTPResponse` to see the possible reason:
+    
+    | Error Code | Reason | Solution |
+    | ---------- | ------ |------ |
+    | No error code | The App Switcher cannot communicate with the server. |Check if the `AppSwitcher_Base_URL` is correct or check Mendix Cloud Status.|
+    | 400 | Bad request. The user ID does not match up or the wrong authentication token is being used. |Make sure Mendix SSO is correctly implemented.|
+    | 401 | Authentication error. The custom auth token expired or the widget is calling a non-corresponding environment. ||
+    | 404 | URL not found. |Make sure the URL is correct.|
+    | 500 | Authentication error. This can occur if the user ID is empty. |Check the user ID.|
+    | 560 | Exception. User does not have the correct access. |Make sure the user has access to the user module role in AppSwitcherModule.|
+    

--- a/content/en/docs/appstore/modules/app-switcher.md
+++ b/content/en/docs/appstore/modules/app-switcher.md
@@ -1,11 +1,15 @@
 ---
-title: "App Switcher"
+title: "App Switcher ⚠"
 url: /appstore/modules/app-switcher/
 category: "Modules"
 description: "Describes the configuration and troubleshooting of the App Switcher module, which is available in the Mendix Marketplace."
 tags: ["marketplace", "marketplace component", "app switcher", "platform support"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
+
+{{% alert color="warning" %}}
+This module is deprecated and has been removed from the Marketplace. Existing users can continue to use the service until June 7, 2024. The service will be switched off on that date.
+{{% /alert %}}
 
 ## 1 Introduction
 


### PR DESCRIPTION
Reverts mendix/docs#7388

Module is not available, but service is deprecated. So restoring documentation and adding a deprecation notice.