### PR TITLE
Release notes for Mendix for Private Cloud 2.20.1 (planned for release on Monday, December 16)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -37,7 +37,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
 * Kubernetes versions 1.19 through 1.31
-* OpenShift 4.6 through 4.16
+* OpenShift 4.6 through 4.17
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.
@@ -193,6 +193,7 @@ The following standard PostgreSQL databases are supported:
 * PostgreSQL 14
 * PostgreSQL 15
 * PostgreSQL 16
+* PostgreSQL 17
 
 {{% alert color="info" %}}
 While Mendix for Private Cloud supports all Postgres versions listed above, the Mendix Runtime might require a more specific Postgres version.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,9 +16,9 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.20.1 {#2.20.1}
 
-* We updated the m2ee-sidecar lifecycle to no longer stop the Mendix Runtime if a `ping` times out or fails; an app will now only be restarted by the liveness probe (Ticket 230648).
-* We adjusted AWS STS token expiration for envrionments using IRSA, which should prevent occasional _SQLState: 28000 Error code: 0 Message: "FATAL: PAM authentication failed for user …", retrying...(1/4)_ errors (Ticket 234454).
-* We switched the log format to JSON for the `build`, `database` and `file` pods, to help with parsing the logs and automatically assigning log levels and timestamps.
+* We have updated the m2ee-sidecar lifecycle to no longer stop the Mendix Runtime if a `ping` times out or fails; an app will now only be restarted by the liveness probe (Ticket 230648).
+* We have adjusted AWS STS token expiration for envrionments using IRSA, which should prevent occasional *SQLState: 28000 Error code: 0 Message: "FATAL: PAM authentication failed for user …", retrying...(1/4)* errors (Ticket 234454).
+* We have switched the log format to JSON for the `build`, `database` and `file` pods, to help with parsing the logs and automatically assigning log levels and timestamps.
 * We have updated a library used to validate licenses to the latest non-alpha version.
 * We have updated documentation that OpenShift 4.17 and Postgres 17 are supported by the Mendix Operator.
 * We have addressed a rare deadlock situation which could prevent a failing environment from restarting.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,18 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
+### December 16, 2024
+
+#### Mendix Operator v2.20.1 {#2.20.1}
+
+* We updated the m2ee-sidecar lifecycle to no longer stop the Mendix Runtime if a `ping` times out or fails; an app will now only be restarted by the liveness probe (Ticket 230648).
+* We adjusted AWS STS token expiration for envrionments using IRSA, which should prevent occasional _SQLState: 28000 Error code: 0 Message: "FATAL: PAM authentication failed for user …", retrying...(1/4)_ errors (Ticket 234454).
+* We switched the log format to JSON for the `build`, `database` and `file` pods, to help with parsing the logs and automatically assigning log levels and timestamps.
+* We have updated a library used to validate licenses to the latest non-alpha version.
+* We have updated documentation that OpenShift 4.17 and Postgres 17 are supported by the Mendix Operator.
+* We have addressed a rare deadlock situation which could prevent a failing environment from restarting.
+* Upgrading to Mendix Operator v2.20.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+
 ### December 12, 2024
 
 #### Portal Improvements


### PR DESCRIPTION
We're planning to release a new version of Mx4PC on Monday - this is a bugfix release with no additional features.