### PR TITLE
Remove Max Retrieve Size runtime setting

### DIFF
--- a/content/en/docs/refguide/runtime/custom-settings/_index.md
+++ b/content/en/docs/refguide/runtime/custom-settings/_index.md
@@ -275,15 +275,7 @@ The settings below influence the behavior of the Mendix web client.
 | <a id="commendixwebuiFeedbackSizeWarningThreshold" href="#commendixwebuiFeedbackSizeWarningThreshold">com.<wbr>mendix.<wbr>webui.<wbr>FeedbackSizeWarningThreshold</a> | A warning is logged when the feedback size exceeds the threshold. Feedback is sent from server to client to instruct (for example, to refresh objects or to open a page). They are serialized as "instructions" in the server response. If there are too many instructions, this can have performance implications, as they all have to be serialized to the client. For this reason, a warning is logged when the threshold is exceeded. | 5000 |
 | <a id="commendixwebuiStateSizeWarningThreshold" href="#commendixwebuiStateSizeWarningThreshold">com.<wbr>mendix.<wbr>webui.<wbr>StateSizeWarningThreshold</a> | A warning is logged when the state size exceeds the threshold. The state consists of changes in objects and of objects not committed to the database (yet). If there is too much state, this will have performance implications, as the whole state has to be serialized to the client. For this reason, a warning is logged when the threshold is exceeded. | 100 |
 | <a id="commendixwebuiCommittedObjectsThreshold" href="#commendixwebuiCommittedObjectsThreshold">com.<wbr>mendix.<wbr>webui.<wbr>CommittedObjectsThreshold</a> | The threshold controls how much data is sent back to the client after executing a microflow. By default, we send back full objects when they are changed or committed. When this threshold is reached, only object GUIDs are sent back instead so that the client knows about the changes while the amount of data sent over the network is reduced. The client will then retrieve the objects later on, if needed. | 100 |
-| <a id="MaxRetrieveSize" href="#MaxRetrieveSize">MaxRetrieveSize</a> | The maximum number of objects the client is allowed to retrieve in a single [XAS request](/refguide/communication-patterns/#RO). This limit exists to prevent malicious actors from being able to overload the runtime by requesting a large number of objects in a single request. | 1000 |
 
-### Max Retrieve Size{#MaxRetrieveSize}
-
-The `MaxRetrieveSize` limits the number of objects that the runtime will return in a single request.
-
-When requesting more objects than allowed with a `retrieve_by_ids` XAS request, the runtime will throw an error: ``retrieve_by_ids action tried to retrieve more objects than allowed by the `MaxRetrieveSize`. Amount of guids requested: (...), max amount of objects allowed: (...)``
-
-When requesting more objects than allowed with a `retrieve`, `retrieve_by_path`, or `retrieve_by_xpath` XAS requests, the runtime will enforce the `MaxRetrieveSize` by setting a limit on the query and will log the following warning: ``A retrieve action requested more objects than allowed by the `MaxRetrieveSize` runtime setting. Amount requested: (...), allowed: (...).``
 
 ## Metrics Settings{#metrics-settings}
 

--- a/content/en/docs/releasenotes/mobile/native-template/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/_index.md
@@ -6,8 +6,6 @@ weight: 12
 description: "Native Template release notes."
 ---
 
-{{% todo %}}[replace 10.22 mention with link to RNs upon release]{{% /todo %}} 
-
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [Build a Mendix Native App in the Cloud](/refguide/mobile/distributing-mobile-apps/building-native-apps/deploying-native-app/) guide. Below you can see the current versions in active development and which Mendix Studio Pro versions they correspond with.
 
 Compatible with Studio Pro 10:

--- a/content/en/docs/releasenotes/mobile/native-template/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/_index.md
@@ -6,6 +6,8 @@ weight: 12
 description: "Native Template release notes."
 ---
 
+{{% todo %}}[replace the 10.22 mention with a link to RNs upon release]{{% /todo %}} 
+
 For more information on native mobile app development, see the [native-template](https://github.com/mendix/native-template/) repository and [Build a Mendix Native App in the Cloud](/refguide/mobile/distributing-mobile-apps/building-native-apps/deploying-native-app/) guide. Below you can see the current versions in active development and which Mendix Studio Pro versions they correspond with.
 
 Compatible with Studio Pro 10:

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-10-parent/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-10-parent/_index.md
@@ -5,8 +5,6 @@ weight: 10
 description: "Studio Pro 10 compatible Native Template release notes."
 ---
 
-{{% todo %}}[replace 10.22 mention with link to RNs upon release]{{% /todo %}} 
-
 These are the current Native Template versions for Studio Pro 10 in active development:
 
 * Native Template versions of [14](/releasenotes/mobile/nt-14-rn/) are compatible with apps built using the following versions of Studio Pro:

--- a/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-10-parent/_index.md
+++ b/content/en/docs/releasenotes/mobile/native-template/nt-studio-pro-10-parent/_index.md
@@ -5,6 +5,8 @@ weight: 10
 description: "Studio Pro 10 compatible Native Template release notes."
 ---
 
+{{% todo %}}[replace the 10.22 mention with a link to RNs upon release]{{% /todo %}} 
+
 These are the current Native Template versions for Studio Pro 10 in active development:
 
 * Native Template versions of [14](/releasenotes/mobile/nt-14-rn/) are compatible with apps built using the following versions of Studio Pro:


### PR DESCRIPTION
This setting will be removed, as it is incurring a KI. Once it's removed, we can remove the KI from RNs.