### PR TITLE
introduction to native template version 11

### DIFF
--- a/content/en/docs/releasenotes/mobile/native-template/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/_index.md
@@ -11,6 +11,7 @@ For more information on native mobile app development, see the [native-template]
 
 Compatible with Studio Pro 10:
 
+* Native Template versions of [11](/releasenotes/mobile/nt-11-rn/) are compatible with apps built using Studio Pro [10.18](/releasenotes/studio-pro/10.18/) and above.
 * Native Template versions of [10](/releasenotes/mobile/nt-10-rn/) are compatible with apps built using Studio Pro [10.17](/releasenotes/studio-pro/10.17/) and above.
 * Native Template versions of [9](/releasenotes/mobile/nt-9-rn/) are compatible with apps built using Studio Pro [10.13](/releasenotes/studio-pro/10.13/)-[10.16](/releasenotes/studio-pro/10.16/).
 * Native Template versions of [8](/releasenotes/mobile/nt-8-rn/) are compatible with apps built using Studio Pro [10.6](/releasenotes/studio-pro/10.6/)-[10.12](/releasenotes/studio-pro/10.12/).

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/_index.md
@@ -7,7 +7,7 @@ description: "Studio Pro 9 and 10 compatible Native Template release notes."
 
 These are the current Native Template versions for Studio Pro 9 in active development:
 
-* Native Template versions of [7](/releasenotes/mobile/nt-7-rn/), [8](/releasenotes/mobile/nt-8-rn/), [9](/releasenotes/mobile/nt-9-rn/), and [10](/releasenotes/mobile/nt-10-rn/) are compatible with apps built using the following versions of Studio Pro:
+* Native Template versions of [7](/releasenotes/mobile/nt-7-rn/), [8](/releasenotes/mobile/nt-8-rn/), [9](/releasenotes/mobile/nt-9-rn/), [10](/releasenotes/mobile/nt-10-rn/) and [11](/releasenotes/mobile/nt-11-rn/) are compatible with apps built using the following versions of Studio Pro:
     * Studio Pro [10.0](/releasenotes/studio-pro/10.0/) and above 
     * Studio Pro [9.24](/releasenotes/studio-pro/9.24/) and above
 * Native Template versions of [6](/releasenotes/mobile/nt-6-rn/) are compatible with apps built using Studio Pro [9.0](/releasenotes/studio-pro/9.0/)-[9.23](/releasenotes/studio-pro/9.23/). 

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-10-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-10-rn.md
@@ -20,6 +20,22 @@ description: "Native Template 10 release notes."
 
 ### Breaking Changes
 
