### PR TITLE
[UFC-1120] Update Communication Patterns document to include Runtime Operations

### DIFF
--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -40,11 +40,48 @@ Communication between these components operates as follows:
 
 * The Mendix Client issues two types of requests:
     * Static resources like pages, stylesheets, widgets, images, etc.
-    * Application data-related communication, which includes CRUD commands on data and logic that may require data
+    * Application data-related communication, which includes CRUD commands on data and logic that may require data. These are executed using [Runtime Operations]{#RO}.
 * The Runtime Server communicates with different (relational) databases using SQL statements handled by a JDBC library
     * Application data is stored in an ER-model in an database
 
-## 3 Basic CRUD Communication Pattern{#crud}
+## 3 Runtime Operations {#RO}
+Data-related communication between the Mendix Client and the Runtime Server is done with Runtime Operations over a REST-like protocol. 
+
+There are various types of Runtime Operations:
+- Create - creates new objects or variables.
+- Retrieve - retrieves a list of entities or a single entity.
+- Rollback - undoes changes.
+- Commit - commits objects and updates an entity if there are changes.
+- CallMicroflow - executes a Microflow.
+- CallExternalAction - executes an external action.
+
+The above operations are requested from the Client and are executed on the Runtime.
+
+When building your application, Studio Pro analyses the domain model. Every data-related action that is used in pages, widgets, microflows or nanoflows is registered in a registry in the Runtime during building as a Runtime Operation.
+
+A registration of the Runtime Operation exsists of the following properties:
+
+| Property             | Explanation                                                  |
+|----------------------|--------------------------------------------------------------|
+| Unique ID            | For every individual Runtime Operation, an unique ID is generated. |
+| Type                 | The generic type of Runtime Operation, e.g. “create” |
+| Constants            | Any constant specific to the Runtime Operation type, e.g. the entity name for “create”. |
+| Parameters           | Which parameters are expected and what should be their type, e.g. the attribute values of the entity for “create” |
+| Allowed module roles | Only these users with an allowed module is able to execute the operation, e.g. “User” and “Admin”. |
+
+
+After all Runtime Operations are registered, they are exported to the Client. Within the Client, the Runtime Operation ID and its parameters are stored at the locations where they are utilized.
+
+| Property             | Explanation                                                  |
+|----------------------|--------------------------------------------------------------|
+| Runtime Operation ID | The unique ID                                                |
+| Parameters           | The parameters that the Runtime Operation expects for its operation. |
+
+Because we are only exporting the ID and the parameters, it is harder for outsiders to understand which data is being requested. Additionally, only the CRUD commands registered as a Runtime Operation with the corresponding ID can be executed. This architecture enhances the security of your application.
+
+When a request is submitted from the Client to the Runtime, the Runtime Operation ID is matched to the corresponding Runtime Operation in the registry. The Runtime Operation is then executed, and its response is sent back to the Client.
+
+## 4 Basic CRUD Communication Pattern{#crud}
 
 The core of most Mendix applications involves variations on the CRUD (create, read, update, and delete) pattern on data stored in Mendix entities.
 
@@ -58,7 +95,7 @@ A basic scenario using an *Employee* entity can be modeled in Mendix using the f
 
 The following sections outline the actions involved when processing these pages. As stated earlier, this pattern can be seen in many Mendix applications, but the exact runtime result depends on many details and design decisions taken while building the application. More advanced data models and pages will result in more (and more complex) queries.
 
-### 3.1 Read the Objects Required to Display a Datagrid
+### 4.1 Read the Objects Required to Display a Datagrid
 
 Displaying a list of objects in a data grid consists of the following steps:
 
@@ -70,37 +107,64 @@ A basic sequence diagram looks like this:
 
 {{< figure src="/attachments/refguide/runtime/communication-patterns/19399030.png" >}}
 
-The Mendix Client uses a REST-like protocol to request data from the Runtime Server. The following example shows what this looks like when requesting objects from the Employee entity:
+The following example shows what a Runtime Operation  request to retrieve objects from the Employee entity looks like:
 
 ```json
 {
-   "action":"retrieve_by_xpath",
-   "params":{
-      "xpath":"//MyFirstModule.Employee",
-      "schema":{
-         "id":"a2916c7c-af2f-4267-a8e9-99604f045861",
-         "offset":0,
-         "sort":[
-            [
-               "Firstname",
-               "asc"
-            ]
-         ],
-         "amount":20
-      },
-      "count":true,
-      "aggregates":false
-   },
-   "context":[],
-   "profiledata":{
-      "204ee5ad0c056a0":15
-   }
+  "action": "runtimeOperation",
+  "operationId": "reyg/iaSXkaXmyztuaHbsA",
+  "params": {},
+  "options": {
+    "offset": 0,
+    "amount": 20,
+    "sort": [],
+    "wantCount": true,
+    "extraXpath": ""
+  },
+  "changes": {},
+  "objects": [],
 }
 ```
+The action property indicates to the Runtime that the request pertains to a Runtime Operation, as specified by the `operationId` property.
 
-The XPath expression states what data is needed. This can be an object containing data of an entity — or just some attributes of an object — as required by the application.
+The Runtime queries its registry to locate any Runtime Operation associated with the ID `reyg/iaSXkaXmyztuaHbsA` In this instance, it identifies an operation type "Retrieve."
 
-The schema section can be used to specify additional restrictions on what data is required (what attributes and how many objects). This approach ensures that the amount of data transferred between Runtime Server and Mendix Client is minimized.
+Under the params section, parameters can be transmitted to the Runtime if required. For this particular operation, no parameters are necessary.
+
+As described, the majority of the information concerning the Runtime Operation is maintained internally within the Runtime. This approach minimizes the amount of data transmitted in the client's request, thereby enhancing security. However, this can also make in debugging the application more difficult.
+
+To assist with debugging, you can configure the `IDResolution` log node to 'debug'. This log node records each instance when a new Runtime Operation ID is resolved to its corresponding Runtime Operation. It includes the stored registration details and any parameter inputs received from the Client.
+
+For our retrieve operation, it looks as follows:
+
+```json
+{
+    "constants": {
+        "UsedAttributes": [
+            "MyFirstModule.Employee/MyFirstModule.Employee.Firstname",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Lastname",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Jobtitle",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Department",
+            "MyFirstModule.Employee/MyFirstModule.Employee.DateOfBirth"
+        ],
+        "XPath": "//MyFirstModule.Employee",
+        "UsedAssociations": [],
+        "PageName": "MyFirstModule.Employee_Overview",
+        "WidgetName": "MyFirstModule.Employee_Overview.dataGrid2_1"
+    },
+    "id": "reyg/iaSXkaXmyztuaHbsA",
+    "parameters": {},
+    "type": "retrieve"
+}
+```
+As seen above, the following constants are stored for the "Retrieve" operation: 
+- UsedAttributed - lists all the attributes retrieved from the entity.
+- XPath - specifies the XPath Constraint used for retrieving the data, in this instance targeting all "Employee" entities.
+- UsedAssociations - enumerates all associations of the entity, which are nonexistent in this case.
+- PageName - indicates the name of the page where the retrieve operation is utilized.
+- WidgetName - since the data retrieval is performed by a widget, the name of the widget is recorded.
+
+Additionally, the ID of the Runtime Operation, the parameters (none are required for the retrieve operation), and the operation type are logged.
 
 This retrieve action results in two SQL queries – one to retrieve the data, and one to retrieve the total number of objects.
 
@@ -124,42 +188,74 @@ The response of the Runtime Server to the Mendix Client is as follows:
 
 ```json
 {
-   "count":2,
-   "mxobjects":[
-      {
-         "objectType":"MyFirstModule.Employee",
-         "guid":"281474976710757",
-         "attributes":{
-            "Firstname":{"value":"peter1"},
-            "DateOfBirth":{"value":-315622800000},
-            "Jobtitle":{"value":"sales"},
-            "Department":{"value":"sales"},
-            "Lastname":{"value":"jones"}
-         }
-      },
-      {
-         "objectType":"MyFirstModule.Employee",
-         "guid":"281474976710657",
-         "attributes":{
-            "Firstname":{"value":"piet"},
-            "DateOfBirth":{"value":476406000000},
-            "Jobtitle":{"value":"consultant"},
-            "Department":{"value":"expert services"},
-            "Lastname":{"value":"jansen"}
-         }
-      }
-   ]
+    "changes": {},
+    "commits": [],
+    "committedObjectsOmitted": false,
+    "count": 2,
+    "deletes": [],
+    "extraGuids": [],
+    "hasMoreItems": false,
+    "newpersistable": [],
+    "objects": [],
+    "partialObjects": [
+        {
+            "objectType": "MyFirstModule.Employee",
+            "guid": "11540474045137130",
+            "attributes": {
+                "Department": {
+                    "value": "Sales"
+                },
+                "Jobtitle": {
+                    "value": "Sales Executive"
+                },
+                "Firstname": {
+                    "value": "Peter"
+                },
+                "Lastname": {
+                    "value": "Jones"
+                },
+                "DateOfBirth": {
+                    "value": 867189600000
+                }
+            }
+        },
+        {
+            "objectType": "MyFirstModule.Employee",
+            "guid": "11540474045137256",
+            "attributes": {
+                "Department": {
+                    "value": "Finance"
+                },
+                "Jobtitle": {
+                    "value": "Accountant"
+                },
+                "Firstname": {
+                    "value": "Elisa"
+                },
+                "Lastname": {
+                    "value": "Walkers"
+                },
+                "DateOfBirth": {
+                    "value": 454629600000
+                }
+            }
+        }
+    ],
+    "resets": {},
+    "resultGuids": [
+        "11540474045137130",
+        "11540474045137256"
+    ]
 }
 ```
 
-### 3.2 Create New Object
+### 4.2 Create New Object
 
 The typical create-new-object flow consists of these steps:
 
-1. Instantiate a new object (the primary key is generated by the database).
+1. Create a new object (the primary key is generated by the database).
 2. Display the Edit/New page (which may already be cached).
-3. Change and validate the updated object in the Runtime Server.
-4. Commit the updated object to the database.
+3. Change and commit the updated object in the Runtime Server.
 
 {{< figure src="/attachments/refguide/runtime/communication-patterns/19399031.png" >}}
 
@@ -167,51 +263,97 @@ Create a new object:
 
 ```json
 {
-   "action":"instantiate",
-   "params":{
-      "objecttype":"MyFirstModule.Employee",
-      "preventCache":1455032246146
-   },
-   "context":[],
-   "profiledata":{
-      "204ee68c92aea60":27
-   }
+    "action": "runtimeOperation",
+    "operationId": "ntjTpU3TgkGh/QiiBMR1PQ",
+    "params": {},
+    "changes": {},
+    "objects": []
 }
 ```
 
-Change and validate the object in the Runtime Server:
+Which resolves to the following in the Runtime:
 
 ```json
 {
-   "action":"change",
-   "params":{
-      "281474976710757":{
-         "Firstname":"peter",
-         "Lastname":"jones",
-         "Jobtitle":"sales",
-         "Department":"sales",
-         "DateOfBirth":-315622800000
-      }
-   },
-   "context":[],
-   "profiledata":{
-      "204ee6970d53960":18
-   }
+    "constants": {
+        "ObjectType": "MyFirstModule.Employee"
+    },
+    "id": "ntjTpU3TgkGh/QiiBMR1PQ",
+    "parameters": {},
+    "type": "create"
 }
 ```
 
-Commit the updates to the database:
+Change and commit the updates to the database:
 
 ```json
 {
-   "action":"commit",
-   "params":{
-      "guid":"281474976710757"
-   },
-   "context":[],
-   "profiledata":{
-      "204ee6e9b5eddc0":25
-   }
+    "action": "runtimeOperation",
+    "operationId": "EjuFdBJ7EUC93YSYtlb7Mg",
+    "params": {
+        "Objects": {
+            "guids": [
+                "11540474045150458"
+            ]
+        }
+    },
+    "changes": {
+        "11540474045150458": {
+            "Firstname": {
+                "value": "Peter"
+            },
+            "Lastname": {
+                "value": "Jones"
+            },
+            "Jobtitle": {
+                "value": "Sales Executive"
+            },
+            "Department": {
+                "value": "Sales"
+            },
+            "DateOfBirth": {
+                "value": 674863200000
+            }
+        }
+    },
+    "objects": [
+        {
+            "objectType": "MyFirstModule.Employee",
+            "guid": "11540474045150458",
+            "attributes": {
+                "Department": {
+                    "value": null
+                },
+                "Jobtitle": {
+                    "value": null
+                },
+                "Firstname": {
+                    "value": null
+                },
+                "Lastname": {
+                    "value": null
+                },
+                "DateOfBirth": {
+                    "value": null
+                }
+            },
+            "hash": "r6PDyFGEXK98NSmSniNLQBzuyodENJpD4x/6Y/QCoy4="
+        }
+    ]
+}
+```
+
+Which is resolved in the Runtime to:
+```json
+{
+    "constants": {},
+    "id": "EjuFdBJ7EUC93YSYtlb7Mg",
+    "parameters": {
+        "Objects": [
+            "AnyObjectList"
+        ]
+    },
+    "type": "commit"
 }
 ```
 
@@ -232,7 +374,7 @@ The commit will cause the Runtime Server to save the object to the database. Bef
  ?)
 ```
 
-### 3.3 Edit an Existing Object
+### 4.3 Edit an Existing Object
 
 The typical edit-existing-object flow consists of these steps:
 
@@ -250,16 +392,36 @@ Change and validate the changed attributes of the object in the Runtime Server:
 
 ```json
 {
-   "action":"change",
-   "params":{
-      "281474976710757":{
-         "Firstname":"peter1"
-      }
-   },
-   "context":[],
-   "profiledata":{
-      "204ee8bb633f9a0":25
-   }
+    "action": "runtimeOperation",
+    "operationId": "EjuFdBJ7EUC93YSYtlb7Mg",
+    "params": {
+        "Objects": {
+            "guids": [
+                "11540474045137256"
+            ]
+        }
+    },
+    "changes": {
+        "11540474045137256": {
+            "Firstname": {
+                "value": "Ellie"
+            }
+        }
+    },
+    "objects": [],
+}
+```
+In the Runtime this resolves to:
+```json
+{
+    "constants": {},
+    "id": "EjuFdBJ7EUC93YSYtlb7Mg",
+    "parameters": {
+        "Objects": [
+            "AnyObjectList"
+        ]
+    },
+    "type": "commit"
 }
 ```
 
@@ -281,22 +443,7 @@ The first step is required to determine all the data business logic and validati
  WHERE "myfirstmodule$employee"."id" = (281474976710857)
 ```
 
