### PR TITLE
Added missing proxy configuration

### DIFF
--- a/content/en/docs/developerportal/deploy/on-premises-design/ms-windows/_index.md
+++ b/content/en/docs/developerportal/deploy/on-premises-design/ms-windows/_index.md
@@ -201,6 +201,7 @@ Rule | Name | Pattern | Rewrite URL
 8 | debugger | `^(debugger/)(.*)` | `http://localhost:8080/{R:1}{R:2}`
 9 | oauth | `^(oauth/)(.*)` | `http://localhost:8080/{R:1}{R:2}`
 10 | p | `^(p/)(.*)` | `http://localhost:8080/{R:1}{R:2}`
+11 | manifest | `^(manifest.webmanifest)(.*)` | `http://localhost:8080/{R:1}{R:2}`
 
 Follow the instructions below and replace *[Name]* with the name of the rule in the table above, *[Pattern]* with the regular expression pattern, and *[Rewrite URL]* with the Rewrite URL. Note that some patterns contain a trailing slash, `/`, when they need to point to an exact path (for example, `/ws-doc/mydoc/1234`).
 


### PR DESCRIPTION
Another rule is needed to retrieve the manifest from the runtime for PWAs.