### PR TITLE
Add Text Template guide to common widget properties

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/property-types-pluggable-widgets-8.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/property-types-pluggable-widgets-8.md
@@ -404,7 +404,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate{#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide8/text#caption) of a text widget.
 
 If a `dataSource` attribute is not specified, or if a `dataSource` attribute is specified but the data source is not configured by the user, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/property-types-pluggable-widgets-8.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-8/property-types-pluggable-widgets-8.md
@@ -404,7 +404,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate{#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/text/#caption) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
 
 If a `dataSource` attribute is not specified, or if a `dataSource` attribute is specified but the data source is not configured by the user, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-9/pluggable-widgets-property-types-9.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-9/pluggable-widgets-property-types-9.md
@@ -431,7 +431,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate {#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide9/text#caption) of a text widget.
 
 If a `dataSource` attribute is not specified, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-9/pluggable-widgets-property-types-9.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-parent-9/pluggable-widgets-property-types-9.md
@@ -431,7 +431,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate {#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/text/#caption) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
 
 If a `dataSource` attribute is not specified, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -434,7 +434,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate {#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/text/#caption) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
 
 If a `dataSource` attribute is not specified, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types.md
@@ -434,7 +434,7 @@ Then the Studio Pro UI for the property appears like this:
 
 ### 4.2 TextTemplate {#texttemplate}
 
-The TextTemplate property allows a user to configure a translatable text template similar to the [Caption](/refguide/common-widget-properties#text-template) of a text widget.
+The TextTemplate property allows a user to configure a translatable text template. The [Label Caption](/refguide/common-widget-properties#label) property is an example of a [Text template](/refguide/common-widget-properties#text-template).
 
 If a `dataSource` attribute is not specified, the interpolated string will be passed to the client component as `DynamicValue<string>`.
 

--- a/content/en/docs/refguide/modeling/pages/button-widgets/button-properties.md
+++ b/content/en/docs/refguide/modeling/pages/button-widgets/button-properties.md
@@ -62,52 +62,9 @@ The **Role type** property determines the `aria-role` attribute value that will 
 
 #### 2.5.1 Caption {#caption}
 
-The **Caption** property defines a text that will be shown on the button. The caption can contain parameters that are written between braces, for example, {1}.  
+The **Caption** property defines a text that will be shown on the button using a Text template.
 
-For more information on using parameters, see the [Parameters](#parameters) section below. 
-
-#### 2.5.2 Parameters {#parameters}
-
-Parameters are attributes the value of which will be displayed. To view **Parameters**, do one of the following:
-
-* Double-click the **Caption** setting in properties
-* Double-click the button on the page and click **Edit** in the **General** section > **Caption**:
-
-    {{< figure src="/attachments/refguide/modeling/pages/button-widgets/button-properties/opening-parameters.png" alt="Opening Parameters" class="no-border" >}} 
-
-Parameters have the following settings:
-
-* **Index** – an identification number of a parameter 
-* **Attribute (path)** – an attribute a value of which will be displayed 
-* **Format** – a format in which an attribute value will be displayed
-
-    {{< figure src="/attachments/refguide/modeling/pages/button-widgets/button-properties/button-parameter-settings.png" alt="Parameter Settings" class="no-border" >}}
-
-##### 2.5.2.1 Adding New Parameters
-
-To add parameters, do the following:
-
-1. Place the **Button** widget in the context of an entity, as in, inside a [data container](/refguide/data-widgets/).
-2. Double-click the **Caption** setting in the button widget properties.
-3. In the **Edit Caption** dialog box > **Parameters** section click **New**:
-
-    {{< figure src="/attachments/refguide/modeling/pages/button-widgets/button-properties/new-parameter.png" alt="Adding New Parameter" class="no-border" >}}
-
-4. In the **Edit Template Parameter** dialog box, click **Select**, choose an attribute and confirm your choice.
-5. In the **Caption** setting, write the text you would like to display and type **Index** of the parameter you would like to include. In the example below, to include a name of your customer , you need to use indexes {1} for the *Name* attribute:  
-
-    {{< figure src="/attachments/refguide/modeling/pages/button-widgets/button-properties/button-parameter-example.png" alt="Parameter Example" class="no-border" >}}
-
-##### 2.5.2.2 Performing Other Actions on Parameters
-
-In addition to adding new parameters, you can perform the following actions on parameters:
-
-* **Delete** – to delete a parameter click Delete or press <kbd>Delete</kbd> on your keyboard
-* **Edit** – double-click a parameter to edit it or click Edit
-* **Move up** – to move a parameter up in the list of parameters and also to change its index, click **Move up**
-* **Move down** – to move a parameter down in the list of parameters and also to change its index, click **Move down**
-
-    {{< figure src="/attachments/refguide/modeling/pages/button-widgets/button-properties/button-parameter-actions.png" alt="Parameter Actions" class="no-border" >}}
+{{% snippet file="/static/_includes/refguide/text-template-link.md" %}}
 
 #### 2.5.3 Tooltip
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -403,3 +403,85 @@ The widget can be made visible to a specific of the user roles available in your
 | Applicable roles  | The widget is visible if access rules allow it (for example if the user that is signed in has a role for which the target is set to be visible/accessible). |
 | All roles         | The widget is always visible. |
 | Selected roles    | This setting will render the widget as invisible to all users that are not linked to one of the selected user roles. |
+
+## 10 Common Property Types
+
+This section details common types of inputs that share common behavior across different page properties.
+
+### 10.1 Text Template {#text-template}
+
+Properties using the Text template offer the ability to display dynamic text on pages. This is done by writing templates with placeholders and specifying parameters. During runtime the placeholders are substituted by the parameters. The template editor consists of a minimized view and a pop-up view.
+
+#### 10.1.1 Template
+
+The template supports both static and dynamic texts. It can be edited from the minimized view as well as the pop up. Open the pop-up with the **Edit ...** button for a full view of the template and its parameters.
+
+Placeholders are used to place parameters in the text. The placholder follows the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times and out of order.
+
+{{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/caption-edit-button.png" alt="Opening Parameters" width="450" >}} 
+
+#### 10.1.3 Parameters {#text-template-parameters}
+
+Parameters define what data is used to replace the placeholders in the template and how they are formatted. Editing parameters is done in the pop-up view, which can be opened in two ways:
+
+* From the properties sidebar: Double click the property (e.g. "Caption") or click the more button (...).
+* From the widget properties form: Click the **Edit ...** button next to the property's textbox.
+
+{{/* TODO: Add screenshot with one from the properties view, preferrably a different one using the template */}}
+
+Parameters have the following settings:
+
+* **Index** – an identification number of a parameter 
+* **Value** – an attribute or an expression value to be displayed
+* **Format** – a format in which the value will be displayed (only for attributes)
+
+{{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameter-settings.png" alt="Parameter Settings" width="450" >}}
+
+{{% alert color="info" %}}
+You can use the formatter functions in the expression editor when using expressions. For more information, see [this list](/refguide/expressions/#expressions-formatter-functions).
+{{% /alert %}}
+
+##### 10.1.3.1 Adding New Parameters
+
+To be able to use parameters, the widget must be in the context of an entity -- such as a [Data Widget](/refguide/data-view). Then to use them:
+
+1. Open the widget properties 
+1. Click the **Edit ...** of the template property to open the pop-up.
+1. In the **Parameters** section click **New**:
+
+    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/adding-parameter.png" alt="Adding New Parameter"  width="450" >}}
+
+1. In the **Edit Template Parameter** dialog box, click **Select**, choose an attribute and confirm your choice.
+1. Edit the template and add a placeholder that matches the index of your parameter, for example `{1}`.
+
+In the example below the *Caption* property of a [Text Widget](/refguide/text) is being edited. Three attributes have been added which are used in the template. The placeholder `{1}` corresponds to the *Title* attribute, `{2}` to *NrOfPages*, and `{3}` to *DatePublished*.
+
+{{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameters-example.png" alt="Parameter Example"  width="450" >}}
+
+
+##### 10.1.3.2 Performing Other Actions on Parameters
+
+In addition to adding new parameters, you can perform the following actions on parameters:
+
+* **Delete** – to delete a parameter click Delete or press <kbd>Delete</kbd> on your keyboard
+* **Edit** – double-click a parameter to edit it or click Edit
+* **Move up** – to move a parameter up in the list of parameters and also to change its index, click **Move up**
+* **Move down** – to move a parameter down in the list of parameters and also to change its index, click **Move down**
+
+{{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameter-actions.png" alt="Parameter Actions" width="450" >}}
+
+
+#### 10.1.4 Fallback Text
+
+The fallback text is shown when the datasource of the template is empty or unavailable. 
+
+Empty attributes used as parameters do not cause the fallback text to be shown. Instead the template is rendered as normal and the placeholders for the empty parameters are substituted by empty strings. 
+
+For example: The template `Hello, {1}!` with the fallback text _"Nobody to greet."_ would get rendered as follows:
+
+| Scenario         | Rendered text      |
+| ---------------- | ------------------ |
+| Filled attribute | "Hello, World!"    |
+| Empty attribute  | "Hello, !"         |
+| Missing object   | "Nobody to greet." |
+

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -400,26 +400,26 @@ The widget can be made visible to a specific of the user roles available in your
 
 ## 10 Common Property Types
 
-This section details common inputs that share behavior, found in the page editor.
+This section explains common inputs that share behavior, found in the page editor.
 
 ### 10.1 Text Template {#text-template}
 
-Properties using the Text template offer the ability to display dynamic text on pages. This is done by writing templates with placeholders and specifying parameters. During runtime the placeholders are substituted by the parameters.
+Properties using **Text Template** allows dynamic text to be displayed on pages. This is done by writing templates with placeholders and specifying parameters. During runtime, the placeholders are substituted by the parameters.
 
 #### 10.1.1 Template
 
-The template supports both static and dynamic text. It can be edited from the properties pane as well as the pop up. Open the pop-up with the **Edit ...** button for a full view of the template and its parameters.
+**Template** supports both static and dynamic text. It can be edited from the properties pane as well as the dialog box. Open the dialog box with the **Edit ...** button for a detailed view of the template and its parameters.
 
-Placeholders are used to place parameters in the text. The placeholder follows the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times and out of order.
+Use placeholders to place parameters in the text. Placeholders must follow the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times, and can be referenced out of order.
 
 {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/caption-edit-button.png" alt="Opening Parameters" width="450" >}} 
 
 #### 10.1.3 Parameters {#text-template-parameters}
 
-Parameters define what data is inserted into the template and how it is formatted. Parameters can refer to object attributes or expressions. Editing parameters is done in the pop-up view, which can be opened in two ways:
+Parameters define what data is inserted into the template and how it is formatted. Parameters can refer to object attributes or expressions. Editing parameters is done in the dialog box view, which can be opened in two ways:
 
-* From the properties sidebar: Double click the property (e.g. "Caption") or click the more button (...).
-* From the widget properties pop-up: Click the **Edit ...** button next to the property's textbox.
+* From the properties sidebar: double-click the property (for example, "Caption") or click the "more" ellipsis (...)
+* From the widget properties dialog box: click the **Edit ...** button next to the property's textbox
 
 Parameters have the following settings:
 
@@ -435,18 +435,18 @@ You can use the formatter functions in the expression editor when using expressi
 
 ##### 10.1.3.1 Adding New Parameters
 
-To be able to use parameters, the widget must be in the context of an entity -- such as a [Data widget](/refguide/data-view), [Snippet parameter](http://localhost:1313/refguide/snippet/#parameters), or [Page parameter](/refguide/page-properties/#parameters). Then to use them:
+To be able to use parameters, the widget must be in the context of an entity such as a [Data widget](/refguide/data-view), [Snippet parameter](http://localhost:1313/refguide/snippet/#parameters), or [Page parameter](/refguide/page-properties/#parameters). To use parameters, do the following:
 
-1. Open the widget properties 
-1. Click the **Edit ...** of the template property to open the pop-up.
-1. In the **Parameters** section click **New**:
+1. Open the relavant widget's properties.
+1. Click the **Edit ...** of the template property to open the properties dialog box.
+1. In the **Parameters** section, click **New**:
 
     {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/adding-parameter.png" alt="Adding New Parameter"  width="450" >}}
 
-1. In the **Edit Template Parameter** dialog box, click **Select**, choose an attribute and confirm your choice.
-1. Edit the template and add a placeholder that matches the index of your parameter, for example `{1}`.
+1. In the **Edit Template Parameter** dialog box, click **Select**, choose an attribute, and confirm your choice.
+1. Edit the template and add a placeholder that matches the index of your parameter (for example `{1}`).
 
-In the example below the *Caption* property of a [Text Widget](/refguide/text) is being edited. Three attributes have been added which are used in the template. The placeholder `{1}` corresponds to the *Title* attribute, `{2}` to *NrOfPages*, and `{3}` to *DatePublished*.
+In the example below, the **Caption** property of a [Text Widget](/refguide/text) is being edited. Three attributes have been added which are used in the template. The placeholder `{1}` corresponds to the **Title** attribute, `{2}` to **NrOfPages**, and `{3}` to **DatePublished**:
 
 {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameters-example.png" alt="Parameter Example"  width="450" >}}
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -404,11 +404,11 @@ This section details common types of inputs that share common behavior across di
 
 ### 10.1 Text Template {#text-template}
 
-Properties using the Text template offer the ability to display dynamic text on pages. This is done by writing templates with placeholders and specifying parameters. During runtime the placeholders are substituted by the parameters. The template editor consists of a minimized view and a pop-up view.
+Properties using the Text template offer the ability to display dynamic text on pages. This is done by writing templates with placeholders and specifying parameters. During runtime the placeholders are substituted by the parameters.
 
 #### 10.1.1 Template
 
-The template supports both static and dynamic texts. It can be edited from the minimized view as well as the pop up. Open the pop-up with the **Edit ...** button for a full view of the template and its parameters.
+The template supports both static and dynamic text. It can be edited from the properties pane as well as the pop up. Open the pop-up with the **Edit ...** button for a full view of the template and its parameters.
 
 Placeholders are used to place parameters in the text. The placeholder follows the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times and out of order.
 
@@ -435,7 +435,7 @@ You can use the formatter functions in the expression editor when using expressi
 
 ##### 10.1.3.1 Adding New Parameters
 
-To be able to use parameters, the widget must be in the context of an entity -- such as a [Data Widget](/refguide/data-view). Then to use them:
+To be able to use parameters, the widget must be in the context of an entity -- such as a [Data widget](/refguide/data-view), [Snippet parameter](http://localhost:1313/refguide/snippet/#parameters), or [Page parameter](/refguide/page-properties/#parameters). Then to use them:
 
 1. Open the widget properties 
 1. Click the **Edit ...** of the template property to open the pop-up.

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -400,7 +400,7 @@ The widget can be made visible to a specific of the user roles available in your
 
 ## 10 Common Property Types
 
-This section details common types of inputs that share common behavior across different page properties.
+This section details common inputs that share behavior, found in the page editor.
 
 ### 10.1 Text Template {#text-template}
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -455,8 +455,8 @@ In the example below, the **Caption** property of a [Text Widget](/refguide/text
 
 In addition to adding new parameters, you can perform the following actions on parameters:
 
-* **Delete** – to delete a parameter click Delete or press <kbd>Delete</kbd> on your keyboard
-* **Edit** – double-click a parameter to edit it or click Edit
+* **Delete** – to delete a parameter click **Delete** or press <kbd>Delete</kbd> on your keyboard
+* **Edit** – double-click a parameter to edit it or click **Edit**
 * **Move up** – to move a parameter up in the list of parameters and also to change its index, click **Move up**
 * **Move down** – to move a parameter down in the list of parameters and also to change its index, click **Move down**
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -209,15 +209,9 @@ This property determines whether the label is rendered and the widget is wrapped
 
 ### 6.2 Label Caption
 
-This property is shown only when Show label is Yes. It specifies what text is rendered within a label.
+This property is shown only when Show label is Yes. It specifies what text is rendered within a label using a Text template.
 
-#### 6.2.1 Text Template
-
-The template for the label can contain parameters that are written as a number between braces (for example, `{1}`). The first parameter has the number `1`, the second `2`, etc. Note that to use template parameters, the widget must be placed in the context of an entity (for example, inside a data container).
-
-#### 6.2.2 Parameters
-
-For each parameter in the template, you define an attribute of the context entity or an associated entity. The value of this attribute will be inserted at the position of the parameter.
+{{% snippet file="/static/_includes/refguide/text-template-link.md" %}}
 
 ## 7 Formatting Section{#numeric-formatting}
 
@@ -416,18 +410,16 @@ Properties using the Text template offer the ability to display dynamic text on 
 
 The template supports both static and dynamic texts. It can be edited from the minimized view as well as the pop up. Open the pop-up with the **Edit ...** button for a full view of the template and its parameters.
 
-Placeholders are used to place parameters in the text. The placholder follows the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times and out of order.
+Placeholders are used to place parameters in the text. The placeholder follows the format `{i}`, where _i_ is the index of a specific parameter from the [parameter list](#text-template-parameters). Parameters can be referenced multiple times and out of order.
 
 {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/caption-edit-button.png" alt="Opening Parameters" width="450" >}} 
 
 #### 10.1.3 Parameters {#text-template-parameters}
 
-Parameters define what data is used to replace the placeholders in the template and how they are formatted. Editing parameters is done in the pop-up view, which can be opened in two ways:
+Parameters define what data is inserted into the template and how it is formatted. Parameters can refer to object attributes or expressions. Editing parameters is done in the pop-up view, which can be opened in two ways:
 
 * From the properties sidebar: Double click the property (e.g. "Caption") or click the more button (...).
-* From the widget properties form: Click the **Edit ...** button next to the property's textbox.
-
-{{/* TODO: Add screenshot with one from the properties view, preferrably a different one using the template */}}
+* From the widget properties pop-up: Click the **Edit ...** button next to the property's textbox.
 
 Parameters have the following settings:
 

--- a/content/en/docs/refguide/modeling/pages/input-widgets/date-picker.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/date-picker.md
@@ -66,7 +66,7 @@ Even though a date picker with a custom date format is editable, the calendar dr
 
 #### 3.1.3 Placeholder Text
 
-The placeholder text is shown if the date attribute is empty. It can be used to give the end-user a hint as to the expected format.
+{{% snippet file="/static/_includes/refguide/placeholder-section-link.md" %}}
 
 {{% alert color="warning" %}}
 Placeholder text will not be displayed if a native date picker is available (that is, for iOS and Android versions 4.0 and above).

--- a/content/en/docs/refguide/modeling/pages/input-widgets/text-area.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/text-area.md
@@ -87,9 +87,7 @@ This property specifies the maximum number of characters that can be typed in th
 
 #### 3.1.6 Placeholder Text
 
-The placeholder text is shown when no text has been entered yet, or when a displayed attribute is empty.
-
-It can be used, for example, to give a hint to the end-user what kind of text should be entered.
+{{% snippet file="/static/_includes/refguide/placeholder-section-link.md" %}}
 
 #### 3.1.7 Autocomplete
 

--- a/content/en/docs/refguide/modeling/pages/input-widgets/text-box.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/text-box.md
@@ -95,9 +95,7 @@ This property specifies the maximum number of characters that can be typed in th
 
 #### 3.1.4 Placeholder Text
 
-The placeholder text is shown when no text has been entered yet, or when a displayed attribute is empty.
-
-It can be used, for example, to give a hint to the end-user what kind of text should be entered.
+{{% snippet file="/static/_includes/refguide/placeholder-section-link.md" %}}
 
 #### 3.1.5 AutoFocus {#autofocus}
 

--- a/content/en/docs/refguide/modeling/pages/text-widgets/text.md
+++ b/content/en/docs/refguide/modeling/pages/text-widgets/text.md
@@ -39,60 +39,10 @@ Styling:
 
 #### 3.1.1 Caption {#caption}
 
-**Caption** defines a text that will be shown. The caption can contain parameters that are written between braces, for example, {1}.  
+**Caption** defines a text that will be shown using a Text template. 
 
-For more information on using parameters, see the [Parameters](#parameters) section below. 
+{{% snippet file="/static/_includes/refguide/text-template-link.md" %}}
 
-#### 3.1.2 Parameters {#parameters}
-
-Parameters are attributes or expressions whose values will be displayed as part of the text defined in the **Caption** setting. To view **Parameters**, do one of the following:
-
-* Double-click the **Caption** setting in properties
-* Double-click the text widget on the page and click **Edit** in the **General** section > **Caption**:
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/caption-edit-button.png" alt="Opening Parameters"   width="450" class="no-border" >}} 
-
-Parameters have the following settings:
-
-* **Index** – an identification number of a parameter 
-* **Value** – an attribute or an expression value to be displayed
-* **Format** – a format in which the value will be displayed (only for attributes)
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameter-settings.png" alt="Parameter Settings"   width="450" class="no-border" >}}
-
-{{% alert color="info" %}}
-You can use the formatter functions in the expression editor when using expressions. For more information, see [this list](/refguide/expressions/#expressions-formatter-functions).
-{{% /alert %}}
-
-##### 3.1.1.1 Adding New Parameters
-
-To use parameters, do the following:
-
-1. Place the **Text** widget in a context of an entity, as in, inside a [data container](/refguide/data-widgets/).
-2. Double-click the **Caption** setting in the text widget properties.
-3. In the **Edit Caption** dialog box > **Parameters** section click **New**:
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/adding-parameter.png" alt="Adding New Parameter"   width="450" class="no-border" >}}
-
-4. In the **Edit Template Parameter** dialog box, click **Select**, choose an attribute and confirm your choice.
-5. In the **Caption** setting, write the text you would like to display and type the **Index** of the parameter you would like to include within braces. In the example below, to include the title of the book, amount of pages it has and the year it was published, you need to use indexes {1} for the *Title* attribute, {2} for the *NrOfPages* attribute and {3} for the *DatePublished* attribute:  
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameters-example.png" alt="Parameter Example"   width="450" class="no-border" >}}
-
-6. In the **Fallback text** setting, write the text you would like to display when no context object is available from the surrounding data widget:
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/fallback-text-example.png" alt="Fallback Text Example"   width="450" class="no-border" >}}
-
-##### 3.1.1.2 Performing Other Actions on Parameters
-
-In addition to adding new parameters, you can perform the following actions on parameters:
-
-* **Delete** – to delete a parameter click Delete or press <kbd>Delete</kbd> on your keyboard
-* **Edit** – double-click a parameter to edit it or click Edit
-* **Move up** – to move a parameter up in the list of parameters and also to change its index, click **Move up**
-* **Move down** – to move a parameter down in the list of parameters and also to change its index, click **Move down**
-
-    {{< figure src="/attachments/refguide/modeling/pages/text-widgets/text/parameter-actions.png" alt="Parameter Actions"   width="450" class="no-border" >}}
 
 #### 3.1.3 Render Mode
 

--- a/static/_includes/refguide/placeholder-section-link.md
+++ b/static/_includes/refguide/placeholder-section-link.md
@@ -1,0 +1,7 @@
+
+The Placeholder determines what text is displayed in the input when the input value is empty.
+
+It can be used, for example, to give a hint to the end-user what kind of text should be entered.
+
+The Placeholder is rendered using a Text template, for more information see the [Text Template Section](/refguide/common-widget-properties/#text-template) section in *Properties Common in the Page Editor*.
+

--- a/static/_includes/refguide/placeholder-section-link.md
+++ b/static/_includes/refguide/placeholder-section-link.md
@@ -3,5 +3,5 @@ The Placeholder determines what text is displayed in the input when the input va
 
 It can be used, for example, to give a hint to the end-user what kind of text should be entered.
 
-The Placeholder is rendered using a Text template, for more information see the [Text Template Section](/refguide/common-widget-properties/#text-template) section in *Properties Common in the Page Editor*.
+The Placeholder is rendered using a Text template. For more information see the [Text Template Section](/refguide/common-widget-properties/#text-template) section in *Properties Common in the Page Editor*.
 

--- a/static/_includes/refguide/text-template-link.md
+++ b/static/_includes/refguide/text-template-link.md
@@ -1,0 +1,3 @@
+
+For more information on Text templates, see the [Text Template Section](/refguide/common-widget-properties/#text-template) section in *Properties Common in the Page Editor*. 
+


### PR DESCRIPTION
Proposed changes for the Client Template placeholders. 

- [x] Copy and rewrite existing explanation from Text Widget
- [x] Add references to the Text Template section where templates are used.
- [x] Remove old explanation from Text Widget and add reference to Text Template section.