### PR TITLE
[RUN-4165] Add documentation for the mx show-java-version command

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool/_index.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/_index.md
@@ -29,6 +29,7 @@ These are the available [app commands](/refguide/mx-command-line-tool/app/):
 | [convert](/refguide/mx-command-line-tool/app/#convert) | Converts the Mendix app. |
 | [create-project](/refguide/mx-command-line-tool/app/#create-project) | Creates a new Mendix app. |
 | [show-version](/refguide/mx-command-line-tool/app/#show-version) | Shows the Studio Pro version that was last used to edit the app. |
+| [show-java-version](/refguide/mx-command-line-tool/app/#show-java-version) | Show the configured Java version of the app. |
 
 ### 3.2 Adaptable Solutions Commands
 

--- a/content/en/docs/refguide/general/mx-command-line-tool/app.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/app.md
@@ -92,7 +92,7 @@ These are the return codes:
 | --- | --- |
 | `0` | The command ran successfully. |
 
-## 4 mx show-java-version Command {#show-java-version}
+## 4 mx show-java-version Command {#show-java-version} [version 10.12.2+]
 
 The `mx show-java-version` command reports what the configured Java version of the app is.
 
@@ -108,7 +108,7 @@ Use the following command pattern for `mx show-java-version`:
 
 `mx show-java-version INPUT`
 
-For `INPUT`, enter a *.mpr* file.
+For `INPUT`, enter an *.mpr* file.
 
 ### 4.2 Examples
 

--- a/content/en/docs/refguide/general/mx-command-line-tool/app.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/app.md
@@ -92,7 +92,42 @@ These are the return codes:
 | --- | --- |
 | `0` | The command ran successfully. |
 
-## 4 mx convert Command {#convert}
+## 4 mx show-java-version Command {#show-java-version}
+
+The `mx show-java-version` command reports what the configured Java version of the app is.
+
+The input is a single MPR file.
+
+{{% alert color="info" %}}
+The MPR file must be the same version as mx.
+{{% /alert %}}
+
+### 4.1 Usage
+
+Use the following command pattern for `mx show-java-version`:
+
+`mx show-java-version INPUT`
+
+For `INPUT`, enter a *.mpr* file.
+
+### 4.2 Examples
+
+Examples of commands are described in the table below:
+
+| Example | Result |
+| --- | --- |
+| `mx show-java-version C:\Mendix\App1\App1.mpr` | Displays the configured Java version of the app. |
+
+### 4.3 Return Codes
+
+Return codes are described in the table below:
+
+| Return Code | Description |
+| --- | --- |
+| 0 | The command ran successfully. |
+| 1 | The command failed. For example because the *.mpr* file could not be found. |
+
+## 5 mx convert Command {#convert}
 
 The `mx convert` command converts the *.mpk* file (or files) of the app (or apps) to a specific Studio Pro version. For example, if you are using the mx command-line tool for Studio Pro 10.0.0,  `mx convert` will convert the app to that version. 
 
@@ -102,7 +137,7 @@ The input can be a single file, directory, or multiple files.
 The mx tool can only upgrade your app. You cannot use it to downgrade the version.
 {{% /alert %}}
 
-### 4.1 Usage
+### 5.1 Usage
 
 Use the following command pattern for `mx convert`:
 
@@ -123,7 +158,7 @@ For `OUTPUT`, enter the output location for the converted results. Please note t
 * When `INPUT...` is a single file, `OUTPUT` can be a single file or directory; otherwise, `OUTPUT` must be a directory
 * When using the `--in-place` option, the `INPUT...` folder will also be used as the `OUTPUT` folder, so you do not need to specify a separate `OUTPUT` folder
 
-### 4.2 Examples
+### 5.2 Examples
 
 These are example commands:
 
@@ -133,7 +168,7 @@ These are example commands:
 | `mx convert C:\Mendix\App1.mpk C:\Mendix\App2.mpk C:\Mendix\ConvertedProjects\` | Converts the *App1.mpk* and *App2.mpk* app packages that are in the *C:\\Mendix\\* folder and puts the results in the *C:\\Mendix\\ConvertedProjects\\* folder. |
 | `mx convert --skip-error-check C:\Mendix\Packages\ C:\Mendix\ConvertedPackages\` | Converts all the app packages in the *C:\\Mendix\\Packages\\* folder to the *C:\\Mendix\\ConvertedPackages\\* folder without checking for errors. |
 
-### 4.3 Return Codes
+### 5.3 Return Codes
 
 These are the return codes:
 
@@ -144,7 +179,7 @@ These are the return codes:
 | `2` | There is something wrong with the command-line options. |
 | `3` | Converting failed. |
 
-## 5 mx check Command {#check}
+## 6 mx check Command {#check}
 
 The `mx check` command checks the app *.mpr* file for issues such as errors, warnings, deprecations, or performance recommendations.
 
@@ -152,7 +187,7 @@ The `mx check` command checks the app *.mpr* file for issues such as errors, war
 The *.mpr* file must be the same version as the mx tool.
 {{% /alert %}}
 
-### 5.1 Usage
+### 6.1 Usage
 
 Use the following command pattern for `mx check`:
 
@@ -175,7 +210,7 @@ For `INPUT`, enter a single *.mpr* file.
 
 You can optionally specify the path to an exported suppress-warnings (JSON) file. This means `mx check -w` will use the list of suppressed warnings in the JSON file, instead of the default behavior (which is to read from the *project-settings.user.json* file in the app directory).
 
-### 5.2 Examples
+### 6.2 Examples
 
 These are example commands:
 
@@ -188,7 +223,7 @@ These are example commands:
 | `mx check C:\MxProjects\App-main\App-main.mpr c:\MxFiles\my-exported-suppressed-warnings.json --warnings` | Checks the app at *C:\MxProjects\App-main\App-main.mpr* for errors and warnings. Suppressed warnings will be read from the JSON file *my-exported-suppressed-warnings.json*. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at *C:\MxProjects\App-main\App-main.mpr* for errors, warnings, deprecations, and performance recommendations. |
 
-### 5.3 Return Codes
+### 6.3 Return Codes
 
 These are the return codes:
 

--- a/content/en/docs/refguide9/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide9/general/mx-command-line-tool.md
@@ -212,48 +212,13 @@ Return codes are described in the table below:
 | --- | --- |
 | 0 | The command ran successfully. |
 
-### 3.5 mx show-java-version Command [version 9.24.26+]
-
-The `mx show-java-version` command reports what the configured Java version of the app is.
-
-The input is a single MPR file.
-
-{{% alert color="info" %}}
-The MPR file must be the same version as mx.
-{{% /alert %}}
-
-#### 3.5.1 Usage
-
-Use the following command pattern for `mx show-java-version`:
-
-`mx show-java-version INPUT`
-
-For `INPUT`, enter a *.mpr* file.
-
-#### 3.5.2 Examples
-
-Examples of commands are described in the table below:
-
-| Example | Result |
-| --- | --- |
-| `mx show-java-version C:\Mendix\App1\App1.mpr` | Displays the configured Java version of the app. |
-
-#### 3.5.3 Return Codes
-
-Return codes are described in the table below:
-
-| Return Code | Description |
-| --- | --- |
-| 0 | The command ran successfully. |
-| 1 | The command failed. For example because the *.mpr* file could not be found. |
-
-### 3.6 mx merge Command [version 9.17+]
+### 3.5 mx merge Command [version 9.17+]
 
 The mx merge command performs a three-way merge of two MPR files having a common base commit.
 
 The input is three MPR files: base, mine, and theirs
 
-#### 3.6.1 Usage
+#### 3.5.1 Usage
 
 Use the following command pattern for `mx merge`:
 
@@ -271,15 +236,15 @@ The `OPTIONS` are described in the table below:
 
 `THEIRS` is the version to merge changes from.
 
-#### 3.6.2 Conflicts
+#### 3.5.2 Conflicts
 
 If there are conflicts during the merge, you have to resolve those by opening the app in Studio Pro.
 
-#### 3.6.3 Examples
+#### 3.5.3 Examples
 
 `mx merge C:\MyApp\MyApp.mpr C:\MyApp-main\MyApp.mpr C:\MyApp-FeatureBranch\MyApp.mpr`
 
-#### 3.6.4 Return Codes
+#### 3.5.4 Return Codes
 
 | Return Code | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
@@ -289,11 +254,11 @@ If there are conflicts during the merge, you have to resolve those by opening th
 | 3           | This code means an exception – an error occurred during the merge. Error details are printed to the command line output. |
 | 4           | The version is unsupported.                                  |
 
-### 3.7 mx show-app-version Command [version 9.24.2+]
+### 3.6 mx show-app-version Command [version 9.24.2+]
 
 The mx show-app-version command allows you to see the [publisher-side](/appstore/creating-content/sol-solutions-guide/) version of your solution (meaning, the version of the solution that you develop) and the [consumer-side](/appstore/creating-content/sol-solutions-impl/) version of the solution package that your app is based on (meaning, the version of the solution package when you consumed the solution).
 
-#### 3.7.1 Usage
+#### 3.6.1 Usage
 
 Use the following command pattern for `mx show-app-version`:
 
@@ -310,13 +275,13 @@ For MPR-FILE enter a *.mpr* file.
 
 `Based on` version is a version of a solution package (.mxsolution) current App is based on.
 
-#### 3.7.2 Examples
+#### 3.6.2 Examples
 
 `mx show-app-version C:\MyApp\MyApp.mpr`
 
 `mx show-app-version C:\MyApp\MyApp.mpr -b`
 
-#### 3.7.3 Return Codes
+#### 3.6.3 Return Codes
 
 This command uses common format exit codes for all app-version related commands.
 
@@ -354,11 +319,11 @@ In case of errors the exit code consists of 3 digits XYZ:
 | 315         | if -b was specified but the app is not based on a solution.  |
 | 313         | if -b was not specified but distribution as a solution is not enabled for the app. |
 
-### 3.8 mx set-app-version Command [version 9.24.2+]
+### 3.7 mx set-app-version Command [version 9.24.2+]
 
 The mx set-app-version command allows you to set the version of your [solution when building it](/appstore/creating-content/sol-solutions-guide/).
 
-#### 3.8.1 Usage
+#### 3.7.1 Usage
 
 Use the following command pattern for `mx set-app-version`:
 
@@ -374,11 +339,11 @@ For MPR-FILE enter a *.mpr* file.
 
 For VERSION enter a version in [SemVer](https://semver.org) format
 
-#### 3.8.2 Examples
+#### 3.7.2 Examples
 
 `mx set-app-version C:\MyApp\MyApp.mpr 1.2.3`
 
-#### 3.8.3 Return Codes
+#### 3.7.3 Return Codes
 
 This command uses common format exit codes for all app-version related commands.
 
@@ -416,6 +381,6 @@ In case of errors the exit code consists of 3 digits XYZ:
 | 124         | if Version is not in SemVer format                       |
 | 313         | if Distribution as a solution is not enabled for the app |
 
-### 3.9 Undocumented Options
+### 3.8 Undocumented Options
 
 The mx tool contains options that are not described in this document. Those are for internal Mendix usage and are not officially supported. This might change in the future, but these options can be used only at your own risk.

--- a/content/en/docs/refguide9/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide9/general/mx-command-line-tool.md
@@ -212,13 +212,48 @@ Return codes are described in the table below:
 | --- | --- |
 | 0 | The command ran successfully. |
 
-### 3.5 mx merge Command [version 9.17+]
+### 3.5 mx show-java-version Command [version 9.24.26+]
+
+The `mx show-java-version` command reports what the configured Java version of the app is.
+
+The input is a single MPR file.
+
+{{% alert color="info" %}}
+The MPR file must be the same version as mx.
+{{% /alert %}}
+
+#### 3.5.1 Usage
+
+Use the following command pattern for `mx show-java-version`:
+
+`mx show-java-version INPUT`
+
+For `INPUT`, enter a *.mpr* file.
+
+#### 3.5.2 Examples
+
+Examples of commands are described in the table below:
+
+| Example | Result |
+| --- | --- |
+| `mx show-java-version C:\Mendix\App1\App1.mpr` | Displays the configured Java version of the app. |
+
+#### 3.5.3 Return Codes
+
+Return codes are described in the table below:
+
+| Return Code | Description |
+| --- | --- |
+| 0 | The command ran successfully. |
+| 1 | The command failed. For example because the *.mpr* file could not be found. |
+
+### 3.6 mx merge Command [version 9.17+]
 
 The mx merge command performs a three-way merge of two MPR files having a common base commit.
 
 The input is three MPR files: base, mine, and theirs
 
-#### 3.5.1 Usage
+#### 3.6.1 Usage
 
 Use the following command pattern for `mx merge`:
 
@@ -236,15 +271,15 @@ The `OPTIONS` are described in the table below:
 
 `THEIRS` is the version to merge changes from.
 
-#### 3.5.2 Conflicts
+#### 3.6.2 Conflicts
 
 If there are conflicts during the merge, you have to resolve those by opening the app in Studio Pro.
 
-#### 3.5.3 Examples
+#### 3.6.3 Examples
 
 `mx merge C:\MyApp\MyApp.mpr C:\MyApp-main\MyApp.mpr C:\MyApp-FeatureBranch\MyApp.mpr`
 
-#### 3.5.4 Return Codes
+#### 3.6.4 Return Codes
 
 | Return Code | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
@@ -254,11 +289,11 @@ If there are conflicts during the merge, you have to resolve those by opening th
 | 3           | This code means an exception – an error occurred during the merge. Error details are printed to the command line output. |
 | 4           | The version is unsupported.                                  |
 
-### 3.6 mx show-app-version Command [version 9.24.2+]
+### 3.7 mx show-app-version Command [version 9.24.2+]
 
 The mx show-app-version command allows you to see the [publisher-side](/appstore/creating-content/sol-solutions-guide/) version of your solution (meaning, the version of the solution that you develop) and the [consumer-side](/appstore/creating-content/sol-solutions-impl/) version of the solution package that your app is based on (meaning, the version of the solution package when you consumed the solution).
 
-#### 3.6.1 Usage
+#### 3.7.1 Usage
 
 Use the following command pattern for `mx show-app-version`:
 
@@ -275,13 +310,13 @@ For MPR-FILE enter a *.mpr* file.
 
 `Based on` version is a version of a solution package (.mxsolution) current App is based on.
 
-#### 3.6.2 Examples
+#### 3.7.2 Examples
 
 `mx show-app-version C:\MyApp\MyApp.mpr`
 
 `mx show-app-version C:\MyApp\MyApp.mpr -b`
 
-#### 3.6.3 Return Codes
+#### 3.7.3 Return Codes
 
 This command uses common format exit codes for all app-version related commands.
 
@@ -319,11 +354,11 @@ In case of errors the exit code consists of 3 digits XYZ:
 | 315         | if -b was specified but the app is not based on a solution.  |
 | 313         | if -b was not specified but distribution as a solution is not enabled for the app. |
 
-### 3.7 mx set-app-version Command [version 9.24.2+]
+### 3.8 mx set-app-version Command [version 9.24.2+]
 
 The mx set-app-version command allows you to set the version of your [solution when building it](/appstore/creating-content/sol-solutions-guide/).
 
-#### 3.7.1 Usage
+#### 3.8.1 Usage
 
 Use the following command pattern for `mx set-app-version`:
 
@@ -339,11 +374,11 @@ For MPR-FILE enter a *.mpr* file.
 
 For VERSION enter a version in [SemVer](https://semver.org) format
 
-#### 3.7.2 Examples
+#### 3.8.2 Examples
 
 `mx set-app-version C:\MyApp\MyApp.mpr 1.2.3`
 
-#### 3.7.3 Return Codes
+#### 3.8.3 Return Codes
 
 This command uses common format exit codes for all app-version related commands.
 
@@ -381,6 +416,6 @@ In case of errors the exit code consists of 3 digits XYZ:
 | 124         | if Version is not in SemVer format                       |
 | 313         | if Distribution as a solution is not enabled for the app |
 
-### 3.8 Undocumented Options
+### 3.9 Undocumented Options
 
 The mx tool contains options that are not described in this document. Those are for internal Mendix usage and are not officially supported. This might change in the future, but these options can be used only at your own risk.


### PR DESCRIPTION
This PR adds documentation for the recently added `mx show-java-version` command, which shows the configured Java version of the app. This command was added in 10.14.0, 10.12.2, 10.6.12 and 9.24.26.