### PR TITLE
Added difference in object attributes between microflows and nanoflows

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
@@ -35,6 +35,7 @@ Below presents a list of main differences between microflows and nanoflows:
 * When used in nanoflow activities, expressions do not support the following objects and variables: `$latestSoapFault`, `$latestHttpResponse`, `$currentSession`, `$currentUser`, `$currentDeviceType`.
 * Nanoflows are not run inside a transaction. So, if an error occurs in a nanoflow, it will not roll back any previous changes.
 * Changes done to the lists in a sub-nanoflow are not reflected in the original nanoflow.
+* Attributes of objects that are `empty` return an empty string instead (`""`).
 
 ## Classic and Modern Logic Editors {#new-editor}
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
@@ -35,7 +35,7 @@ Below presents a list of main differences between microflows and nanoflows:
 * When used in nanoflow activities, expressions do not support the following objects and variables: `$latestSoapFault`, `$latestHttpResponse`, `$currentSession`, `$currentUser`, `$currentDeviceType`.
 * Nanoflows are not run inside a transaction. So, if an error occurs in a nanoflow, it will not roll back any previous changes.
 * Changes done to the lists in a sub-nanoflow are not reflected in the original nanoflow.
-* Attributes of objects that are `empty` return an empty string instead (`""`).
+* Attributes of objects that are `empty` return an empty string instead (`''`).
 
 ## Classic and Modern Logic Editors {#new-editor}
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
@@ -35,7 +35,7 @@ Below presents a list of main differences between microflows and nanoflows:
 * When used in nanoflow activities, expressions do not support the following objects and variables: `$latestSoapFault`, `$latestHttpResponse`, `$currentSession`, `$currentUser`, `$currentDeviceType`.
 * Nanoflows are not run inside a transaction. So, if an error occurs in a nanoflow, it will not roll back any previous changes.
 * Changes done to the lists in a sub-nanoflow are not reflected in the original nanoflow.
-* Attributes of objects that are `empty` return an empty string instead (`''`).
+* In nanoflows, when retrieving an `empty` attribute of an object, an empty string (`''`) is returned.
 
 ## Classic and Modern Logic Editors {#new-editor}
 


### PR DESCRIPTION
When retrieving an empty attribute of an object, an empty string is returned instead inside nanoflows.