### PR TITLE
Better explanation of why not to use ID as your unique key.

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -74,7 +74,7 @@ These features make it easier to refactor the domain model without affecting ext
 
 ## 5 Key {#key}
 
-Every entity in Mendix has an [ID](/refguide/odata-representation/#id-representation) that is used internally to store the object in the database. However, this ID is not stable over time, as it can change in certain scenarios (such as data migration). That means it is not recommended to use the ID as a key. A published entity should have a key attribute or a combination of attributes that form a key instead. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
+A published entity should have a key attribute or a combination of attributes that form a key. This allows you to easily retrieve the entity and makes it easy to combine data referring to the same object (for example a customer) from several systems. The attribute (or attributes) can be of type **Integer**, **Long**, **String**, or **AutoNumber**.
 
 Select a combination of attributes with the following constraints:
 
@@ -91,6 +91,8 @@ Selecting a key is required when the **Readable** capability is enabled.
 {{% alert color="info" %}}
 Selecting more than one attribute as the key is only available for published OData services that use OData v4.
 {{% /alert %}}
+
+It is not recommended to use the entity [ID](/refguide/odata-representation/#id-representation) as a key as it has no meaning outside the Mendix app. 
 
 ## 6 Capabilities {#capabilities}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/published-odata-entity.md
@@ -92,7 +92,7 @@ Selecting a key is required when the **Readable** capability is enabled.
 Selecting more than one attribute as the key is only available for published OData services that use OData v4.
 {{% /alert %}}
 
-It is not recommended to use the entity [ID](/refguide/odata-representation/#id-representation) as a key as it has no meaning outside the Mendix app. 
+Mendix recommends that you do not use the entity [ID](/refguide/odata-representation/#id-representation) as a key as it has no meaning outside the Mendix app. 
 
 ## 6 Capabilities {#capabilities}
 


### PR DESCRIPTION
Customers were confused over the description of why you shouldn't use the object ID as the unique key in a published OData entity.
This provides a more business-oriented reason,