### PR TITLE
File uploader new context object committed before upload

### DIFF
--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/file-uploader.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/file-uploader.md
@@ -19,6 +19,8 @@ Read below for either [simple setup](#simple-setup) instructions, or a more [adv
 
 {{% alert color="info" %}}
 In the following sections, the term "context entity" refers to the entity of the context object in which the file uploader widget is placed. This can be either a data view or a page parameter.
+
+Please make sure, when using a new context object, it is commited before the upload, else it can cause unique constrain violations when uploading mulitple files.
 {{% /alert %}}
 
 ### Simple Setup {#simple-setup}


### PR DESCRIPTION
When a new context object is not committed before the multiple upload starts, the upload of the file will trigger the commit via the associated to the object.  When context is not in the DB many simultaneous request might cause the the commit to happen multiple times. Cause an error:

```
com.mendix.systemwideinterfaces.connectionbus.data.UniqueConstraintViolationRuntimeException: Duplicate column value violates its unique constraint: 
integrity constraint violation: unique constraint or index violation ; 
SYS_PK_10349 table: "fileuploader$fileuploadcontext" (SQL State: 23505, Error Code: -104) 
Detail Message: org.hsqldb.HsqlException: integrity constraint violation: unique constraint or index violation ; 
SYS_PK_10349 table: "fileuploader$fileuploadcontext"
```