### PR TITLE
Add PAT steps during APD signup

### DIFF
--- a/content/en/docs/appstore/use-content/partner-solutions/apd/ig/ig-three.md
+++ b/content/en/docs/appstore/use-content/partner-solutions/apd/ig/ig-three.md
@@ -17,6 +17,13 @@ Before starting this how-to, make sure you have completed the following prerequi
     * Write down the current values for the constant **APMAgent2.APMAPIKey** (and, if set, **APMAgent2.APMAdvancedSettings**),
     * Use the values for **APDAgent.APIKey** and, if applicable, **APDAgent.AdvancedSettings**
 * Remove APM 1 and/or APM 2 if they are installed (for details, see [Uninstall Steps APM 1](/appstore/partner-solutions/apd/ig-one-uninstall-steps/))
+* Create a Mendix Personal Access Token to retrieve your apps in APD:
+    * Go to the [Developer Settings](https://user-settings.mendix.com/link/developersettings) of your Mendix Developer Profile.
+    * Click on the button **New Token**.
+    * Specify a token name, for example *APD Sync apps*.
+    * Select option *mx:app:metadata:read* under **Project API**.
+    * Click on the button **Create**.
+    * Write down the generate token.
 
 ## Installation
 
@@ -24,14 +31,17 @@ To install APD 3, follow these steps:
 
 1. Arrange a license for the app to use APD 3.
 2. In a browser, log in using your Mendix account to the [APD Manager](https://apd.mendix.com/). (For backward compatibility with APM 1, APM 2 you are forwarded to [https://apmmanager100.mendixcloud.com](https://apmmanager100.mendixcloud.com)).
-3. Select your app in the dashboard.
-4. In the **Environments** dashboard, select the **New Environment** tile. If you are a [Scrum Master](/developerportal/general/app-roles/) of the Mendix app, you can add test, acceptance, and production environments. If you are not, you can only add Mendix Studio Pro environments. For more details, see [Environments](/appstore/partner-solutions/apd/rg-three-environments/).
-5. Choose an environment name.
-6. Click **Save and generate API key**, then use this key as the value for the **APDAgent.APIKey** constant in step 10 below.
-7. In Studio Pro with your app, import the [Mendix Application Performance Monitor](https://marketplace.mendix.com/link/component/6127/) module from the Mendix Marketplace.
-8. Add the **USE_ME/APDAfterStartup** microflow to your app's **After startup** microflow.
-9. Use the snippet **USE_ME/APDBrowserAgentWidget** in the layout (or layouts) of your app. Please note that it will only be loaded once, regardless of how many times the user opens a page containing the widget.
-10. Set the value of the **USE_ME/APDAgent.APIKey** constant with the key you generated at step 6 above.
+3. If it is your first time opening [APD Manager](https://apd.mendix.com/), you must confirm signing up.
+    1. Enter the Mendix Personal Access Token created in the Prerequisites steps into the field **Mendix PAT**
+    2. Click the button **Confirm signup**. 
+4. Select your app in the dashboard.
+5. In the **Environments** dashboard, select the **New Environment** tile. If you are a [Scrum Master](/developerportal/general/app-roles/) of the Mendix app, you can add test, acceptance, and production environments. If you are not, you can only add Mendix Studio Pro environments. For more details, see [Environments](/appstore/partner-solutions/apd/rg-three-environments/).
+6. Choose an environment name.
+7. Click **Save and generate API key**, then use this key as the value for the **APDAgent.APIKey** constant in step 10 below.
+8. In Studio Pro with your app, import the [Mendix Application Performance Monitor](https://marketplace.mendix.com/link/component/6127/) module from the Mendix Marketplace.
+9. Add the **USE_ME/APDAfterStartup** microflow to your app's **After startup** microflow.
+10. Use the snippet **USE_ME/APDBrowserAgentWidget** in the layout (or layouts) of your app. Please note that it will only be loaded once, regardless of how many times the user opens a page containing the widget.
+11. Set the value of the **USE_ME/APDAgent.APIKey** constant with the key you generated at step 6 above.
 
 ## Upgrading
 
@@ -44,4 +54,4 @@ To upgrade an APD 3 agent, follow these steps:
 
 ## Security
 
-The agent initiates all communication to the [APD 3 manager](https://apmmanager100.mendixcloud.com) in HTTPS over port 443. So, for some on-premises installations, a firewall might need to be opened.
+The agent initiates all communication to the [APD 3 manager](https://apmmanager100.mendixcloud.com) in HTTPS over port 443. For on-premises installations a firewall might need to be opened.


### PR DESCRIPTION
Add steps for creating a Mendix Personal Access Token required for synchronizing the list of Apps of the user with the new Project Permissions API