### PR TITLE
docs: switch to graviton instance type for new mendix app databases

### DIFF
--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -17,6 +17,12 @@ To see the current status of the Mendix Developer Portal, see [Mendix Status](ht
 
 ## 2024
 
+### May 14
+
+#### New features
+
+* We now use Arm-based AWS Graviton 2 processors for databases of environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+
 ### May 5
 
 #### New features


### PR DESCRIPTION
Add Graviton2 instance type support announcement.