### PR TITLE
List missing breaking change in MxBuild download

### DIFF
--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -20,7 +20,7 @@ The table below can help you find the correct MxBuild. Copy a URL from the corre
 
 {{% alert color="info" %}}
 
-A build number is included in the version, which has to be included in the link path mentioned above (for example, `10.0.0.9976` is the 5003 build of the 10.0.0 Studio Pro release).
+A build number is included in the version, which has to be included in the link path mentioned above (for example, `10.0.0.9976` is the 9976 build of the 10.0.0 Studio Pro release).
 
 You can find the build number in path of your Mendix installation (for example, if your installation looks like this `C:\Program Files\Mendix\10.0.0.9976`, use this URL to get your files: [https://cdn.mendix.com/runtime/mxbuild-10.0.0.9976.tar.gz](https://cdn.mendix.com/runtime/mxbuild-10.0.0.9976.tar.gz)).
 

--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -20,9 +20,9 @@ The table below can help you find the correct MxBuild. Copy a URL from the corre
 
 {{% alert color="info" %}}
 
-A build number is included in the version, which has to be included in the link path mentioned above (for example, `10.0.0.5003` is the 5003 build of the 10.0.0 Studio Pro release).
+A build number is included in the version, which has to be included in the link path mentioned above (for example, `10.0.0.9976` is the 5003 build of the 10.0.0 Studio Pro release).
 
-You can find the build number in path of your Mendix installation (for example, if your installation looks like this `C:\Program Files\Mendix\10.0.0.5003`, use this URL to get your files: [https://cdn.mendix.com/runtime/mxbuild-10.0.0.5003.tar.gz](https://cdn.mendix.com/runtime/mxbuild-10.0.0.5003.tar.gz)).
+You can find the build number in path of your Mendix installation (for example, if your installation looks like this `C:\Program Files\Mendix\10.0.0.9976`, use this URL to get your files: [https://cdn.mendix.com/runtime/mxbuild-10.0.0.9976.tar.gz](https://cdn.mendix.com/runtime/mxbuild-10.0.0.9976.tar.gz)).
 
 Any public version of Studio Pro in this [Studio Pro Releases List](https://marketplace.mendix.com/link/studiopro/) will allow you to download MxBuild files. If you experience trouble downloading files, make sure your build is listed there.
 

--- a/content/en/docs/releasenotes/studio-pro/10/10.0.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.0.md
@@ -165,7 +165,7 @@ For details on upgrading to Studio Pro 10, see [Upgrading from Mendix Studio Pro
 * The fields in Java actions are now generated as final fields.
 * The `Entity` and `List of Entity` parameters in Java actions are now initialized in the constructor, and the accompanying `__[FieldName]` field will be generated as deprecated. To get access to the `IMendixObject` variant, call the `getMendixObject()` method on the field (or items in the list, in case of a list).
 * We changed the exception type from `CoreRuntimeException` to `ReadOnlyAttributeException` that occurs when trying to change a virtual method through `setValue`.
-* The Linux package for MxBuild no longer contains `mxbuild.exe`, instead `mxbuild` should be used to execute MxBuild on Linux.
+* The Linux package for MxBuild no longer contains `mxbuild.exe`. Instead, `mxbuild` should be used to execute MxBuild on Linux.
 
 ### Known Issues
 

--- a/content/en/docs/releasenotes/studio-pro/10/10.0.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.0.md
@@ -165,6 +165,7 @@ For details on upgrading to Studio Pro 10, see [Upgrading from Mendix Studio Pro
 * The fields in Java actions are now generated as final fields.
 * The `Entity` and `List of Entity` parameters in Java actions are now initialized in the constructor, and the accompanying `__[FieldName]` field will be generated as deprecated. To get access to the `IMendixObject` variant, call the `getMendixObject()` method on the field (or items in the list, in case of a list).
 * We changed the exception type from `CoreRuntimeException` to `ReadOnlyAttributeException` that occurs when trying to change a virtual method through `setValue`.
+* The Linux package for MxBuild no longer contains `mxbuild.exe`, instead `mxbuild` should be used to execute MxBuild on Linux.
 
 ### Known Issues
 


### PR DESCRIPTION
A customer mentions that `mxbuild.exe` was missing from the Linux download. This is as intended, but not documented as a breaking change. The PR rectifies that.