### PR TITLE
Documentation for using Google Secret Manager with Private Cloud

### DIFF
--- a/content/en/docs/deployment/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/deployment/private-cloud/secret-store-credentials.md
@@ -858,11 +858,11 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
 
     {{% alert color="info" %}}Google Secret Manager doesn't support any sort of hierarchy at the moment, and keys can only be stored as a flat list. As a typical environment would likely need a dozen keys, we recommend adding labels and using a pattern when creating keys. For example, use `<namespace>-<environment-id>-database-type` for the `database-type` key.{{% /alert %}}
 
-    Alternatively, the `gcloud` CLI tool can be used to create keys in an automated way (replace `<namespace-name>` with the namespace where the app is deployed, and `<mendixapp-cr-name>` with the name of the MendixApp CR):
+    Alternatively, the `gcloud` CLI tool can be used to create keys in an automated way (replace `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR):
 
     ```shell
-    NAMESPACE=<namespace-name>
-    ENVIRONMENT_NAME=<mendixapp-cr-name>
+    NAMESPACE=<{Kubernetes namespace}>
+    ENVIRONMENT_NAME=<{Mendix App CR name}>
     # Example: set the database-type to PostgreSQL
     printf "PostgreSQL" | gcloud secrets create ${NAMESPACE}-${ENVIRONMENT_NAME}-database-type --data-file=- --replication-policy=automatic
     ```
@@ -870,18 +870,18 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
 6. For every secret created on step 5, allow the Mendix app to access it by adding a **Secret Manager Secret Accessor** role to the following principal:
 
     ```
-    principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<PROJECT_ID>svc.id.goog/subject/ns/<namespace-name>/sa/<mendixapp-cr-name>
+    principal://iam.googleapis.com/projects/<{Project number}>/locations/global/workloadIdentityPools/<{Project ID}>.svc.id.goog/subject/ns/<{Kubernetes namespace}>/sa/<{Mendix App CR name}>
     ```
 
-    replacing `<PROJECT_NUMBER>` and `<PROJECT_ID>` with the project number and project ID from step 4; `<namespace-name>` with the namespace where the app is deployed, and `<mendixapp-cr-name>` with the name of the MendixApp CR.
+    replacing `<{Project number}>` and `<{Project ID}>` with the project number and project ID from step 4; `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR.
 
     This can also be done using the `gcloud` CLI tool:
 
     ```shell
-    NAMESPACE=<namespace-name>
-    ENVIRONMENT_NAME=<mendixapp-cr-name>
-    PROJECT_ID=<project-id>
-    PROJECT_NUMBER=<project-project-number>
+    NAMESPACE=<{Kubernetes namespace}>
+    ENVIRONMENT_NAME=<{Mendix App CR name}>
+    PROJECT_ID=<{Project ID}>
+    PROJECT_NUMBER=<{Project number}>
     # Example: grand access ENVRIONMENT_NAME in NAMESPACE permissions to access its database-type secret
     gcloud secrets add-iam-policy-binding ${NAMESPACE}-${ENVIRONMENT_NAME}-database-type --role=roles/secretmanager.secretAccessor\
       --member=principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/${NAMESPACE}/sa/${ENVIRONMENT_NAME}
@@ -897,11 +897,11 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
 8. Attach the secret to the environment by applying the following Kubernetes yaml:
 
     ```yaml
-    NAMESPACE=<namespace-name>
-    ENVIRONMENT_NAME=<mendixapp-cr-name>
-    PROJECT_ID=<project-id>
-    PROJECT_NUMBER=<project-project-number>
-    cat <<EOF |kubectl apply -n dmitrii-test -f -
+    NAMESPACE=<{Kubernetes namespace}>
+    ENVIRONMENT_NAME=<{Mendix App CR name}>
+    PROJECT_ID=<{Project ID}>
+    PROJECT_NUMBER=<{Project number}>
+    cat <<EOF |kubectl apply -n $NAMESPACE -f -
     apiVersion: secrets-store.csi.x-k8s.io/v1
     kind: SecretProviderClass
     metadata:

--- a/content/en/docs/deployment/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/deployment/private-cloud/secret-store-credentials.md
@@ -806,9 +806,9 @@ After completing the prerequisites, follow these steps to switch from password-b
 
 To enable your environment to use [Google Secret Manager Provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) as external secret storage, follow these steps:
 
-1. Enable workload identity federation for your GKE cluster as described in the [Google Cloud documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#console_1). This only needs to be done once per cluster.
+1. Enable workload identity federation for your GKE cluster as described in the [Google Cloud documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#console_1) (this only needs to be done once per cluster).
 
-2. Install the [CSI Secret Store Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html#install-the-secrets-store-csi-driver), as shown in the following example. This only need to be done once per cluster.
+2. Install the [CSI Secret Store Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html#install-the-secrets-store-csi-driver), as follows (this only need to be done once per cluster):
 
     ```shell
     helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
@@ -816,20 +816,22 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
     --set syncSecret.enabled=true
     ```
 
-3. Install and enable the [Google Secret Manager Provider for Secret Store CSI Driver](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp?tab=readme-ov-file#install) by doing the following steps (this only needs to be done once per cluster):
+3. Install and enable the [Google Secret Manager Provider for Secret Store CSI Driver](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp?tab=readme-ov-file#install) using the following steps (this only needs to be done once per cluster):
 
-    1. Clone or download a copy of the [secrets-store-csi-driver-provider-gcp](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) repository, for example:
+    1. Clone or download a copy of the [secrets-store-csi-driver-provider-gcp](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) repository.
 
     2. Navigate to the root folder of the local `secrets-store-csi-driver-provider-gcp` copy.
     3. Run the following command to install the provider using Helm:
 
-    ```shell
-    helm upgrade --install secrets-store-csi-driver-provider-gcp charts/secrets-store-csi-driver-provider-gcp
-    ```
+        ```shell
+        helm upgrade --install secrets-store-csi-driver-provider-gcp charts/secrets-store-csi-driver-provider-gcp
+        ```
 
-4. Get the Google Cloud account _Project Number_ and _Project ID_ from the Google Cloud welcome page, or using the `gcloud projects list` command.
+4. Get the Google Cloud account **Project Number** and **Project ID** from the Google Cloud welcome page, or using the `gcloud projects list` command.
 
-5. Create an app with the secret store enabled. If you are using connected mode, secret stores are enabled automatically if the **Enable Secrets Store** option is activated for the namespace where you create the app. For a standalone app, you must set the value of the setting `allowOverrideSecretsWithSecretStoreCSIDriver` to `true` in the Mendix app CRD.
+5. Create an app with the secret store enabled.
+
+    If you are using connected mode, secret stores are enabled automatically if the **Enable Secrets Store** option is activated for the namespace where you create the app. For a standalone app, you must set the value of the setting `allowOverrideSecretsWithSecretStoreCSIDriver` to `true` in the Mendix app CRD.
 
     The following yaml shows an example Mendix app CRD:
 
@@ -859,11 +861,12 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
       sourceVersion: 0.0.0.87
     EOF
     ```
-6. Go to the **Secrets Manager** page in the Google Cloud console, and use the **Create Secret** button to create keys for every key listed in the [SecretProviderClass Keys](#keys) section above.
 
-    {{% alert color="info" %}}Google Secret Manager doesn't support any sort of hierarchy at the moment, and keys can only be stored as a flat list. As a typical environment would likely need a dozen keys, we recommend adding labels and using a pattern when creating keys. For example, use `<namespace>-<environment-id>-database-type` for the `database-type` key.{{% /alert %}}
+6. Go to the **Secrets Manager** page in the Google Cloud console, and use the **Create Secret** button to create keys for every key listed in the [`SecretProviderClass` Keys](#keys) section above.
 
-    Alternatively, the `gcloud` CLI tool can be used to create keys in an automated way (replace `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR):
+    {{% alert color="info" %}}Keys can only be stored as a flat list as Google Secret Manager does not support any sort of hierarchy at the moment. A typical environment needs about a dozen keys so Mendix recommends adding labels and using a pattern when creating keys. For example, use `<namespace>-<environment-id>-database-type` for the `database-type` key.{{% /alert %}}
+
+    Alternatively, the `gcloud` CLI tool can be used to create keys in an automated way as follows:
 
     ```shell
     NAMESPACE=<{Kubernetes namespace}>
@@ -872,13 +875,15 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
     printf "PostgreSQL" | gcloud secrets create ${NAMESPACE}-${ENVIRONMENT_NAME}-database-type --data-file=- --replication-policy=automatic
     ```
 
-6. For every secret created on step 5, allow the Mendix app to access it by adding a **Secret Manager Secret Accessor** role to the following principal:
+    Replace `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR. 
+
+7. For every secret created in the previous step, allow the Mendix app to access it by adding a **Secret Manager Secret Accessor** role to the following principal:
 
     ```
     principal://iam.googleapis.com/projects/<{Project number}>/locations/global/workloadIdentityPools/<{Project ID}>.svc.id.goog/subject/ns/<{Kubernetes namespace}>/sa/<{Mendix App CR name}>
     ```
 
-    replacing `<{Project number}>` and `<{Project ID}>` with the project number and project ID from step 4; `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR.
+    Replace `<{Project number}>` and `<{Project ID}>` with the Google Cloud account **Project Number** and **Project ID** which you found earlier, `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR.
 
     This can also be done using the `gcloud` CLI tool:
 
@@ -892,14 +897,16 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
       --member=principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/${NAMESPACE}/sa/${ENVIRONMENT_NAME}
     ```
 
-7. Create a Kubernetes `ServiceAccount` for your environment, replacing `<{environment name}>` with the name of the MendixApp CR:
+8. Create a Kubernetes `ServiceAccount` for your environment as follows:
 
     ```shell
     kubectl -n <{Kubernetes namespace}> create serviceaccount <{environment name}>
     kubectl -n <{Kubernetes namespace}> annotate serviceaccount <{environment name}> privatecloud.mendix.com/environment-account=true
     ```
 
-8. Attach the secret to the environment by applying the following Kubernetes yaml:
+    Replacing `<{environment name}>` with the name of the MendixApp CR:
+
+9. Attach the secret to the environment by applying the following Kubernetes yaml:
 
     ```yaml
     NAMESPACE=<{Kubernetes namespace}>
@@ -942,12 +949,15 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
             fileName: storage-bucket-name
           - resourceName: projects/${PROJECT_ID}/secrets/${NAMESPACE}-${ENVIRONMENT_NAME}-storage-perform-delete/versions/latest
             fileName: storage-perform-delete
-          # Example: use MyFirstModule.MyConstant constant value from the namespace1-myapp1-myfirstmodule-myconstant secret
+          # Example: to get the MyFirstModule.MyConstant constant value from the namespace1-myapp1-myfirstmodule-myconstant secret you would use the following:
+          #
           #- resourceName: namespace1-myapp1-myfirstmodule-myconstant
           #  fileName: "mx-const-MyFirstModule.MyConstant"
     ```
 
     In the above example, `resourceName` specifies the secret ID from the Google Cloud project, and `fileName` specifies how it will be named when mounted into the sidecar.
+
+    Replace `<{Project number}>` and `<{Project ID}>` with the Google Cloud account **Project Number** and **Project ID** which you found earlier, `<{Kubernetes namespace}>` with the namespace where the app is deployed, and `<{Mendix App CR name}>` with the name of the MendixApp CR.
 
 For more information, refer to the the official [Google Secret Manager Provider for Secret Store CSI Driver](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) repository and [Google Secret Manager documentation](https://cloud.google.com/secret-manager/docs/overview).
 

--- a/content/en/docs/deployment/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/deployment/private-cloud/secret-store-credentials.md
@@ -712,7 +712,7 @@ For more information, see the [Azure Key Vault Provider](https://azure.github.io
 
 [Azure Postgres (Flexible Server)](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/service-overview) databases can use [managed identity authentication](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-connect-with-managed-identity) instead of regular passwords.
 
-{{% alert color="warning" %}}azure has a legacy postgres (single server) database. the mendix operator does not support [managed identity authentication for single server databases](https://learn.microsoft.com/en-us/azure/postgresql/single-server/how-to-configure-sign-in-azure-ad-authentication), only the new flexible server is supported. this section only applies to flexible server databases.{{% /alert %}}
+{{% alert color="warning" %}}Azure has a legacy Postgres (Single Server) database. The Mendix Operator does not support [managed identity authentication for Single Server databases](https://learn.microsoft.com/en-us/azure/postgresql/single-server/how-to-configure-sign-in-azure-ad-authentication), only the new Flexible Server is supported. This section only applies to Flexible Server databases.{{% /alert %}}
 
 To use this feature, you need to:
 

--- a/content/en/docs/deployment/private-cloud/secret-store-credentials.md
+++ b/content/en/docs/deployment/private-cloud/secret-store-credentials.md
@@ -804,6 +804,14 @@ After completing the prerequisites, follow these steps to switch from password-b
 
 ### Configuring a Secret Store with Google Secret Manager {#google-secret-manager}
 
+To follow these instructions you will need:
+
+* A [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) cluster and access permissions.
+* Mendix Operator version 2.9.0 and above installed in the cluster.
+* The [Helm](https://helm.sh) package manager.
+
+{{% alert color="warning" %}}Google Kubernetes Engine has an alternative Secret Manager CSI driver, called `secrets-store-gke.csi.k8s.io` and enabled using the [Secret Manager add-on](https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component) in the cluster settings. The driver installed with the Secret Manager add-on **is not supported** by the Mendix Operator. Please use the `secrets-store-csi-driver-provider-gcp` documented below.{{% /alert %}}
+
 To enable your environment to use [Google Secret Manager Provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) as external secret storage, follow these steps:
 
 1. Enable workload identity federation for your GKE cluster as described in the [Google Cloud documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#console_1) (this only needs to be done once per cluster).
@@ -961,7 +969,6 @@ To enable your environment to use [Google Secret Manager Provider](https://githu
 
 For more information, refer to the the official [Google Secret Manager Provider for Secret Store CSI Driver](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp) repository and [Google Secret Manager documentation](https://cloud.google.com/secret-manager/docs/overview).
 
-{{% alert color="warning" %}}Google Kubernetes Engine has an alternative Secret Manager CSI driver, called `secrets-store-gke.csi.k8s.io` and enabled using the [Secret Manager add-on](https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component) in the cluster settings. The driver installed with the Secret Manager add-on **is not supported** by the Mendix Operator. Please use the `secrets-store-csi-driver-provider-gcp` documented above.{{% /alert %}}
 
 ## Additional Considerations {#additional-considerations}
 

--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -16,7 +16,7 @@ Follow the links in the table below to see the release notes you want:
 | Type of Deployment | Last Updated |
 | --- | --- |
 | [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | February 2, 2025 |
-| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | January 23, 2025 |
+| [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | February 12, 2025 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | August 27, 2024 |
 | [Other Deployment Options](/releasenotes/developer-portal/on-premises/) | September 15, 2023 |
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,12 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
+### February ???, 2025
+
+#### Documentation Updates
+
+* We have updated the [CSI Secrets Storage](/developerportal/deploy/secret-store-credentials/) documentation to include instructions on storing credentials and configuration in Google Cloud Secret Manager.
+
 ### January 23, 2025
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
-### February ???, 2025
+### February 12, 2025
 
 #### Documentation Updates
 

--- a/layouts/partials/landingpage/latest-releases.html
+++ b/layouts/partials/landingpage/latest-releases.html
@@ -17,6 +17,6 @@
     </li>
     <li class="lp-panel-list">
         <a href="/releasenotes/developer-portal/deployment/">Deployment</a>
-        <p class="rn-date">Feb 2, 2025</p>
+        <p class="rn-date">Feb 12, 2025</p>
     </li>
 </ul>


### PR DESCRIPTION
Mendix for Private Cloud was compatible with Google Secret Manager for quite some time, but we didn't have any documentation explaining how to use it.

This PR adds instructions how to install Google Secret Manager and use it with Mendix for Private Cloud apps.

This document is not linked with any releases and can be reviewed and published at any convenient time.