### PR TITLE
Release notes and documentation for Mendix for Private Cloud 2.21.0 (planned for release on Wednesday, February 19)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -955,6 +955,11 @@ Each path is mounted as a separate `subPath` to keep data separated.
 The `emptyDir` size is set to the `ephemeral-storage` [resource limit](#advanced-resource-customization).
 In addition to internal Mendix Runtime paths, `/tmp` is mounted for any temporary files that might be created through Java actions; for Java actions to work correctly, please make sure they only create files in `/tmp`, for example by using `File.createTempFile` or `File.createTempDirectory` Java methods.
 
+{{% alert color="info" %}}
+If your app works without issues when read-only root filesystem is enabled, it's best to enable it wherever possible.
+We recommend using a non-production environment to validate that your app keeps working correctly.
+{{% /alert %}}
+
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}
 
 In GKE Autopilot, one of the key features is its ability to automatically adjust resource settings based on the observed resource utilization of the containers. GKE Autopilot verifies the resource allocations and limits for all containers, and makes adjustments to deployments when the resources are not as per its requirements.

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -952,24 +952,16 @@ Some container runtimes or network configurations prevent a terminating pod from
 
 ### Read-only RootFS {#readonlyrootfs}
 
-Mendix app container images are locked down reasonably well out of the box - they run as a non-root user, cannot request elevated permissions, and file ownership and permissions prevent modification of system and critical paths.
+Mendix app container images are locked down by default - they run as a non-root user, cannot request elevated permissions, and file ownership and permissions prevent modification of system and critical paths. Kubernetes allows you to lock down containers even further, by mounting the container filesystem as read-only if the container's security context specifies [readOnlyRootFilesystem: true](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). With this option enabled, any files and paths from the container image cannot be modified by any user.
 
-Kubernetes allows to lock down containers even further, by mounting the container filesystem as read-only - if the container's security context specifies [readOnlyRootFilesystem: true](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
-With this option enabled, any files and paths from the container image cannot be modified by any user.
+Starting from Mendix Operator version 2.21.0, all system containers and pods use `readOnlyRootFilesystem` by default. It is possible to specify if an environment's app container should also have a read-only filesystem. For Mendix apps, the `readOnlyRootFilesystem` option is off by default, as some Java actions in marketplace modules might expect some paths to be writable.
 
