### PR TITLE
Improve Google Search

### DIFF
--- a/content/en/docs/catalog/manage/user-roles.md
+++ b/content/en/docs/catalog/manage/user-roles.md
@@ -28,7 +28,7 @@ A Mendix Admin can do the following:
 * Curate the Catalog according to the organization's data governance policy
 * Access all the registered assets in the Catalog for the organization
 
-For more information, see the [Catalog](/control-center/catalog-admin/) section of *Control Center*. 
+For more information, see the [Catalog Administration](/control-center/catalog-admin/) section of *Control Center*. 
 
 ### External Users
 

--- a/content/en/docs/control-center/apps.md
+++ b/content/en/docs/control-center/apps.md
@@ -1,5 +1,6 @@
 ---
-title: "Apps"
+title: "Apps Overview"
+linktitle: "Apps"
 url: /control-center/apps/
 description: "Describes the Apps page in the Mendix Control Center."
 weight: 15

--- a/content/en/docs/control-center/catalog-admin.md
+++ b/content/en/docs/control-center/catalog-admin.md
@@ -1,5 +1,6 @@
 ---
-title: "Catalog"
+title: "Catalog Administration"
+linktitle: "Catalog"
 url: /control-center/catalog-admin/
 weight: 60
 description: "Describes the catalog administration in the Mendix Control Center."

--- a/content/en/docs/control-center/security/_index.md
+++ b/content/en/docs/control-center/security/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Security"
+title: "Security Settings in Control Center"
+linktitle: "Security"
 url: /control-center/security/
 description: "Describes the Security page in the Mendix Control Center."
 weight: 40

--- a/content/en/docs/control-center/software-composition.md
+++ b/content/en/docs/control-center/software-composition.md
@@ -1,5 +1,6 @@
 ---
-title: "Software Composition"
+title: "Software Composition (Control Center)"
+linktitle: "Software Composition"
 url: /control-center/software-composition/
 description: "Describes the Software Composition page in the Mendix Control Center."
 weight: 80

--- a/content/en/docs/deployment/_index.md
+++ b/content/en/docs/deployment/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Deployment"
+title: "Deploying Apps"
+linktitle: "Deployment"
 url: /deployment/
 description: "Describes how to deploy Mendix apps to different environments and how to manage those deployments."
 weight: 32

--- a/content/en/docs/deployment/cloud-foundry-deploy.md
+++ b/content/en/docs/deployment/cloud-foundry-deploy.md
@@ -6,13 +6,11 @@ description: "Describes how to deploy to a Cloud Foundry environment which does 
 aliases:
     - /deployment/cloud-foundry/index.html
     - /howto/deploying-a-mendix-app-to-cloud-foundry.html
-    - /howto7/deploying-a-mendix-app-to-cloud-foundry.html
     - /refguide/deploying-a-mendix-app-to-cloud-foundry.html
     - /refguide8/deploying-a-mendix-app-to-cloud-foundry.html
     - /refguide9/deploying-a-mendix-app-to-cloud-foundry.html
     - /deployment/cloud-foundry/
     - /howto/deploying-a-mendix-app-to-cloud-foundry
-    - /howto7/deploying-a-mendix-app-to-cloud-foundry
     - /refguide/deploying-a-mendix-app-to-cloud-foundry
     - /refguide8/deploying-a-mendix-app-to-cloud-foundry 
     - /refguide9/deploying-a-mendix-app-to-cloud-foundry

--- a/content/en/docs/deployment/general/software-composition.md
+++ b/content/en/docs/deployment/general/software-composition.md
@@ -1,5 +1,5 @@
 ---
-title: "Software Composition (App)"
+title: "Software Composition"
 linktitle: "Software Composition"
 url: /developerportal/deploy/software-composition/
 description: "Describes the Software Composition page in Apps."

--- a/content/en/docs/deployment/general/software-composition.md
+++ b/content/en/docs/deployment/general/software-composition.md
@@ -1,5 +1,6 @@
 ---
-title: "Software Composition"
+title: "Software Composition (App)"
+linktitle: "Software Composition"
 url: /developerportal/deploy/software-composition/
 description: "Describes the Software Composition page in Apps."
 weight: 3

--- a/content/en/docs/deployment/mendix-cloud-deploy/_index.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/_index.md
@@ -78,7 +78,7 @@ If the standard environments that you get with a licensed app do not meet your r
 
 Apps deployed to Mendix Cloud are configured to use a PostgreSQL database. It is not possible to configure your app to use an alternative database if it is deployed to Mendix Cloud.
 
