### PR TITLE
Remove old versions from Sitemap

### DIFF
--- a/content/en/docs/howto7/_index.md
+++ b/content/en/docs/howto7/_index.md
@@ -12,6 +12,7 @@ cascade:
     - banner: "Mendix 7 is no longer supported unless you have Extended Support (for details, please contact Mendix Support). Mendix 7 documentation will remain available for customers with Extended Support until July, 2024."
     - old_content: true
     - hide_feedback: true
+    - notsitemap: true
     - sitemap:
         priority: 0.1
 ---

--- a/content/en/docs/howto8/_index.md
+++ b/content/en/docs/howto8/_index.md
@@ -11,6 +11,7 @@ cascade:
     - mendix_version: 8
     - old_content: true
     - hide_feedback: true
+    - notsitemap: true
     - sitemap:
         priority: 0.2
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/en/docs/howto9/_index.md
+++ b/content/en/docs/howto9/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Studio Pro 9 How-tos"
     - mendix_version: 9
     - old_content: true
+    - notsitemap: true
     - sitemap:
         priority: 0.3
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.

--- a/content/en/docs/refguide7/_index.md
+++ b/content/en/docs/refguide7/_index.md
@@ -12,6 +12,7 @@ cascade:
     - banner: "Mendix 7 is no longer supported unless you have Extended Support (for details, please contact Mendix Support). Mendix 7 documentation will remain available for customers with Extended Support until July, 2024."
     - old_content: true
     - hide_feedback: true
+    - notsitemap: true
     - sitemap:
         priority: 0.1
 ---

--- a/content/en/docs/refguide8/_index.md
+++ b/content/en/docs/refguide8/_index.md
@@ -11,6 +11,7 @@ cascade:
     - mendix_version: 8
     - old_content: true
     - hide_feedback: true
+    - notsitemap: true
     - sitemap:
         priority: 0.3
 ---

--- a/content/en/docs/refguide9/_index.md
+++ b/content/en/docs/refguide9/_index.md
@@ -10,6 +10,7 @@ cascade:
     - space: "Studio Pro 9 Guide"
     - mendix_version: 9
     - old_content: true
+    - notsitemap: true
     - sitemap:
         priority: 0.4
 ---

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,27 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<!-- Updated to exclude pages which have the front matter sitemapexclude: true - can then exclude all but the latest version see https://dereckcurry.com/posts/excluding-pages-from-the-sitemap/ -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if .Permalink -}}
+        {{- if or (eq (isset .Params "notsitemap") false) (ne .Params.notsitemap true) -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.LanguageCode }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.LanguageCode }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+        {{- end -}}
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
Google is choosing refguide7 as canonical which leads to bad search experience.
This PR allows you to exclude pages from the sitemap, and is set up to exclude everything which isn't the current version.
Also need to update the technical site description to document this.