+#### Library Updates and Improvements
+
+- **@react-native-async-storage/async-storage:** 2.0.0  
+- **@react-native-community/datetimepicker:** 8.2.0  
+- **@react-native-masked-view/masked-view:** 0.3.1  
+- **@react-native-picker/picker:** 2.8.1  
+- **@react-navigation/native:** 6.1.18  
+- **react-native-device-info:** 13.0.0  
+- **react-native-gesture-handler:** 2.20.2  
+- **react-native-localize:** 3.2.1  
+- **react-native-pager-view:** 6.4.1  
+- **react-native-safe-area-context:** 4.11.0  
+- **react-native-svg:** 15.7.1  
+- **react-native-tab-view:** 3.5.2  
+- **react-native-vector-icons:** 10.2.0  
+
 #### Library Migration
 
 * `@react-native-community/async-storage` has been replaced by `@react-native-async-storage/async-storage`. Ensure your imports and project dependencies reflect this change.

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-10-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-10-rn.md
@@ -18,8 +18,6 @@ description: "Native Template 10 release notes."
 * Projects created in Studio Pro 10.17 and above will automatically use the latest React Native version without additional configuration.
 * For projects upgrading from Mendix versions below 10.17 to 10.17 and above, follow the steps in [Upgrade Instructions](#upgrade-instructions) below to migrate your project.
 
-### Breaking Changes
-
 #### Library Updates and Improvements
 
 - **@react-native-async-storage/async-storage:** 2.0.0  
@@ -35,6 +33,8 @@ description: "Native Template 10 release notes."
 - **react-native-svg:** 15.7.1  
 - **react-native-tab-view:** 3.5.2  
 - **react-native-vector-icons:** 10.2.0  
+
+### Breaking Changes
 
 #### Library Migration
 

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
@@ -1,0 +1,22 @@
+---
+title: "Native Template 11"
+url: /releasenotes/mobile/nt-11-rn/
+weight: 5
+description: "Native Template 11 release notes."
+---
+
+## 11.0.0 {#1000}
+
+**Release date: December 17, 2024**
+
+### Breaking Changes
+
+#### JSC and Hermes Support
+
+* We disabled JavascriptCore(JSC) entirely and now only support Hermes.
+
+#### Important Notes
+
+* Projects created in Studio Pro 10.18 and above will automatically use Hermes without any additional configuration.
+* For projects upgrading from Mendix versions below 10.18 to 10.18 and above, follow the steps in [Upgrade Instructions](#upgrade-instructions) below to migrate your project.
+* Even if your project is already using Hermes, the update is still necessary.

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
@@ -20,3 +20,17 @@ description: "Native Template 11 release notes."
 * Apps created in Studio Pro 10.18 and above will automatically use Hermes without any additional configuration.
 * For projects upgrading to 10.18 and above, follow the steps in [Upgrade Instructions](#upgrade-instructions) to migrate your app.
 * Even if your project is already using Hermes, the update is still required.
+
+### Upgrade Instructions {#upgrade-instructions}
+
+If you are upgrading from Mendix versions below 10.17, please follow these steps to use the new React Native version:
+
+1. Update required modules:
+    1. Native Mobile Resources: ensure you update this module to the latest version available in the Mendix Marketplace.
+    1. Nanoflow Commons: update this module to its latest version.
+1. Update widgets in Studio Pro:
+    1. After updating the Native Mobile Resources module, right-click the warning in Studio Pro and click **Update All Widgets** to complete the process.
+1. Test your application:
+    1. Thoroughly test your application to ensure that all features work as expected after the updates.
+
+For the most direct information on the Native Template, visit our [GitHub Releases page](https://github.com/mendix/native-template/releases/tag/v10.0.0).

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
@@ -11,12 +11,12 @@ description: "Native Template 11 release notes."
 
 ### Breaking Changes
 
-#### JSC and Hermes Support
+#### JSC and Hermes Support {#jsc-hermes}
 
-* We disabled JavascriptCore(JSC) entirely and now only support Hermes.
+* We disabled JavaScriptCore(JSC) entirely and now only support Hermes.
 
 #### Important Notes
 
-* Projects created in Studio Pro 10.18 and above will automatically use Hermes without any additional configuration.
-* For projects upgrading from Mendix versions below 10.18 to 10.18 and above, follow the steps in [Upgrade Instructions](#upgrade-instructions) below to migrate your project.
-* Even if your project is already using Hermes, the update is still necessary.
+* Apps created in Studio Pro 10.18 and above will automatically use Hermes without any additional configuration.
+* For projects upgrading to 10.18 and above, follow the steps in [Upgrade Instructions](#upgrade-instructions) to migrate your app.
+* Even if your project is already using Hermes, the update is still required.

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-9-parent/nt-11-rn.md
@@ -33,4 +33,4 @@ If you are upgrading from Mendix versions below 10.17, please follow these steps
 1. Test your application:
     1. Thoroughly test your application to ensure that all features work as expected after the updates.
 
-For the most direct information on the Native Template, visit our [GitHub Releases page](https://github.com/mendix/native-template/releases/tag/v10.0.0).
+For the most direct information on the Native Template, visit our [GitHub Releases page](https://github.com/mendix/native-template/releases/tag/v11.0.0).


### PR DESCRIPTION
Introduction of Native Template version 11, a breaking change that we brought by disabling JSC.

Why this is draft: There'll be 1-2 more small changes regarding other features that we've brought