-If all validations run correctly, the client can commit the changes to the database:
-
-```json
-{
-   "action":"commit",
-   "params":{
-      "guid":"281474976710757"
-   },
-   "context":[],
-   "profiledata":{
-      "204ee8ca8f775a0":20
-   }
-}
-```
-
-This will trigger the actual database update and commit.
+If all validations run correctly, the actual database will be triggered to update and commit.
 
 ```sql
  UPDATE "myfirstmodule$employee"
@@ -304,7 +451,7 @@ This will trigger the actual database update and commit.
  WHERE "id" = ?
 ```
 
-### 3.4 Delete an Existing Object
+### 4.4 Delete an Existing Object
 
 The typical delete flow consists of these steps:
 
@@ -324,14 +471,31 @@ Delete the object:
 
 ```json
 {
-   "action":"delete",
-   "params":{
-      "guids":["281474976710757"]
-   },
-   "context":[],
-   "profiledata":{
-      "204eeae128284c0":323
-   }
+    "action": "runtimeOperation",
+    "operationId": "FrPcy03Wm0u/u3QdXKqw6Q",
+    "params": {
+        "Objects": {
+            "guids": [
+                "11540474045149887"
+            ]
+        }
+    },
+    "changes": {},
+    "objects": [],
+}
+```
+
+In the Runtime:
+```json
+{
+    "constants": {},
+    "id": "FrPcy03Wm0u/u3QdXKqw6Q",
+    "parameters": {
+        "Objects": [
+            "[MyFirstModule.Employee]"
+        ]
+    },
+    "type": "delete"
 }
 ```
 
