### PR TITLE
Update .NET version in 9.24 ref guide

### DIFF
--- a/content/en/docs/refguide9/general/install.md
+++ b/content/en/docs/refguide9/general/install.md
@@ -102,11 +102,11 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 5. Rename the following dependencies:
     * Microsoft .NET Desktop Runtime
         * For Studio Pro versions 9.0.0 through 9.24.33, rename the Microsoft .NET Desktop Runtime 6.0.x
-            * On x64, rename *windowsdesktop-runtime-6.0.35-win-x64.exe* to *windowsdesktop-runtime-6.  0-x64.exe*
-            * On ARM64, rename *windowsdesktop-runtime-6.0.35-win-arm64.exe* to *windowsdesktop-runtime-6.  0-arm64.exe*
+            * On x64, rename *windowsdesktop-runtime-6.0.35-win-x64.exe* to *windowsdesktop-runtime-6.0-x64.exe*
+            * On ARM64, rename *windowsdesktop-runtime-6.0.35-win-arm64.exe* to *windowsdesktop-runtime-6.0-arm64.exe*
         * For Studio Pro versions 9.24.34 and above, rename the Microsoft .NET Desktop Runtime 8.0.x
-            * On x64, rename *windowsdesktop-runtime-8.0.14-win-x64.exe* to *windowsdesktop-runtime-8.  0-x64.exe*
-            * On ARM64, rename *windowsdesktop-runtime-8.0.14-win-arm64.exe* to *windowsdesktop-runtime-8.  0-arm64.exe*
+            * On x64, rename *windowsdesktop-runtime-8.0.14-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
+            * On ARM64, rename *windowsdesktop-runtime-8.0.14-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
     * The Java Development Kit 11 or 17 (x64) *msi* (for example, *OpenJDK17U-jdk_x64_windows_hotspot_17.0.10_7.msi*) to one of the following, depending on the Studio Pro version:
         * *adoptiumjdk_17_x64.msi* – for versions 9.24.16 and above
         * *adoptiumjdk_11_x64.msi* – for versions between 9.14.0 and 9.24.15 

--- a/content/en/docs/refguide9/general/install.md
+++ b/content/en/docs/refguide9/general/install.md
@@ -61,7 +61,11 @@ Sometimes you can run into problems when installing Studio Pro. One work-around 
 
 The prerequisites are the following:
 
