### PR TITLE
Update system requirements

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -286,7 +286,7 @@ For native and progressive web apps built with Mendix, the following operating s
 
 Only devices running on these operating system versions receive up-to-date security fixes from their vendors and thus minimize being vulnerable to known exploits.
 
-You can build native and progressive web apps with Mendix that run on older operating system versions than the ones we support. However, to receive official Mendix support you must demonstrate that your problem also occurs on a supported operating system version.
+You can build native and progressive web apps with Mendix that run on older operating system versions than the ones we support. However, to receive official Mendix support you must demonstrate that your problem also occurs on a supported operating system version. The oldest operating system version where Mendix native mobile apps can run is determined by [React Native](https://github.com/facebook/react-native?tab=readme-ov-file#-requirements).
 
 Mendix recommends the following minimum hardware requirements for all mobile devices running native and progressive web Mendix apps:
 


### PR DESCRIPTION
Added reference to React Native Requirements to explain the oldest os version Mendix native apps can run (without official support)

@ConnorLand 