### PR TITLE
[WTF-2113] Add documentation on the use of variables on pages and snippets

### DIFF
--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -103,7 +103,7 @@ This property identifies the value which is used in an input widget.
 
 #### Input Elements
 
-With the following widgets, the property specifies the value which is being changed (or displayed) by the widget:
+In the following widgets, this property specifies the value which is being changed (or displayed) by the widget:
 
 * [Text Box](/refguide/text-box/)
 * [Text Area](/refguide/text-area/)
@@ -114,14 +114,14 @@ With the following widgets, the property specifies the value which is being chan
 
 The value can be one of the following:
 
-1. An attribute of the entity of the data container that contains the widget.
-2. An attribute of the entity of any enclosing data container that contains the widget. 
-3. An attribute of an entity associated with the data container entity by following one or more associations of type reference through the domain model.
-4. A variable defined on the page or snippet that contains the widget.
+* An attribute of the entity of the data container that contains the widget.
+* An attribute of the entity of any enclosing data container that contains the widget. 
+* An attribute of an entity associated with the data container entity by following one or more associations of type reference through the domain model.
+* A variable defined on the page or snippet that contains the widget.
 
-In the first two cases we say the widget is connected to an **attribute**, in the third case to an **attribute path**, and in the last case to a **variable**.
+In the first two cases the widget is connected to an **attribute**, in the third case to an **attribute path**, and in the last case to a **variable**.
 
-You can edit attributes of any enclosing data container including grandparent data containers.
+You can edit attributes of any enclosing data container (including grandparent data containers).
 
 #### Association Input Elements
 
@@ -179,14 +179,14 @@ Only Boolean and enumeration attributes can be used for this purpose.
 
 When selected, this enables the widget while a provided [expression](/refguide/expressions/) evaluates to true. The expression may use the variables listed in the expression editor, including:
 
