### PR TITLE
Remove duplicate {#widgets} key

### DIFF
--- a/content/en/docs/refguide/runtime/mendix-client/react.md
+++ b/content/en/docs/refguide/runtime/mendix-client/react.md
@@ -53,7 +53,7 @@ Review the prerequisites below that your application must fulfill before it can 
 
 The React client was introduced in Mendix 10.7.0 as a [beta feature](/releasenotes/beta-features/). It became general availability in [Mendix 10.18](/releasenotes/studio-pro/10.18/) as an opt-in feature.
 
-### Widgets{#widgets}
+### Widgets{#widgets-prerequisites}
 
 Widgets must fulfill the following requirements to be compatible with apps leveraging the React client:
 
@@ -99,7 +99,7 @@ Not all Mendix Marketplace components are ready for the React client. Refer to [
 
 Mendix recommends refreshing all Marketplace components in your app before enabling the React client.
 
-### Widgets{#widgets}
+### Widgets{#supported-widgets}
 
 Not all widgets are supported by the React client. Mendix recommends migrating widgets in apps below [10.18](/releasenotes/studio-pro/10.18/) using the automatic conversion capabilities in Studio Pro (right-click a widget and select **Convert in-place**). For a list of configuration options unsupported by automatic conversions, see [Widget Conversion Limitations](/refguide/mendix-client/widget-conversion-limitations/).
 

--- a/content/en/docs/releasenotes/studio-pro/10/10.19.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.19.md
@@ -78,7 +78,7 @@ We added **View Entities** to the domain model editor. A view entity represents 
 * We changed the way that OpenTelemetry is [configured](/refguide/tracing-in-runtime/#min-configuration) for the tracing beta. The project should now run with the OpenTelemetry Java agent in order to configure and enable tracing. The runtime settings related to tracing were removed. 
 * We made the usage of the [variable name](/refguide/java-actions/#variable-name) more consistent when adding Java or JavaScript action calls from the **Toolbox**, toolbar, App Explorer, or **Logic Recommender**.
 * We expanded the message that is logged when a runtime operation fails to be executed for security reasons with a short description of that runtime operation.
-* We updated the [widget conversions](/refguide/mendix-client/react/#widgets) to a combo box to include the read-only style of a drop-down, a reference selector and an input reference set selector.
+* We updated the [widget conversions](/refguide/mendix-client/react/#supported-widgets) to a combo box to include the read-only style of a drop-down, a reference selector and an input reference set selector.
 * We updated the External Database Connector, which now supports connecting to any database by using the Java dependency specified by the user for the respective database in the module settings.
 * We updated remaining button labels in the **Changes** pane to use **local** and **server** instead of **mine** and **theirs** for selecting the source when resolving file conflicts.
 


### PR DESCRIPTION
There were two {#widgets} keys, so the last one redirected to the first one higher up on the page.