### PR TITLE
[RUN-3713] Add Java version migration document (lts/9.24)

### DIFF
--- a/content/en/docs/refguide/java-programming/java-version-migration.md
+++ b/content/en/docs/refguide/java-programming/java-version-migration.md
@@ -14,7 +14,7 @@ New information will be added to this page as it is reported. Feel free to updat
 
 ## 2 From Java 11 to 17
 
-The following changes in behavior have been noticed when migrating from Java version 11 to Java versions 17.
+The following changes in behavior have been noticed when migrating from Java version 11 to Java version 17.
 
 ### 2.1 Changes in Date Formatting When Locale Is Dutch {#date-locale-dutch}
 

--- a/content/en/docs/refguide9/java-programming/java-version-migration.md
+++ b/content/en/docs/refguide9/java-programming/java-version-migration.md
@@ -1,0 +1,46 @@
+---
+title: "Java Version Migration"
+url: /refguide9/java-version-migration/
+weight: 45
+description: "Describes consequences for a Mendix app when migrating from one Java version to another."
+tags: ["runtime", "java", "studio pro", "expressions", "formatting"]
+---
+
+## 1 Introduction
+
+Mendix applications run in a Java Virtual Machine (JVM). The version of Java can influence the behavior of an application. It is important to know how application behavior can change when you migrate an application to a higher Java version. This page shows known implications of Java version migrations.
+
+New information will be added to this page as it is reported. Feel free to update it yourself, or raise an issue if you identify a change in behavior.
+
+## 2 From Java 11 to 17
+
+The following changes in behavior have been noticed when migrating from Java version 11 to Java version 17.
+
+### 2.1 Changes in Date Formatting When Locale Is Dutch {#date-locale-dutch}
+
+[Locale data was updated in Java version 13](https://www.oracle.com/java/technologies/javase/13-relnote-issues.html#JDK-8221432) in such a way that [date formatting microflow expressions](/refguide9/parse-and-format-date-function-calls/#3-formatdatetimeutc) have changed what they produce when the locale is Dutch and no format argument is given.
+
+#### 2.1.1 Dutch, Belgium (nl_BE)
+
+| Microflow expression                            | Output under Java 11 | Output under Java 17 |
+| ----------------------------------------------- | -------------------- | -------------------- |
+| `formatDate(dateTime(2006, 5, 4))`              | 4/05/06              | 4/05/2006            |
+| `formatDateTime(dateTime(2006, 5, 4, 3, 2, 1))` | 4/05/06 03:02        | 4/05/2006 03:02      |
+
+
+#### 2.1.2 Dutch, Netherlands (nl_NL)
+
+| Microflow expression                            | Output under Java 11 | Output under Java 17 |
+| ----------------------------------------------- | -------------------- | -------------------- |
+| `formatDate(dateTime(2006, 5, 4))`              | 04-05-06             | 04-05-2006           |
+| `formatDateTime(dateTime(2006, 5, 4, 3, 2, 1))` | 04-05-06 03:02       | 04-05-2006 03:02     |
+
+## 3 From Java 11 or 17 to 21
+
+The following changes in behavior have been noticed when migrating from Java version 11 or 17 to Java version 21.
+
+### 3.1 Changes in Date Formatting {#date-formatting-21}
+
+[Locale data updates in Java version 20](https://www.oracle.com/java/technologies/javase/20-relnote-issues.html#JDK-8284840) mean that [date formatting microflow expressions](/refguide9/parse-and-format-date-function-calls/#format-datetime-utc) return a different result when the format string contains AM or PM.
+
+In Java versions below 20, a space would be included before the AM/PM, but now it will be a Unicode non-breaking space (NBSP or NNBSP, \u202f). In a microflow expression, this non-breaking space can be included in a string using `urlDecode('%E2%80%AF')`—for example `'8:24' + urlDecode('%E2%80%AF') + 'AM'`.

--- a/content/en/docs/refguide9/java-programming/java-version-migration.md
+++ b/content/en/docs/refguide9/java-programming/java-version-migration.md
@@ -18,7 +18,7 @@ The following changes in behavior have been noticed when migrating from Java ver
 
 ### 2.1 Changes in Date Formatting When Locale Is Dutch {#date-locale-dutch}
 
-[Locale data was updated in Java version 13](https://www.oracle.com/java/technologies/javase/13-relnote-issues.html#JDK-8221432) in such a way that [date formatting microflow expressions](/refguide9/parse-and-format-date-function-calls/#3-formatdatetimeutc) have changed what they produce when the locale is Dutch and no format argument is given.
+[Locale data was updated in Java version 13](https://www.oracle.com/java/technologies/javase/13-relnote-issues.html#JDK-8221432) in such a way that [date formatting microflow expressions](/refguide9/parse-and-format-date-function-calls/#format-datetime-utc) have changed what they produce when the locale is Dutch and no format argument is given.
 
 #### 2.1.1 Dutch, Belgium (nl_BE)
 

--- a/content/en/docs/refguide9/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
+++ b/content/en/docs/refguide9/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
@@ -111,7 +111,7 @@ The examples below illustrate which value the expression returns:
     Mon Jan 01 00:00:00 CET 2007
     ```
 
-## 3 formatDateTime[UTC]
+## 3 formatDateTime[UTC]{#format-datetime-utc}
 
 Converts the Date and time value to a string, formatted according to the format parameter. Without the format parameter, a standard format is used, which depends on the [Java version](/refguide/java-version-migration/#date-locale-dutch) and user locale. The function `formatDateTime` uses the users calendar and `formatDateTimeUTC` uses the UTC calendar.
 


### PR DESCRIPTION
In a coming version of 9.24 we will support Java 21. I noticed we forgot to also add the Java version migration document to the 9 refguide when we introduced Java 17 support in lts/9.24. This PR adds the document, including the Java 21 changes from https://github.com/mendix/docs/pull/7506.

Likely Java 21 support will be released with 9.24.22, but this is not certain yet.