-If you need to use a different database, consider deploying your app to a different platform. For more information, see [Deployment](/deployment/).
+If you need to use a different database, consider deploying your app to a different platform. For more information, see [Deploying Apps](/deployment/).
 
 ### URLs and Ports
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/access-restrictions.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/access-restrictions.md
@@ -168,6 +168,6 @@ If the `/ws/` path should still be reachable from the office location without us
 ## Read More
 
 * [Certificates](/developerportal/deploy/certificates/)
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Environments](/developerportal/deploy/environments/)
 * [Environment Details](/developerportal/deploy/environments-details/)

--- a/content/en/docs/deployment/mendix-cloud-deploy/environments.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/environments.md
@@ -169,7 +169,7 @@ Once a service has been enabled for an app, Technical Contacts can selectively e
 
 ## Read More
 
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Environment Details](/developerportal/deploy/environments-details/)
 * [How to Receive Environment Status Alerts](/developerportal/operate/receive-alerts/)
 * [How to Restrict Access for Incoming Requests](/developerportal/deploy/access-restrictions/)

--- a/content/en/docs/deployment/mendix-cloud-deploy/scale-environment.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/scale-environment.md
@@ -67,6 +67,6 @@ For example, you can use one instance with 2 GiB RAM. The remaining 6 GiB in you
 
 ## Read More
 
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/)
 * [About Mendix Cloud](/developerportal/deploy/mxcloudv4/)

