### PR TITLE
Remove limitation for React client support

### DIFF
--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -46,8 +46,6 @@ The [PDF Document Generation](https://marketplace.mendix.com/link/component/2115
 
     {{% alert color="info" %}}This is only applicable for apps built in Mendix 9.24.5 and below and Mendix 10.0.0.{{% /alert %}}
 
-* The new React client that is introduced in [10.7.0](/releasenotes/studio-pro/10.7/#react-client) is not yet supported. Generating PDF documents does not work when setting the 'Use React client (Beta)' to 'Yes' in the runtime settings of your app. We will introduce support for the React client soon.
-
 ## 2 Installation {#installation}
 
 Follow the instructions in [Using Marketplace Content](/appstore/overview/use-content/) to import the Documentation Generation module into your app.

--- a/content/en/docs/appstore/modules/document-generation.md
+++ b/content/en/docs/appstore/modules/document-generation.md
@@ -46,6 +46,10 @@ The [PDF Document Generation](https://marketplace.mendix.com/link/component/2115
 
     {{% alert color="info" %}}This is only applicable for apps built in Mendix 9.24.5 and below and Mendix 10.0.0.{{% /alert %}}
 
+### 1.3 Dependencies
+
+* [Combo Box](https://marketplace.mendix.com/link/component/219304) widget
+
 ## 2 Installation {#installation}
 
 Follow the instructions in [Using Marketplace Content](/appstore/overview/use-content/) to import the Documentation Generation module into your app.


### PR DESCRIPTION
We'll soon release version 1.9.0 of the PDF Document Generation module, which will add support for React client. This PR removes the limitation on React client support from the limitations section to reflect this.

Note: This PR should only be merged after the version 1.9.0 has been released to the marketplace, we expect to release this version later today. We will send an update whenever the version is published.