### PR TITLE
[WTF-1983] Update React Client Migration Guide

### DIFF
--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -156,7 +156,3 @@ JavaScript actions should be mostly unaffected by React. Problems arise only if 
 Problems in JavaScript actions are not captured by the consistency checker. To validate that JavaScript actions work with the React client, the checker should be executed with the React client active. Any errors reported by the **Browser Console** (Press <kbd>F12</kbd> to access it) will help identify the problem.
 
 If you encounter problems with platform-supported JavaScript actions (for example from the [Nanoflow Commons](/appstore/modules/nanoflow-commons/) module) make sure to update the module containing the action from the Marketplace. In most cases, this will resolve the issue. If it is not resolved, reach out to the maintainer of the module and let them know of the issue.
-
-### Batch Conversion{#batch-conversion}
-
-We are working on a batch conversion component that lets you convert all incompatible widgets in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).

--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -95,43 +95,33 @@ The [Dynamic Image](/refguide/image-viewer/) and [Static Image](/refguide/image/
 
 To automatically convert a dynamic image or a static image, right-click the widget (or the error message) and select **Convert to Image**.
 
-{{% alert color="info" %}}
-We are working on a batch conversion for image widgets that lets you convert all images in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).
-{{% /alert %}}
+Note that the configuration options on the table below are not supported in the universal Image widget and will be skipped during the automatic conversion: 
 
-### Reference Selector{#reference-selector}
+| Unsupported Configuration Options |
+|-----------------------------------|
+| Height in Percentage              |
 
-The reference selector widgets ([Reference Selector](/refguide/reference-selector/), [Reference Set Selector](/refguide/reference-set-selector/), and [Input Reference Set Selector](/refguide/input-reference-set-selector/)) are not supported in the React client. To leverage React, replace them with the [Combo Box](/appstore/widgets/combobox/) widget. The combo box widget can be [downloaded from the Mendix Marketplace](https://marketplace.mendix.com/link/component/219304).
+### Reference Selectors & Drop-down{#reference-selectors-drop-down}
 
-To replace a reference selector widget, follow these steps:
+The reference selector widgets ([Reference Selector](/refguide/reference-selector/), [Reference Set Selector](/refguide/reference-set-selector/), and [Input Reference Set Selector](/refguide/input-reference-set-selector/)) and the [Drop-down](/refguide/drop-down/) are not supported in the React client. To leverage React, replace them with the [Combo Box](/appstore/widgets/combobox/) widget. The combo box widget can be [downloaded from the Mendix Marketplace](https://marketplace.mendix.com/link/component/219304).
 
-1. Add a combo box widget next to the original widget.
-1. Set the **Attribute**, **Caption**, and **Label** properties to match the original widget.
-1. Set any other properties to match the original widget.
+To automatically convert a reference selector widget or a drop-down to a combo box, right-click on the widget (or the consistency error message) and select **Convert to combo box**.
 
-To replace a reference set selector widget, follow these steps:
+Note that the configuration options on the table below are not supported in the Combo box widget and will be skipped during the automatic conversion:
 
-1. Add a combo box widget next to the original widget.
-1. Set the **Attribute** to the association that was used as data source in the original widget.
-1. Set the **Caption** to the attribute used in the column of the original widget, or use an expression to reflect multiple columns.
-1. Set the **Label** to a meaningful label for the attribute.
+| Unsupported Configuration Options |
+|-----------------------------------|
+| Go to Page                        |
+| Screen Reader Caption             |
+| 'Text' Read-only Style            |
+| 'Required' Validation             |
+| 'Custom' Validation               |
+| Constrained By                    |
+| Decimal Precision Formatting      |
+| Group Digits Formatting           |
 
-This will replace the table from the reference set selector with a more commonly used [drop-down widget](/refguide/drop-down/) supporting multiple selection.
-
-To replace an input reference set selector, follow these steps:
-
-1. Add a combo box widget next to the original widget.
-1. Set the **Attribute** to the association used as data source on the select page used by the original widget.
-1. Set the **Caption** to the attribute used on the select page, or use an expression to reflect multiple columns.
-1. Set the **Label** and any other properties to match the original widget.
-1. Remove the select page.
-
-This will replace the pop-up showing a table for selection with a more commonly used dropdown widget supporting multiple selection (see above).
-
-We also recommended you replace drop down widgets with combo box widgets for a better user experience. This change is not required.
-
-{{% alert color="info" %}}
-We are working on an automatic conversion for reference selector widgets that lets you convert a reference selector automatically to a combo box. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).
+{{% alert color="warning" %}}
+Since the Reference Set Selector widget is technically a grid while Combo box is a drop-down, only the applicable configuration options will be transferred to the resulting Combo box during conversion.
 {{% /alert %}}
 
 ### Data Grid{#data-grid}
@@ -140,9 +130,30 @@ The data grid widget is not supported in the React client. To leverage React, re
 
 To automatically convert a data grid widget to a data grid 2, right-click the widget (or the error message) and select **Convert to Data Grid 2**.
 
-{{% alert color="info" %}}
-We are working on a batch conversion for data grid widgets that lets you convert all data grids in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).
-{{% /alert %}}
+Note that the configuration options on the table below are not supported in the Data grid 2 widget and will be skipped during the automatic conversion:
+
+| Unsupported Configuration Options               |
+|-------------------------------------------------|
+| Data Source Wait for Search                     |
+| Server Side Paging                              |
+| Show Empty Rows                                 |
+| Column Size in Pixels                           |
+| Tooltip Page                                    |
+| Paging Bar Without Total Count                  |
+| Single and Maintain Selection                   |
+| Select First                                    |
+| All Rows Variable                               |
+| Select All Button                               |
+| Export to CSV Button                            |
+| Inline Editing                                  |
+| Range Search Field                              |
+| Search Field for a Invisible Column             |
+| Search Field for Read-only Type                 |
+| Search Field for Hidden Type with Default Value |
+| Reference Set Columns                           |
+| Editable Columns                                |
+| Aggregate Functions and Column Captions         |
+| Multiple Search Fields for an Attribute         |
 
 ### Template Grid{#template-grid}
 
