### PR TITLE
[WTF-1915] Release note for export issue selection pages

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.18.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.18.md
@@ -112,6 +112,7 @@ We are introducing a new beta feature that provides an overview of your app’s 
 
 * <a id="fix-line-endings"></a>We fixed a [known issue](/releasenotes/studio-pro/10.0/#css-ki) where Studio Pro theme files (such as *theme-cache/theme.compiled.css.map*) showed up as changed. This situation was caused by incorrect generation of line endings in automatically generated content. For existing apps that have mixed line endings possibly on different branches, the file can show up as changed again. To correct the issue for your app on the opened branch, commit the change.
 * In the logic editors, we fixed an issue when extracting a submicroflow with annotations that were not in the same looped activity as other objects. (Ticket 207767)
+* We fixed a deployment issue with reference (set) selection pages where they sometimes lost selection functionality after other documents had been changed. (Ticket 221185)
 * We fixed an issue in the logic editors where using the middle mouse button to pan the canvas did not work when the mouse was over connection points, error handler icons, resize handles, and Bézier curve handles. (Ticket 224031)
 * In the logic editors, extracting a microflow did not create parameters for variables that were created inside the new microflow. (Ticket 226919)
 * In the logic editors, we fixed the displayed output variable type for retrieve actions when following a self-association. (Ticket 227953)
@@ -130,8 +131,7 @@ We are introducing a new beta feature that provides an overview of your app’s 
 * We fixed several issues in the Offline Profile validations where an **Oops** pop-up window appeared.
 * We fixed an issue in the new entity access rules editor on high DPI screens, where icons sometimes appeared blurry and content peeked through borders during scrolling.
 * We fixed an issue where user tasks from excluded workflows did not get properly converted when updating a Mendix app to 10.12.
-* We fixed a deployment issue with reference (set) selection pages. After changing other documents they would sometimes lose selection functionality. (Ticket 221185)
-
+  
 ### Deprecations
 
 * We no longer support Gradle versions below 8.5.

--- a/content/en/docs/releasenotes/studio-pro/10/10.18.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.18.md
@@ -130,6 +130,7 @@ We are introducing a new beta feature that provides an overview of your app’s 
 * We fixed several issues in the Offline Profile validations where an **Oops** pop-up window appeared.
 * We fixed an issue in the new entity access rules editor on high DPI screens, where icons sometimes appeared blurry and content peeked through borders during scrolling.
 * We fixed an issue where user tasks from excluded workflows did not get properly converted when updating a Mendix app to 10.12.
+* We fixed a deployment issue with reference (set) selection pages. After changing other documents they would sometimes lose selection functionality. (Ticket 221185)
 
 ### Deprecations
 


### PR DESCRIPTION
After investigating Ticket 221185 we discovered that the release of [CTRL-3124] fixed this issue. This PR adds a release note specifically for the ticket for reference.

> We fixed an issue in the error check that led to a crash when a document was changed again after an earlier change introduced errors because selected elements could not be found.
> CTRL-3124
