### PR TITLE
Add new documentation for runtime request handlers

### DIFF
--- a/content/en/docs/refguide/runtime/_index.md
+++ b/content/en/docs/refguide/runtime/_index.md
@@ -27,7 +27,7 @@ The *Runtime Server* is launched on a cloud platform. It executes microflows, an
 
 The *Mendix Client* is started by the user, either within a web browser, or on another supported device. If it is in online mode, it starts a session with the Runtime Server which may or may not require authentication. The Runtime Server records the session details in the database, so that the Mendix Client can make requests. The Mendix Client is described in more detail in [Mendix Client](/refguide/mendix-client/).
 
-The user interacts with the Mendix Client, which then makes requests to the Runtime Server to process data or perform server-side functions (for example, microflows). At the end of the request, all state (including uncommitted data) is passed back to the Mendix Client. You can find more details of how this communication takes place in [Communication Patterns in the Mendix Runtime](/refguide/communication-patterns/).
+The user interacts with the Mendix Client, which then makes requests, via the [request handlers](/refguide/request-handlers/), to the Runtime Server to process data or perform server-side functions (for example, to run microflows). At the end of the request, all state (including uncommitted data) is passed back to the Mendix Client. You can find more details of how this communication takes place in [Communication Patterns in the Mendix Runtime](/refguide/communication-patterns/).
 
 Passing state from the Runtime Server to the Mendix Client enables the Runtime Server to be stateless, which means that any Runtime Server instance can respond to a request from the Mendix Client. A load balancer decides which Runtime Server instance will respond to a request. When a user session ends, the Runtime Server removes references to that session.
 

--- a/content/en/docs/refguide/runtime/communication-patterns.md
+++ b/content/en/docs/refguide/runtime/communication-patterns.md
@@ -44,7 +44,7 @@ Communication between these components operates as follows:
 
 ## 3 Runtime Operations {#RO}
 
-Data-related communication between the Mendix Client and the Runtime Server is controlled by Runtime Operations over a REST-like protocol. 
+Data-related communication between the Mendix Client and the Runtime Server is controlled by Runtime Operations over a REST-like protocol. This uses the `/xas` [request handler](/refguide/request-handlers/) of the app's runtime server.
 
 For every data-related Client action, there is a corresponding Runtime Operation type:
 

