### PR TITLE
Documentation fixes

### DIFF
--- a/content/en/docs/deployment/mx-azure/mx-azure-getting-started.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-getting-started.md
@@ -19,7 +19,7 @@ To adopt Mendix on Azure, you need to have the following:
 * As an optional best practice, add multiple cluster manager to your clusters
 * An Azure account with the following permissions:
     * Permission to grant admin consent on the Mendix on Azure portal app registration
-    * Owner role assigned on the target subscription level
+    * Owner role assigned on the target subscription
 
 {{% alert color="info" %}} To comply with the principle of least privilege, you can also create a custom role for the Mendix Operator instead of assigning the Owner or Contributor role. For the required permissions, see below:
 

--- a/content/en/docs/deployment/mx-azure/mx-azure-getting-started.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-getting-started.md
@@ -19,7 +19,7 @@ To adopt Mendix on Azure, you need to have the following:
 * As an optional best practice, add multiple cluster manager to your clusters
 * An Azure account with the following permissions:
     * Permission to grant admin consent on the Mendix on Azure portal app registration
-    * Owner or Contributor role assigned on the target subscription level
+    * Owner role assigned on the target subscription level
 
 {{% alert color="info" %}} To comply with the principle of least privilege, you can also create a custom role for the Mendix Operator instead of assigning the Owner or Contributor role. For the required permissions, see below:
 

--- a/content/en/docs/deployment/mx-azure/mx-azure-installation.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-installation.md
@@ -17,7 +17,7 @@ Before starting the installation and implementation process, make sure that you 
 
 * Obtain and configure a Microsoft Azure account. For more information, refer to the the Microsoft Azure documentation.
 * Purchase the Mendix on Azure offering in the [Azure Marketplace](https://azuremarketplace.microsoft.com/).
-* The Azure account used to purchasing the offering **must** also be used to sign-in to Mendix on Azure portal. Otherwise the cluster will not be visible for initialization.
+* You must sign in to the Mendix on Azure portal with the same Azure account that was used to purchasing the offering. If you sign in with another account, the cluster is not visible for initialization.
 
 {{< figure src="/attachments/deployment/mx-azure/coadmin-permission.png" class="no-border" >}}
 

--- a/content/en/docs/deployment/mx-azure/mx-azure-installation.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-installation.md
@@ -17,7 +17,7 @@ Before starting the installation and implementation process, make sure that you 
 
 * Obtain and configure a Microsoft Azure account. For more information, refer to the the Microsoft Azure documentation.
 * Purchase the Mendix on Azure offering in the [Azure Marketplace](https://azuremarketplace.microsoft.com/).
-* Enable co-access permissions for the offering.
+* The Azure account used to purchasing the offering **must** also be used to sign-in to Mendix on Azure portal. Otherwise the cluster will not be visible for initialization.
 
 {{< figure src="/attachments/deployment/mx-azure/coadmin-permission.png" class="no-border" >}}
 


### PR DESCRIPTION
- Documentation incorrectly states that Contributor role on subscription will also suffice for deployment, but reality is that Owner role is required.
- Clarify same account needs to be used on Azure Portal and Mendix on Azure