### PR TITLE
Add release note for fixing CVE-2024-28168

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.12.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.12.md
@@ -90,6 +90,7 @@ This is the [MTS](/releasenotes/studio-pro/lts-mts/#mts) version 10 release for 
 * We fixed an issue where trying to edit the name of an entity, attribute or association using <kbd>F2</kbd> in a read-only domain model. Previously this resulted in an error; now pressing <kbd>F2</kbd> does nothing.
 * We fixed an issue where updating a consumed OData contract resulted in a readable entity  turning into a non-readable entity. Resolving the consistency error led to an error when one of the attributes had been deleted as well.
 * We fixed an issue where Studio Pro threw the CE0570 (*URL not unique*) consistency error when a user undid removing a URL from a page or a microflow.
+* We upgraded the Apache XML Graphics FOP dependency to fix CVE-2024-28168.
 
 ### Deprecations
 

--- a/content/en/docs/releasenotes/studio-pro/10/10.16.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.16.md
@@ -115,6 +115,7 @@ We added Structure mode to macOS as an [experimental feature](/releasenotes/beta
 * We fixed an issue where an incorrectly configured template (or data) broke page navigation.
 * We fixed an issue where Studio Pro crashed when a **Retrieve Workflows** action was configured without a **Workflow Context** variable. Additionally, we now allow using a context entity and workflows from different modules. Previously this raised a consistency error.
 * We fixed an issue in the App Selector that the loading spinner stayed visible forever even when loading apps had finished.
+* We upgraded the Apache XML Graphics FOP dependency to fix CVE-2024-28168.
 
 ### Known Issues
 

--- a/content/en/docs/releasenotes/studio-pro/10/10.6.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.6.md
@@ -36,6 +36,7 @@ This is the [MTS](/releasenotes/studio-pro/lts-mts/#mts) version 10 release for 
 * We fixed an issue where trying to edit the name of an entity, attribute or association using <kbd>F2</kbd> in a read-only domain model. Previously this resulted in an error; now pressing <kbd>F2</kbd> does nothing.
 * We fixed an issue in Studio Pro where after deleting an attribute from the domain model, choosing a key for that entity in a published OData service resulted in an error.
 * We fixed an issue where Studio Pro threw the CE0570 (*URL not unique*) consistency error when a user undid removing a URL from a page or a microflow.
+* We upgraded the Apache XML Graphics FOP dependency to fix CVE-2024-28168.
 
 ### Deprecations
 

--- a/content/en/docs/releasenotes/studio-pro/9/9.24.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.24.md
@@ -70,6 +70,7 @@ This is the [LTS](/releasenotes/studio-pro/lts-mts/#lts) version 9 release for a
 * We fixed an issue in the editor for operations of published REST services where double-clicking a consistency error showed an error rather than showing the operation with its parameters.
 * We fixed an issue where there was a consistency error reporting that Gradle 8.5 should be used with Java 21, even if **Build using Gradle** was disabled.
 * We upgraded the Apache commons-io dependency to fix CVE-2024-47554. Note that the Mendix runtime was not vulnerable.
+* We upgraded the Apache XML Graphics FOP dependency to fix CVE-2024-28168.
 
 ### Deprecations
 


### PR DESCRIPTION
Upon customer request we are adding release notes for a library upgrade we did for earlier released versions.