--- a/content/en/docs/refguide/runtime/mendix-client/_index.md
+++ b/content/en/docs/refguide/runtime/mendix-client/_index.md
@@ -139,7 +139,7 @@ For a description of the session and authentication tokens, see [Session Managem
 
 ### 2.13 Runtime Server
 
-The Runtime Server waits for requests from the Mendix Client, processes the request, and returns the requested data (plus any additional state information where appropriate). This is done through a private API called *xas*.
+The Runtime Server waits for requests from the Mendix Client, processes the request, and returns the requested data (plus any additional state information where appropriate). This is done using a number of [request handlers](/refguide/request-handlers/) called over a private API. One of these, for example, is called xas.
 
 It will also notify the Mendix Client when changes are made to the app, and allows developers to connect a debugger to the client to debug nanoflows.
 

--- a/content/en/docs/refguide/runtime/request-handlers.md
+++ b/content/en/docs/refguide/runtime/request-handlers.md
@@ -1,0 +1,26 @@
+---
+title: "Request handlers"
+url: /refguide/request-handlers/
+description: "Describes the various request handlers that are available in the runtime."
+---
+
+## 1 Introduction
+
+Communication with the runtime happens through various different request handlers. 
+
+## 2 Request handlers
+
+The following request handlers are available:
+
+| Name | Endpoint | Description |
+| ---- | -------- | ----------- |
+| Resources | `/` | Handles serving static files, such as the `index.html` |
+| XAS | `/xas` | Handles the client/runtime communication. See [Communication Patterns in the Mendix Runtime](/refguide/communication-patterns/) for more information. |
+| File | `/file` | Handles file upload/download from the Mendix client. |
+| Page/Microflow URLs | `/p` (default) | Handles opening pages and executing microflows that have a URL configured. The endpoint can be configured in the [app settings](/refguide/app-settings/#url-prefix). |
+| PWA Manifest | `/manifest.webmanifest` | Serves the manifest file that is required for [PWA applications](/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app/). |
+| Mx Dev Tools | `/mxdevtools` | Websocket endpoint that handles client logs + nanoflow debugging. Only enabled during development. |
+
+## 3 Custom request handlers
+
+Custom request handlers can be added using the `com.mendix.core.Core#addRequestHandler({name of the request handler})` API call. 

--- a/content/en/docs/refguide/runtime/request-handlers.md
+++ b/content/en/docs/refguide/runtime/request-handlers.md
@@ -2,25 +2,26 @@
 title: "Request handlers"
 url: /refguide/request-handlers/
 description: "Describes the various request handlers that are available in the runtime."
+weight: 45
 ---
 
 ## 1 Introduction
 
-Communication with the runtime happens through various different request handlers. 
+Communication between the Mendix client and the runtime server happens through various different request handlers. 
 
-## 2 Request handlers
+## 2 Standard Request Handlers
 
-The following request handlers are available:
+The following standard request handlers are used:
 
 | Name | Endpoint | Description |
 | ---- | -------- | ----------- |
-| Resources | `/` | Handles serving static files, such as the `index.html` |
+| Resources | `/` | Serves static files, such as the `index.html`. |
 | XAS | `/xas` | Handles the client/runtime communication. See [Communication Patterns in the Mendix Runtime](/refguide/communication-patterns/) for more information. |
-| File | `/file` | Handles file upload/download from the Mendix client. |
+| File | `/file` | Handles file uploads and downloads from the Mendix client. |
 | Page/Microflow URLs | `/p` (default) | Handles opening pages and executing microflows that have a URL configured. The endpoint can be configured in the [app settings](/refguide/app-settings/#url-prefix). |
 | PWA Manifest | `/manifest.webmanifest` | Serves the manifest file that is required for [PWA applications](/refguide/mobile/introduction-to-mobile-technologies/progressive-web-app/). |
-| Mx Dev Tools | `/mxdevtools` | Websocket endpoint that handles client logs + nanoflow debugging. Only enabled during development. |
+| Mx Dev Tools | `/mxdevtools` | Websocket endpoint that handles client logs and nanoflow debugging. Only enabled during development. |
 
-## 3 Custom request handlers
+## 3 Custom Request Handlers
 
-Custom request handlers can be added using the `com.mendix.core.Core#addRequestHandler({name of the request handler})` API call. 
+Custom request handlers can be added using the `com.mendix.core.Core#addRequestHandler({name of the request handler})` API call.

--- a/content/en/docs/refguide/runtime/runtime-server.md
+++ b/content/en/docs/refguide/runtime/runtime-server.md
@@ -93,11 +93,7 @@ This runs custom Java which is held as Java actions in the app model.
 
 This receives requests from the Mendix Client, decodes them and passes them to the runtime core or the object manager, and formats a response to the Mendix Client once the request has been processed. The Mendix Client API is known as xas (XML Application Server).
 
-### 2.18 Custom Request Handler
-
-This is a request handler added to the app using the `com.mendix.core.Core#addRequestHandler({name of the request handler})` API call.
-
-### 2.19 External Service Requests
+### 2.18 External Service Requests
 
 This receives requests from other services, decodes them, and passes them to the runtime core or the object manager. After the request has been processed, this component formats a response to the request. The following requests can be processed:
 
@@ -106,11 +102,11 @@ This receives requests from other services, decodes them, and passes them to the
 * OData – this exposes entity data as an OData endpoint
 * Other – these are metadata interfaces including WSDL and Swagger
 
-### 2.20 HTTPS Server
+### 2.19 HTTPS Server
 
 This decodes HTTPS requests from Mendix Clients or other services, and passes them to the Runtime Server.
 
-### 2.21 Mendix Client
+### 2.20 Mendix Client
 
 This is the web browser (for example, Google Chrome) or mobile device (for example, an iPhone) which allows the user to interact with the app. It typically has a screen, pointer device, and input device to allow users to use the app.
 

--- a/content/en/docs/refguide/runtime/runtime-server.md
+++ b/content/en/docs/refguide/runtime/runtime-server.md
@@ -110,6 +110,6 @@ This decodes HTTPS requests from Mendix Clients or other services, and passes th
 
 This is the web browser (for example, Google Chrome) or mobile device (for example, an iPhone) which allows the user to interact with the app. It typically has a screen, pointer device, and input device to allow users to use the app.
 
-The Runtime Server communicates with the Mendix Client by using a private API called xas.
+The Runtime Server communicates with the Mendix Client using a number of [request handlers](/refguide/request-handlers/) called over a private API. One of these, for example, is called xas.
 
 For a description of the Mendix Client, see [Mendix Client](/refguide/mendix-client/).


### PR DESCRIPTION
Added new documentation to describe the various runtime request handlers that the client uses. More request handlers can be added in the future by other teams.