### PR TITLE
Update build-hybrid-locally.md

### DIFF
--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
@@ -5,7 +5,7 @@ weight: 9
 ---
 
 {{% alert color="warning" %}}
-Hybrid mobile packages require Node.js v12 with npm v6. Versions above those fail to install and compile dependencies. We are working to update hybrid mobile packages to support later versions.
+Hybrid mobile packages require Node.js v18. Versions above those fail to install and compile dependencies. We are working to update hybrid mobile packages to support later versions.
 
 To support multiple node or npm versions on Windows, use the [Node Version Switcher (NVM)](https://github.com/coreybutler/nvm-windows) utility.
 {{% /alert %}}
@@ -19,7 +19,7 @@ This document describes how to build your hybrid apps locally.
 **Prerequisites:**
 
 * A Mac OSX machine
-* Install [NodeJS 12 with NPM 6](https://nodejs.org/download/release/latest-v12.x/) using the all-in-one installation option
+* Install [NodeJS 18](https://nodejs.org/download/release/latest-v18.x/) using the all-in-one installation option
 * Download your [local build package](/developerportal/deploy/mobileapp/#doing-it-yourself) from Cloud Portal and unzip it in a known location
 * Register for an [Apple Developer Account](https://developer.apple.com/register/index.action)
 * Install [XCode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) and its command-line tools
@@ -113,7 +113,7 @@ Using XCode can be easier than the Cordova CLI due to XCode's friendly visual in
 **Prerequisites:**
 
 * Install [AndroidStudio](https://developer.android.com/studio)
-* Install [NodeJS 12 with NPM 6](https://nodejs.org/download/release/latest-v12.x/) using the all-in-one installation option
+* Install [NodeJS 18](https://nodejs.org/download/release/latest-v18.x/) using the all-in-one installation option
 * Install JDK 1.8
 * Create a keystore using [Generating a Keystore](/refguide8/managing-app-signing-keys/#generating-a-keystore)
 * Download the [local build package](/howto8/mobile/customizing-phonegap-build-packages/#download-local-package) from Cloud Portal and unzip it in a known location


### PR DESCRIPTION
Changed the required Node.js version to v18 from v12 in alignment with the readme file of Mendix Hybrid template.