### PR TITLE
Add renderMode to pluggable-widgets-studio-apis.md

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
@@ -170,9 +170,9 @@ It is possible to require the following modules:
 The `preview` export is expected to be a `class` or `function` representing a `React` component. This component, the values object (see the [Values API](#values) section above), and the following properties will be rendered along with the values as properties:
 
 * `readOnly` (`boolean`): `true` if the widget is read-only (for example, if it is configured to be so due to the `Editability` system property, or if it is inside a read-only data view)
-* `renderMode` (`string`): a string providing information on which mode the rendering editor is in.
-    * `design`: the current editor is in design mode.
-    * `xray`: the current editor is in x-ray mode.
+* `renderMode` (`string`): a string providing information on which mode the rendering editor is in
+    * `design`: the current editor is in design mode
+    * `xray`: the current editor is in x-ray mode
 * `class` (`string`): the classes from the system, which will include manually configured classes through the `class` property in Studio Pro, and the classes resulting from configured design properties
 * `style` (`string`): a string representation of the styles as entered in the `style` property in Studio Pro
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-studio-apis.md
@@ -170,6 +170,9 @@ It is possible to require the following modules:
 The `preview` export is expected to be a `class` or `function` representing a `React` component. This component, the values object (see the [Values API](#values) section above), and the following properties will be rendered along with the values as properties:
 
 * `readOnly` (`boolean`): `true` if the widget is read-only (for example, if it is configured to be so due to the `Editability` system property, or if it is inside a read-only data view)
+* `renderMode` (`string`): a string providing information on which mode the rendering editor is in.
+    * `design`: the current editor is in design mode.
+    * `xray`: the current editor is in x-ray mode.
 * `class` (`string`): the classes from the system, which will include manually configured classes through the `class` property in Studio Pro, and the classes resulting from configured design properties
 * `style` (`string`): a string representation of the styles as entered in the `style` property in Studio Pro
 


### PR DESCRIPTION
Added some information on the renderMode that will be passed to the pluggable widget api to indicate the current mode that the page editor is in.

It will be introduced in version 10.11.0.