### PR TITLE
Update hermes.md

### DIFF
--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/hermes.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/hermes.md
@@ -4,7 +4,7 @@ url: /refguide/mobile/building-efficient-mobile-apps/enable-hermes/
 weight: 15
 description: "Improve native app performance by enable the Hermes engine."
 aliases:
-    - /refguide/mobile/building-efficient-mobile-apps/hermes/
+    - /refguide/mobile/hermes
 ---
 
 ## 1 Introduction


### PR DESCRIPTION
@ConnorLand 
@Ahmad-Elsayed 

The link in Studio Pro 10.11.0 points to https://docs.mendix.com/refguide/mobile/hermes - can we update the alias to match that? We will correct the link in 10.12.