@@ -185,3 +196,7 @@ JavaScript actions should be mostly unaffected by React. Problems arise only if 
 Problems in JavaScript actions are not captured by the consistency checker. To validate that JavaScript actions work with the React client, the checker should be executed with the React client active. Any errors reported by the **Browser Console** (Press <kbd>F12</kbd> to access it) will help identify the problem.
 
 If you encounter problems with platform-supported JavaScript actions (for example from the [Nanoflow Commons](/appstore/modules/nanoflow-commons/) module) make sure to update the module containing the action from the Marketplace. In most cases, this will resolve the issue. If it is not resolved, reach out to the maintainer of the module and let them know of the issue.
+
+### Batch Conversion{#batch-conversion}
+
+We are working on a batch conversion component that lets you convert all incompatible widgets in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).

--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -91,22 +91,22 @@ Mendix recommends refreshing all Marketplace components in your app before enabl
 
 ### Widgets{#widgets}
 
-Not all Widgets are supported by the React client. Mendix recommends migrating your old widgets using the automatic conversions in Studio Pro. For a list of unsupported configuration options in automatic conversions, see [Widget Conversion Limitations](/refguide/mendix-client/widget-conversion-limitations/).
+Not all widgets are supported by the React client. Mendix recommends migrating widgets in apps below [10.18](/releasenotes/studio-pro/10.18/) using the automatic conversion capabilities in Studio Pro (right-click a widget and select **Convert in-place**). For a list of configuration options unsupported by automatic conversions, see [Widget Conversion Limitations](/refguide/mendix-client/widget-conversion-limitations/).
 
 #### Dynamic & Static Image{#dynamic-static}
 
