### PR TITLE
Replace LoginAction with authentication microflows for published services

### DIFF
--- a/content/en/docs/refguide/installation/upgrading-from-9-to-10.md
+++ b/content/en/docs/refguide/installation/upgrading-from-9-to-10.md
@@ -134,9 +134,9 @@ In Studio Pro 10, the glyphicon is slowly being phased out. Although a currently
 
 If your application is currently using the Atlas theme, this is easily solved by upgrading [Atlas Core](https://marketplace.mendix.com/link/component/117187) to version 3.11 or above. Otherwise, a possible workaround for this is to manually add the [Atlas icons module](https://github.com/mendix/atlas/raw/main/resources/Atlas_Icons.mpk) to your app.
 
-### Custom login for published services
+### Custom Login for Published Services
 
-In Mendix 10, published OData, REST and Web services use sessions that do not communicate with the database. This also means that these services ignore [customized login behavior using a LoginAction](/refguide/login-behavior/#customizing-login-behavior). When upgrading an app that uses this feature to Mendix 10, you need to reimplement the login behavior in an authentication microflow. See [OData authentication  microflow](/refguide/published-odata-services/#authentication-microflow), [REST authentication microflow](/refguide/published-rest-service/#authentication-microflow) or [Web service authentication](/refguide/integration/expose-a-web-service/#authentication-and-users) for more information.
+In Studio Pro 10, published OData, REST, and Web services use sessions that do not communicate with the database. This also means these services ignore [customized login behavior using a LoginAction](/refguide/login-behavior/#customizing-login-behavior). When upgrading an app that uses these features to Studio Pro 10, you need to reimplement the login behavior in an authentication microflow. For more information, see [OData authentication  microflow](/refguide/published-odata-services/#authentication-microflow), [REST authentication microflow](/refguide/published-rest-service/#authentication-microflow), or [Web service authentication](/refguide/integration/expose-a-web-service/#authentication-and-users).
 
 ## Read More
 

--- a/content/en/docs/refguide/installation/upgrading-from-9-to-10.md
+++ b/content/en/docs/refguide/installation/upgrading-from-9-to-10.md
@@ -134,6 +134,10 @@ In Studio Pro 10, the glyphicon is slowly being phased out. Although a currently
 
 If your application is currently using the Atlas theme, this is easily solved by upgrading [Atlas Core](https://marketplace.mendix.com/link/component/117187) to version 3.11 or above. Otherwise, a possible workaround for this is to manually add the [Atlas icons module](https://github.com/mendix/atlas/raw/main/resources/Atlas_Icons.mpk) to your app.
 
+### Custom login for published services
+
+In Mendix 10, published OData, REST and Web services use sessions that do not communicate with the database. This also means that these services ignore [customized login behavior using a LoginAction](/refguide/login-behavior/#customizing-login-behavior). When upgrading an app that uses this feature to Mendix 10, you need to reimplement the login behavior in an authentication microflow. See [OData authentication  microflow](/refguide/published-odata-services/#authentication-microflow), [REST authentication microflow](/refguide/published-rest-service/#authentication-microflow) or [Web service authentication](/refguide/integration/expose-a-web-service/#authentication-and-users) for more information.
+
 ## Read More
 
 * [Studio Pro 10 Release Notes](/releasenotes/studio-pro/10.0/)

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -203,9 +203,9 @@ Support for using a list of `System.HttpHeader` in authentication microflows was
 
 Specify which microflow to use for custom authentication. The microflow may take the following as a parameter:
 
-* A list of [HttpHeader](/refguide/http-request-and-response-entities/#http-header). This cannot be used in combination with [HttpRequest](/refguide/http-request-and-response-entities/#http-request) parameter.
+* A list of [HttpHeader](/refguide/http-request-and-response-entities/#http-header). These are the HTTP headers in the client's request. Use this parameter for authentication schemes that are based on HTTP headers.
+* Alternatively, an [HttpRequest](/refguide/http-request-and-response-entities/#http-request). Use this parameter for authentication schemes that are based on more thatn just the HTTP headers, for instance when the client supplies credentials in the request body. You cannot use this parameter together with a list of HttpHeader. Instead, use a [retrieve activity](/refguide/retrieve/) to retrieve the associated request headers.
 * [HttpResponse](/refguide/http-request-and-response-entities/#http-response). When the microflow sets the status code of this response to something other then **200**, this value is returned and the operation will not be executed. Any headers set on the response are returned (except when the microflow returns an empty user).
-* [HttpRequest](/refguide/http-request-and-response-entities/#http-request), so it can inspect the incoming request.
 
 The authentication microflow should return a User.
 

--- a/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
+++ b/content/en/docs/refguide/modeling/integration/odata-services/published-odata-services/_index.md
@@ -204,7 +204,7 @@ Support for using a list of `System.HttpHeader` in authentication microflows was
 Specify which microflow to use for custom authentication. The microflow may take the following as a parameter:
 
 * A list of [HttpHeader](/refguide/http-request-and-response-entities/#http-header). These are the HTTP headers in the client's request. Use this parameter for authentication schemes that are based on HTTP headers.
-* Alternatively, an [HttpRequest](/refguide/http-request-and-response-entities/#http-request). Use this parameter for authentication schemes that are based on more thatn just the HTTP headers, for instance when the client supplies credentials in the request body. You cannot use this parameter together with a list of HttpHeader. Instead, use a [retrieve activity](/refguide/retrieve/) to retrieve the associated request headers.
+* [HttpRequest](/refguide/http-request-and-response-entities/#http-request). Use this parameter for authentication schemes that are based on more than just the HTTP headers (for example, when the client supplies credentials in the request body). You cannot use this parameter together with a list of HttpHeader. Instead, use a [retrieve activity](/refguide/retrieve/) to retrieve the associated request headers.
 * [HttpResponse](/refguide/http-request-and-response-entities/#http-response). When the microflow sets the status code of this response to something other then **200**, this value is returned and the operation will not be executed. Any headers set on the response are returned (except when the microflow returns an empty user).
 
 The authentication microflow should return a User.


### PR DESCRIPTION
Mendix 10, does not use LoginAction for published services, so for apps that use that, users must reimplement that functionality in authentication microflows.