@@ -355,31 +519,52 @@ DELETE FROM "myfirstmodule$employee"
 WHERE "id" = ?
 ```
 
-Refresh the data grid:
-
+Request from the client to refresh the data grid:
 ```json
 {
-   "action":"retrieve_by_xpath",
-   "params":{
-      "xpath":"//MyFirstModule.Employee",
-      "schema":{
-         "id":"a2916c7c-af2f-4267-a8e9-99604f045861",
-         "offset":0,
-         "sort":[["Firstname","asc"]],
-         "amount":20
-      },
-      "count":true,
-      "aggregates":false
-   },
-   "context":[],
-   "releaseids":["281474976710757"],
-   "profiledata":{
-      "204eeb2972550c0":28
-   }
+    "action": "runtimeOperation",
+    "operationId": "d7OowNqyCU+2ZqE2+Fv6rg",
+    "params": {},
+    "options": {
+        "offset": 0,
+        "amount": 20,
+        "sort": [],
+        "wantCount": true,
+        "extraXpath": ""
+    },
+    "changes": {},
+    "objects": [],
+    "profiledata": {
+        "1714641974355-33": 158
+    }
 }
 ```
 
-### 3.5 Security Issues{#security}
+Which resolves to the following in the Runtime:
+
+Runtime:
+```json
+{
+    "constants": {
+        "UsedAttributes": [
+            "MyFirstModule.Employee/MyFirstModule.Employee.Firstname",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Lastname",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Jobtitle",
+            "MyFirstModule.Employee/MyFirstModule.Employee.Department",
+            "MyFirstModule.Employee/MyFirstModule.Employee.DateOfBirth"
+        ],
+        "XPath": "//MyFirstModule.Employee",
+        "UsedAssociations": [],
+        "PageName": "MyFirstModule.Employee_Overview",
+        "WidgetName": "MyFirstModule.Employee_Overview.dataGrid2_1"
+    },
+    "id": "d7OowNqyCU+2ZqE2+Fv6rg",
+    "parameters": {},
+    "type": "retrieve"
+}
+```
+
+### 4.5 Security Issues{#security}
 
 The security model of Mendix ensures that attributes that the user cannot see are never transferred to the client. This means that changes made in the Runtime Server (for example, in a microflow) to an attribute that the user cannot see will not be persisted if an object is sent to the Mendix Client without being committed to the database. See the blog post [Transient attributes and access rights - be careful](https://gandy84.medium.com/transient-attributes-and-access-rights-be-careful-mendix-and-me-57cf0aa1c98e) published on *Medium* for a deeper discussion of this.
 
@@ -389,11 +574,11 @@ https://www.plantuml.com/plantuml/uml/ZL9DRzD04BtxLmpD6QajAX8zL7NY-5IaYd3CPUATn4
 
 {{< figure src="/attachments/refguide/runtime/communication-patterns/attribute-security.png" >}}
 
-## 4 Executing Business Logic
+## 5 Executing Business Logic
 
 The business logic is modeled using microflows in Mendix. The following sections present some typical flows involving microflows.
 
-### 4.1 Displaying the Grid of Data Retrieved by Microflow
+### 5.1 Displaying the Grid of Data Retrieved by Microflow
 
 A data grid on a page is often directly linked to an entity in the domain model. An alternative approach is to use a microflow to create a list of objects to be displayed in a data grid.
 
@@ -411,15 +596,24 @@ JSON action executed from Mendix Client to Runtime Server:
 
 ```json
 {
-   "action":"executeaction",
-   "params":{
-      "actionname":"MyFirstModule.GetAllEmployees",
-      "applyto":"none"
-   },
-   "context":[],
-   "profiledata":{
-      "204f418ba05e7c0":55
-   }
+    "action": "runtimeOperation",
+    "operationId": "5i0E8lZXMFaIhjn/9ZdEYA",
+    "params": {},
+    "validationGuids": [],
+    "changes": {},
+    "objects": [],
+}
+```
+
+In the Runtime:
+```json
+{
+    "constants": {
+        "MicroflowName": "MyFirstModule.GetAllEmployees"
+    },
+    "id": "5i0E8lZXMFaIhjn/9ZdEYA",
+    "parameters": {},
+    "type": "callMicroflow"
 }
 ```
 
@@ -439,40 +633,68 @@ Response from the Runtime Server to the Mendix Client:
 
 ```json
 {
-   "actionResult":[
-      {
-         "objectType":"MyFirstModule.Employee",
-         "guid":"281474976710657",
-         "attributes":{
-            "Firstname":{"value":"piet"},
-            "DateOfBirth":{"value":476406000000},
-            "Jobtitle":{"value":"consultant"},
-            "Department":{"value":"expert services"},
-            "Lastname":{"value":"jansen"}
-         }
-      },
-      {
-         "objectType":"MyFirstModule.Employee",
-         "guid":"281474976710957",
-         "attributes":{
-            "Firstname":{"value":"wee"},
-            "DateOfBirth":{"value":1454886000000},
-            "Jobtitle":{"value":"ewji"},
-            "Department":{"value":"wew"},
-            "Lastname":{"value":"ewfeew"}
-         }
-      },
-      {
-         "objectType":"MyFirstModule.Employee",
-         "guid":"281474976710958"
-         …
-      }
-      …
-   ]
+    "actionResult": {
+        "type": "ObjectReferenceSet",
+        "value": [
+            "11540474045137130",
+            "11540474045137256",
+            "11540474045150458"
+        ]
+    },
+    "changes": {},
+    "commits": [],
+    "committedObjectsOmitted": false,
+    "deletes": [],
+    "newpersistable": [],
+    "objects": [
+        {
+            "objectType": "MyFirstModule.Employee",
+            "guid": "11540474045137130",
+            "attributes": {
+                "Department": {
+                    "value": "Sales"
+                },
+                "Jobtitle": {
+                    "value": "Sales Executive"
+                },
+                "Firstname": {
+                    "value": "Peter"
+                },
+                "Lastname": {
+                    "value": "Jones"
+                },
+                "DateOfBirth": {
+                    "value": 867189600000
+                }
+            }
+        },
+        {
+            "objectType": "MyFirstModule.Employee",
+            "guid": "11540474045137256",
+            "attributes": {
+                "Department": {
+                    "value": "Finance"
+                },
+                "Jobtitle": {
+                    "value": "Accountant"
+                },
+                "Firstname": {
+                    "value": "Ellie"
+                },
+                "Lastname": {
+                    "value": "Walkers"
+                },
+                "DateOfBirth": {
+                    "value": 454629600000
+                }
+            }
+        }
+    ],
+    "resets": {}
 }
 ```
 
-## 5 Mendix Runtime Internals
+## 6 Mendix Runtime Internals
 
 As can be seen in the description of the CRUD scenario, the Mendix Platform ensures efficiency while running the application in a number of ways:
 
@@ -482,7 +704,7 @@ As can be seen in the description of the CRUD scenario, the Mendix Platform ensu
     * Native SQL protocol for database communication
 * Data already available in the Mendix Client is reused if possible (see the edit scenario where the data fetched for the data grid is reused in the Edit/New page)
 
-### 5.1 Data Transformation
+### 6.1 Data Transformation
 
 Data is transported between Mendix Client and database as required. The following transformation are applied when going full circle from Mendix Client to database and back again:
 
@@ -493,13 +715,13 @@ Data is transported between Mendix Client and database as required. The followin
 * JDBC result set data is transformed to MxObjects
 * MxObjects are serialized to JSON when send to the Mendix Client
 
-### 5.2 State
+### 6.2 State
 
 To facilitate (horizontal) scalability, the Mendix Runtime retains no state between requests. The overall strategy is to only have dirty objects in memory during a request. Objects are considered dirty if they have been changed, but the changes have not yet been persisted to the database.
 
 {{< figure src="/attachments/refguide/runtime/communication-patterns/19399036.png" >}}
 
-### 5.3 Persistency
+### 6.3 Persistency
 
 Mendix automatically takes care of the translation of an application-specific entity model (domain model) to a technical database specific ER-model. As illustrated in the read part of the CRUD scenarios, data retrieval is expressed by an XPath construct that is easy to understand. For example, to retrieve all employee objects, the following XPath can be used:
 
@@ -512,10 +734,10 @@ This XPath expression is translated in a number of steps to a database query:
 3. Domain model security constraints are applied to the OQL statement.
 4. OQL is translated to SQL and executed through JDBC on the configured database.
 
-### 5.4 Scalability
+### 6.4 Scalability
 
 The Runtime Server can run as a single process, or it can be horizontally scaled to facilitate more concurrent users and improve availability. In this scenario, multiple Mendix Studio Pro instances are running. These instances run independently, there will not be any communication between the processes.
 
-#### 5.4.1 Multi-Instance
+#### 6.4.1 Multi-Instance
 
 Mendix Runtime state is stored in the Mendix Client. This means that, when running in a horizontally scaled scenario, all instances run behind a load balancer and requests are sent to whichever instance is available.

--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -362,7 +362,7 @@ Which is resolved in the Runtime to:
 }
 ```
 
