### PR TITLE
Remove Try It Out button

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/projects-api-v2.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/projects-api-v2.md
@@ -35,4 +35,4 @@ Authorization: MxToken 7LJE…vk
 
 ## 3 API Reference
 
-{{< swaggerui src="/openapi-spec/projects-v2.yaml"  >}}
+{{< swaggerui-disable-try-it-out src="/openapi-spec/projects-v2.yaml"  >}}

--- a/content/en/docs/apidocs-mxsdk/apidocs/projects-api-v2.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/projects-api-v2.md
@@ -35,4 +35,8 @@ Authorization: MxToken 7LJE…vk
 
 ## 3 API Reference
 
+{{% alert color="warning" %}}
+You cannot call endpoints in the Swagger UI below on this page.
+{{% /alert %}}
+
 {{< swaggerui-disable-try-it-out src="/openapi-spec/projects-v2.yaml"  >}}

--- a/layouts/shortcodes/swaggerui-disable-try-it-out.html
+++ b/layouts/shortcodes/swaggerui-disable-try-it-out.html
@@ -1,0 +1,16 @@
+{{ $original := .Get "src" }}
+ <div data-stt-ignore id="docsy_swagger_ui"></div>
+ <script>
+   window.onload = function () {
+     const ui = SwaggerUIBundle({
+       url: {{ $original | relURL }},
+       dom_id: '#docsy_swagger_ui',
+       supportedSubmitMethods: [],
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ]
+    });
+    window.ui = ui;
+  };
+</script>

--- a/layouts/shortcodes/swaggerui.html
+++ b/layouts/shortcodes/swaggerui.html
@@ -5,7 +5,6 @@
      const ui = SwaggerUIBundle({
        url: {{ $original | relURL }},
        dom_id: '#docsy_swagger_ui',
-       supportedSubmitMethods: [],
       presets: [
         SwaggerUIBundle.presets.apis,
         SwaggerUIStandalonePreset

--- a/layouts/shortcodes/swaggerui.html
+++ b/layouts/shortcodes/swaggerui.html
@@ -5,6 +5,7 @@
      const ui = SwaggerUIBundle({
        url: {{ $original | relURL }},
        dom_id: '#docsy_swagger_ui',
+       supportedSubmitMethods: [],
       presets: [
         SwaggerUIBundle.presets.apis,
         SwaggerUIStandalonePreset


### PR DESCRIPTION
Seems that we can disable the buttonby setting [supportedSubmitMethods](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#user-content-supportedsubmitmethods) to an empty array.