### PR TITLE
Update community-best-practices-for-app-performance.md

### DIFF
--- a/content/en/docs/refguide/modeling/community-best-practices-for-app-performance.md
+++ b/content/en/docs/refguide/modeling/community-best-practices-for-app-performance.md
@@ -81,7 +81,6 @@ Indexes is a topic with a long history of best practices from the database world
     * If loops contain decisions, consider if the decision logic can be a query before the loop to minimize iterations.
 * Prevent unnecessary retrieves if objects or lists can be passed as parameters.
 * Know and use the retrieve + aggregate optimization. If you retrieve a list and count the list, Mendix will optimize this to one query. If you need the list later in the microflow, after some decisions, it is wise to retrieve the list again so that you only retrieve the data when needed. This also works in batches where you can retrieve the total count optimized and retrieve chunks in a separate query.
-* Use the retrieve over association if possible. This uses caching, it is more readable, and it uses an index. If business logic requires the database value (because the value over association might be changed), then of course a database retrieve is needed.
 * Commit as late as possible. A commit locks that record (or list of records). This means that any other user/logic that wants to commit the same object has to wait until the first transaction is finished.
 * To prevent locking, do scheduled events that commit data in small chunks. This is so the data does not get locked over a longer period of time.
 


### PR DESCRIPTION
Remove microflow recommendation on 'retrieve by association'. The statement 'Use the retrieve over association if possible. This uses caching, it is more readable, and it uses an index. If business logic requires the database value (because the value over association might be changed), then of course a database retrieve is needed.' is wrong or misleading. There is no such caching mechanism documented anywhere and also the statement about indexes is lacking any explanation,