-The commit will cause the Runtime Server to save the object to the database. Before the commit, the data is only kept in the Runtime Server. This optimizes performance and minimizes the impact on the database.
+The commit will cause the Runtime Server to save the object to the database. Before the commit, the data is only kept in the client. This optimizes performance and minimizes the impact on the runtime and the database.
 
 ```sql
  INSERT INTO "myfirstmodule$employee" ("id",

--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -47,19 +47,18 @@ Communication between these components operates as follows:
 ## 3 Runtime Operations {#RO}
 Data-related communication between the Mendix Client and the Runtime Server is done with Runtime Operations over a REST-like protocol. 
 
-There are various types of Runtime Operations:
+For every data-related Client action, there is a corresponding Runtime Operation type:
 - Create - creates new objects or variables.
 - Retrieve - retrieves a list of entities or a single entity.
 - Rollback - undoes changes.
 - Commit - commits objects and updates an entity if there are changes.
 - CallMicroflow - executes a Microflow.
-- CallExternalAction - executes an external action.
 
 The above operations are requested from the Client and are executed on the Runtime.
 
-When building your application, Studio Pro analyses the domain model. Every data-related action that is used in pages, widgets, microflows or nanoflows is registered in a registry in the Runtime during building as a Runtime Operation.
+During building, Studio Pro analyses your application. All data-related Client actions used in pages, widgets, or nanoflows are registered in the Runtime registry as a Runtime Operation.
 
-A registration of the Runtime Operation exsists of the following properties:
+A registration of the Runtime Operation has the following properties:
 
 | Property             | Explanation                                                  |
 |----------------------|--------------------------------------------------------------|
@@ -134,6 +133,8 @@ Under the params section, parameters can be transmitted to the Runtime if requir
 As described, the majority of the information concerning the Runtime Operation is maintained internally within the Runtime. This approach minimizes the amount of data transmitted in the client's request, thereby enhancing security. However, this can also make in debugging the application more difficult.
 
 To assist with debugging, you can configure the `IDResolution` log node to 'debug'. This log node records each instance when a new Runtime Operation ID is resolved to its corresponding Runtime Operation. It includes the stored registration details and any parameter inputs received from the Client.
+
+Additionally, the Runtime Registry is stored in the app's deployment directory under `model/operations.json` for debugging purposes.
 
 For our retrieve operation, it looks as follows:
 


### PR DESCRIPTION
Since 9.24, we are using Runtime Operations for most of the data-related communication between the Mendix Client and Runtime Server. 

The Communication Patterns document is updated to explain how the data communication works now, explain what Runtime Operations are and how to debug them.
