### PR TITLE
Release notes and documentation changes for Mx4PC 2.21.1 (planned for release around March 12)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -965,7 +965,7 @@ If your app works without issues when read-only root filesystem is enabled, it i
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Enabling the `runtimeReadOnlyRootFilesystem` option will cause the `model/resources` directory to be empty. If your app (or Marketplace modules such as SAML) uses the `model/resources` directory for resources such as configuration data and other resources, consider moving those resources to another location (such as `model/userlib`) or loading them from FileDocument entities.
+Enabling the `runtimeReadOnlyRootFilesystem` option causes the `model/resources` directory to be empty. If your app (or a Marketplace module such as SAML) uses the `model/resources` directory for resources such as configuration data, consider moving those resources to another location (for example, `model/userlib`) or loading them from FileDocument entities.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -194,13 +194,13 @@ kind: OperatorConfiguration
 # omitted lines for brevity
 # ...
 spec:
-  baseOSImageTagTemplate: 'ubi8-1-jre{{.JavaVersion}}-entrypoint'
+  baseOSImageTagTemplate: 'ubi9-1-jre{{.JavaVersion}}-entrypoint'
 ```
 
 At the moment, the `baseOSImageTagTemplate` can be set to one of the following values:
 
-* `ubi8-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 8 Micro images; this is the default option.
-* `ubi9-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 9 Micro images; this option can be used to use a newer OS and improve security scores.
+* `ubi8-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 8 Micro images; this option can be used for some cases where backward compatibility is needed.
+* `ubi9-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 9 Micro images; this is the default option.
 
 {{% alert color="info" %}}
 
@@ -962,6 +962,10 @@ In addition to internal Mendix Runtime paths, `/tmp` is mounted for any temporar
 
 {{% alert color="info" %}}
 If your app works without issues when read-only root filesystem is enabled, it is best to enable it wherever possible. We recommend using a non-production environment to validate that your app keeps working correctly with a read-only RootFS.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+Enabling the `runtimeReadOnlyRootFilesystem` option will cause the `model/resources` directory to be empty. If your app (or Marketplace modules such as SAML) uses the `model/resources` directory for resources such as configuration data and other resources, consider moving those resources to another location (such as `model/userlib`) or loading them from FileDocument entities.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,14 +12,14 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
-### March ???, 2025
+### March 10, 2025
 
 #### Mendix Operator v2.21.1 {#2.21.1}
 
 * We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
-* For new installations, the Operator will now use ubi9 as the base image for Mendix apps. Existing installations will keep their configuration and stay on ubi8. For more information on base image versions, see the [Runtime Base Image](/developerportal/deploy/private-cloud-cluster/#runtime-base-image) section.
-* We've fixed a regression that caused the `model/resources` directory to appear empty, and caused problems with some Marketplace modules such as SAML (Ticket 242648).
-* Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+* For new installations, the Operator now uses ubi9 as the base image for Mendix apps. Existing installations will keep their configuration and stay on ubi8. For more information on base image versions, see the [Runtime Base Image](/developerportal/deploy/private-cloud-cluster/#runtime-base-image) section.
+* We have fixed a regression that caused the `model/resources` directory to appear empty and caused problems with some Marketplace modules, such as SAML (Ticket 242648).
+* Upgrading to Mendix Operator v2.21.0 from a previous version now restarts environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### March 6, 2025
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
+### March ???, 2025
+
+#### Mendix Operator v2.21.1 {#2.21.1}
+
+* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
+* For new installations, the Operator will now use ubi9 as the base image for Mendix apps. Existing installations will keep their configuration and stay on ubi8. For more information on base image versions, see the [Runtime Base Image](/developerportal/deploy/private-cloud-cluster/#runtime-base-image) section.
+* We've fixed a regression that caused the `model/resources` directory to appear empty, and caused problems with some Marketplace modules such as SAML (Ticket 242648).
+* Upgrading to Mendix Operator v2.21.0 from a previous version will restart environments managed by that version of the Operator. Environments with 2 or more replicas and a **PreferRolling** update strategy will be restarted without downtime.
+
 ### March 6, 2025
 
 #### Portal Improvements
@@ -39,6 +48,12 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Important Upgrade Information
 
 With the introduction of ephemeral storage requests and limits, building an app requires at least 2 GB of ephemeral storage available on the Kubernetes node. If your nodes do not have enough temporary storage, the build pods cannot start and their status remains **Pending**. To resolve this issue, you can lower the values for `ephemeral-storage` in the [buildResources](/developerportal/deploy/private-cloud-cluster/#resource-definition-ocm) configuration.
+
+#### Known Issue
+
+This issue has been fixed in Mendix Operator [version 2.21.1](#2.21.1).
+
+* The `model/resources` directory is empty when starting the app, causing issues with some Marketplace modules (such as SAML) that use that location to store configuration data and other resources.
 
 ### February 12, 2025
 


### PR DESCRIPTION
We're planning to release a patch version of the Mendix for Private Cloud Operator, and are planning to release it in the middle of next week.