### PR TITLE
Remove fix note for stable sbom generation which is not actually fixed

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.11.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.11.md
@@ -37,7 +37,6 @@ We recommend that you upgrade apps and Marketplace modules to Java 21.
 ### Improvements
 
 * We changed the log level of the *Tasks cannot be executed anymore due to model changes* message in the task queue from **critical** to **error**.  (Ticket 199565)
-* We ensure that the `vendorlib-sbom.json` file does not change when dependencies do not change, reducing the number of git conflicts related to this file. (Ticket 208993)
 * We now pass a render mode to the pluggable widgets API to indicate which mode the page editor is in.
 * We added a `CanApplyJumpTo` attribute to the `System.Workflow` entity to indicate whether you can apply a jump-to option to the workflow in its current state.
 * We made some performance improvements when finding usages in protected modules.

--- a/content/en/docs/releasenotes/studio-pro/10/10.6.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.6.md
@@ -85,7 +85,6 @@ We recommend that you upgrade apps and Marketplace modules to Java 21.
 ### Improvements
 
 * We changed the log level of the "tasks cannot be executed anymore due to model changes" message in the task queue from "critical" to "error". (Ticket 199565)
-* We ensure that the `vendorlib-sbom.json` file does not change when dependencies do not change, reducing the number of git conflicts related to this file. (Ticket 208993)
 * We have made a couple of small performance improvements to the Logic Bot.
 * We fixed memory leaks that happened when closing and opening applications in Studio Pro.
 * We added a Support Tools submenu to the **Help** menu, this submenu contains the following tools (Performance logging, Profiling, and Optimize MPR).


### PR DESCRIPTION
The fix for stable sbom generation does not work consistently. Removing the fix note.