### PR TITLE
New v1.0.5 release of the Tekton Pipelines (planned for release on December 11)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-tekton/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-tekton/_index.md
@@ -45,8 +45,7 @@ To follow these instructions you will need:
 If you have any issues when following these instructions, see the [Troubleshooting](#troubleshooting) section to see if there is a solution.
 
 {{% alert color="info" %}}
-The Tekton pipeline was tested to be compatible with Mendix Operator versions v2.20.0 and earlier.
-Future Mendix Operator versions might need an updated version of the pipeline.
+The Tekton pipeline is compatible with Mendix Operator versions v2.20.0 and earlier. Future Mendix Operator versions might need an updated version of the pipeline.
 {{% /alert %}}
 
 ## Overview of Tekton and the Mendix for Private Cloud Pipelines

--- a/content/en/docs/deployment/private-cloud/private-cloud-tekton/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-tekton/_index.md
@@ -44,6 +44,11 @@ To follow these instructions you will need:
 
 If you have any issues when following these instructions, see the [Troubleshooting](#troubleshooting) section to see if there is a solution.
 
+{{% alert color="info" %}}
+The Tekton pipeline was tested to be compatible with Mendix Operator versions v2.20.0 and earlier.
+Future Mendix Operator versions might need an updated version of the pipeline.
+{{% /alert %}}
+
 ## Overview of Tekton and the Mendix for Private Cloud Pipelines
 
 ### Tekton Components

--- a/content/en/docs/deployment/private-cloud/private-cloud-tekton/private-cloud-tekton-airgap.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-tekton/private-cloud-tekton-airgap.md
@@ -103,7 +103,7 @@ aip init https://cdn.mendix.com/mendix-for-private-cloud/airgapped-image-package
 aip pull
 ```
 
-Add build and runtime images for a specific Mendix version, and a base OS with a speicific Java version, or for a range of versions:
+Add build and runtime images for a specific Mendix version, and a base OS with a specific Java version, or for a range of versions:
 
 ```bash
 # add one specific version (in this example 8.18.11.27969)

--- a/content/en/docs/deployment/private-cloud/private-cloud-tekton/private-cloud-tekton-airgap.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-tekton/private-cloud-tekton-airgap.md
@@ -43,7 +43,7 @@ Get the Tekton package:
 
 ```bash
 mkdir tekton && cd tekton
-aip init https://cdn.mendix.com/mendix-for-private-cloud/airgapped-image-package/packages/tekton-package-v1.0.4.json
+aip init https://cdn.mendix.com/mendix-for-private-cloud/airgapped-image-package/packages/tekton-package-v1.0.5.json
 aip pull
 ```
 
@@ -99,20 +99,24 @@ Get the pipeline package:
 
 ```bash
 mkdir pipeline && cd pipeline
-aip init https://cdn.mendix.com/mendix-for-private-cloud/airgapped-image-package/packages/pipeline-package-v1.0.4.json
+aip init https://cdn.mendix.com/mendix-for-private-cloud/airgapped-image-package/packages/pipeline-package-v1.0.5.json
 aip pull
 ```
 
-Add build and runtime images for a specific Mendix version, or for a range of versions:
+Add build and runtime images for a specific Mendix version, and a base OS with a speicific Java version, or for a range of versions:
 
 ```bash
 # add one specific version (in this example 8.18.11.27969)
 aip addimage mxbuild8.18.11 private-cloud.registry.mendix.com/mxbuild:8.18.11.27969
-aip addimage runtime-base8.18.11 private-cloud.registry.mendix.com/runtime-base:8.18.11.27969-rhel
+aip addimage runtime8.18.11 private-cloud.registry.mendix.com/app-building-blocks:runtime-8.18.11.27969
+aip addimage ubi8-1-java11 private-cloud.registry.mendix.com/app-building-blocks:ubi8-1-jre11-entrypoint
 
 # add multiple versions (in this example all patch versions of 8.18)
 aip addimagesquery private-cloud.registry.mendix.com/mxbuild '^8.18.*'
-aip addimagesquery private-cloud.registry.mendix.com/runtime-base '^8.18.*-rhel$'
+aip addimagesquery private-cloud.registry.mendix.com/app-building-blocks '^runtime-8.18.*$'
+
+# add all base OS images
+aip addimagesquery private-cloud.registry.mendix.com/app-building-blocks '^ubi\d+-\d-jre\d+-entrypoint$'
 
 aip pull
 ```
@@ -193,15 +197,15 @@ cd $PATH_TO_DOWNLOADED_FOLDERS && cd helm/charts
 helm install -n $NAMESPACE_WITH_PIPELINES mx-tekton-pipeline ./pipeline/ \
   -f ./pipeline/values.yaml \
   --set images.imagePushURL=$URL_TO_YOUR_REPO_WITHOUT_TAG \
-  --set images.fetch=$PRIVATE_REGISTRY/mxpc-pipeline-tools:git-init-0.0.2 \
-  --set images.verExtraction=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 \
+  --set images.fetch=$PRIVATE_REGISTRY/mxpc-pipeline-tools:gitinit-0.0.3 \
+  --set images.verExtraction=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9 \
   --set images.build=$PRIVATE_REGISTRY/mxbuild \
-  --set images.imageBuild=$PRIVATE_REGISTRY/mxpc-pipeline-tools:imagebuild-0.0.2 \
-  --set images.constantsAndEventsResolver=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 \
-  --set images.k8sPatch=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 \
-  --set images.createAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 \
-  --set images.deleteAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 \
-  --set images.configureAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.8 
+  --set images.imageBuild=$PRIVATE_REGISTRY/mxpc-pipeline-tools:imagebuild-0.0.9 \
+  --set images.constantsAndEventsResolver=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9 \
+  --set images.k8sPatch=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9 \
+  --set images.createAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9 \
+  --set images.deleteAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9 \
+  --set images.configureAppEnv=$PRIVATE_REGISTRY/mxpc-pipeline-tools-cli:0.0.9
 ```
 
 ## Installing Triggers{#installing-triggers}

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
+### December ???, 2024
+
+#### CI/CD with Tekton pipeline v1.0.5
+
+* We updated the [CI/CD with Tekton pipeline](/developerportal/deploy/private-cloud-tekton/) to support Java 17 and 21.
+* We updated Mendix images and components to the latest version [Unsafe repository error](https://github.com/tektoncd/pipeline/issues/4966).
+* To use the updated pipeline, the latest version of the `pipeline` Helm chart will need to be installed.
+
 ### November 14, 2024
 
 #### Private Cloud Portal

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -19,6 +19,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We updated the [CI/CD with Tekton pipeline](/developerportal/deploy/private-cloud-tekton/) to support Java 17 and 21.
 * We updated Mendix images and components to the latest version [Unsafe repository error](https://github.com/tektoncd/pipeline/issues/4966).
 * To use the updated pipeline, the latest version of the `pipeline` Helm chart will need to be installed.
+* We updated the pipeline to be compatible with Mendix Operator v2.20.0 (Ticket 235777).
 
 ### November 14, 2024
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,10 +16,10 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### CI/CD with Tekton pipeline v1.0.5
 
-* We updated the [CI/CD with Tekton pipeline](/developerportal/deploy/private-cloud-tekton/) to support Java 17 and 21.
-* We updated Mendix images and components to the latest version [Unsafe repository error](https://github.com/tektoncd/pipeline/issues/4966).
+* We have updated the [CI/CD with Tekton pipeline](/developerportal/deploy/private-cloud-tekton/) to support Java 17 and 21.
+* We have updated Mendix images and components to the latest version [Unsafe repository error](https://github.com/tektoncd/pipeline/issues/4966).
 * To use the updated pipeline, the latest version of the `pipeline` Helm chart will need to be installed.
-* We updated the pipeline to be compatible with Mendix Operator v2.20.0 (Ticket 235777).
+* We updated the pipeline to be compatible with Mendix Operator v2.20.0. (**Ticket 235777**)
 
 ### November 14, 2024
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
-### December ???, 2024
+### December 11th, 2024
 
 #### CI/CD with Tekton pipeline v1.0.5
 


### PR DESCRIPTION
Our team has released a new version of the Private Cloud Tekton pipeline, this MR contains the release notes and small documentation updates.

December 11 is not a hard release date - it's OK to review the changes and release a bit later if this helps with planning or other stories.