### PR TITLE
New env. variables description added for Splunk and New Relic integrations

### DIFF
--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/newrelic-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/newrelic-metrics.md
@@ -50,6 +50,8 @@ To send your runtime information to New Relic, you must provide the New Relic AP
     | `NEW_RELIC_METRICS_URI` | URI for the New Relic's Metrics API. For more information, consult [New Relic Regions](#uri-regions). Example: `https://metric-api.eu.newrelic.com/metric/v1`. |
     | `NEW_RELIC_APP_NAME` (optional) | Mendix Application name shown on New Relic's APM & Services. Default: Domain host name. |
     | `LOGS_REDACTION` (optional) | Email addresses are automatically redacted before log entries are sent to New Relic. To disable this redaction, set `LOGS_REDACTION` to `false`. Default: `true`. |
+    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing of this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
+    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they're processed or flushed to storage/output. Limits memory which can be consumed by Fluentbit agent | `50MB` |  
 
 1. Return to the **Environments** page for your app and **Deploy** or **Transport** your app into the selected environment.
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/newrelic-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/newrelic-metrics.md
@@ -39,24 +39,24 @@ To make use of New Relic, you need a New Relic API key. To find an existing key 
 To send your runtime information to New Relic, you must provide the New Relic API key to your environment.
 
 1. From [Apps](https://sprintr.home.mendix.com), go to the **Environments** page of your app.
-1. Click **Details** on the environment you wish to monitor with New Relic. 
+1. Click **Details** on the environment you wish to monitor with New Relic.
 1. Switch to the **Runtime** tab.
 1. Add the following **Custom Environment Variables**:
 
-    | Variable | Description |
-    | --- | --- |
-    | `NEW_RELIC_LICENSE_KEY` | License key or API key from New Relic. Obtained in the [New Relic API Key](#newrelic-api-key) section.
-    | `NEW_RELIC_LOGS_URI` | URI for the New Relic's Logs API. For more information, consult [New Relic Regions](#uri-regions). Example: `https://log-api.eu.newrelic.com/log/v1`. |
-    | `NEW_RELIC_METRICS_URI` | URI for the New Relic's Metrics API. For more information, consult [New Relic Regions](#uri-regions). Example: `https://metric-api.eu.newrelic.com/metric/v1`. |
-    | `NEW_RELIC_APP_NAME` (optional) | Mendix Application name shown on New Relic's APM & Services. Default: Domain host name. |
-    | `LOGS_REDACTION` (optional) | Email addresses are automatically redacted before log entries are sent to New Relic. To disable this redaction, set `LOGS_REDACTION` to `false`. Default: `true`. |
-    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing of this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
-    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they're processed or flushed to storage/output. Limits memory which can be consumed by Fluentbit agent | `50MB` |  
+    | Variable | Description | Default |
+    | --- | --- | --- |
+    | `NEW_RELIC_LICENSE_KEY` | License key or API key from New Relic. Obtained in the [New Relic API Key](#newrelic-api-key) section. | |
+    | `NEW_RELIC_LOGS_URI` | URI for the New Relic's Logs API. For more information, consult [New Relic Regions](#uri-regions). Example: `https://log-api.eu.newrelic.com/log/v1`. | |
+    | `NEW_RELIC_METRICS_URI` | URI for the New Relic's Metrics API. For more information, consult [New Relic Regions](#uri-regions). Example: `https://metric-api.eu.newrelic.com/metric/v1`. | |
+    | `NEW_RELIC_APP_NAME` (optional) | Mendix Application name shown on New Relic's APM & Services. Default: Domain host name. | |
+    | `LOGS_REDACTION` (optional) | Email addresses are automatically redacted before log entries are sent to New Relic. To disable this redaction, set `LOGS_REDACTION` to `false`. Default: `true`. ||
+    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
+    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they are processed or flushed to storage/output. Limits memory which can be consumed by the Fluentbit agent | `50MB` |
 
 1. Return to the **Environments** page for your app and **Deploy** or **Transport** your app into the selected environment.
 
     {{% alert color="warning" %}}To start sending data to New Relic, you must redeploy your app and then restart it. Just restarting the app is not sufficient because additional dependencies need to be included.{{% /alert %}}
-    
+
 ## Tagging Metrics for New Relic
 
 To help you with analyzing your app metrics as described in the [App Metrics](/developerportal/operate/monitoring-with-apm/#app-metrics) section of *Monitoring Your Mendix Apps with an APM Tool*, Mendix adds tags to metrics from microflows and activities when using New Relic.
@@ -86,7 +86,7 @@ Mendix recommends using the following tags:
 To set these tags, do the following:
 
 1. From [Apps](https://sprintr.home.mendix.com), go to the **Environments** page of your app.
-1. Click **Details** on an environment you are monitoring with New Relic. 
+1. Click **Details** on an environment you are monitoring with New Relic.
 1. On the **Tags** tab, add a tag. This is the string that is sent to New Relic as a tag.
 1. Restart the app.
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/splunk-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/splunk-metrics.md
@@ -42,7 +42,8 @@ To send your runtime information to Splunk Cloud Platform, you need to set it up
     | `SPLUNK_PORT` | The HTTP (or HTTPS) port of the Splunk Cloud Platform Controller. | `8088` |
     | `SPLUNK_TOKEN` | An access token to the Splunk Cloud Platform. To create a new token on the Splunk Cloud dashboard, open the Splunk Cloud dashboard in a browser, go to **Settings** > **Data Input** > **HTTP Event Collector**, and click **New Token** (on the upper-right corner of the page). | |
     | `LOGS_REDACTION` | Email addresses are automatically redacted before log entries are sent to Splunk Cloud Platform. To disable this redaction, set `LOGS_REDACTION` to `false`. The environment variable `SPLUNK_LOGS_REDACTION` is still supported, but it is now deprecated and will be removed in a later version. Its use is not recommended. | `true` |
-
+    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing of this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
+    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they're processed or flushed to storage/output. Limits memory which can be consumed by Fluentbit agent | `50MB` |   
 1. Return to the **Environments** page for your app and **Deploy** or **Transport** your app into the selected environment.
 
     {{% alert color="warning" %}}The first time you set up the Splunk Cloud Platform integration, you must redeploy your app and then restart it. Just restarting the app is not sufficient because additional dependencies need to be included.{{% /alert %}}

--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/splunk-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/splunk-metrics.md
@@ -32,7 +32,7 @@ To use the Splunk Cloud Platform and send data to Splunk Cloud Platform from you
 To send your runtime information to Splunk Cloud Platform, you need to set it up using environment variables in the Mendix Portal.
 
 1. From [Apps](https://sprintr.home.mendix.com), go to the **Environments** page of your app.
-1. Click **Details** on the environment you wish to monitor with Splunk Cloud Platform. 
+1. Click **Details** on the environment you wish to monitor with Splunk Cloud Platform.
 1. Switch to the [**Runtime** tab](/developerportal/deploy/environments-details/#runtime-tab).
 1. Add the following **Custom Environment Variables**.
 
@@ -42,8 +42,9 @@ To send your runtime information to Splunk Cloud Platform, you need to set it up
     | `SPLUNK_PORT` | The HTTP (or HTTPS) port of the Splunk Cloud Platform Controller. | `8088` |
     | `SPLUNK_TOKEN` | An access token to the Splunk Cloud Platform. To create a new token on the Splunk Cloud dashboard, open the Splunk Cloud dashboard in a browser, go to **Settings** > **Data Input** > **HTTP Event Collector**, and click **New Token** (on the upper-right corner of the page). | |
     | `LOGS_REDACTION` | Email addresses are automatically redacted before log entries are sent to Splunk Cloud Platform. To disable this redaction, set `LOGS_REDACTION` to `false`. The environment variable `SPLUNK_LOGS_REDACTION` is still supported, but it is now deprecated and will be removed in a later version. Its use is not recommended. | `true` |
-    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing of this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
-    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they're processed or flushed to storage/output. Limits memory which can be consumed by Fluentbit agent | `50MB` |   
+    | `FLUENTBIT_LOGS_BUFFER_SIZE` | Sets the maximum amount of data (in KB) that the TCP input plugin reads from the socket per read operation. Increasing this value can help to get rid of data flow delay, and errors related to queue buffer overflow.  | `128` |
+    | `FLUENTBIT_LOGS_MEM_BUF_LIMIT` | Defines the maximum total memory an input plugin can use for buffering log records before they are processed or flushed to storage/output. Limits memory which can be consumed by the Fluentbit agent | `50MB` |
+
 1. Return to the **Environments** page for your app and **Deploy** or **Transport** your app into the selected environment.
 
     {{% alert color="warning" %}}The first time you set up the Splunk Cloud Platform integration, you must redeploy your app and then restart it. Just restarting the app is not sufficient because additional dependencies need to be included.{{% /alert %}}
@@ -71,7 +72,7 @@ You can also set up custom tags in the format `key:value`. Mendix recommends add
 To set these tags, do the following:
 
 1. From [Apps](https://sprintr.home.mendix.com), go to the **Environments** page of your app.
-1. Click **Details** on an environment you are monitoring with Splunk. 
+1. Click **Details** on an environment you are monitoring with Splunk.
 1. Switch to the **Tags** tab.
 1. Click **Add** and type in the string to be sent to Splunk as a tag.
 1. Restart the app.

--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -15,7 +15,7 @@ Follow the links in the table below to see the release notes you want:
 
 | Type of Deployment | Last Updated |
 | --- | --- |
-| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | February 27, 2025 |
+| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | April 17, 2025 |
 | [Mendix for Private Cloud](/releasenotes/developer-portal/mendix-for-private-cloud/) | March 20, 2025 |
 | [Mendix on Azure](/releasenotes/developer-portal/mendix-on-azure/) | March 20, 2025 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | August 27, 2024 |

--- a/content/en/docs/releasenotes/deployment/mendix-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud.md
@@ -16,6 +16,12 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## 2025
 
+### April 17, 2025
+
+#### Improvements
+
+* We have added new environment variables which allow you to control the buffer size and buffer memory for the Fluentbit agent for Splunk and New Relic.
+
 ### February 27, 2025
 
 #### Improvements


### PR DESCRIPTION
Planned 17 April

Added env variables description: FLUENTBIT_LOGS_BUFFER_SIZE and FLUENTBIT_LOGS_MEM_BUF_LIMIT. Related PR: https://github.com/mendix/cf-mendix-buildpack/pull/864/files