### PR TITLE
Added KI for MaxRetrieveSize

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.20.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.20.md
@@ -3,6 +3,7 @@ title: "10.20"
 url: /releasenotes/studio-pro/10.20/
 description: "The release notes for Mendix Studio Pro 10.20 (including all patches) with details on new features, bug fixes, and known issues."
 weight: 80
+# KI: "`MaxRetrieveSize` runtime setting": UFC-1518 
 ---
 
 ## 10.20.0 {#10200}
@@ -115,4 +116,5 @@ This setting is relevant only for apps that:
 
 ### Known Issues
 
-* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)
+* The `MaxRetrieveSize` runtime setting also affects **Synchronization** and **Retrieve by Association** actions in microflows. 
+    * Workaround – Change the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)

--- a/content/en/docs/releasenotes/studio-pro/10/10.20.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.20.md
@@ -112,3 +112,7 @@ This setting is relevant only for apps that:
 2. Have users that are marked as web service user, and
 3. Have clients accessing published OData and/or REST services using the credentials of one of these web service users,
 4. Are unable to delete these web service users and recreate them as regular users. 
+
+### Known Issues
+
+* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)

--- a/content/en/docs/releasenotes/studio-pro/10/10.21.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.21.md
@@ -3,6 +3,7 @@ title: "10.21"
 url: /releasenotes/studio-pro/10.21/
 description: "The release notes for Mendix Studio Pro 10.21 (including all patches) with details on new features, bug fixes, and known issues."
 weight: 79
+# KI: "`MaxRetrieveSize` runtime setting": UFC-1518 
 ---
 ## 10.21.1 {#10211}
 
@@ -16,7 +17,8 @@ weight: 79
 
 ### Known Issues
 
-* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)
+* The `MaxRetrieveSize` runtime setting also affects **Synchronization** and **Retrieve by Association** actions in microflows. 
+    * Workaround – Change the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)
 
 ## 10.21.0 {#10210}
 
@@ -178,4 +180,5 @@ This improvement simplifies widget code. Widget developers no longer need to set
 
 * <a id="ki-installer-certification"></a>The installer for Studio Pro 10.21.0 is not properly signed with the official Mendix code signing certificate. Because of this, Windows/Edge may show warnings or errors when downloading and/or installing this version (depending on your Windows Smart App Control/SmartScreen settings). This issue will be resolved in Studio Pro 10.21.1.
     * Fixed in [10.21.1](#fix-installer-certification)
-* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)
+* The `MaxRetrieveSize` runtime setting also affects **Synchronization** and **Retrieve by Association** actions in microflows. 
+    * Workaround – Change the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)

--- a/content/en/docs/releasenotes/studio-pro/10/10.21.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.21.md
@@ -14,6 +14,10 @@ weight: 79
 
 * <a id="fix-installer-certification"></a> We fixed a [known issue](#ki-installer-certification) where the previous installer was not properly digitally signed, which could trigger security warnings from Windows or Microsoft Edge during download and installation. 
 
+### Known Issues
+
+* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)
+
 ## 10.21.0 {#10210}
 
 **Release date: March 25, 2025**
@@ -174,3 +178,4 @@ This improvement simplifies widget code. Widget developers no longer need to set
 
 * <a id="ki-installer-certification"></a>The installer for Studio Pro 10.21.0 is not properly signed with the official Mendix code signing certificate. Because of this, Windows/Edge may show warnings or errors when downloading and/or installing this version (depending on your Windows Smart App Control/SmartScreen settings). This issue will be resolved in Studio Pro 10.21.1.
     * Fixed in [10.21.1](#fix-installer-certification)
+* The `MaxRetrieveSize` runtime setting also affects synchronization and retrieve by association in microflows. As a workaround, you can set the setting to a number higher than the amount of objects that should be retrieved. This issue will be resolved in Studio Pro 10.22.0. (Ticket 245365)


### PR DESCRIPTION
The new MaxRetrieveSize setting has unforeseen consequences. We will add a KI for now and revert the changes in the next Mendix version