### PR TITLE
[WTF-1862] Handle expression variables with long paths in the linked action property 

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -56,11 +56,21 @@ export interface ActionValue {
 }
 ```
 
-The flag `canExecute` indicates if an action can be run under the current conditions. This helps you prevent executing actions that are not allowed by the app's security settings. User roles can be set in the microflows and nanoflows, allowing users to call them. For more information on user roles and security, see the [Module Security Reference Guide](/refguide/module-security/). You can also employ this flag when using a **Call microflow** action triggering a microflow with a parameter. Such an action cannot be run until a parameter object is available, for example when a parent Data view has finished loading. An attempt to `execute` an action that cannot be run will have no effect except generating a debug-level warning message. 
+#### 4.1.1 canExecute
+
+The flag `canExecute` indicates if an action can be run under the current conditions. This helps you prevent executing actions that are not allowed by the app's security settings. User roles can be set in the microflows and nanoflows, allowing users to call them. For more information on user roles and security, see the [Module Security Reference Guide](/refguide/module-security/).
+
+You can also employ this flag when using a **Call microflow** action triggering a microflow with a parameter. Such an action cannot be run until a parameter object is available, for example when a parent Data view has finished loading. An attempt to `execute` an action that cannot be run will have no effect except generating a debug-level warning message.
+
+The exception to this behavior is when the `ActionValue` is returned by [`ListActionValue.get()`](http://localhost:1313/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listactionvalue). In this case the flag will be true when not all arguments have been loaded. Calling `execute()` for an action with loading arguments will run the action as soon as all arguments become available. While waiting, `isExecuting` will be set to true and subsequent calls to `execute()` are ignored. If any arguments become unavailable after loading, the action will not run and a debug-level warning message will be logged.
+
+#### 4.1.2 isExecuting
 
 The flag `isExecuting` indicates whether an action is currently running. A long-running action can take seconds to complete. Your component might use this information to render an inline loading indicator which lets users track loading progress. Often it is not desirable to allow a user to trigger multiple actions in parallel. Therefore, a component (maybe based on a configuration) can decide to skip triggering an action while a previous execution is still in progress.
 
 Note that `isExecuting` indicates only whether the current action is running. It does not indicate whether a target nanoflow, microflow, or object operation is running due to another action.
+
+#### 4.1.3 execute
 
 The method `execute` triggers the action. It returns nothing and does not guarantee that the action will be started synchronously. But when the action does start, the component will receive a new prop with the `isExecuting` flag set.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -58,11 +58,11 @@ export interface ActionValue {
 
 #### 4.1.1 canExecute
 
-The flag `canExecute` indicates if an action can be run under the current conditions. This helps you prevent executing actions that are not allowed by the app's security settings. User roles can be set in the microflows and nanoflows, allowing users to call them. For more information on user roles and security, see the [Module Security Reference Guide](/refguide/module-security/).
+The flag `canExecute` indicates if an action can be run under current conditions. This prevents executing actions that are not allowed by the app's security settings. User roles can be set in the microflows and nanoflows, allowing users to call them. For more information on user roles and security, see the [Module Security Reference Guide](/refguide/module-security/).
 
-You can also employ this flag when using a **Call microflow** action triggering a microflow with a parameter. Such an action cannot be run until a parameter object is available, for example when a parent Data view has finished loading. An attempt to `execute` an action that cannot be run will have no effect except generating a debug-level warning message.
+You can also employ this flag when using a **Call microflow** action triggering a microflow with a parameter. Such an action cannot be run until a parameter object is available, for example when a parent data view has finished loading. Attempting to `execute` an action that cannot be run will have no effect, and generates a debug-level warning message.
 
-The exception to this behavior is when the `ActionValue` is returned by [`ListActionValue.get()`](http://localhost:1313/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listactionvalue). In this case the flag will be true when not all arguments have been loaded. Calling `execute()` for an action with loading arguments will run the action as soon as all arguments become available. While waiting, `isExecuting` will be set to true and subsequent calls to `execute()` are ignored. If any arguments become unavailable after loading, the action will not run and a debug-level warning message will be logged.
+The exception to this behavior is when the `ActionValue` is returned by [`ListActionValue.get()`](http://localhost:1313/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listactionvalue). In this case, the flag will be true when not all arguments have been loaded. Calling `execute()` for an action with loading arguments will run the action as soon as all arguments become available. While waiting, `isExecuting` will be set to `true` and subsequent calls to `execute()` are ignored. If any arguments become unavailable after loading, the action will not run and a debug-level warning message will be logged.
 
 #### 4.1.2 isExecuting
 


### PR DESCRIPTION
Documentation update to reflect our changes to the behavior of expression arguments for linked Microflow and Nanoflow actions. They now support long paths, allowing Mendix developers to supply argument values over associations. For widget developers this change means that ActionValues may state that they can be executed while they are still waiting for all arguments to be loaded.

- [x] Update Pluggable Widget API ActionValue documentation
- [x] Search for and update Modeling documentation stating that associations cannot be used for supplying Action Expression Argument values.
  - Descriptions of relevant actions refer to the page [On Click Event and Events Section](https://docs.mendix.com/refguide/on-click-event/#3322-microflow-arguments) which does not mention any restriction on long paths.
- [x] Will add a comment whether this is for 10.13 or 10.14.
  - This will be for 10.14