### PR TITLE
Remove mention of Documentation URL for Building Block

### DIFF
--- a/content/en/docs/refguide/modeling/pages/page-resources/building-block.md
+++ b/content/en/docs/refguide/modeling/pages/page-resources/building-block.md
@@ -41,10 +41,6 @@ The category is used to group building blocks inside the **Toolbox**.
 
 The category weight determines the order of categories inside the **Toolbox** (in ascending order). If building blocks with the same category have different category weights, the lowest is used to determine the position.
 
-### Documentation URL
-
-The documentation URL can be used to link to a documentation page for the building block. These links will appear in the **Building Blocks** tab of Studio Pro's **Toolbox**.
-
 ## Common Properties
 
 {{% snippet file="/static/_includes/refguide/common-section-link.md" %}}


### PR DESCRIPTION
We're removing the Documentation URL field from Building Block properties.