### PR TITLE
docs: switch to graviton instance type for new mendix app databases

### DIFF
--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -13,7 +13,7 @@ Follow the links in the table below to see the release notes you want:
 
 | Type of Deployment | Last Updated |
 | --- | --- |
-| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | April 25, 2024 |
+| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | May 14, 2024 |
 | [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | April 4, 2024 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | November 17, 2022 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | December 12, 2022 |

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -17,7 +17,7 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## 2024
 
-### May 14
+### May 14, 2024
 
 #### New features
 

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -21,7 +21,9 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 #### New features
 
-* We now use Arm-based AWS Graviton 2 processors for databases of environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+* We now use Arm-based AWS Graviton 2 processors for databases of new environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+
+    Existing environments will not automatically use Graviton 2 processors for their databases. Graviton 2 processors will be used for new environments and those which are cleared or downsized.
 
 ### April 25, 2024
 

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -17,6 +17,12 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## 2024
 
+### May 14
+
+#### New features
+
+* We now use Arm-based AWS Graviton 2 processors for databases of environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+
 ### April 25, 2024
 
 #### Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -21,7 +21,7 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 #### New features
 
-* We now use Arm-based AWS Graviton 2 processors for databases of new environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+* We now use Arm-based AWS Graviton 2 processors for databases of new environments on all plans in Mendix Public Cloud for best performance. Graviton 2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
 
     Existing environments will not automatically use Graviton 2 processors for their databases. Graviton 2 processors will be used for new environments and those which are cleared or downsized.
 

--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -17,6 +17,12 @@ To see the current status of the Mendix Developer Portal, see [Mendix Status](ht
 
 ## 2024
 
+### May 14
+
+#### New features
+
+* We now use Arm-based AWS Graviton2 processors for provisioning databases within newly created environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
+
 ### May 5
 
 #### New features

--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -17,12 +17,6 @@ To see the current status of the Mendix Developer Portal, see [Mendix Status](ht
 
 ## 2024
 
-### May 14
-
-#### New features
-
-* We now use Arm-based AWS Graviton2 processors for provisioning databases within newly created environments on all plans in Mendix Public Cloud for best performance. Graviton2 processors can provide significant performance improvements over previous generation instances. For database operations, this means faster processing of queries and better handling of concurrent requests.
-
 ### May 5
 
 #### New features

--- a/layouts/partials/landingpage/latest-releases.html
+++ b/layouts/partials/landingpage/latest-releases.html
@@ -21,7 +21,7 @@
     </li>
     <li class="link-list">
         <a href="/releasenotes/developer-portal/deployment/">Deployment</a>
-        <p class="rn-date">Apr 4, 2024</p>
+        <p class="rn-date">May 14, 2024</p>
     </li>
     <li class="link-list">
         <a href="/releasenotes/control-center/">Control Center</a>


### PR DESCRIPTION
Add Graviton2 instance type support announcement.