-The [Dynamic Image](/refguide/image-viewer/) and [Static Image](/refguide/image/) widgets are not supported in the React client. To use React, replace them with the universal [Image](/appstore/widgets/image/) widget. You can [download the Image widget from the Mendix Marketplace](https://marketplace.mendix.com/link/component/118579).
+The [Dynamic Image](/refguide/image-viewer/) and [Static Image](/refguide/image/) widgets are not supported in the React client. To use a React version of these widgets, replace them with the universal Image widget; it is documented [here](/appstore/widgets/image/), and downloadable [here](https://marketplace.mendix.com/link/component/118579). 
 
 To automatically convert a dynamic image or a static image, right-click the widget (or the error message) and select **Convert to Image**.
 
 #### Reference Selectors & Drop-down{#reference-selectors-drop-down}
 
-The reference selector widgets ([Reference Selector](/refguide/reference-selector/), [Reference Set Selector](/refguide/reference-set-selector/), and [Input Reference Set Selector](/refguide/input-reference-set-selector/)) and the [Drop-down](/refguide/drop-down/) are not supported in the React client. To leverage React, replace them with the [Combo Box](/appstore/widgets/combobox/) widget. The combo box widget can be [downloaded from the Mendix Marketplace](https://marketplace.mendix.com/link/component/219304).
+The reference selector widgets ([Reference Selector](/refguide/reference-selector/), [Reference Set Selector](/refguide/reference-set-selector/), and [Input Reference Set Selector](/refguide/input-reference-set-selector/)) and the [Drop-down](/refguide/drop-down/) widget are not supported in the React client. To leverage React, replace unsupported widgets with the combo box widget; it is documented [here](/appstore/widgets/combobox/), and downloadable [here](https://marketplace.mendix.com/link/component/219304). 
 
-To automatically convert a reference selector widget or a drop-down to a combo box, right-click on the widget (or the consistency error message) and select **Convert to combo box**.
+To automatically convert a reference selector widget or a drop-down to a combo box, right-click on the widget (or consistency error message) and select **Convert to combo box**.
 
 {{% alert color="warning" %}}
-Since the Reference Set Selector widget is technically a grid while Combo box is a drop-down, only the applicable configuration options will be transferred to the resulting Combo box during conversion.
+Because the reference set selector widget is technically a grid, while combo box is a drop-down, only the applicable configuration options will be transferred to the resulting combo box during conversion.
 {{% /alert %}}
 
 #### Data Grid{#data-grid}

--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -89,73 +89,33 @@ Not all Mendix Marketplace components are ready for the React client. Refer to [
 
 Mendix recommends refreshing all Marketplace components in your app before enabling the React client.
 
-### Dynamic & Static Image{#dynamic-static}
+### Widgets{#widgets}
+
+Not all Widgets are supported by the React client. Mendix recommends migrating your old widgets using the automatic conversions in Studio Pro. For a list of unsupported configuration options in automatic conversions, see [Widget Conversion Limitations](/refguide/mendix-client/widget-conversion-limitations/).
+
+#### Dynamic & Static Image{#dynamic-static}
 
 The [Dynamic Image](/refguide/image-viewer/) and [Static Image](/refguide/image/) widgets are not supported in the React client. To use React, replace them with the universal [Image](/appstore/widgets/image/) widget. You can [download the Image widget from the Mendix Marketplace](https://marketplace.mendix.com/link/component/118579).
 
 To automatically convert a dynamic image or a static image, right-click the widget (or the error message) and select **Convert to Image**.
 
-Note that the configuration options on the table below are not supported in the universal Image widget and will be skipped during the automatic conversion: 
-
-| Unsupported Configuration Options |
-|-----------------------------------|
-| Height in Percentage              |
-
-### Reference Selectors & Drop-down{#reference-selectors-drop-down}
+#### Reference Selectors & Drop-down{#reference-selectors-drop-down}
 
 The reference selector widgets ([Reference Selector](/refguide/reference-selector/), [Reference Set Selector](/refguide/reference-set-selector/), and [Input Reference Set Selector](/refguide/input-reference-set-selector/)) and the [Drop-down](/refguide/drop-down/) are not supported in the React client. To leverage React, replace them with the [Combo Box](/appstore/widgets/combobox/) widget. The combo box widget can be [downloaded from the Mendix Marketplace](https://marketplace.mendix.com/link/component/219304).
 
 To automatically convert a reference selector widget or a drop-down to a combo box, right-click on the widget (or the consistency error message) and select **Convert to combo box**.
 
-Note that the configuration options on the table below are not supported in the Combo box widget and will be skipped during the automatic conversion:
-
-| Unsupported Configuration Options |
-|-----------------------------------|
-| Go to Page                        |
-| Screen Reader Caption             |
-| 'Text' Read-only Style            |
-| 'Required' Validation             |
-| 'Custom' Validation               |
-| Constrained By                    |
-| Decimal Precision Formatting      |
-| Group Digits Formatting           |
-
 {{% alert color="warning" %}}
 Since the Reference Set Selector widget is technically a grid while Combo box is a drop-down, only the applicable configuration options will be transferred to the resulting Combo box during conversion.
 {{% /alert %}}
 
-### Data Grid{#data-grid}
+#### Data Grid{#data-grid}
 
 The data grid widget is not supported in the React client. To leverage React, replace it with the [Data Grid 2](/appstore/modules/data-grid-2/) widget. The data grid 2 widget is part of the [Data Widgets Module](https://marketplace.mendix.com/link/component/116540) in the Mendix Marketplace.
 
 To automatically convert a data grid widget to a data grid 2, right-click the widget (or the error message) and select **Convert to Data Grid 2**.
 
-Note that the configuration options on the table below are not supported in the Data grid 2 widget and will be skipped during the automatic conversion:
-
-| Unsupported Configuration Options               |
-|-------------------------------------------------|
-| Data Source Wait for Search                     |
-| Server Side Paging                              |
-| Show Empty Rows                                 |
-| Column Size in Pixels                           |
-| Tooltip Page                                    |
-| Paging Bar Without Total Count                  |
-| Single and Maintain Selection                   |
-| Select First                                    |
-| All Rows Variable                               |
-| Select All Button                               |
-| Export to CSV Button                            |
-| Inline Editing                                  |
-| Range Search Field                              |
-| Search Field for a Invisible Column             |
-| Search Field for Read-only Type                 |
-| Search Field for Hidden Type with Default Value |
-| Reference Set Columns                           |
-| Editable Columns                                |
-| Aggregate Functions and Column Captions         |
-| Multiple Search Fields for an Attribute         |
-
-### Template Grid{#template-grid}
+#### Template Grid{#template-grid}
 
 The template grid widget is not supported in the React client. It should be replaced with the [Gallery widget](/appstore/modules/gallery/). The gallery widget is part of the [Data Widgets Module](https://marketplace.mendix.com/link/component/116540) in the Mendix Marketplace.
 
@@ -167,7 +127,7 @@ To replace a template grid widget, follow these steps:
 1. Add any actions that items from your original widget as icon buttons to the content area.
 1. Add any actions that do not affect rows as buttons to the gallery widget's header.
 
-### Custom Widgets{#custom-widgets}
+#### Custom Widgets{#custom-widgets}
 
 Dojo widgets are no longer supported in the React client. They should be replaced with a pluggable widget based on React. 
 

--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -7,7 +7,7 @@ weight: 10
 
 ## Introduction
 
-In Studio Pro versions 10.7.0 and above, there is an alternative version of the Mendix Client written in React. The React version of the client is currently a [beta feature](/releasenotes/beta-features/). You can enable this React client in [App Settings](/refguide/app-settings/#react-client).
+In Studio Pro versions 10.7.0 and above, there is an alternative version of the Mendix Client written in React. You can enable this React client in [App Settings](/refguide/app-settings/#react-client).
 
 The React client replaces [Dojo](https://dojotoolkit.org/) with [React](https://react.dev/) for the view layer. This change allows for improved performance, enables incremental loading, and future-proofs your application. For more information on these three aspects, see the sections below:
 
@@ -51,7 +51,7 @@ Review the prerequisites below that your application must fulfill before it can 
 
 ### Mendix Version{#mendix-version}
 
-The React client was introduced in Mendix 10.7.0 as a [beta feature](/releasenotes/beta-features/). It is planned to be released for general availability in Mendix 10.18 as an opt-in feature.
+The React client was introduced in Mendix 10.7.0 as a [beta feature](/releasenotes/beta-features/). It became general availability in [Mendix 10.18](/releasenotes/studio-pro/10.18/) as an opt-in feature.
 
 ### Widgets{#widgets}
 

--- a/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
+++ b/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
@@ -7,7 +7,7 @@ weight: 20
 
 ## Introduction
 
-Studio Pro, provides a quick and automatic method to easily migrate the widgets that are unsupported by the React client. However, not all the configuration options are currently supported by the replacement React client-ready widgets.
+Mendix Studio Pro provides a quick and automatic method to easily migrate the widgets that are unsupported by the React client. However, not all configuration options are currently supported by the replacement (React ready) widgets. To better understand which configuration options cannot be used as expected, see the sections below. This document will be updated we make as more widgets and configuration options React ready.
 
 ## Automatic Widget Conversion Limitations
 
@@ -41,7 +41,7 @@ The following sections list the unsupported widget configuration options.
 | Group Digits Formatting      |
 
 {{% alert color="warning" %}}
-Since the Reference Set Selector widget is technically a grid while Combo box is a drop-down, only the applicable configuration options will be transferred to the resulting Combo box during conversion.
+Because the reference set selector widget is technically a grid, while combo box is a drop-down, only the applicable configuration options will be transferred to the resulting combo box during conversion.
 {{% /alert %}}
 
 ### Input Reference Set Selector

--- a/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
+++ b/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
@@ -9,10 +9,6 @@ weight: 20
 
 Studio Pro, provides a quick and automatic method to easily migrate the widgets that are unsupported by the React client. However, not all the configuration options are currently supported by the replacement React client-ready widgets.
 
-{{% alert color="info" %}}
-We are working on a batch conversion component that lets you convert all incompatible widgets in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).
-{{% /alert %}}
-
 ## Automatic Widget Conversion Limitations
 
 The following sections list the unsupported widget configuration options.

--- a/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
+++ b/content/en/docs/refguide/runtime/mendix-client/widget-conversion-limitations.md
@@ -1,0 +1,86 @@
+---
+title: "Widget Conversion Limitations"
+url: /refguide/mendix-client/widget-conversion-limitations/
+description: "Describes the limitations of the automatic widget conversions."
+weight: 20
+---
+
+## Introduction
+
+Studio Pro, provides a quick and automatic method to easily migrate the widgets that are unsupported by the React client. However, not all the configuration options are currently supported by the replacement React client-ready widgets.
+
+{{% alert color="info" %}}
+We are working on a batch conversion component that lets you convert all incompatible widgets in your project with a few clicks. We will announce the release in our [Release Notes](/releasenotes/studio-pro/10/).
+{{% /alert %}}
+
+## Automatic Widget Conversion Limitations
+
+The following sections list the unsupported widget configuration options.
+
+### Static and Dynamic Image
+
+| Unsupported in Image |
+|----------------------|
+| Height in Percentage |
+
+### Reference Selectors
+
+| Unsupported in Combo Box           |
+|------------------------------------|
+| Go to Page                         |
+| Screen Reader Caption              |
+| 'Text' Read-only Style             |
+| 'Text' Read-only Style (inherited) |
+| 'Required' Validation              |
+| 'Custom' Validation                |
+| Decimal Precision Formatting       |
+| Group Digits Formatting            |
+
+### Reference Set Selector
+
+| Unsupported in Combo Box     |
+|------------------------------|
+| Constrained By               |
+| Decimal Precision Formatting |
+| Group Digits Formatting      |
+
+{{% alert color="warning" %}}
+Since the Reference Set Selector widget is technically a grid while Combo box is a drop-down, only the applicable configuration options will be transferred to the resulting Combo box during conversion.
+{{% /alert %}}
+
+### Input Reference Set Selector
+
+| Unsupported in Combo Box           |
+|------------------------------------|
+| Screen Reader Caption              |
+| 'Text' Read-only Style             |
+| 'Text' Read-only Style (inherited) |
+| Constrained By                     |
+| Decimal Precision Formatting       |
+| Group Digits Formatting            |
+
+### Data Grid
+
+| Unsupported in Data Grid 2              |
+|-----------------------------------------|
+| Data Source Wait for Search             |
+| Server Side Paging                      |
+| Show Empty Rows                         |
+| Column Size in Pixels                   |
+| Tooltip Page                            |
+| Paging Bar Without Total Count          |
+| Single and Maintain Selection           |
+| Select First                            |
+| Aggregate Caption                       |
+| Aggregate Function                      |
+| Editable Columns                        |
+| Tooltip Pages                           |
+| Reference Set Columns                   |
+| Range Search Field                      |
+| Read-only Search Field                  |
+| Hidden Search Field with Default Value  |
+| Multiple Search Fields for an Attribute |
+| All Rows Variable                       |
+| Select All Button                       |
+| Export to CSV Button                    |
+| Inline Editing                          |


### PR DESCRIPTION
This PR updates the migration part of the documentation for the new React based client. These changes should be released with 10.18 as it is the version when the React client switches from beta to generally available. 

Specifically:
- The widget migration sections are updated
- A new page is added for listing the automatic widget conversion limitations
- The batch conversion parts are decided to be removed altogether