-- `$currentObject`, representing the object of the closest enclosing data container.
-- The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
-- [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
+* `$currentObject`, representing the object of the closest enclosing data container.
+* The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
+* [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
 
-The expression provided is evaluated in the browser and, currently, does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
+The expression provided is evaluated in the browser but does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
 
 {{% alert color="info" %}}
-As the expression is evaluated in the browser, we advise against using "secret" values (like access keys) in it. In particular, we disallow usages of [constants](/refguide/constants/).
+As the expression is evaluated in the browser, we advise against using secret values (like access keys) in it. In particular, we disallow usages of [constants](/refguide/constants/).
 {{% /alert %}}
 
 ### Read-Only Style
@@ -231,15 +231,15 @@ For each parameter in the template, you define a source for the value. The value
 
 ##### Value Parameter Type
 
-When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container. Number and Date Time value types offer formatting options.
+When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container. Number and DateTime value types offer formatting options.
 
 ##### Expression Parameter Type
 
 When selected, the result of the given [expression](/refguide/expressions/) is used as the value of the parameter. The expression may use the variables listed in the expression editor, including:
 
-- `$currentObject`, representing the object of the closest enclosing data container.
-- The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
-- [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
+* `$currentObject`, representing the object of the closest enclosing data container.
+* The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
+* [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
 
 The expression provided is evaluated in the browser and, currently, does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -169,13 +169,17 @@ If the editable property is set to **Conditionally**, the widget is made editabl
 
 For example, imagine you are creating a personal details form in which the end-user must enter their marital status. In this case, you might wish to disable the input of a marriage date until the end-user indicates that they are married.
 
-#### Based on Attribute Value
+#### Based on Value
 
-When selected, this enables the widget when a particular attribute has a certain value. Only Boolean and enumeration attributes can be used for this purpose.
+When selected, this enables the widget while a chosen value matches specific values. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet.
 
 #### Based on Expression
 
-When selected, this enables the widget when a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as the `$currentObject` variable. Objects of all data containers surrounding the widget and variables on the page or snippet are available as well.
+When selected, this enables the widget while a provided [expression](/refguide/expressions/) evaluates to true. The expression may use the variables listed in the expression editor, including:
+
+- `$currentObject`, representing the object of the closest enclosing data container.
+- The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
+- [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
 
 The expression provided is evaluated in the browser and, currently, does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
 
@@ -221,7 +225,21 @@ The template for the label can contain parameters that are written as a number b
 
 #### Parameters
 
-For each parameter in the template, you define an attribute of the context entity or an associated entity. The value of this attribute will be inserted at the position of the parameter.
+For each parameter in the template, you define a source for the value. The value of the parameter will be inserted at the position of the parameter placeholder.
+
+##### Value Parameter Type
+
+When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet. Number and Date Time value types offer formatting options.
+
+##### Expression Parameter Type
+
+When selected, the result of the given [expression](/refguide/expressions/) is used as the value of the parameter. The expression may use the variables listed in the expression editor, including:
+
+- `$currentObject`, representing the object of the closest enclosing data container.
+- The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
+- [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
+
+The expression provided is evaluated in the browser and, currently, does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
 
 ## Formatting Section{#numeric-formatting}
 
@@ -367,9 +385,9 @@ The widget can be made visible only if the object of the data container that con
 
 A practical example would be a web shop in which the user must submit both billing and delivery information. In this case, you might not wish to bother the user with a second set of address input fields unless they indicate that the billing address and delivery address are not the same. You can accomplish this by making the delivery address fields conditionally visible based on the Boolean attribute `SameBillingAndDeliveryAddress`.
 
-##### Based on Attribute Value{#visibility-based-on-attribute-value}
+##### Based on Value {#visibility-based-on-attribute-value}
 
-When selected, this shows the widget while a particular attribute has a certain value. 
+When selected, this shows the widget while a chosen value matches specific values. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet.
 
 {{% alert color="info" %}}
 Visibility based on an attribute value can be set only for widgets that are inside data containers (a data view, list view, or data grid). 
@@ -390,7 +408,11 @@ The visibility of the billing address depends whether the customer checks that t
 
 ##### Based on Expression{#visibility-based-on-expression}
 
-When selected, this shows the widget while a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as a `$currentObject` variable. The expression can access objects of all the data containers enclosing that data container widget and variables defined on the page or snippet. These objects are available under the name of the widget they originate from (for example, `$dataView1`).
+When selected, this shows the widget while a provided [expression](/refguide/expressions/) evaluates to true. The expression may use the variables listed in the expression editor, including:
+
+- `$currentObject`, representing the object of the closest enclosing data container.
+- The objects of any enclosing data container, available under the name of the widget that exposes them (for example `$dataView1`).
+- [Parameters](/refguide/page-properties/#parameters) and [variables](/refguide/page-properties/#variables) defined on the page or snippet.
 
 For example, you might want a button to only be visible if a condition is met. Assume the object has an attribute called `myAttribute`, and you want the button to be visible only if `myAttribute` actually has a value stored. To achieve this goal put this expression into the field: `$currentObject/myAttribute != empty`.
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -171,7 +171,7 @@ For example, imagine you are creating a personal details form in which the end-u
 
 #### Based on Value
 
-When selected, this enables the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can choose what options enable the widget.
+When selected, this enables the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can select which options enable the widget.
 
 Only Boolean and enumeration attributes can be used for this purpose.
 
@@ -267,9 +267,9 @@ There are three options, described below:
 This mode only applies to values of type Decimal.
 {{% /alert %}}
 
-If set to *Fixed*, the decimal part always will be displayed with the number of places specified in the [Decimal precision](#decimal-precision) property. The value will be rounded using the method defined in the [Rounding](/refguide/app-settings/#rounding) section of **App Settings**.
+If set to **Fixed**, the decimal part always will be displayed with the number of places specified in the [Decimal precision](#decimal-precision) property. The value will be rounded using the method defined in the [Rounding](/refguide/app-settings/#rounding) section of **App Settings**.
 
-If set to *Auto*, the whole decimal part of the value will be displayed. No decimal part will be displayed if the value is an integer.
+If set to **Auto**, the whole decimal part of the value will be displayed. No decimal part will be displayed if the value is an integer.
 
 Default: *Fixed*
 
@@ -389,7 +389,7 @@ A practical example would be a web shop in which the user must submit both billi
 
 ##### Based on Value {#visibility-based-on-attribute-value}
 
-When selected, this shows the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can choose what options show the widget.
+When selected, this shows the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can select which options show the widget.
 
 {{% alert color="info" %}}
 Visibility based on an attribute value can be set only for widgets that are inside data containers (a data view, list view, or data grid). 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -171,7 +171,9 @@ For example, imagine you are creating a personal details form in which the end-u
 
 #### Based on Value
 
-When selected, this enables the widget while a chosen value matches specific values. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet.
+When selected, this enables the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can choose what options enable the widget.
+
+Only Boolean and enumeration attributes can be used for this purpose.
 
 #### Based on Expression
 
@@ -229,7 +231,7 @@ For each parameter in the template, you define a source for the value. The value
 
 ##### Value Parameter Type
 
-When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet. Number and Date Time value types offer formatting options.
+When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container. Number and Date Time value types offer formatting options.
 
 ##### Expression Parameter Type
 
@@ -387,7 +389,7 @@ A practical example would be a web shop in which the user must submit both billi
 
 ##### Based on Value {#visibility-based-on-attribute-value}
 
-When selected, this shows the widget while a chosen value matches specific values. The source of the value can be an attribute of an enclosing data container, or a [variable](/refguide/page-properties/#variables) defined on the page or snippet.
+When selected, this shows the widget while a chosen value matches specific options. The source of the value can be an attribute of an enclosing data container. Using the checkboxes you can choose what options show the widget.
 
 {{% alert color="info" %}}
 Visibility based on an attribute value can be set only for widgets that are inside data containers (a data view, list view, or data grid). 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -71,7 +71,7 @@ The style property allows you to specify additional CSS styling. If a class is a
 
 ### Dynamic Classes{#dynamicclasses}
 
-The dynamic classes property allows you to specify one or more cascading stylesheet (CSS) class like the class property, but based on an [expression](/refguide/expressions/). This allows you to dynamically construct classes based on data from an enclosing data container. The dynamic classes constructed in the expression are appended to the classes defined in the [`Class`](#class) property.
+The dynamic classes property allows you to specify one or more cascading stylesheet (CSS) class like the class property, but based on an [expression](/refguide/expressions/). This allows you to dynamically construct classes based on data from an enclosing data container or a variable on the page or snippet. The dynamic classes constructed in the expression are appended to the classes defined in the [`Class`](#class) property.
 
 {{< figure src="/attachments/refguide/modeling/pages/common-widget-properties/dynamic-classes.png" class="no-border" >}}
 
@@ -97,13 +97,13 @@ Some widgets, for example snippets and building blocks, have a **Documentation**
 
 {{< figure src="/attachments/refguide/modeling/pages/common-widget-properties/data-source-section.png" alt="Data Source Section" class="no-border" >}}
 
-### Attribute(Path)
+### Value
 
-This property identifies an attribute which is used in an input widget.
+This property identifies the value which is used in an input widget.
 
-#### Attribute Input Elements
+#### Input Elements
 
-With the following widgets, the Attribute (Path) specifies the attribute which is being changed (or displayed) by the widget:
+With the following widgets, the property specifies the value which is being changed (or displayed) by the widget:
 
 * [Text Box](/refguide/text-box/)
 * [Text Area](/refguide/text-area/)
@@ -112,19 +112,20 @@ With the following widgets, the Attribute (Path) specifies the attribute which i
 * [Radio Buttons](/refguide/radio-buttons/)
 * [Date Picker](/refguide/date-picker/)
 
-The attribute can be one of the following:
+The value can be one of the following:
 
 1. An attribute of the entity of the data container that contains the widget.
 2. An attribute of the entity of any enclosing data container that contains the widget. 
 3. An attribute of an entity associated with the data container entity by following one or more associations of type reference through the domain model.
+4. A variable defined on the page or snippet that contains the widget.
 
-In the first two cases we say the widget is connected to an **attribute** and in the third case to an **attribute path**.
+In the first two cases we say the widget is connected to an **attribute**, in the third case to an **attribute path**, and in the last case to a **variable**.
 
 You can edit attributes of any enclosing data container including grandparent data containers.
 
 #### Association Input Elements
 
-For widgets which manipulate associations, the Attribute (Path) specifies an attribute which is from an entity which is reachable from the current data container using an association. This applies to the following input elements:
+For widgets which manipulate associations, the value specifies an attribute which is from an entity which is reachable from the current data container using an association. This applies to the following input elements:
 
 * [Reference Selector](/refguide/reference-selector/)
 * [Reference Set Selector](/refguide/reference-set-selector/)
@@ -174,7 +175,7 @@ When selected, this enables the widget when a particular attribute has a certain
 
 #### Based on Expression
 
-When selected, this enables the widget when a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as the `$currentObject` variable.
+When selected, this enables the widget when a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as the `$currentObject` variable. Objects of all data containers surrounding the widget and variables on the page or snippet are available as well.
 
 The expression provided is evaluated in the browser and, currently, does not support all the functions that are available in microflows. The autocomplete function will only list those functions which are supported.
 
@@ -226,13 +227,13 @@ For each parameter in the template, you define an attribute of the context entit
 
 {{< figure src="/attachments/refguide/modeling/pages/common-widget-properties/numeric-formatting-section.png" alt="Numeric Formatting Section" class="no-border" >}}
 
-Formatting describes the way that numeric attributes are displayed. These are attributes of the following data types:
+Formatting describes the way that numeric values are displayed. These are attributes or variables of the following data types:
 
 * Decimal
 * Integer
 * Long
 
-When a widget contains a numeric attribute, the **Formatting** section allows you to change the way it is displayed.
+When a widget contains a numeric value, the **Formatting** section allows you to change the way it is displayed.
 
 There are three options, described below:
 
@@ -243,12 +244,12 @@ There are three options, described below:
 ### Decimal Mode{#decimal-mode}
 
 {{% alert color="info" %}}
-This mode only applies to attributes of type Decimal.
+This mode only applies to values of type Decimal.
 {{% /alert %}}
 
 If set to *Fixed*, the decimal part always will be displayed with the number of places specified in the [Decimal precision](#decimal-precision) property. The value will be rounded using the method defined in the [Rounding](/refguide/app-settings/#rounding) section of **App Settings**.
 
-If set to *Auto*, the whole decimal part of the attribute value will be displayed. No decimal part will be displayed if the attribute value is an integer.
+If set to *Auto*, the whole decimal part of the value will be displayed. No decimal part will be displayed if the value is an integer.
 
 Default: *Fixed*
 
@@ -267,7 +268,7 @@ Default: *Fixed*
 ### Decimal Precision{#decimal-precision}
 
 {{% alert color="info" %}}
-This only applies to attributes of type Decimal and is available only when the [Decimal mode](#decimal-mode) is set to **Fixed**.
+This only applies to values of type Decimal and is available only when the [Decimal mode](#decimal-mode) is set to **Fixed**.
 {{% /alert %}}
 
 The precision of a value describes the number of decimal places that are used to express that value. This property indicates the number of decimal places (the number of digits following the point).
@@ -329,7 +330,7 @@ There are a number of variables you can use in your expression:
 * `$value` – the current member (attribute or association) value
 
 {{% alert color="info" %}}
-The expression can access objects of **all** the data containers enclosing the input widget. The objects are given the name of the widget they originate from (for example, `$dataView1`).
+The expression can access objects of **all** the data containers enclosing the input widget and variables defined on the page or snippet. The objects are given the name of the widget they originate from (for example, `$dataView1`).
 {{% /alert %}}
 
 When a validation is set and it fails for this widget, the message you specify will be shown before the user can use the value in the app.
@@ -389,7 +390,7 @@ The visibility of the billing address depends whether the customer checks that t
 
 ##### Based on Expression{#visibility-based-on-expression}
 
-When selected, this shows the widget while a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as a `$currentObject` variable. The expression can access objects of all the data containers enclosing that data container widget. These objects are available under the name of the widget they originate from (for example, `$dataView1`).
+When selected, this shows the widget while a provided [expression](/refguide/expressions/) evaluates to true. The object of the containing data container is available inside an expression as a `$currentObject` variable. The expression can access objects of all the data containers enclosing that data container widget and variables defined on the page or snippet. These objects are available under the name of the widget they originate from (for example, `$dataView1`).
 
 For example, you might want a button to only be visible if a condition is met. Assume the object has an attribute called `myAttribute`, and you want the button to be visible only if `myAttribute` actually has a value stored. To achieve this goal put this expression into the field: `$currentObject/myAttribute != empty`.
 

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -125,7 +125,7 @@ You can edit attributes of any enclosing data container including grandparent da
 
 #### Association Input Elements
 
-For widgets which manipulate associations, the value specifies an attribute which is from an entity which is reachable from the current data container using an association. This applies to the following input elements:
+For widgets which manipulate associations, the value specifies an attribute that is reachable from an enclosing data container using one or more associations. This applies to the following input elements:
 
 * [Reference Selector](/refguide/reference-selector/)
 * [Reference Set Selector](/refguide/reference-set-selector/)

--- a/content/en/docs/refguide/modeling/pages/common-widget-properties.md
+++ b/content/en/docs/refguide/modeling/pages/common-widget-properties.md
@@ -231,7 +231,7 @@ For each parameter in the template, you define a source for the value. The value
 
 ##### Value Parameter Type
 
-When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container. Number and DateTime value types offer formatting options.
+When selected, the chosen value is used as the value of the parameter. The source of the value can be an attribute of an enclosing data container. Number and date value types offer formatting options.
 
 ##### Expression Parameter Type
 

--- a/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
@@ -53,7 +53,7 @@ The values for the platform property are:
 The list of **Variables** defined on the snippet. Variables are non-persistent, primitive values that can be used as attributes by widgets in the snippet. They behave the same as [variables on pages](/refguide/page-properties/#variables), with the exception that default values cannot reference snippet parameters.
 
 {{% alert color="info" %}}
-[Snippet extraction](#extract-snippet) does not automatically recreate variables in the resulting snippet. Missing variables mut be added manually.
+[Snippet extraction](#extract-snippet) does not automatically recreate variables in the resulting snippet. Missing variables must be added manually.
 {{% /alert %}}
 
 {{% alert color="info" %}}

--- a/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
@@ -53,11 +53,11 @@ The values for the platform property are:
 The list of **Variables** defined on the snippet. Variables are non-persistent, primitive values that can be used as attributes by widgets in the snippet. They behave the same as [variables on pages](/refguide/page-properties/#variables), with the exception that default values cannot reference snippet parameters.
 
 {{% alert color="info" %}}
-[Snippet extraction](#extract-snippet) does not automatically recreate variables in the resulting snippet. Missing variables need to be added manually.
+[Snippet extraction](#extract-snippet) does not automatically recreate variables in the resulting snippet. Missing variables mut be added manually.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-[Inlining a snippet](https://docs.mendix.com/refguide/snippet-call/#inline-snippet) does not automatically create variables on a page. Missing variables need to be added manually. If the snippet and the page have identically named variables, references will automatically carry over.
+[Inlining a snippet](/refguide/snippet-call/#inline-snippet) does not automatically create variables on a page. Missing variables must be added manually. If the snippet and the page have identically named variables, then references will automatically carry over.
 {{% /alert %}}
 
 ### Designer Section {#designer}

--- a/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/snippet.md
@@ -48,6 +48,18 @@ The values for the platform property are:
 
 **Snippet Parameters** works the same way as [Page Parameter](/refguide/page-properties/#parameters) with the difference that a snippet's parameter can be accessed at the top level, for example when creating expressions or selecting attributes.
 
+#### Variables {#variables}
+
+The list of **Variables** defined on the snippet. Variables are non-persistent, primitive values that can be used as attributes by widgets in the snippet. They behave the same as [variables on pages](/refguide/page-properties/#variables), with the exception that default values cannot reference snippet parameters.
+
+{{% alert color="info" %}}
+[Snippet extraction](#extract-snippet) does not automatically recreate variables in the resulting snippet. Missing variables need to be added manually.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+[Inlining a snippet](https://docs.mendix.com/refguide/snippet-call/#inline-snippet) does not automatically create variables on a page. Missing variables need to be added manually. If the snippet and the page have identically named variables, references will automatically carry over.
+{{% /alert %}}
+
 ### Designer Section {#designer}
 
 #### Canvas Width

--- a/content/en/docs/refguide/modeling/pages/page/_index.md
+++ b/content/en/docs/refguide/modeling/pages/page/_index.md
@@ -129,7 +129,7 @@ To delete an element from a page, select this element and press <kbd>Delete</kbd
 The top bar of the Page Editor features both the **Parameters** and **Variables** buttons. These allow you to change the parameters or variables for a page. Both buttons display the current number of parameters or variables in their caption. Additionally, the tooltip of the parameters button will list all parameters and their type, while the tooltip of the variables button lists each variable and its type.
 
 
-For more information about page parameters and variables, refer to the [Data section](/refguide/page-properties/#data) in *Page Properties*.
+For more information about page parameters and variables, see the [Data](/refguide/page-properties/#data) section in *Page Properties*.
 
 ## Page Editor Modes {#page-editor-modes}
 

--- a/content/en/docs/refguide/modeling/pages/page/_index.md
+++ b/content/en/docs/refguide/modeling/pages/page/_index.md
@@ -124,9 +124,12 @@ You can cut/copy/paste elements on a page to different apps in Studio Pro if the
 
 To delete an element from a page, select this element and press <kbd>Delete</kbd> or right-click an element and select **Delete** in a drop-down menu. 
 
-### Changing the Parameters of a Page {#change-parameters}
+### Changing Page Parameters and Variables {#change-parameters}
 
-To change the parameters of the page, click the **Parameters** button in the top bar. This opens a dialog box which allows you to add, modify, and remove parameters. The **Parameters** button shows the current number of parameters in its caption, while its tooltip shows the name and type of each parameter. For more information about page parameters, see the [Parameters](/refguide/page-properties/#parameters) section in *Page Properties*.
+The top bar of the Page Editor features both the **Parameters** and **Variables** buttons. These allow you to change the parameters or variables for a page. Both buttons display the current number of parameters or variables in their caption. Additionally, the tooltip of the parameters button will list all parameters and their type, while the tooltip of the variables button lists each variable and its type.
+
+
+For more information about page parameters and variables, refer to the [Data section](/refguide/page-properties/#data) in *Page Properties*.
 
 ## Page Editor Modes {#page-editor-modes}
 

--- a/content/en/docs/refguide/modeling/pages/page/page-properties.md
+++ b/content/en/docs/refguide/modeling/pages/page/page-properties.md
@@ -101,7 +101,7 @@ You can also use multiple page parameters. Multiple page parameters allow you to
 
 The list of variables defined on this page. The variables can be used by widgets directly without the need for a [data view](/refguide/data-view/).
 
-Variables represent non-persistant, primitive values that are available to widgets on a page. Widgets can read and write to them as they were attributes, supporting features like formatting and validation. Variables are also available in expressions, so you can use them for page logic, such as conditional visibility, editability, and as parameters to microflows and nanoflows.
+Variables represent non-persistant, primitive values that are available to widgets on a page. Widgets can read and write to them as they were attributes, supporting features like formatting and validation. Variables are also available in expressions, so you can use them for page logic, such as conditional visibility, editability, text template parameters, and as arguments to microflows and nanoflows.
 
 You can also define a default value for variables. The expression is used to instantiate the variable at runtime and can make use of page parameters. Note that the default value is only set once for the lifetime of the page: A variable using the attribute of a page parameter will not receive updates made to the attribute as long as the page is open.
 
@@ -110,7 +110,7 @@ Variables for pages were introduced in Mendix Studio Pro 10.21.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-For apps with [React Client](/refguide/mendix-client/react) set to **Yes** or **Migration mode**, all widgets can use variables. When turned off, widgets built with Dojo cannot use variables.  
+For apps with [React Client](/refguide/mendix-client/react) set to **Yes** or **Migration mode**, all widgets can use variables. When turned off, widgets built with Dojo cannot use variables. Regardless of the React Client setting, all widgets on native pages can use variables.  
 Note that Dojo widgets may force neighboring widgets to be Dojo as well. To counteract this, a widget that normally accepts variables can be wrapped in a container.
 {{% /alert %}}
 

--- a/content/en/docs/refguide/modeling/pages/page/page-properties.md
+++ b/content/en/docs/refguide/modeling/pages/page/page-properties.md
@@ -110,8 +110,9 @@ Variables for pages were introduced in Mendix Studio Pro 10.21.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-For apps with [React Client](/refguide/mendix-client/react) set to **Yes** or **Migration mode**, all widgets can use variables. When turned off, widgets built with Dojo cannot use variables. Regardless of the React Client setting, all widgets on native pages can use variables.  
-Note that Dojo widgets may force neighboring widgets to be Dojo as well. To counteract this, a widget that normally accepts variables can be wrapped in a container.
+For apps with [React Client](/refguide/mendix-client/react) set to **Yes** or **Migration mode**, all widgets can use variables. When set to **No**, widgets built with Dojo cannot use variables. If present, unsupported widgets will be listed on the variables dialog.  
+
+Note that Dojo widgets may affect neighboring widgets as well. For example, they may lose their ability to use variables in conditional visibility expressions. To counteract this, the affected widget can be wrapped in a container.
 {{% /alert %}}
 
 ### Usage Section {#usage}

--- a/content/en/docs/refguide/modeling/pages/page/page-properties.md
+++ b/content/en/docs/refguide/modeling/pages/page/page-properties.md
@@ -97,6 +97,23 @@ A page parameter is an input that needs to be passed from the calling page, micr
 
 You can also use multiple page parameters. Multiple page parameters allow you to easily use multiple objects on a page that are not associated with each other. Using multiple page parameters, you can pass multiple arguments when opening a page, the same as with microflows and nanoflows.
 
+#### Variables {#variables}
+
+The list of variables defined on this page. The variables can be used by widgets directly without the need for a [data view](/refguide/data-view/).
+
+Variables represent non-persistant, primitive values that are available to widgets on a page. Widgets can read and write to them as they were attributes, supporting features like formatting and validation. Variables are also available in expressions, so you can use them for page logic, such as conditional visibility, editability, and as parameters to microflows and nanoflows.
+
+You can also define a default value for variables. The expression is used to instantiate the variable at runtime and can make use of page parameters. Note that the default value is only set once for the lifetime of the page: A variable using the attribute of a page parameter will not receive updates made to the attribute as long as the page is open.
+
+{{% alert color="info" %}}
+Variables for pages were introduced in Mendix Studio Pro 10.21.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+For apps with [React Client](/refguide/mendix-client/react) set to **Yes** or **Migration mode**, all widgets can use variables. When turned off, widgets built with Dojo cannot use variables.  
+Note that Dojo widgets may force neighboring widgets to be Dojo as well. To counteract this, a widget that normally accepts variables can be wrapped in a container.
+{{% /alert %}}
+
 ### Usage Section {#usage}
 
 #### Mark as Used

--- a/content/en/docs/refguide/modeling/pages/page/page-properties.md
+++ b/content/en/docs/refguide/modeling/pages/page/page-properties.md
@@ -101,9 +101,11 @@ You can also use multiple page parameters. Multiple page parameters allow you to
 
 The list of variables defined on this page. The variables can be used by widgets directly without the need for a [data view](/refguide/data-view/).
 
-Variables represent non-persistant, primitive values that are available to widgets on a page. Widgets can read and write to them as they were attributes, supporting features like formatting and validation. Variables are also available in expressions, so you can use them for page logic, such as conditional visibility, editability, text template parameters, and as arguments to microflows and nanoflows.
+Variables represent non-persistent, primitive values that are available to widgets on a page. Widgets can read and write to them as they were attributes, supporting features like formatting and validation. Variables are also available in expressions, so you can use them for page logic, such as conditional visibility, editability, text template parameters, and as arguments to microflows and nanoflows.
 
-You can also define a default value for variables. The expression is used to instantiate the variable at runtime and can make use of page parameters. Note that the default value is only set once for the lifetime of the page: A variable using the attribute of a page parameter will not receive updates made to the attribute as long as the page is open.
+You can also define a default value for variables. The expression is used to instantiate the variable at runtime and can make use of page parameters. 
+
+Note that the default value is only set once for the lifetime of the page. Thus, a variable using the attribute of a page parameter will not receive updates made to the attribute as long as the page is open.
 
 {{% alert color="info" %}}
 Variables for pages were introduced in Mendix Studio Pro 10.21.


### PR DESCRIPTION
This PR adds instructions on how to use variables on pages and snippets.

As the feature changes the UI and terminology in several places, we will submit a follow-up PR updating outdated references.