### PR TITLE
Mx4PC 2.16.0 release notes (planned for release on April 24)

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
@@ -458,22 +458,22 @@ If the environment cannot be deleted, you will receive a warning, but can go ahe
 
 {{< figure src="/attachments/developerportal/deploy/private-cloud/private-cloud-deploy/delete-environment.png" >}}
 
-For a *connected* cluster, the top level MendixApp​ CRD will be deleted from the namespace – this will cause the following environment resources set up by the Operator to be garbage collected:
+For a *connected* cluster, the top level MendixApp CRD will be deleted from the namespace – this will cause the following environment resources set up by the Operator to be garbage collected:
 
-* ​​The database will be dropped and the database user will be deleted from the database server — databases and users from other environments will remain untouched.
+* The database will be dropped and the database user will be deleted from the database server — databases and users from other environments will remain untouched.
 
     {{% alert color="info" %}}If the storage plan is using a JDBC plan (not Postgres or SQL Server), the database and the user will remain untouched).{{% /alert %}}
 
-* ​​Files related to that environment will be deleted from the S3/Minio storage bucket (or prefix if this is using a shared bucket).
+* Files related to that environment will be deleted from the S3/Minio storage bucket (or prefix if this is using a shared bucket).
 
     {{% alert color="info" %}}If you are using the S3 [create account with existing policy](/developerportal/deploy/standard-operator/#storage-plan) plan - the files remain untouched.{{% /alert %}}
 
-* ​​S3/Minio users and policies will be deleted (if there is a storage plan specified to create those objects).
+* S3/Minio users and policies will be deleted (if there is a storage plan specified to create those objects).
 
-* ​​Network resources: ingress, service will be removed. This might also garbage collect other resources (for example Load Balancers and TLS certificates), depending on how your network is set up,
+* Network resources: ingress, service will be removed. This might also garbage collect other resources (for example Load Balancers and TLS certificates), depending on how your network is set up,
 
 {{% alert color="info" %}}
-​​Images are not deleted from the container registry. You should delete those images manually.
+Images are not deleted from the container registry. You should delete those images manually.
 {{% /alert %}}
 
 {{% alert color="warning" %}}

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -57,7 +57,7 @@ spec:
     servicePlan: dev
   storage: # Specification of Storage CR
     servicePlan: dev
-  mendixRuntimeVersion: 8.0.0 # Mendix version to use for placeholder runtime image.
+  mendixRuntimeVersion: 8.0.0 # Studio Pro version of the Mendix app
   sourceURL: https://example.com/example-app.mda # URL of App's source MDA or prebuilt OCI image
   appURL: example-mendixapp.k8s-cluster.example.com # URL to access the app
   tls: # Optional, can be omitted : set a custom TLS configuration, overriding the default operator configuration
@@ -174,7 +174,7 @@ You need to make the following changes:
 
 * **name**: – You can deploy multiple apps in one project/namespace — the app name in the CR doesn't have to match the app name in the mda and will have an **Environment UUID** added when it is deployed to ensure that it is unique in the project — see [Reserved Names for Mendix Apps](#reserved-names), below, for restrictions on naming your app
 * **database/storage** – ensure that these have the correct **Database Plan** and **Storage Plan** — they have to have the same names that you [registered in the namespace](/developerportal/deploy/standard-operator/#configure-namespace)
-* **mendixRuntimeVersion** – the full runtime version of the app. From Operator version 2.15.0 onwards, this field is not read (but needs to be specified).
+* **mendixRuntimeVersion** – the full runtime version of the app. In Operator versions 2.15.0 and 2.15.1, this field is not read (but needs to be specified). From Operatore version 2.16.0 onwards, this field doesn't need to be specified.
 * **sourceURL** – an HTTP or HTTPS URL specifying the location of the deployment package (this must be accessible from your cluster without any authentication; use expiring URLs for security). Alternatively, to deploy an existing app image built by the Mendix Operator, specify it using an `oci-image://` schema.
 * **appURL** – the endpoint where you can connect to your running app — this is optional, and if it is supplied it must be a URL which is supported by your platform
 * **tls** – the TLS configuration — this is optional, and if it is supplied it will override the default Mendix Operator network configuration

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -174,7 +174,7 @@ You need to make the following changes:
 
 * **name**: – You can deploy multiple apps in one project/namespace — the app name in the CR doesn't have to match the app name in the mda and will have an **Environment UUID** added when it is deployed to ensure that it is unique in the project — see [Reserved Names for Mendix Apps](#reserved-names), below, for restrictions on naming your app
 * **database/storage** – ensure that these have the correct **Database Plan** and **Storage Plan** — they have to have the same names that you [registered in the namespace](/developerportal/deploy/standard-operator/#configure-namespace)
-* **mendixRuntimeVersion** – the full runtime version of the app. In Operator versions 2.15.0 and 2.15.1, this field is not read (but needs to be specified). From Operatore version 2.16.0 onwards, this field doesn't need to be specified.
+* **mendixRuntimeVersion** – the full runtime version of the app. In Operator versions 2.15.0 and 2.15.1, this field is not read (but needs to be specified). From Operator version 2.16.0 onwards, this field doesn't need to be specified.
 * **sourceURL** – an HTTP or HTTPS URL specifying the location of the deployment package (this must be accessible from your cluster without any authentication; use expiring URLs for security). Alternatively, to deploy an existing app image built by the Mendix Operator, specify it using an `oci-image://` schema.
 * **appURL** – the endpoint where you can connect to your running app — this is optional, and if it is supplied it must be a URL which is supported by your platform
 * **tls** – the TLS configuration — this is optional, and if it is supplied it will override the default Mendix Operator network configuration

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-operator.md
@@ -174,7 +174,7 @@ You need to make the following changes:
 
 * **name**: – You can deploy multiple apps in one project/namespace — the app name in the CR doesn't have to match the app name in the mda and will have an **Environment UUID** added when it is deployed to ensure that it is unique in the project — see [Reserved Names for Mendix Apps](#reserved-names), below, for restrictions on naming your app
 * **database/storage** – ensure that these have the correct **Database Plan** and **Storage Plan** — they have to have the same names that you [registered in the namespace](/developerportal/deploy/standard-operator/#configure-namespace)
-* **mendixRuntimeVersion** – the full runtime version of the app. In Operator versions 2.15.0 and 2.15.1, this field is not read (but needs to be specified). From Operator version 2.16.0 onwards, this field doesn't need to be specified.
+* **mendixRuntimeVersion** – the full runtime version of the app. In Operator versions 2.15.0 and 2.15.1, this field is not read (but needs to be specified). From Operator version 2.16.0 onwards, this field does not need to be specified.
 * **sourceURL** – an HTTP or HTTPS URL specifying the location of the deployment package (this must be accessible from your cluster without any authentication; use expiring URLs for security). Alternatively, to deploy an existing app image built by the Mendix Operator, specify it using an `oci-image://` schema.
 * **appURL** – the endpoint where you can connect to your running app — this is optional, and if it is supplied it must be a URL which is supported by your platform
 * **tls** – the TLS configuration — this is optional, and if it is supplied it will override the default Mendix Operator network configuration

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,6 +13,20 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
+### April ???, 2024
+
+#### Mendix Operator v2.16.0 {#2.16.0}
+
+* The `mendixRuntimeVersion` parameter no longer needs to specified in the MendixApp CR.
+* When creating a new app environment in AWS, the IAM region will be autodetected based on the bucket region. For AWS GovCloud and China, it's no longer necessary to manually specify the `--iam-region` argument.
+* We've addressed a few issues which affected environments that use PCLM with Global Operator:
+   * The MendixApp status will now correctly show if an environment is configured to use PCLM.
+   * License claims will now be correctly refreshed to ensure that licenses from running apps are not reassigned to other environments.
+* Global Operator is now available for use and no longer hidden behind a feature flag.
+* When upgrading Global Operator, `the `mxpc-cli` configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
+* We have updated components to use Go 1.22 and the latest dependency versions, in order to improve security score ratings for all container images.
+* Upgrading to Mendix Operator v2.16.0 from a previous version will restart environments managed by that version of the Operator.
+
 ### April 18th, 2024
 
 #### Documentation Updates

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -23,7 +23,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
    * The MendixApp status will now correctly show if an environment is configured to use PCLM.
    * License claims will now be correctly refreshed to ensure that licenses from running apps are not reassigned to other environments.
 * Global Operator is now available for use and no longer hidden behind a feature flag.
-* When upgrading Global Operator, `the `mxpc-cli` configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
+* When upgrading Global Operator, the `mxpc-cli` installation and configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
 * We have updated components to use Go 1.22 and the latest dependency versions, in order to improve security score ratings for all container images.
 * Upgrading to Mendix Operator v2.16.0 from a previous version will restart environments managed by that version of the Operator.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -19,9 +19,10 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 * The `mendixRuntimeVersion` parameter no longer needs to specified in the MendixApp CR.
 * When creating a new app environment in AWS, the IAM region will be autodetected based on the bucket region. For AWS GovCloud and China, it's no longer necessary to manually specify the `--iam-region` argument.
-* We've addressed a few issues which affected environments that use PCLM with Global Operator:
+* We've completed integration between Global Operator and PCLM and addressed remaining issues:
    * The MendixApp status will now correctly show if an environment is configured to use PCLM.
    * License claims will now be correctly refreshed to ensure that licenses from running apps are not reassigned to other environments.
+   * License claims are now correctly reported.
 * Global Operator is now available for use and no longer hidden behind a feature flag.
 * When upgrading Global Operator, the `mxpc-cli` installation and configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
 * We have updated components to use Go 1.22 and the latest dependency versions, in order to improve security score ratings for all container images.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -18,13 +18,13 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Mendix Operator v2.16.0 {#2.16.0}
 
 * The `mendixRuntimeVersion` parameter no longer needs to specified in the MendixApp CR.
-* When creating a new app environment in AWS, the IAM region will be autodetected based on the bucket region. For AWS GovCloud and China, it's no longer necessary to manually specify the `--iam-region` argument.
-* We've completed integration between Global Operator and PCLM and addressed remaining issues:
+* When creating a new app environment in AWS, the IAM region is autodetected based on the bucket region. For AWS GovCloud and China, it is no longer necessary to manually specify the `--iam-region` argument.
+* We have completed the integration between Global Operator and PCLM and addressed the remaining issues:
    * The MendixApp status will now correctly show if an environment is configured to use PCLM.
    * License claims will now be correctly refreshed to ensure that licenses from running apps are not reassigned to other environments.
    * License claims are now correctly reported.
-* Global Operator is now available for use and no longer hidden behind a feature flag.
-* When upgrading Global Operator, the `mxpc-cli` installation and configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
+* The Global Operator is now available for use and no longer hidden behind a feature flag.
+* When upgrading the Global Operator, the `mxpc-cli` installation and configuration tool will now also update all of its managed namespaces as well. To upgrade an entire cluster, the upgrade procedure only needs to run once - for the Global Operator.
 * We have updated components to use Go 1.22 and the latest dependency versions, in order to improve security score ratings for all container images.
 * Upgrading to Mendix Operator v2.16.0 from a previous version will restart environments managed by that version of the Operator.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -13,7 +13,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
-### April ???, 2024
+### April 24th, 2024
 
 #### Mendix Operator v2.16.0 {#2.16.0}
 


### PR DESCRIPTION
Our team is planning to release a new version of Mx4PC Operator this Wednesday; this PR contains release notes and an update that Mx4PC 2.16.0 no longer needs `mendixRuntimeVersion` to be specified in the MendixApp CR.

In addition, a few invisible/unprintable spaces were removed in the content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md file.