### PR TITLE
Update build-hybrid-locally.md

### DIFF
--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
@@ -45,7 +45,7 @@ To target a specific DTAP endpoint with your app, you can specify it as a parame
 npm run package -- --env target=test  # target the test endpoint for ARM architecture
 ```
 
-Possible targets are `development`, `test`, `acceptance`, `production` (default), and `sandbox`. For convenience you can shorten these to their first letters. Note that if no `--env.target` parameter is provided, the hybrid app endpoint will default to the production environment. 
+Possible targets are `development`, `test`, `acceptance`, `production` (default), and `sandbox`. For convenience you can shorten these to their first letters. Note that if no `--env target` parameter is provided, the hybrid app endpoint will default to the production environment. 
 
 ### 2.2 Building Your Prepared Project
 


### PR DESCRIPTION
with the latest buildpack, it's `env target` instead of `env.target` (see also: the code above without the dot)