### PR TITLE
React moving into GA

### DIFF
--- a/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
+++ b/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
@@ -28,7 +28,7 @@ These settings influence the behavior of the Runtime when running your applicati
 
 ### Use React Client {#react-client}
 
-This setting enables the new React version of the Mendix Client. This React client was released into beta in [Mendix 10.7](/releasenotes/studio-pro/10.7/#react-client). As of [Mendix 10.18](/releasenotes/studio-pro/10.7/#react-client), it is in GA. There are three options:
+This setting enables the new React version of the Mendix Client. This React client was released into beta in [Mendix 10.7](/releasenotes/studio-pro/10.7/#react-client). As of [Mendix 10.18](/releasenotes/studio-pro/10.18/), it is in GA. There are three options:
 
 * **No**: Do not use the React client (default).
 * **Yes**: Use the React client. In this mode, you will get consistency errors for incompatible widgets.

--- a/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
+++ b/content/en/docs/refguide/modeling/app-explorer/app/app-settings/_index.md
@@ -26,9 +26,9 @@ For more information on settings in a configuration, see [Configuration](/refgui
 
 These settings influence the behavior of the Runtime when running your application.
 
-### Use React Client (Beta) {#react-client}
+### Use React Client {#react-client}
 
-This setting enables the new React version of the Mendix Client. This React client was released into beta in [Mendix 10.7](/releasenotes/studio-pro/10.7/#react-client). There are three options:
+This setting enables the new React version of the Mendix Client. This React client was released into beta in [Mendix 10.7](/releasenotes/studio-pro/10.7/#react-client). As of [Mendix 10.18](/releasenotes/studio-pro/10.7/#react-client), it is in GA. There are three options:
 
 * **No**: Do not use the React client (default).
 * **Yes**: Use the React client. In this mode, you will get consistency errors for incompatible widgets.


### PR DESCRIPTION
I need to comb all docs and ensure that when React goes GA in 10.18, the docs have no more beta flags.