### PR TITLE
Update mqtt.md

### DIFF
--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
@@ -96,8 +96,9 @@ To subscribe to the MQTT broker, follow these steps:
 When subscribing to a topic, define in the subscribe action which microflow is triggered for each message, and that the topic and payload is passed on into that microflow.
 
 {{% alert color="info" %}} 
-Once a connection is established with the broker, that connection can be used to publish and subscribe to multiple topics.
-* If the broker is sending messages on multiple topics at the same time, the **OnMessageMicroflow** configured in the *Subscribe to MQTT* activity will be called concurrently.
+Once a connection is established with the broker, that connection can be used to publish and subscribe to multiple topics in the following order:
+
+* If the broker is sending messages on multiple topics at the same time, the **OnMessageMicroflow** configured in the **Subscribe to MQTT** activity will be called concurrently.
 * If the broker is sending multiple messages at the same time on a given topic, the microflow will be called sequentially.
 {{% /alert %}}
 

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
@@ -96,9 +96,9 @@ To subscribe to the MQTT broker, follow these steps:
 When subscribing to a topic, define in the subscribe action which microflow is triggered for each message, and that the topic and payload is passed on into that microflow.
 
 {{% alert color="info" %}} 
-Once connection is established with the broker (by providing host, port, authentication method), that connection can be used to publish/subscribe to multiple topics.
-- If broker is sending messages on multiple topics at the same instant then the **OnMessageMicroflow** configured in the *Subscribe to MQTT* activity will be called concurrently.
-- But on the other hand, if broker is sending multiple messages at the same instant on a given topic, then the Microflow will be called sequentially.
+Once a connection is established with the broker, that connection can be used to publish and subscribe to multiple topics.
+* If the broker is sending messages on multiple topics at the same time, the **OnMessageMicroflow** configured in the *Subscribe to MQTT* activity will be called concurrently.
+* If the broker is sending multiple messages at the same time on a given topic, the microflow will be called sequentially.
 {{% /alert %}}
 
 #### Unsubscribe

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/mqtt.md
@@ -95,6 +95,12 @@ To subscribe to the MQTT broker, follow these steps:
 
 When subscribing to a topic, define in the subscribe action which microflow is triggered for each message, and that the topic and payload is passed on into that microflow.
 
+{{% alert color="info" %}} 
+Once connection is established with the broker (by providing host, port, authentication method), that connection can be used to publish/subscribe to multiple topics.
+- If broker is sending messages on multiple topics at the same instant then the **OnMessageMicroflow** configured in the *Subscribe to MQTT* activity will be called concurrently.
+- But on the other hand, if broker is sending multiple messages at the same instant on a given topic, then the Microflow will be called sequentially.
+{{% /alert %}}
+
 #### Unsubscribe
 
 To unsubscribe from the MQTT broker, follow these steps:


### PR DESCRIPTION
Update the MQTT documentation to clarify that the onmessageMF can be called concurrently or sequentially depending on how messages are being sent by broker and if they are on same topic or diff topics.