-* [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – Mendix recommends using version 6.0.6 or above
+* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
+    | --- | --- |
+    |  [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – Mendix recommends using version 6.0.6 or above | [Microsoft .NET Desktop Runtime 8.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) – Mendix recommends using version 8.0.14 or above |
+    
+   
 * Java JDK
      
     * For Mendix Studio Pro 9.24.16 and above – [Eclipse Temurin JDK 17 (x64)](https://github.com/adoptium/temurin17-binaries/releases)
@@ -96,7 +100,9 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 3. Create a folder with the name **Dependencies** in the same location where the Mendix Studio Pro installer was placed.
 4. Download the prerequisites listed in the [Troubleshooting](#troubleshooting) section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
-    * The Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe*
+    * | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
+    | --- | --- |
+    | The Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe* | The Microsoft .NET Desktop Runtime 8.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-8.0-x64.exe* |
     * The Java Development Kit 11 or 17 (x64) *msi* (for example, *OpenJDK17U-jdk_x64_windows_hotspot_17.0.10_7.msi*) to one of the following, depending on the Studio Pro version:
         * *adoptiumjdk_17_x64.msi* – for versions 9.24.16 and above
         * *adoptiumjdk_11_x64.msi* – for versions between 9.14.0 and 9.24.15 

--- a/content/en/docs/refguide9/general/install.md
+++ b/content/en/docs/refguide9/general/install.md
@@ -100,9 +100,13 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 3. Create a folder with the name **Dependencies** in the same location where the Mendix Studio Pro installer was placed.
 4. Download the prerequisites listed in the [Troubleshooting](#troubleshooting) section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
-    * | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
-    | --- | --- |
-    | The Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe* | The Microsoft .NET Desktop Runtime 8.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-8.0-x64.exe* |
+    * Microsoft .NET Desktop Runtime
+        * For Studio Pro versions 9.0.0 through 9.24.33, rename the Microsoft .NET Desktop Runtime 6.0.x
+            * On x64, rename *windowsdesktop-runtime-6.0.35-win-x64.exe* to *windowsdesktop-runtime-6.  0-x64.exe*
+            * On ARM64, rename *windowsdesktop-runtime-6.0.35-win-arm64.exe* to *windowsdesktop-runtime-6.  0-arm64.exe*
+        * For Studio Pro versions 9.24.34 and above, rename the Microsoft .NET Desktop Runtime 8.0.x
+            * On x64, rename *windowsdesktop-runtime-8.0.14-win-x64.exe* to *windowsdesktop-runtime-8.  0-x64.exe*
+            * On ARM64, rename *windowsdesktop-runtime-8.0.14-win-arm64.exe* to *windowsdesktop-runtime-8.  0-arm64.exe*
     * The Java Development Kit 11 or 17 (x64) *msi* (for example, *OpenJDK17U-jdk_x64_windows_hotspot_17.0.10_7.msi*) to one of the following, depending on the Studio Pro version:
         * *adoptiumjdk_17_x64.msi* – for versions 9.24.16 and above
         * *adoptiumjdk_11_x64.msi* – for versions between 9.14.0 and 9.24.15 

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -40,9 +40,9 @@ The following frameworks are required. They will be installed automatically by t
 
 If you are running Studio Pro on an ARM64 device (for example, an M1 Mac), you need the following version of .NET in addition to the x64 version listed above:
 
-* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
-  | --- | --- |
-  | .NET 6 Desktop Runtime (arm64) | .NET 8 Desktop Runtime (arm64) |
+| Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
+| --- | --- |
+| .NET 6 Desktop Runtime (arm64) | .NET 8 Desktop Runtime (arm64) |
 
 {{% alert color="info" %}}
 You can choose which JDK is used for building and running locally via the **Edit** > **Preferences** menu item in Studio Pro.

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -20,7 +20,12 @@ Mendix [Studio Pro](/refguide9/modeling/) version 9 is supported on 64-bit versi
 
 The following frameworks are required. They will be installed automatically by the Studio Pro installer if necessary:
 
-* Microsoft .NET 6.0.x desktop runtime (x64) and all applicable Windows security patches
+* Microsoft .NET desktop runtime (x64) and all applicable Windows security patches
+
+    | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
+    | --- | --- |
+    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime |
+    
 * Microsoft Visual C++ 2015 Redistributable Package (x64)
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
 * A Java Developer Kit (JDK) version 11, 17, or 21 - the flavor which will be installed if the correct version of Java is not already installed on your machine—this depends on which version of Studio Pro you are installing
@@ -33,9 +38,11 @@ The following frameworks are required. They will be installed automatically by t
 * Microsoft Edge WebView2 Evergreen Runtime (x64)
 * For Studio Pro 9.24 and above: Gradle version 8.5 or above (if your Java version is 11 or 17, Gradle version 7.6 or above will also work) - if Gradle is not yet installed on your machine, Mendix will install Gradle version 8.5
 
-If you are running Studio Pro on an ARM64 device (for example, an M1 Mac), you need the following version of .NET 6 in addition to the x64 version listed above:
+If you are running Studio Pro on an ARM64 device (for example, an M1 Mac), you need the following version of .NET in addition to the x64 version listed above:
 
-* .NET 6 Desktop Runtime (arm64)
+* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
+  | --- | --- |
+  | .NET 6 Desktop Runtime (arm64) | .NET 8 Desktop Runtime (arm64) |
 
 {{% alert color="info" %}}
 You can choose which JDK is used for building and running locally via the **Edit** > **Preferences** menu item in Studio Pro.


### PR DESCRIPTION
Starting from 9.24.34 the dotnet prerequisite changed to NET8. These changes reflect that in the documentation

The publication of these changes should match with the release of 9.24.34