### PR TITLE
fix(docs): Correct capitalization of 'curl' in documentation

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/deploy-api-1.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deploy-api-1.md
@@ -607,7 +607,7 @@ Content-Disposition: form-data;
 --MultipartBoundary--
 ```
 
-Curl example:
+curl example:
 
 ```bash
 curl -v -F "file=@%USERPROFILE%/Documents/Mendix/calc-main/releases/calc_1.0.0.45.mda"  -X POST -H "Mendix-Username: richard.ford51@example.com" -H "Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6" "https://deploy.mendix.com/api/1/apps/calc/packages/upload?name=calc_1.0.0.45.mda"

--- a/content/en/docs/apidocs-mxsdk/apidocs/deploy-api-2.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deploy-api-2.md
@@ -70,7 +70,7 @@ Content-Disposition: form-data;
 --MultipartBoundary--
 ```
 
-Curl example:
+curl example:
 
 ```bash
 curl -v -F "file=@%USERPROFILE%/Documents/Mendix/calc-main/releases/calc_1.0.0.45.mda"  -X POST -H "Mendix-Username: richard.ford51@example.com" -H "Mendix-ApiKey: 26587896-1cef-4483-accf-ad304e2673d6" "https://deploy.mendix.com/api/v2/apps/calc/packages/upload?name=calc_1.0.0.45.mda"

--- a/content/en/docs/deployment/mendix-cloud-deploy/custom-domains.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/custom-domains.md
@@ -129,7 +129,7 @@ Once you have a signed SSL/TLS certificate, you can upload it by following these
 
     {{< figure src="/attachments/deployment/mendix-cloud-deploy/custom-domains/signed-certificate.png" width=80% class="no-border" >}}
 
-    {{% alert color="warning" %}}The intermediate certificates of the main certificate authorities are included in the built-in CA databases of modern browsers. Therefore, you do not need to include an intermediate certificate to serve your website through SSL/TLS to users of modern browsers. However, you cannot predict how your users will attempt to connect to your website; not including an intermediate certificate may result in connection issues for some users. Tools such as cURL do not recognize intermediate certificates automatically. Because of this, intermediate certificates are highly recommended but optional.{{% /alert %}}
+    {{% alert color="warning" %}}The intermediate certificates of the main certificate authorities are included in the built-in CA databases of modern browsers. Therefore, you do not need to include an intermediate certificate to serve your website through SSL/TLS to users of modern browsers. However, you cannot predict how your users will attempt to connect to your website; not including an intermediate certificate may result in connection issues for some users. Tools such as curl do not recognize intermediate certificates automatically. Because of this, intermediate certificates are highly recommended but optional.{{% /alert %}}
 
 You can now configure your custom domain. See [Configuring a Custom Domain](#Configuring), below.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -449,7 +449,7 @@ This feature is currently in a [beta release](/releasenotes/beta-features/).
 * We have updated components to use Go 1.19 and the latest dependency versions, in order to improve security score ratings for all container images.
 * We fixed an issue where applying a custom TLS trust config in [non-interactive mode](/developerportal/deploy/private-cloud-cli-non-interactive/) failed.
 * We added a `runtimeLeaderSelection` option that allows you to run an environment without a leader replica - so that an app can be deployed into multiple regions.
-* We refactored the way the Mendix Runtime is launched. This removes the need to use Bash and Curl to start the Runtime.
+* We refactored the way the Mendix Runtime is launched. This removes the need to use Bash and curl to start the Runtime.
 * It is now possible to choose between plaintext and JSON formats for Mendix app logs.
 * We have extended the options for configuring Ceph RADOS storage buckets. It is now possible to share a bucket between multiple environments.
 * We have updated the list of supported platforms to include OpenShift 4.12.


### PR DESCRIPTION
### Summary

This merge request corrects the capitalization of 'curl' in the documentation. Previously, instances of 'Curl' and 'cURL' were used inconsistently. This update ensures that all references to the curl command-line tool use the correct lowercase spelling.

### Changes

- Replaced all instances of 'Curl' and 'cURL' with 'curl' in the documentation.

### Reasons

- To maintain consistency and accuracy in the documentation.
- To align with the official spelling as per the [curl project website](https://curl.se/).

### Impact

- Documentation consistency and accuracy improvements.

