### PR TITLE
GraphQL feedback

### DIFF
--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -24,7 +24,7 @@ This document describes the options available to you when you create a published
 {{% alert color="info" %}}
 Published OData services deployed to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/) are automatically registered in the [Catalog](/catalog/).{{% /alert %}}
 
-If you want the published service to be a GraphQL service as well, you can indicate that it [supports GraphQL](#supports-graphql).
+If you want the published service to be a GraphQL service as well, you can indicate that it [supports GraphQL](#supports-graphql). We welcome your feedback about published GraphQL services. Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback).
 
 ## General {#general}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -24,7 +24,7 @@ This document describes the options available to you when you create a published
 {{% alert color="info" %}}
 Published OData services deployed to the [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/) are automatically registered in the [Catalog](/catalog/).{{% /alert %}}
 
-If you want the published service to be a GraphQL service as well, you can indicate that it [supports GraphQL](#supports-graphql). We welcome your feedback about published GraphQL services. Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback).
+If you want the published service to be a GraphQL service as well, you can indicate that it [supports GraphQL](#supports-graphql). Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback) to provide feedback about published GraphQL services. 
 
 ## General {#general}
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
@@ -4,4 +4,4 @@ url: /refguide/graphql-feedback/
 hidden: true
 ---
 
-We welcome your feedback about published GraphQL services. Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback).
+Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback) to provide feedback about published GraphQL services.

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
@@ -1,7 +1,9 @@
 ---
 title: GraphQL Representation
 url: /refguide/graphql-feedback/
-hidden: true
+toc_hide: true
+hide_summary: true
+# This doc is hidden as part of the GraphQL survey request. 
 ---
 
 We welcome your feedback about published GraphQL services. Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback).

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/graphql-feedback.md
@@ -1,0 +1,7 @@
+---
+title: GraphQL Representation
+url: /refguide/graphql-feedback/
+hidden: true
+---
+
+We welcome your feedback about published GraphQL services. Please fill out [this survey](https://survey.alchemer.eu/s3/90711630/Mendix-GraphQL-Beta-Feedback).


### PR DESCRIPTION
Customers can fill out a survey about GraphQL. We added a separate hidden document for this so that Studio Pro 10.15.0 can link to it directly. In the future, once the survey closes after some time, we will replaces the text with "Use the idea forum to submit feedback"

Can be merged now, but should be merged before Studio Pro 10.15.0 is released.