### PR TITLE
Ensure navigation is still shown on non-JS browsers (e.g. Google Search).

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,7 +1,7 @@
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
 {{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
 {{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
-<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }} overflow-auto"> <!-- NK - added overflow-auto for scrolling -->
+<div id="td-sidebar-menu" class="td-sidebar__inner overflow-auto"> <!-- NK - added overflow-auto for scrolling: MvM - removed conditional d-none (`{{ if $shouldDelayActive }} d-none{{ end }}` to show navigation on non-JS sites -->
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,23 @@
+{{/* The "active" toggle here may delay rendering, so we only cache this side bar menu for bigger sites. */ -}}
+{{ $sidebarCacheLimit := .Site.Params.ui.sidebar_cache_limit | default 2000 -}}
+{{ $shouldCache := ge (len .Site.Pages) $sidebarCacheLimit -}}
+{{ $sidebarCacheTypeRoot := .Site.Params.ui.sidebar_cache_type_root | default false -}}
+{{ if $shouldCache -}}
+  {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+  <script>
+    $(function() {
+    $("#td-section-nav a").removeClass("active");
+    $("#td-section-nav #{{ $mid }}").addClass("active"); 
+    $("#td-section-nav #{{ $mid }}-li span").addClass("td-sidebar-nav-active-item"); 
+    $("#td-section-nav #{{ $mid }}").parents("li").addClass("active-path"); 
+    $("#td-section-nav li.active-path").addClass("show"); 
+    $("#td-section-nav li.active-path").children("input").prop('checked', true);
+    $("#td-section-nav #{{ $mid }}-li").siblings("li").addClass("show");  
+    $("#td-section-nav #{{ $mid }}-li").children("ul").children("li").addClass("show");
+    {{/* Remove `$("#td-sidebar-menu").toggleClass("d-none");` to ensure that navigation is shown for non-JS browsers - see related change in sidebar-tree.html which removes d-none from the td-sidebar-menu div*/ -}}      
+    });
+  </script>
+  {{ partialCached "sidebar-tree.html" . .FirstSection.RelPermalink }}
+{{ else -}}
+  {{ partial "sidebar-tree.html" . }}
+{{- end }}


### PR DESCRIPTION
Google does not have JavaScript enabled when it crawls - therefore it was missing the navigation pane.

It doesn't work very well for non-JS browsers, but is better than not being shown at all.