### PR TITLE
Reflect in docs that 'Add' list operation now functions the same in nanoflows as they do in microflows

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/list-activities/change-list.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/list-activities/change-list.md
@@ -6,10 +6,6 @@ tags: ["studio pro", "List"]
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
 
-{{% alert color="info" %}}
-This activity can be used in both microflows and nanoflows. However, there are minor differences between the way it works in microflows and in nanoflows.
-{{% /alert %}}
-
 ## 1 Introduction
 
 The **Change list** activity allows you to change a list by adding objects to, and removing objects from, it. The activity works directly on the list provided, in contrast to the [List operation](/refguide/list-operation/) activity.
@@ -53,10 +49,6 @@ Defines the type of change that is applied to the list.
 #### 3.2.1 Notes When Using the Add Type{#notes}
 
 If you do not want duplicates in your (microflow) list, you can either remove the object (or objects) first, or use the **Contains** [list operation](/refguide/list-operation/) to examine the list before adding the object (or objects).
-
-{{% alert color="warning" %}}
-Currently, this works differently in **nanoflows** and **microflows**. In a **nanoflow** objects will *not* be added if they are already in the list whereas, in a **microflow**, the same object can be added multiple times.
-{{% /alert %}}
 
 ### 3.3 Value
 


### PR DESCRIPTION
Hi,

In 10.10, we improved the behavior of the 'Add' list operation in nanoflows to allow for duplicates. Because of this, microflows and nanoflows behave the same, and there is no need for a disclaimer in the docs anymore.