### PR TITLE
Add small clarification to security best practices

### DIFF
--- a/content/en/docs/howto/security/best-practices-security.md
+++ b/content/en/docs/howto/security/best-practices-security.md
@@ -268,5 +268,5 @@ Security in Mendix does not include scanning files that end-users upload or down
 
 To scan uploaded files for malicious content, do one of the following:
 
-* Create a custom module and configure the functionality yourself, for example, by using a [Before Commit event](/refguide/setting-up-data-validation/#validation-before-commit-event).
+* Create a custom module and configure the functionality yourself, for example, by using a [before a commit event](/refguide/setting-up-data-validation/#validation-before-commit-event).
 * Check available modules in the [Mendix Marketplace](https://marketplace.mendix.com/). For more information on how to use the Mendix Marketplace content, see [Using Marketplace Content](/appstore/overview/use-content/).

--- a/content/en/docs/howto/security/best-practices-security.md
+++ b/content/en/docs/howto/security/best-practices-security.md
@@ -268,5 +268,5 @@ Security in Mendix does not include scanning files that end-users upload or down
 
 To scan uploaded files for malicious content, do one of the following:
 
-* Create a custom module and configure the functionality yourself, for example, by using a [Before Commit event](/refguide/setting-up-data-validation/#4-advanced-data-validation-with-the-before-commit-event).
+* Create a custom module and configure the functionality yourself, for example, by using a [Before Commit event](/refguide/setting-up-data-validation/#validation-before-commit-event).
 * Check available modules in the [Mendix Marketplace](https://marketplace.mendix.com/). For more information on how to use the Mendix Marketplace content, see [Using Marketplace Content](/appstore/overview/use-content/).

--- a/content/en/docs/howto/security/best-practices-security.md
+++ b/content/en/docs/howto/security/best-practices-security.md
@@ -268,5 +268,5 @@ Security in Mendix does not include scanning files that end-users upload or down
 
 To scan uploaded files for malicious content, do one of the following:
 
-* Create a custom module and configure the functionality yourself.
+* Create a custom module and configure the functionality yourself, for example, by using a [Before Commit event](/refguide/setting-up-data-validation/#4-advanced-data-validation-with-the-before-commit-event).
 * Check available modules in the [Mendix Marketplace](https://marketplace.mendix.com/). For more information on how to use the Mendix Marketplace content, see [Using Marketplace Content](/appstore/overview/use-content/).

--- a/content/en/docs/refguide/modeling/domain-model/setting-up-data-validation.md
+++ b/content/en/docs/refguide/modeling/domain-model/setting-up-data-validation.md
@@ -60,7 +60,7 @@ An example of checking the input for the **Name** attribute of a **Customer** en
 
 For more information on input widget validation, see the [Validation](/refguide/common-widget-properties/#validation) section in *Properties Common in the Page Editor*. 
 
-## 4 Advanced Data Validation with the Before Commit Event
+## 4 Advanced Data Validation with the Before Commit Event {#validation-before-commit-event}
 
 Validation rules are great for simple validations, but Mendix also offers ways to handle more complex validations. The domain model allows you to define event handlers on entity level. The **Before Commit** and **After Commit** events are triggered when an object is committed to the database. The **After Commit** is most commonly used to calculate values of denormalized data. With the **Before Commit** event, you can run a microflow that must return a Boolean value. If the microflow returns `false`, the entire commit is aborted, otherwise the object is stored in the database. This mechanism is great for data validation. 
 


### PR DESCRIPTION
Added a small clarification to the security best practices as to how to implement custom validation of files, such as scanning the content of a file.