### PR TITLE
Remove beta status for the whole page

### DIFF
--- a/content/en/docs/control-center/apps/deployed-apps.md
+++ b/content/en/docs/control-center/apps/deployed-apps.md
@@ -3,14 +3,8 @@ title: "Deployed Apps"
 url: /control-center/deployed-apps/
 description: "Describes the Deployed Apps page in the Mendix Control Center."
 weight: 40
-beta: true
 no_list: true
-
 ---
-
-{{% alert color="info" %}}
-This feature is currently in beta. For more information, see [Beta Releases](/releasenotes/beta-features/).
-{{% /alert %}}
 
 ## Introduction
 


### PR DESCRIPTION
These tabs are not in beta anymore:
* Free apps
* Apps with license keys

Only Mendix Cloud tab remains in beta.