### PR TITLE
Removed info box with duplicate content

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/lts-mts.md
+++ b/content/en/docs/releasenotes/studio-pro/lts-mts.md
@@ -51,8 +51,8 @@ An LTS version is the last minor release of a major version. Its release is alig
 
 These are the current LTS versions of Studio Pro:
 
-* [9.24](/releasenotes/studio-pro/9.24/) (started in March, 2023)
 * [8.18](/releasenotes/studio-pro/8.18/) (started in March, 2021)
+* [9.24](/releasenotes/studio-pro/9.24/) (started in March, 2023)
 
 Release notes for the current LTS versions are marked with an LTS badge (<text class="badge badge-pill badge-lts" style="margin-left:0px">LTS</text>) in the left sidebar.
 
@@ -94,9 +94,9 @@ An MTS is a minor version released approximately every 6 months after a new majo
 
 This is the current MTS version of Studio Pro:
 
-* [10.18](/releasenotes/studio-pro/10.18/) (started in December, 2024)
-* [10.12](/releasenotes/studio-pro/10.12/) (started in June, 2024)
 * [10.6](/releasenotes/studio-pro/10.6/) (started in December, 2023)
+* [10.12](/releasenotes/studio-pro/10.12/) (started in June, 2024)
+* [10.18](/releasenotes/studio-pro/10.18/) (started in December, 2024)
 
 Release notes for the current MTS version are marked with an MTS badge (<text class="badge badge-pill badge-mts" style="margin-left:0px">MTS</text>) in the left sidebar.
 

--- a/content/en/docs/releasenotes/studio-pro/lts-mts.md
+++ b/content/en/docs/releasenotes/studio-pro/lts-mts.md
@@ -95,14 +95,10 @@ An MTS is a minor version released approximately every 6 months after a new majo
 This is the current MTS version of Studio Pro:
 
 * [10.18](/releasenotes/studio-pro/10.18/) (started in December, 2024)
-* [10.6](/releasenotes/studio-pro/10.6/) (started in December, 2023)
 * [10.12](/releasenotes/studio-pro/10.12/) (started in June, 2024)
+* [10.6](/releasenotes/studio-pro/10.6/) (started in December, 2023)
 
 Release notes for the current MTS version are marked with an MTS badge (<text class="badge badge-pill badge-mts" style="margin-left:0px">MTS</text>) in the left sidebar.
-
-{{% alert color="info" %}}
-MTS versions (for example, 9.6) remain supported until the next major version has been released for general availability (for example, 10.0).
-{{% /alert %}}
 
 Mendix MTS versions offer a balance between getting the latest and greatest Mendix has to offer every month, and security and stability.
 


### PR DESCRIPTION
The content was wrong (MTS is supported until 3 months after the LTS release)
Also fixed the order of current MTS versions

@ConnorLand