### PR TITLE
Update private-cloud-deploy.md

### DIFF
--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
@@ -436,13 +436,15 @@ If an application is in the Stopped state, the scaling does not come into effect
 
 ##### 5.1.3.4 Clear Admin Password
 
-This allows you to clear the password for the local admin user set in the Private Cloud environment. This means that there will be no password pushed to your environment when your app is deployed - any password currently set in the environment will be retained.
+This allows you to clear the password for the [Mendix administration account](/refguide/administrator/) set in the Private Cloud environment. This means that there will be no password pushed to your environment when your app is deployed - any password currently set in the environment will be retained.
 
 ##### 5.1.3.5 Change Admin Password
 
-This allows you to change the password for the local admin user in your app. The password you set here will be pushed to your app environment every time the app is deployed. However, if the MxAdmin password is configured in both the Developer Portal (or MendixApp CR) and CSI Secrets Storage, then the secret storage will have a higher priority and will override the value specified elsewhere.
+This allows you to change the password for the [Mendix administration account](/refguide/administrator/) in your app. The password you set here will be pushed to your app environment every time the app is deployed. However, if the Mendix administration account password is configured in both the Developer Portal (or MendixApp CR) and CSI Secrets Storage, then the secret storage will have a higher priority and will override the value specified elsewhere.
 
 Please make sure that the password set in the portal fulfills the password requirements set in Studio Pro. For security purpose, the password must have at least eight characters, including at least one special character, one capital letter, and one number.
+
+[Mendix for Private Cloud Deploy API](/apidocs-mxsdk/apidocs/private-cloud-deploy-api/).
 
 {{% alert color="info" %}}
 By default, there will be no admin password set for your environment. This means that the Mendix administration account will be inactive unless you set (change) a password.

--- a/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/developerportal/deploy/private-cloud/private-cloud-deploy.md
@@ -444,8 +444,6 @@ This allows you to change the password for the [Mendix administration account](/
 
 Please make sure that the password set in the portal fulfills the password requirements set in Studio Pro. For security purpose, the password must have at least eight characters, including at least one special character, one capital letter, and one number.
 
-[Mendix for Private Cloud Deploy API](/apidocs-mxsdk/apidocs/private-cloud-deploy-api/).
-
 {{% alert color="info" %}}
 By default, there will be no admin password set for your environment. This means that the Mendix administration account will be inactive unless you set (change) a password.
 {{% /alert %}}


### PR DESCRIPTION
The docs refer to the "local admin user" and "MxAdmin". 

Updated this refer to the Mendix administration account such that there is no doubt this only impacts that account (and not other user-created admin accounts).

Confirmed with the mx-private-cloud team here https://mendix.slack.com/archives/C0161BEMQ4B/p1714729360475809