### PR TITLE
Add underscore to list of reserved keywords

### DIFF
--- a/content/en/docs/refguide/modeling/resources/enumerations.md
+++ b/content/en/docs/refguide/modeling/resources/enumerations.md
@@ -57,6 +57,7 @@ The name of an enumeration value must be a technical name, starting with a lette
 
 <details><summary>It cannot be a reserved word (click to see a list of reserved words)</summary>
 
+* `_`
 * `abstract`
 * `assert`
 * `boolean`


### PR DESCRIPTION
We now also check if "_" is used as an enumeration value. This could cause errors when trying to start the app.
This fix is part of 10.13.