### PR TITLE
AWS Authentication - Costs documentation Update

### DIFF
--- a/content/en/docs/appstore/use-content/modules/aws/aws-authentication.md
+++ b/content/en/docs/appstore/use-content/modules/aws/aws-authentication.md
@@ -39,7 +39,7 @@ If you plan to use AWS Authentication with a [platform-supported AWS connector](
 
 ### 1.3 Licensing and Cost
 
-This connector is available as a free download from the Mendix Marketplace, but the AWS service to which is connects may incur a usage cost. For more information, refer to AWS documentation.
+This connector is available as a free download from the Mendix Marketplace. While obtaining temporary and static credentials through this connector is free, using these credentials with other AWS Mendix Marketplace modules may incur usage costs. For more information, refer to the AWS documentation.
 
 {{% alert color="info" %}}
 Most AWS services provide a free tier that allows easy access to most services. To find out if this service is included in the free tier, see [AWS Free Tier](https://aws.amazon.com/free/). To calculate the potential cost of using an AWS service outside of the free tier, use the [AWS Cost calculator](https://calculator.aws/).


### PR DESCRIPTION
Updated the documentation to make it more clear to the User that the AWS Authentication module is 100% free to use for creating credentials. However what you use these credentials for might cost money.