### PR TITLE
Update mendix-cloud release notes

### DIFF
--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -20,9 +20,7 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 #### Improvements
 
-* Updated the custom JMX metrics prefix from `jmx` to `mx`
-
-  * This change ensures that these metrics are not indexed as `custom metrics` in Datadog
+* We have updated the custom JMX metrics prefix from `jmx` to `mx`. This change ensures that these metrics are not indexed as `custom metrics` in Datadog.
 
 ### February 2, 2025
 

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -16,6 +16,14 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## 2025
 
+### February 20, 2025
+
+#### Improvements
+
+* Updated the custom JMX metrics prefix from `jmx` to `mx`
+
+  * This change ensures that these metrics are not indexed as `custom metrics` in Datadog
+
 ### February 2, 2025
 
 #### New Features


### PR DESCRIPTION
Updated the release notes of mendix-cloud to reflect the recent updates in the buildpack regarding the update in names of some metrics used in Datadog integration