-Starting from Mendix Operator version 2.21.0, all system containers and pods use `readOnlyRootFilesystem` by default, and it's possible to specify if an environment's app container should also have a read-only filesystem.
+If you enable the `runtimeReadOnlyRootFilesystem` option in the MendixApp CRD (for standalone clusters) or in the Private Cloud Portal, the Mendix app container also uses a read-only root filesystem. As Mendix apps needs certain paths to be writable, an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) is used for writable paths. Each path is mounted as a separate `subPath` to keep data separated. The `emptyDir` size is set to the `ephemeral-storage` [resource limit](#advanced-resource-customization).
 
-For Mendix apps, the `readOnlyRootFilesystem` option is off by default, as some Java actions in marketplace modules might expect some paths to be writable.
-
-By enabling the `runtimeReadOnlyRootFilesystem` option in the MendixApp CRD (for standalone clusters) or in the Private Cloud Portal, the Mendix app container will also use a read-only root filesystem.
-As Mendix apps needs certain paths to be writable, an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will be used for writable paths.
-Each path is mounted as a separate `subPath` to keep data separated.
-The `emptyDir` size is set to the `ephemeral-storage` [resource limit](#advanced-resource-customization).
-In addition to internal Mendix Runtime paths, `/tmp` is mounted for any temporary files that might be created through Java actions; for Java actions to work correctly, please make sure they only create files in `/tmp`, for example by using `File.createTempFile` or `File.createTempDirectory` Java methods.
+In addition to internal Mendix Runtime paths, `/tmp` is mounted for any temporary files that might be created through Java actions. For Java actions to work correctly, ensure that they only create files in `/tmp`, for example, by using the `File.createTempFile` or `File.createTempDirectory` Java methods.
 
 {{% alert color="info" %}}
-If your app works without issues when read-only root filesystem is enabled, it's best to enable it wherever possible.
-We recommend using a non-production environment to validate that your app keeps working correctly with a read-only RootFS.
+If your app works without issues when read-only root filesystem is enabled, it is best to enable it wherever possible. We recommend using a non-production environment to validate that your app keeps working correctly with a read-only RootFS.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -439,9 +439,11 @@ spec:
           limits:
             cpu: 1
             memory: 512Mi
+            ephemeral-storage: 4Mi
           requests:
             cpu: 100m
             memory: 512Mi
+            ephemeral-storage: 4Mi
 # ...
 # omitted lines for brevity
 # ...
@@ -462,30 +464,38 @@ spec:
     limits:
       cpu: 250m
       memory: 32Mi
+      ephemeral-storage: 4Mi
     requests:
       cpu: 100m
       memory: 16Mi
+      ephemeral-storage: 4Mi
   metricsSidecarResources:
     limits:
       cpu: 100m
       memory: 32Mi
+      ephemeral-storage: 4Mi
     requests:
       cpu: 100m
       memory: 16Mi
+      ephemeral-storage: 4Mi
   buildResources:
     limits:
       cpu: '1'
       memory: 256Mi
+      ephemeral-storage: 2Gi
     requests:
       cpu: 250m
       memory: 64Mi
+      ephemeral-storage: 2Gi
   runtimeResources:
     limits:
       cpu: 1000m
       memory: 512Mi
+      ephemeral-storage: 256Mi
     requests:
       cpu: 100m
       memory: 512Mi
+      ephemeral-storage: 256Mi
   runtimeLivenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 15
@@ -629,9 +639,11 @@ resources:
   limits:
     cpu: 1
     memory: 512Mi
+    ephemeral-storage: 256Mi
   requests:
     cpu: 100m
     memory: 512Mi
+    ephemeral-storage: 256Mi
 ```
 
 This section allows the configuration of the lower and upper resource boundaries, the `requests` and `limits` respectively.
@@ -976,16 +988,20 @@ spec:
     limits:
       cpu: "1"
       memory: 256Mi
+      ephemeral-storage: 2Gi
     requests:
       cpu: "1"
       memory: 256Mi
+      ephemeral-storage: 2Gi
   metricsSidecarResources:
     limits:
       cpu: 100m
       memory: 32Mi
+      ephemeral-storage: 4Mi
     requests:
       cpu: 100m
       memory: 32Mi
+      ephemeral-storage: 4Mi
 ```
 
 Run the following command in order to update the core resources in the `OperatorConfiguration`:

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -952,10 +952,10 @@ Some container runtimes or network configurations prevent a terminating pod from
 
 ### Read-only RootFS {#readonlyrootfs}
 
-Mendix app container images are locked down quite well out of the box - they run as a non-root user, cannot request elevated permissions, and file ownership make all system and non-critical paths read-only.
+Mendix app container images are locked down reasonably well out of the box - they run as a non-root user, cannot request elevated permissions, and file ownership and permissions prevent modification of system and critical paths.
 
 Kubernetes allows to lock down containers even further, by mounting the container filesystem as read-only - if the container's security context specifies [readOnlyRootFilesystem: true](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
-With this option enabled, any files and paths from the container image are impossible to modify by any user.
+With this option enabled, any files and paths from the container image cannot be modified by any user.
 
 Starting from Mendix Operator version 2.21.0, all system containers and pods use `readOnlyRootFilesystem` by default, and it's possible to specify if an environment's app container should also have a read-only filesystem.
 
@@ -969,7 +969,7 @@ In addition to internal Mendix Runtime paths, `/tmp` is mounted for any temporar
 
 {{% alert color="info" %}}
 If your app works without issues when read-only root filesystem is enabled, it's best to enable it wherever possible.
-We recommend using a non-production environment to validate that your app keeps working correctly.
+We recommend using a non-production environment to validate that your app keeps working correctly with a read-only RootFS.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -173,6 +173,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 50%
+  runtimeReadOnlyRootFilesystem: true # Optional: specify if the Mendix Runtime container should use a read-only root filesystem
 ```
 
 You need to make the following changes:
@@ -230,6 +231,7 @@ You need to make the following changes:
 * **customPodLabels** - specify additional pod labels (please avoid using labels that start with the `privatecloud.mendix.com/` prefix)
     * **general** - specify additional labels for all pods of the app
 * **deploymentStrategy** - specify parameters for the deployment strategy; for more information, see the reduced downtime deployment documentation.
+* **runtimeReadOnlyRootFilesystem** - specify if the Runtime container should mount the root filesystem in [read-only mode](/developerportal/deploy/private-cloud-cluster/#readonlyrootfs).
 
 #### Setting App Constants{#set-app-constants}
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -79,9 +79,11 @@ spec:
     limits: # Upper limit - process will be stopped if it tries to use more
       cpu: 500m # 500 millicores - half of a vCPU
       memory: 512Mi # 512 megabytes - suitable for small-scale non-production apps
+      ephemeral-storage: 256Mi # 256 megabytes - for temporary files such as generated Excel documents
     requests: # Lower limit - needs at least these resources
       cpu: 250m
       memory: 256Mi
+      ephemeral-storage: 256Mi
   runtimeDeploymentPodAnnotations: # Optional, can be omitted : set custom annotations for Mendix Runtime Pods
     # example: inject the Linkerd proxy sidecar
     linkerd.io/inject: enabled

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -36,7 +36,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.31
+* Kubernetes versions 1.19 through 1.32
 * OpenShift 4.6 through 4.17
 
 {{% alert color="warning" %}}
@@ -65,7 +65,7 @@ To install the Mendix Operator, the cluster administrator will need permissions 
 * Create roles in the target namespace or project
 * Create role bindings in the target namespace or project
 
-The cluster should have at least 2 CPU cores and 2 GB memory *available*. This is enough to run one simple app - but does not include additional resources required by Kubernetes core components.
+The cluster should have at least 2 CPU cores, 2 GB memory and 3GB ephemeral-storage *available* on a Kubernetes node. This is enough to run one simple app - but does not include additional resources required by Kubernetes core components.
 
 In OpenShift, the cluster administrator must have a `system:admin` role.
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -65,7 +65,7 @@ To install the Mendix Operator, the cluster administrator will need permissions 
 * Create roles in the target namespace or project
 * Create role bindings in the target namespace or project
 
-The cluster should have at least 2 CPU cores, 2 GB memory and 3GB ephemeral-storage *available* on a Kubernetes node. This is enough to run one simple app - but does not include additional resources required by Kubernetes core components.
+The cluster should have at least 2 CPU cores, 2 GB memory and 3 GB ephemeral-storage available on a Kubernetes node. This is enough to run one simple app, but does not include additional resources required by Kubernetes core components.
 
 In OpenShift, the cluster administrator must have a `system:admin` role.
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-upgrade-guide.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-upgrade-guide.md
@@ -12,11 +12,18 @@ This document describes how an existing installation of Mendix for Private Cloud
 This procedure allows you to upgrade to any supported (v1.9.0 and later) version of the Mendix for Private Cloud Operator.
 
 {{% alert color="warning" %}}
+Read this carefully when
+
+* using the `mxpc-cli` installation and configuration tool version 2.20.1 or earlier;
+* or manually installing or upgrading CRDs with `kubectl apply`.
+
 Upgrading the Mendix for Private Cloud Operator in a namespace will modify global resources such as Mendix Custom Resource Definitions in the cluster.
 
 [Custom Resource Definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) allow Mendix applications to be managed with Kubernetes APIs and tools such as `kubectl` and `oc`.
 
 Once you have installed a particular version of the Mendix Operator into any namespace in the cluster, you should not install older versions of the Mendix Operator into the same cluster, even if they are in other namespaces. This is because all the CRDs are global resources and operators in all namespaces use the same one, which may not be compatible across versions.
+
+Starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will check to see if the cluster has a newer CRD version than the CRDs bundled with `mxpc-cli`. If the cluster has newer CRDs, `mxpc-cli` will skip the CRD installation step - and avoid downgrading CRDs.
 {{% /alert %}}
 
 If you are using your own private registry, follow the [Migrating to Your Own Registry](/developerportal/deploy/private-cloud-migrating/) guide first

--- a/content/en/docs/deployment/private-cloud/private-cloud-upgrade-guide.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-upgrade-guide.md
@@ -12,10 +12,10 @@ This document describes how an existing installation of Mendix for Private Cloud
 This procedure allows you to upgrade to any supported (v1.9.0 and later) version of the Mendix for Private Cloud Operator.
 
 {{% alert color="warning" %}}
-Read this carefully when
+There are special considerations that you must be aware of in the following cases:
 
-* using the `mxpc-cli` installation and configuration tool version 2.20.1 or earlier;
-* or manually installing or upgrading CRDs with `kubectl apply`.
+* when using the `mxpc-cli` installation and configuration tool version 2.20.1 or earlier.
+* when manually installing or upgrading CRDs with `kubectl apply`.
 
 Upgrading the Mendix for Private Cloud Operator in a namespace will modify global resources such as Mendix Custom Resource Definitions in the cluster.
 
@@ -23,7 +23,7 @@ Upgrading the Mendix for Private Cloud Operator in a namespace will modify globa
 
 Once you have installed a particular version of the Mendix Operator into any namespace in the cluster, you should not install older versions of the Mendix Operator into the same cluster, even if they are in other namespaces. This is because all the CRDs are global resources and operators in all namespaces use the same one, which may not be compatible across versions.
 
-Starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will check to see if the cluster has a newer CRD version than the CRDs bundled with `mxpc-cli`. If the cluster has newer CRDs, `mxpc-cli` will skip the CRD installation step - and avoid downgrading CRDs.
+Starting from `mxpc-cli` version 2.21.0, the installation or upgrade process checks to see if the CRDs in the cluster are newer than the CRDs bundled with `mxpc-cli`. If the cluster has newer CRDs, `mxpc-cli` will skip the CRD installation step and avoid downgrading CRDs.
 {{% /alert %}}
 
 If you are using your own private registry, follow the [Migrating to Your Own Registry](/developerportal/deploy/private-cloud-migrating/) guide first

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -28,6 +28,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2024
 
+### January ???, 2025
+
+#### Mendix Operator v2.21.0 {#2.21.0}
+
+* We have switched all system containers to use a read-only root filesystem, and added an option to run Mendix app containers with a read-only rootfs.
+* We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
+* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
+* Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+
 ### December 16, 2024
 
 #### Mendix Operator v2.20.1 {#2.20.1}
@@ -38,7 +47,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have updated a library used to validate licenses to the latest non-alpha version.
 * We have updated documentation that OpenShift 4.17 and Postgres 17 are supported by the Mendix Operator.
 * We have addressed a rare deadlock situation which could prevent a failing environment from restarting.
-* Upgrading to Mendix Operator v2.20.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+* Upgrading to Mendix Operator v2.20.1 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
 
 #### Known Limitations
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,16 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
+### February 19, 2025
+
+#### Mendix Operator v2.21.0 {#2.21.0}
+
+* We have switched all system containers to use a read-only root filesystem, and added an option to run Mendix app containers with a read-only rootfs.
+* We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
+* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
+* We have fixed a _Failed to determine if DDL migration needs approval_ error message that sometimes appeared when using a **Recreate** deployment strategy. This error message doesn't mean there's an issue and can be ignored.
+* Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+
 ### February 12, 2025
 
 #### Documentation Updates
@@ -27,15 +37,6 @@ For information on the current status of deployment to Mendix for Private Cloud 
 * We have improved the labels for Runtime and Operator licenses to clearly indicate which licenses are applied to the app.
 
 ## 2024
-
-### January ???, 2025
-
-#### Mendix Operator v2.21.0 {#2.21.0}
-
-* We have switched all system containers to use a read-only root filesystem, and added an option to run Mendix app containers with a read-only rootfs.
-* We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
-* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
-* Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
 
 ### December 16, 2024
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,14 +16,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.21.0 {#2.21.0}
 
-* We have switched all system containers to use a read-only root filesystem, and added an option to run Mendix app containers with a read-only rootfs.
+* We have switched all system containers to use a read-only root filesystem. For Mendix app containers, we added an option to use a read-only rootfs, which is disabled by default.
 * We have added a default on ephemeral storage usage - to ensure that temporary file storage is reserved and is limited, so that a container gets a guaranteed amount of temporary file storage that cannot be exceeded.
 * We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
 * We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
-* We have fixed a _Failed to determine if DDL migration needs approval_ error message that sometimes appeared when using a **Recreate** deployment strategy. This error message doesn't mean there's an issue and can be ignored.
+* We have fixed a *Failed to determine if DDL migration needs approval* error message that sometimes appeared when using a **Recreate** deployment strategy. This error message doesn't mean there's an issue and can be ignored.
+* We have updated documentation that Kubernetes 1.32 is supported by the Mendix Operator.
 * Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
 
-#### Known Issue
+#### Important note for upgrading
 
 With the introduction of ephemeral storage requests and limits, building an app requires at least 2GB of ephemeral storage available on the Kubernetes node.
 If your nodes don't have enough temporary storage, build pods won't be able to start and will stay in a `Pending` phase.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,18 +17,16 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Mendix Operator v2.21.0 {#2.21.0}
 
 * We have switched all system containers to use a read-only root filesystem. For Mendix app containers, we added an option to use a read-only rootfs, which is disabled by default.
-* We have added a default on ephemeral storage usage - to ensure that temporary file storage is reserved and is limited, so that a container gets a guaranteed amount of temporary file storage that cannot be exceeded.
-* We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
+* We have added a default on ephemeral storage usage to ensure that temporary file storage is reserved and is limited, so that a container gets a guaranteed amount of temporary file storage that cannot be exceeded.
+* We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs than what is included with the installer.
 * We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
-* We have fixed a *Failed to determine if DDL migration needs approval* error message that sometimes appeared when using a **Recreate** deployment strategy. This error message doesn't mean there's an issue and can be ignored.
-* We have updated documentation that Kubernetes 1.32 is supported by the Mendix Operator.
+* We have fixed a *Failed to determine if DDL migration needs approval* error message that sometimes appeared when using a **Recreate** deployment strategy. This error message does not mean that there is an issue, and can therefore be ignored.
+* We have updated documentation with information that Kubernetes 1.32 is supported by the Mendix Operator.
 * Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
 
-#### Important note for upgrading
+#### Important Upgrade Information
 
-With the introduction of ephemeral storage requests and limits, building an app requires at least 2GB of ephemeral storage available on the Kubernetes node.
-If your nodes don't have enough temporary storage, build pods won't be able to start and will stay in a `Pending` phase.
-To resolve this issue, you can lower the valus for `ephemeral-storage` in the [buildResources](/developerportal/deploy/private-cloud-cluster/#resource-definition-ocm) configuration.
+With the introduction of ephemeral storage requests and limits, building an app requires at least 2 GB of ephemeral storage available on the Kubernetes node. If your nodes do not have enough temporary storage, the build pods cannot start and their status remains **Pending**. To resolve this issue, you can lower the values for `ephemeral-storage` in the [buildResources](/developerportal/deploy/private-cloud-cluster/#resource-definition-ocm) configuration.
 
 ### February 12, 2025
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -17,10 +17,17 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Mendix Operator v2.21.0 {#2.21.0}
 
 * We have switched all system containers to use a read-only root filesystem, and added an option to run Mendix app containers with a read-only rootfs.
+* We have added a default on ephemeral storage usage - to ensure that temporary file storage is reserved and is limited, so that a container gets a guaranteed amount of temporary file storage that cannot be exceeded.
 * We have added a check in `mxpc-cli` to prevent CRD downgrades; starting from `mxpc-cli` version 2.21.0, the installation or upgrade process will keep cluster CRDs unchanged if the cluster has newer CRDs (compared to what is included with the installer).
 * We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
 * We have fixed a _Failed to determine if DDL migration needs approval_ error message that sometimes appeared when using a **Recreate** deployment strategy. This error message doesn't mean there's an issue and can be ignored.
 * Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+
+#### Known Issue
+
+With the introduction of ephemeral storage requests and limits, building an app requires at least 2GB of ephemeral storage available on the Kubernetes node.
+If your nodes don't have enough temporary storage, build pods won't be able to start and will stay in a `Pending` phase.
+To resolve this issue, you can lower the valus for `ephemeral-storage` in the [buildResources](/developerportal/deploy/private-cloud-cluster/#resource-definition-ocm) configuration.
 
 ### February 12, 2025
 


### PR DESCRIPTION
We're planning to release a new version of Mx4PC this Wednesday - this MR includes release notes and documentation updates for the new features.