### PR TITLE
Add information banner to boundary event scope variables documentation

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/workflows/boundary-events.md
+++ b/content/en/docs/refguide/modeling/application-logic/workflows/boundary-events.md
@@ -82,6 +82,10 @@ With non-interrupting boundary events, the parent activity remains active/in pro
 
 ## Boundary Event Variables
 
+{{% alert color="info" %}}
+Boundary event variables are available starting from Studio Pro version 10.16.
+{{% /alert %}}
+
 Boundary events have dedicated variables that can be used to get direct access to the values of the parent activity if it is either a user task or Call workflow activity. You can get information such as the parent activity's `DueDate`, which can be used in the boundary event flow and its expressions. For instance, you can use the expression `addDays($ParentTask/DueDate, -2)` to configure a timer boundary event so that it is triggered two days before the due date of its parent user task.
 
 The list of variables is described below: 


### PR DESCRIPTION
With this PR we add a banner to the boundary event documentation about variables. The variables are available starting from version 10.16. 

I would like to add this since we have already had a question why these were not available while a user was running a version below 10.16.