### PR TITLE
Mx4PC Operator 2.20.0 release notes (planned for release around October 31)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -916,11 +916,9 @@ The Mendix Operator uses some labels for internal use. To avoid conflicts with t
 
 ### Delaying App Shutdown {#termination-delay}
 
-In some situations, shutting down a replica immediately could cause isses.
-For example, the [Azure Gateway Ingress Controller](https://azure.github.io/application-gateway-kubernetes-ingress/how-tos/minimize-downtime-during-deployments/) needs up to 90 seconds to remove a pod from its routing table.
-Stopping an app pod immediately would still send traffic to the pod for a few minutes, causing random 502 errors to appear in the client web browser.
+In some situations, shutting down a replica immediately can cause isses. For example, the [Azure Gateway Ingress Controller](https://azure.github.io/application-gateway-kubernetes-ingress/how-tos/minimize-downtime-during-deployments/) needs up to 90 seconds to remove a pod from its routing table. Stopping an app pod immediately would still send traffic to the pod for a few minutes, causing random 502 errors to appear in the client web browser.
 
-You can add (or adjust) the timeout by adding a `runtimeTerminationDelaySeconds` value to the `OperatorConfiguration` CR:
+You can add or change the timeout by adding a `runtimeTerminationDelaySeconds` value to the `OperatorConfiguration` CR:
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
@@ -932,12 +930,12 @@ spec:
   runtimeTerminationDelaySeconds: 90
 ```
 
-Setting `runtimeTerminationDelaySeconds` to `90` will keep the app running for 90 seconds after a pod receives a shutdown signal.
+For example, if you set `runtimeTerminationDelaySeconds` to `90`, the app continues to run for 90 seconds after a pod receives a shutdown signal.
 
 In most cases, this option is only needed when an app is partially scaled down (for example, by a [Horizontal pod autoscaler](#horizontal-autoscaling)), and is still running.
 
 {{% alert color="warning" %}}
-Some container runtimes or network configurations will prevent a terminating pod from receiving traffic or opening new connections. The Mendix Runtime can still use its existing database connections from the connection pool and keep processing any running microflows and requests, but uploading files or calling external REST services might fail.
+Some container runtimes or network configurations prevent a terminating pod from receiving traffic or opening new connections. The Mendix Runtime can still use its existing database connections from the connection pool and keep processing any running microflows and requests, but uploading files or calling external REST services may fail.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -805,9 +805,9 @@ Mendix recommends using horizontal pod autoscaling to adjust environments to mee
 Vertical pod autoscaling cannot be combined with horizontal pod autoscaling.
 {{% /alert %}}
 
-### Log format
+### Log Format
 
-#### Runtime log format{#runtime-log-format}
+#### Runtime Log Format {#runtime-log-format}
 
 Mendix Operator version 2.11.0 or above allows you to specify the log format used by Mendix apps.
 
@@ -842,7 +842,7 @@ In the `json` format, newline characters will be sent as `\n` (as specified in t
 For example, to correctly display newline characters in Grafana, use the [Escape newlines](https://github.com/grafana/grafana/pull/31352) button.
 {{% /alert %}}
 
-### Log levels {#log-levels}
+### Log Levels {#log-levels}
 
 Mendix Operator version 2.19.0 and above allows you to configure the log levels for your Operator pods. 
 
@@ -886,9 +886,9 @@ spec:
 
 By default, the log level value is set to L1 level for operator pods.
 
-### Pod labels {#pod-labels}
+### Pod Labels {#pod-labels}
 
-#### General pod labels
+#### General Pod Labels
 
 Mendix Operator version 2.13.0 or above allows you to specify default pod labels for app-related pods: task pods (build and storage provisioners) and runtime (app) pods.
 
@@ -914,7 +914,7 @@ Alternatively, for Standalone clusters, pod labels can be specified in the `Mend
 The Mendix Operator uses some labels for internal use. To avoid conflicts with these internal pod labels, please avoid using labels starting with the `privatecloud.mendix.com/` prefix.
 {{% /alert %}}
 
-### Delaying app shutdown {#termination-delay}
+### Delaying App Shutdown {#termination-delay}
 
 In some situations, shutting down a replica immediately could cause isses.
 For example, the [Azure Gateway Ingress Controller](https://azure.github.io/application-gateway-kubernetes-ingress/how-tos/minimize-downtime-during-deployments/) needs up to 90 seconds to remove a pod from its routing table.

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -167,6 +167,12 @@ spec:
     general: # Optional: general pod labels (applied to all app-related pods)
       azure.workload.identity/use: "true" # Example: enable Azure Workload Identity
   runtimeLicenseProduct: # Optional: Specify the type of product required for the Runtime License. This is applicable when PCLM is used for licensing. By default, the value is set to Standard, if left empty
+  deploymentStrategy: # Optional: Specify a deployment strategy to reduce app downtime
+    type: PreferRolling
+    switchoverThreshold: 50%
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 50%
 ```
 
 You need to make the following changes:
@@ -223,6 +229,7 @@ You need to make the following changes:
 * **runtimeLeaderSelection** – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
 * **customPodLabels** - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
     * **general** - specify additional labels for all pods of the app
+* **deploymentStrategy** - specify parameters for the deployment strategy; for more information, see the [reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime/#use-preferrolling-strategy-in-standalone-environments) documentation.
 
 #### Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -229,7 +229,7 @@ You need to make the following changes:
 * **runtimeLeaderSelection** – specify how the leader replica should be selected - valid options are `assigned` (default mode: the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
 * **customPodLabels** - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
     * **general** - specify additional labels for all pods of the app
-* **deploymentStrategy** - specify parameters for the deployment strategy; for more information, see the [reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime/#use-preferrolling-strategy-in-standalone-environments) documentation.
+* **deploymentStrategy** - specify parameters for the deployment strategy; for more information, see the reduced downtime deployment documentation.
 
 #### Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-velero.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-velero.md
@@ -78,7 +78,9 @@ To restore a backup that you created with Velero, follow these steps:
 3. Optional: After restoring the backup, add finalizers to `StorageInstances` by entering the following command:
 
     ```text
-    kubectl patch storageinstances $(kubectl get storageinstances --no-headers -o custom-columns=":metadata.name") -p '{"metadata":{"finalizers":["finalizer.privatecloud.mendix.com"]}}' --type=merge
+    kubectl patch storageinstances $(kubectl get storageinstances --no-headers -o custom-columns=":metadata.name") -p '{"metadata":{"finalizers":["privatecloud.mendix.com/storage-provisioner"]}}' --type=merge
     ```
 
     {{% alert color="info" %}}Adding finalizers is not required, but it is recommended as a best practice. It ensures that the Kubernetes garbage collection cleans up the storage from deleted environments.{{% /alert %}}
+
+    {{% alert color="info" %}}For Mendix Operator versions earlier than 2.20, use `finalizer.privatecloud.mendix.com` instead of `privatecloud.mendix.com/storage-provisioner` in the command above.{{% /alert %}}

--- a/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
+++ b/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
@@ -1,76 +1,64 @@
 ---
-title: "Reduced downtime deployment"
-linktitle: "Reduced downtime deployment"
+title: "Reducing Deployment Downtime"
 url: /developerportal/deploy/private-cloud-reduced-downtime/
-description: "Describes how to reduce downtime when deploying apps in Private Cloud environments"
+description: "Describes how to reduce downtime when deploying apps in Private Cloud environments."
 weight: 35
 ---
 ## Introduction
 
-Kubernetes allows to update an app without downtime by [performing a rolling update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/). Instead of stopping an app and then starting it with an updated version or configuration, Kubernetes can replace pods (replicas) one by one with an updated version. Existing pods will handle requests until the newer version is fully started.
+Kubernetes allows to update an app without downtime by [performing a rolling update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/). Instead of stopping an app and then starting it with an updated version or configuration, Kubernetes can replace pods (replicas) one by one with an updated version. Existing pods handle requests until the newer version is fully started.
 
-Any changes in the [domain model](/refguide/domain-model/) need a database (schema) update; while Mendix is updating the schema, it's not possible to modify any persistent entities.
+Any changes in the [domain model](/refguide/domain-model/) need a database (schema) update. While the update process runs, you cannot modify any persistent entities.
 
-The Private Cloud Operator uses a [recreate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) strategy by default: stop the current version (configuration) of an app, then start the new version.
+The Private Cloud Operator uses a [recreate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) strategy by default. That is, the current version (configuration) of an app stops, and then the new version starts.
 
-Alternatively, the Private Cloud Operator can a `PreferRolling` strategy:
+Alternatively, the Private Cloud Operator can use a **PreferRolling** strategy. That is, the Operator tries to perform a rolling update whenever possible. If the Operator detects that a database schema update is needed, it switches to a Recreate strategy to perform a full restart. 
 
-* the Operator will _try_ to perform a rolling update whenever possible;
-* if the Operator detects that a database (schema) update is needed, it will switch to a Recreate strategy to perform a full restart.
+If the new version of the app has model changes, deploying it requires a schema update. In this case, the Private Cloud Operator automatically stops all replicas of the app, causing downtime.
 
-If the new version of the app has model changes, deploying it will require a schema update.
-In this case, the Private Cloud Operator will automatically stop all replicas of the app, causing downtime.
+This feature works with Mendix for Private Cloud version 2.20 and later.
 
-This feature works with Mendix for Private Cloud version 2.20 (and later).
+### How a PreferRolling Strategy Works
 
-### How a PreferRolling strategy works
+When the Operator is configured to use a **PreferRolling** strategy, it will try to do an optimistic update and use a **Rolling** strategy. If the app needs to perform a database schema update, it signals to the Operator that it is waiting for approval to perform the update. The Operator then switches the app to use a **Recreate** strategy (stop all current replicas and start an updated version) and wait until all replicas of the app are running the same MDA version. Then, the Operator lets the app know that it is safe to update the database schema, and approve the process.
 
-When the Operator is configured to use a `PreferRolling` strategy, it will try to do an optimistic update and use a `Rolling` strategy.
+As a **Rolling** strategy can run multiple versions of the app at the same time, requests from the browser must be routed to a matching app version (that is, an app that has the same microflow or nanoflow parameters). The Operator uses Kubernetes service labels to perform an atomic switch, and instantly switch all clients to the updated version. This is done automatically once the number of updated replicas reaches a certain threshold. By default the threshold is 50% of all replicas. The value is specified in the [switchoverThreshold](#prefer-rolling-in-standalone) parameter.
 
-If the app needs to perform a database (schema) update, it will signal the Operator that it's waiting for approval to perform the update.
-The Operator will then switch the app to use a `Recreate` strategy (stop all current replicas and start an updated version) and wait until all replicas of the app are running the same MDA version.
+## Enabling Reduced Deployment Downtime
 
-Then, the Operator will let the app know it's safe to update the database schema, and approve the process.
+You can enable the `PreferRolling` deployment strategy if your environment fulfills the following requirements:
 
-As a `Rolling` strategy can run multiple versions of the app at the same time, requests from the browser need to be routed to a matching app version (an app that has the same microflow or nanoflow parameters).
-The operator uses Kubernetes Service labels to perform an atomic switch, and instantly switch all clients to the updated version.
-This will be done automatically once the number of updated replicas reaches a certain threshold (default: 50% of all replicas, specified in the [switchoverThreshold](#prefer-rolling-in-standalone) parameter).
+* The app must have two or more replicas specified in the MendixApp CR or Developer Portal.
+* For Connected environments, the **Low Downtime Deployment Strategy** option must be enabled in the Cloud Portal.
+* For Standalone environments, **deploymentStrategy** must be set to **PreferRolling** in the MendixApp CR.
 
-## How to enable reduced deployment downtime
+If the app can be deployed without having to modify the database schema (model), it will now be deployed using a Rolling deployment strategy.
 
-To enable the `PreferRolling` deployment strategy:
-
-* The app needs to have 2 or more replicas specified in the `MendixApp` CR or Developer Portal.
-* For Connected environments, the _Low downtime Deployment Strategy_ option needs to be enabled in the Cloud Portal.
-* For Standalone environments, `deploymentStrategy` needs to be set to `PreferRolling` in the `MendixApp` CR.
-
-If the app can be deployed without having to modify the database schema (model), it will be deployed using a Rolling deployment strategy.
-
-For example, these changes can be done without downtime:
+For example, the following changes can be done without downtime:
 
 * Changing app constants, MxAdmin password or debugger settings
 * Changing environment variables, Runtime or Java options
 * Changing Runtime Metrics settings
 * Upgrading the Mendix Operator version
 * Rebuilding the same MDA version to get the latest CVE updates
-* Changes in microflows or Java actions that don't affect the model
+* Changes in microflows or Java actions that do not affect the model
 * Updating Java dependencies
 
-Changes in the UI can be done without downtime, but as soon as the new version becomes available, all clients will be log in again:
+The following changes in the UI can be done without downtime, but as soon as the new version becomes available, all clients must log in again:
 
 * Page changes, including layout or CSS changes
-* Changes in nanoflows or microflow parameters (if the microflow is used on a page)
+* Changes in nanoflows or microflow parameters, if the microflow is used on a page
 * Changes in Javascript actions
 
-These changes will be deployed with downtime, because the model needs to be updated:
+Thes following changes will be deployed with downtime, because the model must be updated:
 
 * Adding Marketplace modules that have persistent entities
 * Updating the object model in the app itself, or its Marketplace modules
 * Updating to a newer Mendix version
 
-#### Use PreferRolling strategy in Standalone environments {#prefer-rolling-in-standalone}
+#### Using the PreferRolling Strategy in Standalone Environments {#prefer-rolling-in-standalone}
 
-To enable reduced downtime deployments, add the `deploymetStrategy` section to your `MendixApp` CR
+To reduce deployment downtime, add the `deploymentStrategy` section to your `MendixApp` CR, as in the following example:
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
@@ -92,28 +80,26 @@ spec:
       maxUnavailable: 50%
 ```
 
-For more information on the `MendixApp` CR, see [Editing CR](/developerportal/deploy/private-cloud-operator/#edit-cr) instructions.
+For more information on the `MendixApp` CR, see [Editing CR](/developerportal/deploy/private-cloud-operator/#edit-cr).
 
-If the `deploymentStrategy` is not specified, the Operator will use the `Recreate` strategy and perform a complete restart on any changes, causing downtime.
-This follows how updates were processed by Mendix for Private Cloud versions before 2.19 and earlier.
+If the `deploymentStrategy` is not specified, the Operator will use the Recreate strategy and perform a complete restart on any changes, causing downtime. This follows how updates were processed by Mendix for Private Cloud versions before 2.19 and earlier.
 
-You can specify the folliwing options:
+You can specify the following options:
 
-* **type**: – specifies a type, `Recreate` (default) or `PreferRolling` (try to deploy without downtime when possible).
-* **switchoverThreshold**: – specifies a threshold (percentage or absolute value) of updated, ready replicas when all clients should switch to the updated version.
-    For example, setting this to `50%` will switch all clients to the updated app version once 50% of all replicas are running the updated version.
-    If not specified, will use `50%` as the default value. This option is only used if the strategy **type** is set to `PreferRolling`.
-* **rollingUpdate**: - specifies parameters for `Rolling` updates if the Operator is able to perform the update without performing a restart. These parameters are used as Kubernetes [rollingUpdate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) parameters:
-    * **maxSurge**: – specifies an absolute (or percentage) value how many additional replicas can be added during the deployment process. The default `0` value means that no additional replicas are added during the rollout process, and instead existing replicas are stopped (to avoid using additional cluster resources).
-    * **maxUnavailable**: – specifies an absolute (or percentage) value how many replicas can be stopped (to be replaced with updated versions) during the rollout process. The default `50%` value means that half of the replicas would be stopped during the update process. Lowering this value slows down the rollout process, but in exchange ensures that less replicas are stopped during the update process.
+* **type** – Specifies a type:
+    * **Recreate** - The default setting
+    * **PreferRolling** - Try to deploy without downtime when possible
+* **switchoverThreshold** – Specifies a threshold of updated, ready replicas after which all clients should switch to the updated version. The threshold can be a percentage or an absolute value.
+    For example, setting this to **50%** will switch all clients to the updated app version once 50% of all replicas are running the updated version. If not otherwise specified, 50% is used as the default value. This option is only used if the strategy **type** is set to **PreferRolling**.
+* **rollingUpdate** - Specifies parameters for rolling updates if the Operator is able to perform the update without a restart. These parameters are used as Kubernetes [rollingUpdate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) parameters:
+    * **maxSurge** – Specifies an absolute or percentage value for how many additional replicas can be added during the deployment process. The default **0** value means that no additional replicas are added during the rollout process, and instead existing replicas are stopped to avoid using additional cluster resources.
+    * **maxUnavailable** – Specifies an absolute or percentage value for how many replicas can be stopped to be replaced with updated versions during the rollout process. The default **50%** value means that half of the replicas would be stopped during the update process. Lowering this value slows down the rollout process, but ensures that less replicas are stopped during the update process.
 
-## Preventing Kubernetes disruptions
+## Preventing Kubernetes Disruptions
 
-Kubernetes can stop an app's pods if needs to stop a node (to scale down and consolidate apps to run on fewer nodes), or perform a node update (for example, install CVE patches on the host OS).
+Kubernetes can stop an app's pods if needed to stop a node (to scale down and consolidate apps to run on fewer nodes), or perform a node update (for example, install CVE patches on the host OS). You can add a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to an app to ensure that Kubernetes only stops a limited number of an app's pods, and if necessary waits for replacement pods to become available.
 
-A [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) can be added to an app to ensure that Kubernetes only stops a limited number of an app's pods, and if necessary wait for replacement pods to become available.
-
-To add a PodDisruptionBudget, create the following PodDisruptionBudget, replacing `<mendixapp-cr-name>` with your app's internal name (MendixApp CR name):
+To add a PodDisruptionBudget, create the following PodDisruptionBudget, replacing `<mendixapp-cr-name>` with your app's internal name (the MendixApp CR name):
 
 ```yaml
 apiVersion: policy/v1
@@ -128,10 +114,9 @@ spec:
       privatecloud.mendix.com/component: mendix-app
 ```
 
-## Known Limitations
+## Limitations
 
 * This feature is only supported by Mendix Operator version 2.20 (and later).
-* If the new app version has are UI changes, all clients will be automatically logged out and will need to sign in into the app
+* If the new app version has UI changes, all clients are automatically logged out and will need to sign back into the app.
 * Deploying a new version of the app will cause downtime if there are changes in the domain model, or the Mendix version.
-* If an app is based on Mendix 9.12 or a later version, a Rolling update will can run scheduled events on any replica. During an update, scheduled events might use a newer or older version of their associated microflows, which will be random. If there are major changes in a scheduled event microflow, consider temporarily disabling scheduled events during an update.
-
+* If an app is based on Mendix 9.12 or a later version, a Rolling update can run scheduled events on any replica. During an update, scheduled events might use a newer or older version of their associated microflows, which will be random. If there are major changes in a scheduled event microflow, consider temporarily disabling scheduled events during an update.

--- a/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
+++ b/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
@@ -1,0 +1,138 @@
+---
+title: "Reduced downtime deployment"
+linktitle: "Reduced downtime deployment"
+url: /developerportal/deploy/private-cloud-reduced-downtime/
+description: "Describes how to reduce downtime when deploying apps in Private Cloud environments"
+weight: 35
+---
+## Introduction
+
+Kubernetes allows to update an app without downtime by [performing a rolling update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/). Instead of stopping an app and then starting it with an updated version or configuration, Kubernetes can replace pods (replicas) one by one with an updated version. Existing pods will handle requests until the newer version is fully started.
+
+Any changes in the [domain model](/refguide/domain-model/) need a database (schema) update, which can only be done safely if no data is written to the database.
+
+The Private Cloud Operator uses a [recreate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) strategy by default: stop the current version (configuration) of an app, then start the new version.
+
+Alternatively, the Private Cloud Operator can a `PreferRolling` strategy:
+
+* the Operator will _try_ to perform a rolling update whenever possible;
+* if the Operator detects that a database (schema) update is needed, it will switch to a Recreate strategy to perform a full restart.
+
+Any time a new version of the app has model changes, deploying it will still cause downtime.  
+
+This feature works with Mendix for Private Cloud version 2.20 (and later).
+
+### How a PreferRolling strategy works
+
+When the Operator is configured to use a `PreferRolling` strategy, it will try to do an optimistic update and use a `Rolling` strategy.
+
+If the app needs to perform a database (schema) update, it will signal the Operator that it's waiting for approval to perform the update.
+The Operator will then switch the app to use a `Recreate` strategy (stop all current replicas and start an updated version) and wait until all replicas of the app are running the same MDA version.
+
+Then, the Operator will let the app know it's safe to update the database schema, and approve the process.
+
+As a `Rolling` strategy can run multiple versions of the app at the same time, requests from the browser need to be routed to a matching app version (an app that has the same microflow or nanoflow parameters).
+The operator uses Kubernetes Service labels to perform an atomic switch, and instantly switch all clients to the updated version.
+This will be done automatically once the number of updated replicas reaches a certain threshold (default: 50% of all replicas).
+
+## How to enable reduced deployment downtime
+
+To enable the `PreferRolling` deployment strategy:
+
+* The app needs to have 2 or more replicas.
+* For Connected environments, the _Low downtime Deployment Strategy_ option needs to be enabled in the Cloud Portal.
+* For Standalone environments, `deploymentStrategy` needs to be set to `PreferRolling` in the `MendixApp` CR.
+
+If the app can be deployed without having to modify the database schema (model), it will be deployed using a Rolling deployment strategy.
+
+For example, these changes can be done without downtime:
+
+* Changing app constants, MxAdmin password or debugger settings
+* Changing environment variables, Runtime or Java options
+* Changing Runtime Metrics settings
+* Updating the Mendix Operator version
+* Rebuilding the same MDA version to get the latest CVE updates
+* Changes in microflows or Java actions that don't affect the model
+* Updating Java dependencies
+
+Changes in the UI can be done without downtime, but as soon as the new version becomes available, all clients will be log in again:
+
+* Page changes, including layout or CSS changes
+* Changes in nanoflows or microflow parameters (if the microflow is used on a page)
+* Changes in Javascript actions
+
+These changes will be deployed with downtime, because the model needs to be updated:
+
+* Adding Marketplace modules that have persistent entities
+* Updating the object model in the app itself, or its Marketplace modules
+* Updating to a newer Mendix version
+
+<!-- TODO: document how to navigate and enable this in Portunus -->
+
+#### Use PreferRolling strategy in Standalone environments
+
+To enable reduced downtime deployments, add the `deploymetStrategy` section to your `MendixApp` CR
+
+```yaml
+apiVersion: privatecloud.mendix.com/v1alpha1
+kind: MendixApp
+metadata:
+# ...
+# omitted lines for brevity
+# ...
+spec:
+  # ...
+  # omitted lines for brevity
+  # ...
+  # Add or update this section:
+  deploymentStrategy:
+    type: PreferRolling
+    switchoverThreshold: 50%
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 50%
+```
+
+For more information on the `MendixApp` CR, see [Editing CR](/developerportal/deploy/private-cloud-operator/#edit-cr) instructions.
+
+If the `deploymentStrategy` is not specified, the Operator will use the `Recreate` strategy and perform a complete restart on any changes, causing downtime.
+This follows how updates were processed by Mendix for Private Cloud versions before 2.19 and earlier.
+
+You can specify the folliwing options:
+
+* **type**: – specifies a type, `Recreate` (default) or `PreferRolling` (try to deploy without downtime when possible).
+* **switchoverThreshold**: – specifies a threshold (percentage or absolute value) of updated, ready replicas when all clients should switch to the updated version.
+    For example, setting this to `50%` will switch all clients to the updated app version once 50% of all replicas are running the updated version.
+    If not specified, will use `50%` as the default value. This option is only used if the strategy **type** is set to `PreferRolling`.
+* **rollingUpdate**: - specifies parameters for `Rolling` updates if the Operator is able to perform the update without performing a restart. These parameters are used as Kubernetes [rollingUpdate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) parameters:
+    * **maxSurge**: – specifies an absolute (or percentage) value how many additional replicas can be added during the deployment process. The default `0` value means that no additional replicas are added during the rollout process, and instead existing replicas are stopped (to avoid using additional cluster resources).
+    * **maxUnavailable**: – specifies an absolute (or percentage) value how many replicas can be stopped (to be replaced with updated versions) during the rollout process. The default `50%` value means that half of the replicas would be stopped during the update process. Lowering this value slows down the rollout process, but in exchange ensures that less replicas are stopped during the update process.
+
+## Preventing Kubernetes disruptions
+
+Kubernetes can stop an app's pods if needs to stop a node (to scale down and consolidate apps to run on fewer nodes), or perform a node update (for example, install CVE patches on the host OS).
+
+A [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) can be added to an app to ensure that Kubernetes only stops a limited number of an app's pods, and if necessary wait for replacement pods to become available.
+
+To add a PodDisruptionBudget, create the following PodDisruptionBudget, replacing `<mendixapp-cr-name>` with your app's internal name (MendixApp CR name):
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: <mendixapp-cr-name> # This should be updated to match the MenedixApp CR name
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      privatecloud.mendix.com/app: <mendixapp-cr-name> # This should be updated to match the MenedixApp CR name
+      privatecloud.mendix.com/component: mendix-app
+```
+
+## Known Limitations
+
+* This feature is only supported by Mendix Operator version 2.20 (and later).
+* If the new app version has are UI changes, all clients will be automatically logged out and will need to sign in into the app
+* Deploying a new version of the app will cause downtime if there are changes in the domain model, or the Mendix version.
+* If an app is based on Mendix 9.12 or a later version, a Rolling update will can run scheduled events on any replica. During an update, scheduled events might use a newer or older version of their associated microflows, which will be random. If there are major changes in a scheduled event microflow, consider temporarily disabling scheduled events during an update.
+

--- a/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
+++ b/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
@@ -68,8 +68,6 @@ These changes will be deployed with downtime, because the model needs to be upda
 * Updating the object model in the app itself, or its Marketplace modules
 * Updating to a newer Mendix version
 
-<!-- TODO: document how to navigate and enable this in Portunus -->
-
 #### Use PreferRolling strategy in Standalone environments {#prefer-rolling-in-standalone}
 
 To enable reduced downtime deployments, add the `deploymetStrategy` section to your `MendixApp` CR

--- a/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
+++ b/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
@@ -122,7 +122,7 @@ kind: PodDisruptionBudget
 metadata:
   name: <mendixapp-cr-name> # This should be updated to match the MenedixApp CR name
 spec:
-  minAvailable: 1
+  maxUnavailable: 1 # Ensure that at most 1 replica is stopped by Kubernetes
   selector:
     matchLabels:
       privatecloud.mendix.com/app: <mendixapp-cr-name> # This should be updated to match the MenedixApp CR name

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,20 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
+### October ???, 2024
+
+#### Mendix Operator v2.20.0 {#2.20.0}
+
+* We've added an option to choose a custom deployment strategy, which **in some situations** allows to update an app (or its configuration) without causing downtime. In ddition, we've also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new [Reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime) page.
+* We have updated components to use Go 1.23 and the latest dependency versions in order to improve security score ratings for container images.
+* We have modified the `mxpc-cli` installation and configuration tool to return an error exit code in non-interactive mode if an error occurrs. If `mxpc-cli` was able to successfully apply changes, a normal exit code (0) will be returned.
+* We fixed a memory leak in the Mendix Gateway Agent.
+* We rephrased a _License server is not configured, runtime will run in trial mode_ log message to indicate this means that PCLM is not used for an environment.
+* We extended the `mxpc-cli version` command to return the version of `mxpc-cli` itself.
+* We changed the StorageInstance finalizers to no longer cause _prefer a domain-qualified finalizer name_ warnings in the Operator logs.
+* We fixed an issue with license checks when using Global Operator with a static license.
+* Upgrading to Mendix Operator v2.20.0 from a previous version will restart environments managed by that version of the Operator.
+
 ### October 17th, 2024
 
 #### Deploy API

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,7 +16,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.20.0 {#2.20.0}
 
-* We have added an option to choose a custom deployment strategy, which in some situations allows you to update an app or its configuration without causing downtime. In ddition, we have also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new **Reduced downtime deployment** page.
+* We have added an option to choose a custom deployment strategy, which in some situations allows you to update an app or its configuration without causing downtime. In ddition, we have also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new [Reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime/) page.
 * We have updated components to use Go 1.23 and the latest dependency versions in order to improve security score ratings for container images.
 * We have modified the `mxpc-cli` installation and configuration tool to return an error exit code in non-interactive mode if an error occurrs. If `mxpc-cli` was able to successfully apply changes, a normal exit code (0) will be returned.
 * We have fixed a memory leak in the Mendix Gateway Agent.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,18 +12,18 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
-### October ???, 2024
+### October 31, 2024
 
 #### Mendix Operator v2.20.0 {#2.20.0}
 
-* We've added an option to choose a custom deployment strategy, which **in some situations** allows to update an app (or its configuration) without causing downtime. In ddition, we've also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new [Reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime) page.
+* We have added an option to choose a custom deployment strategy, which in some situations allows you to update an app or its configuration without causing downtime. In ddition, we have also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new [Reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime) page.
 * We have updated components to use Go 1.23 and the latest dependency versions in order to improve security score ratings for container images.
 * We have modified the `mxpc-cli` installation and configuration tool to return an error exit code in non-interactive mode if an error occurrs. If `mxpc-cli` was able to successfully apply changes, a normal exit code (0) will be returned.
-* We fixed a memory leak in the Mendix Gateway Agent.
-* We rephrased a _License server is not configured, runtime will run in trial mode_ log message to indicate this means that PCLM is not used for an environment.
-* We extended the `mxpc-cli version` command to return the version of `mxpc-cli` itself.
-* We changed the StorageInstance finalizers to no longer cause _prefer a domain-qualified finalizer name_ warnings in the Operator logs.
-* We fixed an issue with license checks when using Global Operator with a static license.
+* We have fixed a memory leak in the Mendix Gateway Agent.
+* We have rephrased the *License server is not configured, runtime will run in trial mode* log message to clarify tha this means that PCLM is not used for an environment.
+* We have extended the `mxpc-cli version` command to return the version of `mxpc-cli` itself.
+* We have changed the StorageInstance finalizers to no longer cause *prefer a domain-qualified finalizer name* warnings in the Operator logs.
+* We have fixed an issue with license checks when using Global Operator with a static license.
 * Upgrading to Mendix Operator v2.20.0 from a previous version will restart environments managed by that version of the Operator.
 
 ### October 17th, 2024

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
-### October 31, 2024
+### November 6, 2024
 
 #### Mendix Operator v2.20.0 {#2.20.0}
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,7 +16,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.20.0 {#2.20.0}
 
-* We have added an option to choose a custom deployment strategy, which in some situations allows you to update an app or its configuration without causing downtime. In ddition, we have also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new [Reduced downtime deployment](/developerportal/deploy/private-cloud-reduced-downtime) page.
+* We have added an option to choose a custom deployment strategy, which in some situations allows you to update an app or its configuration without causing downtime. In ddition, we have also documented how to use PodDisruptionBudgets to reduce downtime during cluster upgrades. For more details, see the new **Reduced downtime deployment** page.
 * We have updated components to use Go 1.23 and the latest dependency versions in order to improve security score ratings for container images.
 * We have modified the `mxpc-cli` installation and configuration tool to return an error exit code in non-interactive mode if an error occurrs. If `mxpc-cli` was able to successfully apply changes, a normal exit code (0) will be returned.
 * We have fixed a memory leak in the Mendix Gateway Agent.


### PR DESCRIPTION
We're planning to release a new version of the Mx4PC Operator in the second half of this week.

This release includes updates, bugfixes and a new feature - an option to reduce downtime by using a Kubernetes Rolling strategy.
There's a new document explaining how exactly this feature works, and what are its limitations. In the near future, users would be able to enable it by enabling one slider in the Cloud Portal - most of the documentation is for users who want to know more about how it works, and which use cases would still cause downtime.

@Nidhi251289 could you please do a review from your side?