### PR TITLE
Update setting-up-google-firebase-cloud-messaging-server.md

### DIFF
--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -67,7 +67,7 @@ For a native mobile app, your bundle ID will be what you specify for the **App i
 * For iOS, open *ios/Config/config.xcconfig* and consult **BUNDLE_IDENTIFIER** to find your ID
 
 {{% alert color="info" %}}
-If you also want to support a [custom developer app](/refguide/mobile/distributing-mobile-apps/building-native-apps/how-to-devapps/), repeat above the steps and append `.developerapp` to the IDs.
+If you also want to support a [custom developer app](/refguide/mobile/distributing-mobile-apps/building-native-apps/how-to-devapps/), repeat the above steps and append `.developerapp` to the IDs.
 {{% /alert %}}
 
 Click **Deploy**, then **Mobile App**. Your ID is listed as **App Identifier**:
@@ -92,7 +92,7 @@ Bundle ID must be matching with your package ID. Make sure to repeat this step f
 
 ## 5 Configuring APNs Credentials (Optional) {#configuring}
 
-If you wish to send push notifications to iOS devices through FCM, you will need to configure your APNs credentials:
+If you wish to send push notifications to iOS devices through FCM (for native mobile apps), you will need to configure your APNs credentials:
 
 1. Click in the upper-left corner of the screen and select **Project settings**.
 1. Navigate to the **Cloud messaging** tab:


### PR DESCRIPTION
added context that 3.5 is only needed for native apps