--- a/content/en/docs/deployment/mobileapp.md
+++ b/content/en/docs/deployment/mobileapp.md
@@ -100,6 +100,6 @@ For Android please follow the instructions in the [Building Your Android App Loc
 
 ## Read More
 
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Offline Reference Guide](/refguide/offline-first/)
 * [Apache Cordova Reference Config.xml](https://cordova.apache.org/docs/en/latest/config_ref/)

--- a/content/en/docs/developerportal/deployment.md
+++ b/content/en/docs/developerportal/deployment.md
@@ -12,7 +12,7 @@ description_list: true
 The **Deployment** category in the **Apps** [navigation pane](/developerportal/#navigation-pane) provides access to built-in deployment and monitoring tools for your app. The pages in this category are listed below.
 
 {{% alert color="info" %}}
-The interface and functionality of these pages vary depending on where your app is deployed. For details about the various deployment options, see the [Deployment](/deployment/) section.
+The interface and functionality of these pages vary depending on where your app is deployed. For details about the various deployment options, see the [Deploying Apps](/deployment/) section.
 {{% /alert %}}
 
 ## Environments

--- a/content/en/docs/developerportal/general/_index.md
+++ b/content/en/docs/developerportal/general/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "General"
+title: "Apps ‒ General"
+linktitle: "General"
 url: /developerportal/general/
 description: "Describes the tools and settings available in the General category in Apps navigation pane."
 weight: 5

--- a/content/en/docs/developerportal/portfolio-management/archive.md
+++ b/content/en/docs/developerportal/portfolio-management/archive.md
@@ -1,5 +1,6 @@
 ---
-title: "Archive"
+title: "Archive Initiatives"
+linktitle: "Archive"
 url: /developerportal/portfolio-management/archive/
 weight: 10
 description: "Describes the Archive page in the Mendix Portfolio Management app."

--- a/content/en/docs/developerportal/project-management/epics/_index.md
+++ b/content/en/docs/developerportal/project-management/epics/_index.md
@@ -20,6 +20,6 @@ Open the app in [Apps](https://sprintr.home.mendix.com/link/myapps) and then go 
 * [Board](/developerportal/project-management/epics/board/)
 * [Planning](/developerportal/project-management/epics/planning/)
 * [Epics](/developerportal/project-management/epics/epics/)
-* [Archive](/developerportal/project-management/epics/archive/)
+* [Archive Stories](/developerportal/project-management/epics/archive/)
 
 After you open the app in Epics, you can easily switch to other apps that you have access to. To do so, click the name of the current app on the upper-left corner, and then select a different app from the drop-down list.

--- a/content/en/docs/developerportal/project-management/epics/archive.md
+++ b/content/en/docs/developerportal/project-management/epics/archive.md
@@ -1,5 +1,6 @@
 ---
-title: "Archive"
+title: "Archive Stories"
+linktitle: "Archive"
 url: /developerportal/project-management/epics/archive/
 weight: 40
 description: "Describes the Archive page in Epics."

--- a/content/en/docs/howto/integration/_index.md
+++ b/content/en/docs/howto/integration/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Integration"
+title: "Integration How-Tos"
+linktitle: "Integration"
 url: /howto/integration/
 weight: 70
 description: "Presents a list of how-tos about integrating Mendix applications with other systems and services."

--- a/content/en/docs/howto/security/_index.md
+++ b/content/en/docs/howto/security/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Security"
+title: "Securing Your Data"
+linktitle: "Security"
 url: /howto/security/
 weight: 90
 description: "Presents a series of how-tos to secure your data and ensure that the right user is seeing the right data."

--- a/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
+++ b/content/en/docs/howto8/mobile/hybrid-mobile/build-hybrid-apps/build-hybrid-locally.md
@@ -205,7 +205,7 @@ You *APK* should now be generated and signed using Android Studio. The resulting
 
 ## Read More
 
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Offline Reference Guide](/refguide8/offline-first/)
 * [How to Publish a Mendix Hybrid Mobile App in App Stores](/howto8/mobile/publishing-a-mendix-hybrid-mobile-app-in-mobile-app-stores/)
 * [Apache Cordova Reference Config.xml](https://cordova.apache.org/docs/en/latest/config_ref/)

--- a/content/en/docs/howto8/mobile/native-mobile/notifications/local-notif-parent/local-notif-action.md
+++ b/content/en/docs/howto8/mobile/native-mobile/notifications/local-notif-parent/local-notif-action.md
@@ -3,6 +3,7 @@ title: "Part 3: Actions"
 url: /howto8/mobile/local-notif-action/
 weight: 30
 description: A tutorial for making your push notifications trigger actions when tapped.
+canonical_url: "https://docs.mendix.com/refguide/mobile/using-mobile-capabilities/local-notifications/local-notif-action/"
 ---
 
 ## Introduction

--- a/content/en/docs/partners/siemens/3d-viewer/_index.md
+++ b/content/en/docs/partners/siemens/3d-viewer/_index.md
@@ -326,7 +326,7 @@ If you have already deployed your app, change the existing **LicenseToken** cons
 
 #### For an App Deployed in Your Own Environment
 
-If you deploy your app in your own environment, you need to configure the license token in your own environment. For more information, see [Deployment](/deployment/).
+If you deploy your app in your own environment, you need to configure the license token in your own environment. For more information, see [Deploying Apps](/deployment/).
 
 ## Usage
 

--- a/content/en/docs/quickstarts/leading-mendix-implementation.md
+++ b/content/en/docs/quickstarts/leading-mendix-implementation.md
@@ -625,7 +625,7 @@ When setting up your deployment strategy, it is important to look at the feature
 
 If your organization is deploying on **Private Cloud or on-prem**, please **make sure that you are ready to take on the effort and responsibility of managing all hosting and support of the application deployments**.
 
-For a list of all the deployment options that are available, see [Deployment](/deployment/). 
+For a list of all the deployment options that are available, see [Deploying Apps](/deployment/). 
 
 Some highlights to consider:
 

--- a/content/en/docs/refguide/_index.md
+++ b/content/en/docs/refguide/_index.md
@@ -40,7 +40,7 @@ When it comes to testing your application, you first need to decide what you are
 
 Studio Pro allows you to run and view your app locally or in the default environment.
 
-For more information on options for deploying your app see [Deployment](/deployment/).
+For more information on options for deploying your app see [Deploying Apps](/deployment/).
 
 ## Version Control
 

--- a/content/en/docs/refguide/general/studio-pro-overview/_index.md
+++ b/content/en/docs/refguide/general/studio-pro-overview/_index.md
@@ -44,7 +44,7 @@ Deploy your app by clicking the **Publish** or **Run Locally** ({{% icon name="c
 
 {{< figure src="/attachments/refguide/studio-pro-overview/view-and-publish.png" alt="View and Publish buttons" class="no-border" >}}
 
-For more information on deployment in Mendix, see [Deployment](/deployment/).
+For more information on deployment in Mendix, see [Deploying Apps](/deployment/).
 
 For more information on deploying and versioning your app, see the [Versioning an App Deployed to the Cloud](/refguide/using-version-control-in-studio-pro/#versioning-app) section in *Using Version Control in Studio Pro*. 
 

--- a/content/en/docs/refguide/mobile/designing-mobile-user-interfaces/_index.md
+++ b/content/en/docs/refguide/mobile/designing-mobile-user-interfaces/_index.md
@@ -16,7 +16,7 @@ Mobile applications have unique properties that must be taken into consideration
 These documents guide you through the process of shaping great mobile user experiences both from a design and an implementation perspective:
 
 * [Design Principles](/refguide/mobile/designing-mobile-user-interfaces/design-principles/) – This guide teaches you how to build a native mobile app's UI.
-* [Navigation](/refguide/mobile/designing-mobile-user-interfaces/navigation/) – This guide gives general information for native navigation in Mendix test.
+* [Navigation In Native Mobile Apps](/refguide/mobile/designing-mobile-user-interfaces/navigation/) – This guide gives general information for native navigation in Mendix test.
 * [Images, Icons, and Fonts](/refguide/mobile/designing-mobile-user-interfaces/images-icons-and-fonts/) – This guide helps you enrich your native mobile app's design with images and custom fonts.
 * [Native Styling](/refguide/mobile/designing-mobile-user-interfaces/native-styling/) – This guide gives general information for native styling in Mendix.
 * [Widget Styling Guide](/refguide/mobile/designing-mobile-user-interfaces/widget-styling-guide/) – This guide contextualizes the style elements Mendix uses in native mobile apps and explains the classes and style properties of Mendix’s widgets.

--- a/content/en/docs/refguide/mobile/designing-mobile-user-interfaces/navigation.md
+++ b/content/en/docs/refguide/mobile/designing-mobile-user-interfaces/navigation.md
@@ -1,5 +1,6 @@
 ---
-title: "Navigation"
+title: "Navigation In Native Mobile Apps"
+linktitle: "Navigation"
 url: /refguide/mobile/designing-mobile-user-interfaces/navigation/
 weight: 20
 description: "General information for native navigation in Mendix."

--- a/content/en/docs/refguide/modeling/menus/app-menu/_index.md
+++ b/content/en/docs/refguide/modeling/menus/app-menu/_index.md
@@ -86,4 +86,4 @@ For more information on using this option, see [Deploy to the Cloud](/refguide/d
 ## Read More
 
 * [Studio Pro Overview](/refguide/studio-pro-overview/)
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)

--- a/content/en/docs/refguide/runtime/runtime-deployment.md
+++ b/content/en/docs/refguide/runtime/runtime-deployment.md
@@ -7,7 +7,7 @@ weight: 30
 
 ## Introduction
 
-To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your app, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deployment](/deployment/).
+To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your app, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deploying Apps](/deployment/).
 
 This description of deployment is based on an app running in the cloud. You can also run Mendix locally for testing, but this is conceptually the same.
 

--- a/content/en/docs/refguide8/_index.md
+++ b/content/en/docs/refguide8/_index.md
@@ -42,7 +42,7 @@ When it comes to testing your application, you first need to decide what you are
 
 Studio Pro allows you to run and view your app locally or in the default environment.
 
-For more information on options for deploying your app, see [Deployment](/deployment/).
+For more information on options for deploying your app, see [Deploying Apps](/deployment/).
 
 ## Version Control
 

--- a/content/en/docs/refguide8/modeling/menus/project-menu/_index.md
+++ b/content/en/docs/refguide8/modeling/menus/project-menu/_index.md
@@ -86,4 +86,4 @@ For more information on using this option, see [Deploy to the Cloud](/refguide8/
 ## Read More
 
 * [Studio Pro Overview](/refguide8/studio-pro-overview/)
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)

--- a/content/en/docs/refguide8/modeling/studio-pro-overview.md
+++ b/content/en/docs/refguide8/modeling/studio-pro-overview.md
@@ -42,7 +42,7 @@ For more information on menus, see [Menus](/refguide8/menus/).
 
 You can deploy your app by clicking the **Run** or **Run locally** buttons. To view your deployed app, click the **View** button. 
 
-For more information on deployment in Mendix, see [Deployment](/deployment/).
+For more information on deployment in Mendix, see [Deploying Apps](/deployment/).
 
 For more information on deploying your app and versioning it, see the [Versioning a Project Deployed to the Cloud](/refguide8/using-version-control-in-studio-pro/#versioning-project) section in *Using Version Control in Studio Pro*. 
 

--- a/content/en/docs/refguide8/runtime/runtime-deployment.md
+++ b/content/en/docs/refguide8/runtime/runtime-deployment.md
@@ -7,7 +7,7 @@ weight: 30
 
 ## Introduction
 
-To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your project, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deployment](/deployment/).
+To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your project, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deploying Apps](/deployment/).
 
 This description of deployment is based on an app running in the cloud. You can also run Mendix locally for testing, but this is conceptually the same.
 

--- a/content/en/docs/refguide9/_index.md
+++ b/content/en/docs/refguide9/_index.md
@@ -40,7 +40,7 @@ When it comes to testing your application, you first need to decide what you are
 
 Studio Pro allows you to run and view your app locally or in the default environment.
 
-For more information on options for deploying your app, see [Deployment](/deployment/).
+For more information on options for deploying your app, see [Deploying Apps](/deployment/).
 
 ## Version Control
 

--- a/content/en/docs/refguide9/mobile/using-mobile-capabilities/local-notifications/local-notif-action.md
+++ b/content/en/docs/refguide9/mobile/using-mobile-capabilities/local-notifications/local-notif-action.md
@@ -3,6 +3,7 @@ title: "Part 3: Actions"
 url: /refguide9/mobile/using-mobile-capabilities/local-notifications/local-notif-action/
 weight: 30
 description: A tutorial for making your push notifications trigger actions when tapped.
+canonical_url: "https://docs.mendix.com/refguide/mobile/using-mobile-capabilities/local-notifications/local-notif-action/"
 ---
 
 ## Introduction

--- a/content/en/docs/refguide9/modeling/menus/app-menu/_index.md
+++ b/content/en/docs/refguide9/modeling/menus/app-menu/_index.md
@@ -84,4 +84,4 @@ For more information on using this option, see [Deploy to the Cloud](/refguide9/
 ## Read More
 
 * [Studio Pro Overview](/refguide9/studio-pro-overview/)
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)

--- a/content/en/docs/refguide9/modeling/studio-pro-overview/_index.md
+++ b/content/en/docs/refguide9/modeling/studio-pro-overview/_index.md
@@ -44,7 +44,7 @@ You can deploy your app by clicking **Publish** or **Run Locally** ({{% icon nam
 
 {{< figure src="/attachments/refguide9/modeling/studio-pro-overview/view-and-publish.png" alt="View App, Publish, and Run Locally buttons" class="no-border" >}}
 
-For more information on deployment in Mendix, see [Deployment](/deployment/).
+For more information on deployment in Mendix, see [Deploying Apps](/deployment/).
 
 For more information on deploying your app and versioning it, see the [Versioning an App Deployed to the Cloud](/refguide9/using-version-control-in-studio-pro/#versioning-app) section in *Using Version Control in Studio Pro*. 
 

--- a/content/en/docs/refguide9/runtime/runtime-deployment.md
+++ b/content/en/docs/refguide9/runtime/runtime-deployment.md
@@ -7,7 +7,7 @@ weight: 30
 
 ## Introduction
 
-To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your app, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deployment](/deployment/).
+To convert your Mendix model into an app running in the cloud, it needs to be deployed. This document describes the concepts behind the deployment of your app, and the processes it goes through to begin running in the cloud. For technical details on how to deploy your app, see [Deploying Apps](/deployment/).
 
 This description of deployment is based on an app running in the cloud. You can also run Mendix locally for testing, but this is conceptually the same.
 

--- a/content/en/docs/releasenotes/catalog/_index.md
+++ b/content/en/docs/releasenotes/catalog/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Catalog"
+title: "Catalog Release Notes"
+linktitle: "Catalog"
 url: /releasenotes/catalog/
 description: "Release notes for updates to the Mendix Catalog"
 weight: 36

--- a/content/en/docs/releasenotes/community-tools/_index.md
+++ b/content/en/docs/releasenotes/community-tools/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Community"
+title: "Community Release Notes"
+linktitle: "Community"
 url: /releasenotes/community-tools/
 description: "Release notes for the community tools in the Mendix Platform."
 weight: 37

--- a/content/en/docs/releasenotes/control-center/_index.md
+++ b/content/en/docs/releasenotes/control-center/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Control Center"
+title: "Control Center Release Notes"
+linktitle: "Control Center"
 url: /releasenotes/control-center/
 description: "Release notes for Control Center"
 weight: 30

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -1,5 +1,6 @@
 ---
-title: "Mendix for Private Cloud"
+title: "Mendix for Private Cloud Release Notes"
+linktitle: "Mendix for Private Cloud"
 url: /releasenotes/developer-portal/mendix-for-private-cloud/
 weight: 20
 description: "Release notes for deployment using Mendix for Private Cloud"

--- a/content/en/docs/releasenotes/deployment/on-premises.md
+++ b/content/en/docs/releasenotes/deployment/on-premises.md
@@ -1,5 +1,6 @@
 ---
-title: "Other Deployment Options"
+title: "Release Notes for Other Deployment Options"
+linktitle: "Other Deployment Options"
 url: /releasenotes/developer-portal/on-premises/
 weight: 40
 description: "Release notes for On-premises deployments based on Virtual Machine (Windows and Linux) and Buildpacks (Cloud Foundry and Docker)"

--- a/content/en/docs/releasenotes/deployment/sap-cloud-platform.md
+++ b/content/en/docs/releasenotes/deployment/sap-cloud-platform.md
@@ -1,5 +1,6 @@
 ---
-title: "SAP BTP"
+title: "SAP BTP Release Notes"
+linktitle: "SAP BTP"
 url: /releasenotes/developer-portal/sap-cloud-platform/
 weight: 30
 description: "Release notes for deployment to SAP Business Technology Platform"

--- a/content/en/docs/releasenotes/developer-portal/_index.md
+++ b/content/en/docs/releasenotes/developer-portal/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Apps"
+title: "Apps Release Notes"
+linktitle: "Apps"
 url: /releasenotes/developer-portal/
 description: "Release notes for app management and other parts of Apps"
 weight: 20

--- a/content/en/docs/releasenotes/marketplace/_index.md
+++ b/content/en/docs/releasenotes/marketplace/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Marketplace"
+title: "Marketplace Release Notes"
+linktitle: "Marketplace"
 url: /releasenotes/marketplace/
 description: "Release notes for updates to the Mendix Marketplace"
 weight: 35

--- a/content/en/docs/releasenotes/mobile/_index.md
+++ b/content/en/docs/releasenotes/mobile/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Mobile"
+title: "Mobile Release Notes"
+linktitle: "Mobile"
 url: /releasenotes/mobile/
 weight: 15
 cascade:

--- a/content/en/docs/releasenotes/mobile/hybrid-app.md
+++ b/content/en/docs/releasenotes/mobile/hybrid-app.md
@@ -1,5 +1,6 @@
 ---
-title: "Hybrid App Base and Template"
+title: "Hybrid App Base and Template Release Notes"
+linktitle: "Hybrid App Base and Template"
 url: /releasenotes/mobile/hybrid-app/
 weight: 30
 description: "Mendix Hybrid App Base and Hybrid App Template release notes."

--- a/content/en/docs/releasenotes/mobile/mendix-mobile-app.md
+++ b/content/en/docs/releasenotes/mobile/mendix-mobile-app.md
@@ -1,5 +1,6 @@
 ---
-title: "Mendix Mobile App"
+title: "Mendix Mobile App Release Notes"
+linktitle: Mendix Mobile App"
 url: /releasenotes/mobile/mendix-mobile-app/
 weight: 20
 description: "These are the release notes for the Mendix Mobile app."

--- a/content/en/docs/releasenotes/mobile/mendix-native-mobile-builder.md
+++ b/content/en/docs/releasenotes/mobile/mendix-native-mobile-builder.md
@@ -1,5 +1,6 @@
 ---
-title: "Mendix Native Mobile Builder"
+title: "Mendix Native Mobile Builder Release Notes"
+linktitle: "Mendix Native Mobile Builder"
 url: /releasenotes/mobile/mendix-native-mobile-builder/
 weight: 11
 description: "Mendix Native Mobile Builder release notes."

--- a/content/en/docs/releasenotes/mobile/native-builder.md
+++ b/content/en/docs/releasenotes/mobile/native-builder.md
@@ -1,5 +1,6 @@
 ---
-title: "Native Builder"
+title: "Native Builder Release Notes"
+linktitle: "Native Builder"
 url: /releasenotes/mobile/native-builder/
 weight: 11
 description: "Native Builder release notes."

--- a/content/en/docs/releasenotes/mobile/native-template/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Native Template"
+title: "Native Template Release Notes"
+linktitle: "Native Template"
 url: /releasenotes/mobile/native-template/
 weight: 12
 description: "Native Template release notes."

--- a/content/en/docs/releasenotes/private-platform/1.10.md
+++ b/content/en/docs/releasenotes/private-platform/1.10.md
@@ -1,5 +1,5 @@
 ---
-title: "1.10"
+title: "Mendix Private Platform Version 1.10 Release Notes"
 linktitle: "1.10"
 url: /releasenotes/private-platform/1-10/
 description: "Release notes for version 1.10 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/1.11.md
+++ b/content/en/docs/releasenotes/private-platform/1.11.md
@@ -1,5 +1,5 @@
 ---
-title: "1.11"
+title: "Mendix Private Platform Version 1.11 Release Notes"
 linktitle: "1.11"
 url: /releasenotes/private-platform/1-11/
 description: "Release notes for version 1.11 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/1.12.md
+++ b/content/en/docs/releasenotes/private-platform/1.12.md
@@ -1,5 +1,5 @@
 ---
-title: "1.12"
+title: "Mendix Private Platform Version 1.12 Release Notes"
 linktitle: "1.12"
 url: /releasenotes/private-platform/1-12/
 description: "Release notes for version 1.12 of Private Mendix Platform"
@@ -20,28 +20,28 @@ Version 1.12.0 of Private Mendix Platform introduces a number of bug fixes, new 
 
 #### New Features
 
-###### MDA Download through an API Endpoint
+##### MDA Download through an API Endpoint
 
 You can now download your *.mda* app packages by using a new endpoint in the Project API. You can also use the API to obtain a list of available packages for a specific project. For more information, see [Private Mendix Platform Project API](/apidocs-mxsdk/apidocs/private-platform-project-api/).
 
 #### Improvements
 
-###### Pipeline Enhancements
+##### Pipeline Enhancements
 
 For the Build and Deploy pipeline, some steps can now automatically time out after a preset time interval. You can number of hours after which the step will time out for the Manual Approve and Waiting for Rest Call steps. For Manual Approve steps, notification messages are sent to the project owners and project members who have manual approval permissions.
 
-###### Webhook Enhancements
+##### Webhook Enhancements
 
 Webhooks are now automatically classified by type depending on where they are placed in the pipeline. Unused webhook registrations are also automatically removed.
 
-##### Engineering Improvements
+#### Engineering Improvements
 
 * Private Mendix Platform now supports Java versions 11, 17, and 21.
 * We have upgraded the Mendix Operator version to 2.18.1.
 * We have upgraded the svix version to 1.25.
 * We have upgraded the PCLM version to 0.7.1.
 
-###### Studio Pro Updates
+##### Studio Pro Updates
 
 * Studio Pro 9.24 LTS latest patch version updated to [9.24.24](/releasenotes/studio-pro/9.24/#92424)
 * Studio Pro 10.6 MTS latest patch version updated to [10.6.11](/releasenotes/studio-pro/10.6/#10611) 

--- a/content/en/docs/releasenotes/private-platform/1.5.md
+++ b/content/en/docs/releasenotes/private-platform/1.5.md
@@ -1,5 +1,6 @@
 ---
-title: "1.5"
+title: "Mendix Private Platform Version 1.5 Release Notes"
+linktitle: "1.5"
 url: /releasenotes/private-platform/1-5/
 description: "Release notes for version 1.5 of Private Mendix Platform"
 weight: 100

--- a/content/en/docs/releasenotes/private-platform/1.6.md
+++ b/content/en/docs/releasenotes/private-platform/1.6.md
@@ -1,5 +1,5 @@
 ---
-title: "1.6 (MTS)"
+title: "Mendix Private Platform Version 1.6 (MTS) Release Notes"
 linktitle: "1.6 (MTS)"
 url: /releasenotes/private-platform/1-6/
 description: "Release notes for version 1.6 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/1.7.md
+++ b/content/en/docs/releasenotes/private-platform/1.7.md
@@ -1,5 +1,5 @@
 ---
-title: "1.7"
+title: "Mendix Private Platform Version 1.7 Release Notes"
 linktitle: "1.7"
 url: /releasenotes/private-platform/1-7/
 description: "Release notes for version 1.7 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/1.8.md
+++ b/content/en/docs/releasenotes/private-platform/1.8.md
@@ -1,5 +1,5 @@
 ---
-title: "1.8"
+title: "Mendix Private Platform Version 1.8 Release Notes"
 linktitle: "1.8"
 url: /releasenotes/private-platform/1-8/
 description: "Release notes for version 1.8 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/1.9.md
+++ b/content/en/docs/releasenotes/private-platform/1.9.md
@@ -1,5 +1,5 @@
 ---
-title: "1.9"
+title: "Mendix Private Platform Version 1.9 Release Notes"
 linktitle: "1.9"
 url: /releasenotes/private-platform/1-9/
 description: "Release notes for version 1.9 of Private Mendix Platform"

--- a/content/en/docs/releasenotes/private-platform/_index.md
+++ b/content/en/docs/releasenotes/private-platform/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Private Mendix Platform"
+title: "Private Mendix Platform Release Notes"
+linktitle: Private Mendix Platform"
 url: /releasenotes/private-platform/
 description: "Release notes for updates to the Private Mendix Platform"
 weight: 40

--- a/content/en/docs/releasenotes/sdk/metamodel/_index.md
+++ b/content/en/docs/releasenotes/sdk/metamodel/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Metamodel"
+title: "Metamodel Release Notes"
+linktitle: "Metamodel"
 url: /releasenotes/sdk/metamodel/
 weight: 3
 ---

--- a/content/en/docs/releasenotes/sdk/metamodel/metamodel-10/_index.md
+++ b/content/en/docs/releasenotes/sdk/metamodel/metamodel-10/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "10"
+title: "Mendix Metamodel Version 10 Release Notes"
+linktitle: "10"
 url: /releasenotes/sdk/metamodel-10/
 weight: 1
 no_list: false

--- a/content/en/docs/releasenotes/sdk/metamodel/metamodel-8/_index.md
+++ b/content/en/docs/releasenotes/sdk/metamodel/metamodel-8/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "8"
+title: "Mendix Metamodel Version 8 Release Notes"
+linktitle: "8"
 url: /releasenotes/sdk/metamodel-8/
 weight: 2
 no_list: false

--- a/content/en/docs/releasenotes/sdk/metamodel/metamodel-9/_index.md
+++ b/content/en/docs/releasenotes/sdk/metamodel/metamodel-9/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "9"
+title: "Mendix Metamodel Version 9 Release Notes"
+linktitle: "9"
 url: /releasenotes/sdk/metamodel-9/
 weight: 1
 no_list: false

--- a/content/en/docs/releasenotes/studio-pro/10/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/10/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "10"
+title: "Mendix Studio Pro Version 10 Release Notes"
+linktitle: "10"
 url: /releasenotes/studio-pro/10/
 description: "The release notes for version 10 of Mendix Studio Pro."
 weight: 9

--- a/content/en/docs/releasenotes/studio-pro/8/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/8/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "8"
+title: "Mendix Studio Pro Version 8 Release Notes"
+linktitle: "8"
 url: /releasenotes/studio-pro/8/
 description: "The release notes for version 8 of Mendix Studio Pro."
 weight: 20

--- a/content/en/docs/releasenotes/studio-pro/9/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/9/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "9"
+title: "Mendix Studio Pro Version 9 Release Notes"
+linktitle: "9"
 url: /releasenotes/studio-pro/9/
 description: "The release notes for version 9 of Mendix Studio Pro."
 weight: 10

--- a/content/en/docs/support/_index.md
+++ b/content/en/docs/support/_index.md
@@ -257,7 +257,7 @@ Mendix Support can analyze these components if your app is running on Mendix Clo
 
 ### Deployment Pipeline
 
-The deployment pipeline takes care of creating and deploying deployment packages. Read more about deployment options in [Deployment](/deployment/).
+The deployment pipeline takes care of creating and deploying deployment packages. Read more about deployment options in [Deploying Apps](/deployment/).
 
 Mendix Support can analyze this component if your app is running on Mendix Cloud, Mendix Cloud Dedicated, Private Cloud Connected, or SAP BTP through the Mendix Portal.
 

--- a/content/en/docs/support/new-app-node-request-template.md
+++ b/content/en/docs/support/new-app-node-request-template.md
@@ -63,5 +63,5 @@ When your app is offboarded, only the deployed app is removed. You still retain 
 
 ## Read More
 
-* [Deployment](/deployment/)
+* [Deploying Apps](/deployment/)
 * [Licensing Apps](/developerportal/deploy/licensing-apps-outside-mxcloud/)

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -2,7 +2,7 @@
 {{- with .Site.Params.search.algolia -}}
 <!-- stylesheet for algolia docsearch -->
 {{- end -}}
-<!-- MvM: Always set page as self-canonical unless another canonical (.Params.canonicalUrl) is set -->
+<!-- MvM: Always set page as self-canonical unless another canonical (.Params.canonical_url) is set -->
 {{- with .Params.canonical_url -}}
     <link rel="canonical" href="{{ . }}">
 {{- else -}}


### PR DESCRIPTION
Google is choosing the wrong canonical because of duplicate page names.

Updating some page names to avoid duplicates.