### PR TITLE
[RUN-4383] Remove reference to Gradle 7.6 from Mendix 10 documentation (10.18.0)

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -47,7 +47,7 @@ The following frameworks are required. They will be installed automatically by t
     
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
 * A Java Developer Kit (JDK) version 11, 17, or 21 - if not yet installed on your machine, Mendix will install 'Eclipse Temurin JDK 21 (x64)'
-* Gradle version 8.5 or above (if your Java version is 11 or 17, Gradle version 7.6 or above will also work) - if Gradle is not yet installed on your machine, Mendix will install Gradle version 8.5
+* Gradle version 8.5 or above - if Gradle is not yet installed on your machine, Mendix will install Gradle version 8.5
 * Git for Windows (x64) version 2.41.0 or above (for more information, see the [Prerequisites](/refguide/install/#prerequisites) section in *Installing Mendix Studio Pro*)
 * Mendix Native Mobile Builder
 * Microsoft Edge WebView2 Evergreen Runtime (x64)


### PR DESCRIPTION
This is a MR for 10.18.0. In this version we will force Gradle 8.5 and no longer support versions below it. This MR removes a reference to Gradle 7.6 from the documentation.