### PR TITLE
WIP: [RUN-4401] Documentation for tracing beta (10.18.0)

### DIFF
--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -11,7 +11,8 @@ This feature is in Public Beta. For more information, see [Beta Releases](/relea
 
 ## Introduction
 
-{{% todo %}}Needs an introduction{{% /todo %}}
+With 10.18.0 Mendix now supports tracing via OpenTelemetry. When tracing is enabled the runtime will generate traces that will help you analyze errors and performance.
+These traces can be sent to backends such as Jaeger or Datadog.
 
 ## Generated spans
 
@@ -31,7 +32,7 @@ The minimal configuration to enable tracing is:
 * Set the `OpenTelemetry.Enabled` runtime setting to `true`
 * Set the `otel.service.name` runtime setting to a service name
 
-This will enable tracing. The traces will be send to http://localhost:4317.
+This will enable tracing. The traces will be sent to http://localhost:4317.
 
 To test you can use [Jaeger](https://www.jaegertracing.io/), for example the all-in-one binary or docker image. Jaeger will listen to the above endpoint by default.
 
@@ -39,18 +40,18 @@ Alternatively you can set up the [OpenTelemetry collector](https://opentelemetry
 
 ### All settings
 
-Below we list the supported tracing-related runtime settings. See [Configure the SDK](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties) for a reference on the settings that are prefixed with `otel`.
+Below we list the supported tracing-related runtime settings. See [Configure the SDK](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties) for a reference on the settings that are prefixed with `otel.`.
 
 | Name | Description | Default |
 |------|-------------|---------|
-| OpenTelemetry.Enabled | Can be set to true or false in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but note that the other settings will only be applied the first time you enable tracing. | false |
-| otel.service.name | The name of the service. This is a required setting if tracing is enabled | |
-| otel.resource.attributes | The resource attributes to include in every span. Example: `attribute1=value1,attribute2=value2` | |
-| otel.traces.exporter | Comma-separated list of span exporters. Supported values are: otlp, console, logging-otlp, and none. | otlp |
-| otel.exporter.otlp.traces.protocol | The transport protocol to use on OTLP trace requests. Options include grpc and http/protobuf. | grpc |
-| otel.exporter.otlp.traces.endpoint | The endpoint to send all OTLP traces to. Must be a URL with a scheme of either http or https based on the use of TLS. | http://localhost:4317 when the protocol is grpc, and http://localhost:4318 when the protocol is http/protobuf |
-| otel.exporter.otlp.traces.certificate | The path to the file containing trusted certificates to use when verifying a trace server’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default the host platform’s trusted root certificates are used. |
-| otel.exporter.otlp.traces.client.key | The path to the file containing the private client key to use when verifying a trace client’s TLS credentials. The file should contain one private key PKCS8 PEM format. | By default no client key file is used. |
-| otel.exporter.otlp.traces.client.certificate | The path to the file containing trusted certificates to use when verifying a trace client’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default no chain file is used. |
+| `OpenTelemetry.Enabled` | Can be set to `true` or `false` in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but note that the other settings will only be applied the first time you enable tracing. | `false` |
+| `otel.service.name` | The name of the service. | `unknown_service:java` |
+| `otel.resource.attributes` | The resource attributes to include in every span. Example: `attribute1=value1,attribute2=value2` | |
+| `otel.traces.exporter` | Comma-separated list of span exporters. Supported values are: `otlp`, `console`, `logging-otlp`, and `none`. | `otlp` |
+| `otel.exporter.otlp.traces.protocol` | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. | `grpc` |
+| `otel.exporter.otlp.traces.endpoint` | The endpoint to send all OTLP traces to. It must be a URL with a scheme of either http or https based on the use of TLS. | http://localhost:4317 when the protocol is grpc, and http://localhost:4318 when the protocol is http/protobuf |
+| `otel.exporter.otlp.traces.certificate` | The path to the file containing trusted certificates to use when verifying a trace server's TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default the host platform's trusted root certificates are used. |
+| `otel.exporter.otlp.traces.client.key` | The path to the file containing the private client key to use when verifying a trace client's TLS credentials. The file should contain one private key in PKCS8 PEM format. | By default no client key file is used. |
+| `otel.exporter.otlp.traces.client.certificate` | The path to the file containing trusted certificates to use when verifying a trace client's TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default no certificate file is used. |
 
 In addition to the above settings, additional settings for OpenTelemetry can be passed as environment variables or system properties. We do not explicitly support these settings, but they will all be passed to the OpenTelemetry system in the runtime. [See here for a list of all OpenTelemetry settings.](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties)

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -12,7 +12,7 @@ This feature is in Public Beta. For more information, see [Beta Releases](/relea
 ## Introduction
 
 With 10.18.0 Mendix now supports tracing via OpenTelemetry. When tracing is enabled the runtime will generate traces that will help you analyze errors and performance.
-These traces can be sent to backends such as Jaeger or Datadog.
+These traces can be sent to observability tools like Jaeger or Datadog.
 
 ## Generated spans
 

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -11,14 +11,14 @@ This feature is in Public Beta. For more information, see [Beta Releases](/relea
 
 ## Introduction
 
-With 10.18.0 Mendix now supports tracing via OpenTelemetry. When tracing is enabled the runtime will generate traces that will help you analyze errors and performance.
-These traces can be sent to observability tools like Jaeger or Datadog.
+Starting in version 10.18.0, Mendix now supports tracing via OpenTelemetry. When tracing is enabled the runtime will generate traces that will help you analyze errors and performance.
+These traces can be sent to observability tools like [Jaeger](https://www.jaegertracing.io/) or [Datadog](https://www.datadoghq.com/).
 
 ## Generated spans
 
-In 10.18.0 the runtime generates spans for:
+In Mendix 10.18.0 and above, the runtime generates spans for:
 
-* Runtime operations coming from the frontend, for example microflow calls, retrieves, commits, and deletes
+* Runtime operations coming from the front end, for example microflow calls, retrieves, commits, and deletes
 * Microflow execution within the runtime, including sub-microflow calls
 * Microflow loops and loop iterations
 * Execution of task queue tasks
@@ -29,7 +29,7 @@ In 10.18.0 the runtime generates spans for:
 
 The minimal configuration to enable tracing is:
 
-* Set the `OpenTelemetry.Enabled` runtime setting to `true`
+* Set the `OpenTelemetry.Enabled` [runtime setting](/refguide/custom-settings/) to `true`
 * Set the `otel.service.name` runtime setting to a service name
 
 This will enable tracing. The traces will be sent to http://localhost:4317.
@@ -44,12 +44,13 @@ Below we list the supported tracing-related runtime settings. See [Configure the
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `OpenTelemetry.Enabled` | Can be set to `true` or `false` in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but note that the other settings will only be applied the first time you enable tracing. | `false` |
+| `OpenTelemetry.Enabled` | Can be set to `true` or `false` in order to disable or enable tracing.<br/> {{% alert color="info" %}}
+We support dynamically enabling/disabling tracing using this setting, but the other settings will only be applied the first time you enable tracing.{{% /alert %}} | `false` |
 | `otel.service.name` | The name of the service. | `unknown_service:java` |
 | `otel.resource.attributes` | The resource attributes to include in every span. Example: `attribute1=value1,attribute2=value2` | |
 | `otel.traces.exporter` | Comma-separated list of span exporters. Supported values are: `otlp`, `console`, `logging-otlp`, and `none`. | `otlp` |
 | `otel.exporter.otlp.traces.protocol` | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. | `grpc` |
-| `otel.exporter.otlp.traces.endpoint` | The endpoint to send all OTLP traces to. It must be a URL with a scheme of either http or https based on the use of TLS. | http://localhost:4317 when the protocol is grpc, and http://localhost:4318 when the protocol is http/protobuf |
+| `otel.exporter.otlp.traces.endpoint` | The endpoint to send all OTLP traces to. It must be a URL with a scheme of either http or https based on the use of TLS. | `http://localhost:4317` when the protocol is `grpc`<br>`http://localhost:4318` when the protocol is `http/protobuf` |
 | `otel.exporter.otlp.traces.certificate` | The path to the file containing trusted certificates to use when verifying a trace server's TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default the host platform's trusted root certificates are used. |
 | `otel.exporter.otlp.traces.client.key` | The path to the file containing the private client key to use when verifying a trace client's TLS credentials. The file should contain one private key in PKCS8 PEM format. | By default no client key file is used. |
 | `otel.exporter.otlp.traces.client.certificate` | The path to the file containing trusted certificates to use when verifying a trace client's TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default no certificate file is used. |

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -1,0 +1,51 @@
+---
+title: "Tracing"
+url: /refguide/tracing-in-runtime/
+description: "Describes how to setup and use tracing in the Mendix Runtime."
+---
+
+{{% alert color="warning" %}}
+This feature is in Public Beta. For more information, see [Beta Releases](/releasenotes/beta-features/).
+{{% /alert %}}
+
+## Introduction
+
+## Generated spans
+
+In 10.18.0 the runtime generates spans for:
+- Runtime operations coming from the fronted, for example microflow calls, retrieves, commit and deletes
+- Microflow execution within the runtime, including sub-microflow calls
+- Microflow loops and loop iterations
+- Execution of task queue tasks
+
+## Configuration
+
+### Minimal configuration
+
+The minimal configuration to enable tracing is:
+- Set the `OpenTelemetry.Enabled` runtime setting to `true`
+- Set the `otel.service.name` runtime setting to a service name
+
+This will enable tracing. The traces will be send to http://localhost:4317.
+
+To test you can use [Jaeger](https://www.jaegertracing.io/), for example the all-in-one binary or docker image. Jaeger will listen to the above endpoint by default.
+
+Alternatively you can set up the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/), which will also listen to the default endpoint and can be configured to send to backends such as Datadog.
+
+### All settings
+
+Below we list the supported tracing-related runtime settings. See [Configure the SDK](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties) for a reference on the settings that are prefixed with `otel`.
+
+| Name | Description | Default |
+|------|-------------|---------|
+| OpenTelemetry.Enabled | Can be set to true or false in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but not that the other settings will only be applied the first time you enable tracing. | false |
+| otel.service.name | The name of the service. This is a required setting if tracing is enabled | |
+| otel.resource.attributes | The resource attributes to include in every span. Example: attribute1=value1,attribute2=value2 | |
+| otel.traces.exporter | Comma-separated list of span exporters. Supported values are: otlp, console, logging-otlp and none. | otlp |
+| otel.exporter.otlp.traces.protocol | The transport protocol to use on OTLP trace requests. Options include grpc and http/protobuf. | grpc |
+| otel.exporter.otlp.traces.endpoint | The endpoint to send all OTLP traces to. Must be a URL with a scheme of either http or https based on the use of TLS. | http://localhost:4317 when the protocol is grpc, and http://localhost:4318 when the protocol is http/protobuf |
+| otel.exporter.otlp.traces.certificate | The path to the file containing trusted certificates to use when verifying a trace server’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default the host platform’s trusted root certificates are used. |
+| otel.exporter.otlp.traces.client.key | The path to the file containing private client key to use when verifying a trace client’s TLS credentials. The file should contain one private key PKCS8 PEM format. | By default no client key file is used. |
+| otel.exporter.otlp.traces.client.certificate | The path to the file containing trusted certificates to use when verifying a trace client’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default no chain file is used. |
+
+In addition to the above settings additional settings for OpenTelemetry can be passed a environment variables or system properties. We do not explicitly support these settings, but they will all be passed to the OpenTelemetry system in the runtime. [See here for a list of all OpenTelemetry settings.](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties)

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -1,6 +1,7 @@
 ---
 title: "Tracing"
 url: /refguide/tracing-in-runtime/
+beta: true
 description: "Describes how to setup and use tracing in the Mendix Runtime."
 ---
 
@@ -10,21 +11,25 @@ This feature is in Public Beta. For more information, see [Beta Releases](/relea
 
 ## Introduction
 
+{{% todo %}}Needs an introduction{{% /todo %}}
+
 ## Generated spans
 
 In 10.18.0 the runtime generates spans for:
-- Runtime operations coming from the fronted, for example microflow calls, retrieves, commit and deletes
-- Microflow execution within the runtime, including sub-microflow calls
-- Microflow loops and loop iterations
-- Execution of task queue tasks
+
+* Runtime operations coming from the frontend, for example microflow calls, retrieves, commits, and deletes
+* Microflow execution within the runtime, including sub-microflow calls
+* Microflow loops and loop iterations
+* Execution of task queue tasks
 
 ## Configuration
 
 ### Minimal configuration
 
 The minimal configuration to enable tracing is:
-- Set the `OpenTelemetry.Enabled` runtime setting to `true`
-- Set the `otel.service.name` runtime setting to a service name
+
+* Set the `OpenTelemetry.Enabled` runtime setting to `true`
+* Set the `otel.service.name` runtime setting to a service name
 
 This will enable tracing. The traces will be send to http://localhost:4317.
 
@@ -38,14 +43,14 @@ Below we list the supported tracing-related runtime settings. See [Configure the
 
 | Name | Description | Default |
 |------|-------------|---------|
-| OpenTelemetry.Enabled | Can be set to true or false in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but not that the other settings will only be applied the first time you enable tracing. | false |
+| OpenTelemetry.Enabled | Can be set to true or false in order to disable or enable tracing. We support dynamically enabling/disabling tracing using this setting, but note that the other settings will only be applied the first time you enable tracing. | false |
 | otel.service.name | The name of the service. This is a required setting if tracing is enabled | |
-| otel.resource.attributes | The resource attributes to include in every span. Example: attribute1=value1,attribute2=value2 | |
-| otel.traces.exporter | Comma-separated list of span exporters. Supported values are: otlp, console, logging-otlp and none. | otlp |
+| otel.resource.attributes | The resource attributes to include in every span. Example: `attribute1=value1,attribute2=value2` | |
+| otel.traces.exporter | Comma-separated list of span exporters. Supported values are: otlp, console, logging-otlp, and none. | otlp |
 | otel.exporter.otlp.traces.protocol | The transport protocol to use on OTLP trace requests. Options include grpc and http/protobuf. | grpc |
 | otel.exporter.otlp.traces.endpoint | The endpoint to send all OTLP traces to. Must be a URL with a scheme of either http or https based on the use of TLS. | http://localhost:4317 when the protocol is grpc, and http://localhost:4318 when the protocol is http/protobuf |
 | otel.exporter.otlp.traces.certificate | The path to the file containing trusted certificates to use when verifying a trace server’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default the host platform’s trusted root certificates are used. |
-| otel.exporter.otlp.traces.client.key | The path to the file containing private client key to use when verifying a trace client’s TLS credentials. The file should contain one private key PKCS8 PEM format. | By default no client key file is used. |
+| otel.exporter.otlp.traces.client.key | The path to the file containing the private client key to use when verifying a trace client’s TLS credentials. The file should contain one private key PKCS8 PEM format. | By default no client key file is used. |
 | otel.exporter.otlp.traces.client.certificate | The path to the file containing trusted certificates to use when verifying a trace client’s TLS credentials. The file should contain one or more X.509 certificates in PEM format. | By default no chain file is used. |
 
-In addition to the above settings additional settings for OpenTelemetry can be passed a environment variables or system properties. We do not explicitly support these settings, but they will all be passed to the OpenTelemetry system in the runtime. [See here for a list of all OpenTelemetry settings.](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties)
+In addition to the above settings, additional settings for OpenTelemetry can be passed as environment variables or system properties. We do not explicitly support these settings, but they will all be passed to the OpenTelemetry system in the runtime. [See here for a list of all OpenTelemetry settings.](https://opentelemetry.io/docs/languages/java/configuration/#environment-variables-and-system-properties)


### PR DESCRIPTION
This MR adds a documentation page for tracing in the runtime, which is a Public Beta feature introduced in 10.18.0. 