### PR TITLE
[RUN-4280] Add release note for commons-io upgrade

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/8/8.18.md
+++ b/content/en/docs/releasenotes/studio-pro/8/8.18.md
@@ -24,6 +24,7 @@ This is the [LTS](/releasenotes/studio-pro/lts-mts/#lts) version 8 release for a
 * We fixed an issue in the call REST service and call web service activities, where setting an empty timeout expression gave an error. Now it gives a consistency error.
 * We fixed an issue in published REST services where in exceptional cases it showed an error about not being able to refresh the grid.
 * We fixed an issue in the editor for operations of published REST services where double-clicking a consistency error showed an error rather than showing the operation with its parameters.
+* We upgraded the Apache commons-io dependency to fix CVE-2024-47554. Note that the Mendix runtime was not vulnerable.
 
 ### Deprecations
 

--- a/content/en/docs/releasenotes/studio-pro/9/9.24.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.24.md
@@ -69,6 +69,7 @@ This is the [LTS](/releasenotes/studio-pro/lts-mts/#lts) version 9 release for a
 * We fixed an issue in published REST services where in exceptional cases it showed an error about not being able to refresh the grid.
 * We fixed an issue in the editor for operations of published REST services where double-clicking a consistency error showed an error rather than showing the operation with its parameters.
 * We fixed an issue where there was a consistency error reporting that Gradle 8.5 should be used with Java 21, even if **Build using Gradle** was disabled.
+* We upgraded the Apache commons-io dependency to fix CVE-2024-47554. Note that the Mendix runtime was not vulnerable.
 
 ### Deprecations
 


### PR DESCRIPTION
We upgraded commons-io in 9.24.30 and 8.18.33, but we did not add a release note at the time. Because of a customer question related to this we would now like to add the release note retroactively.