### PR TITLE
Update how-to-set-up-your-partner-profile.md

### DIFF
--- a/content/en/docs/community-tools/how-to-set-up-your-partner-profile.md
+++ b/content/en/docs/community-tools/how-to-set-up-your-partner-profile.md
@@ -1,59 +1,80 @@
 ---
-title: "Set Up Your Partner Profile"
+title: "Setting Up Your Partner Profile"
 url: /community-tools/how-to-set-up-your-partner-profile/
 weight: 5
-description: "Describes how to configure the various parts of your Mendix Partner Profile, such as projects."
+description: "Describes how to configure the various parts of your Mendix Partner Profile."
 aliases:
     - /developerportal/community-tools/how-to-set-up-your-partner-profile/
 ---
 
-## 1. Introduction
-The Partner Finder is a platform that allows Mendix partners to showcase their organization, services, and successful customer projects to (potential) clients.
+## Introduction
 
-## 2. Prerequisites
-- An active Mendix account
-- Partner status with Mendix 
-- Partner Admin rights (If you need Partner Admin access, please contact your Partner Manager)
+The Partner Finder allows Mendix partners to showcase their organization, services, and successful customer projects.  
 
-## 3. Accessing the Partner Finder
-1. Log in to your Mendix account at https://partners.home.mendix.com
-2. Click on your avatar in the top right corner
-3. Select 'Partner Admin' from the dropdown menu
+A Partner Profile within the Partner Finder is a simple and clear way for each partner to present themselves through such details as the number of developers in the organization, the company's projects, customer reviews, contact information, a company video, and a description.
 
-## 4. Setting Up Your Profile
-### 4.1 Basic Information
-On the Profile Page, you can add the following information:
-1. Public Website and Logo
-2. Contact Information:
-   - Email address
-   - Phone number
-   - Headquarters location
-3. Organization description
-4. Mendix-related professional and managed services
-5. Industry-specific competencies and experience
-6. Service areas where you operate
+## Prerequisites
 
-## 5. Managing Administrators
-### 5.1 Adding Admins
-1. Navigate to the Admins Page
-2. Click on 'Invite Member'
-3. Enter the email address of the Mendix user you want to invite
+Before you begin, make sure you have the following:
 
-**Note:** Invited admins must have an active Mendix account before they can be added.
+* An active Mendix account
+* Partner status with Mendix 
+* Partner Admin rights—If you need Partner Admin rights, contact your Partner Manager.
+  
+## Accessing the Partner Finder
 
-## 6. Publishing Projects
-### 6.1 Adding Project References
-1. Go to the Projects tab
-2. Click "Add Projects" in the top-right corner
-3. On the Project Editing Page, provide:
-   - Project Summary (title, industry, timeframe)
-   - Client information
-   - Business value metrics
-   - Project details
-   - Team member information (optional)
+Follow these steps to access the Partner Finder:
 
-### 6.2 Project Guidelines
-- Did you already have projects available in the old partner profile (Mendix Developers - Meet Our Partners)? These can be automatically imported into your new profile by using the migration button.
-- Ensure you have customer approval for publishing project references
+1. Log in to your Mendix account at https://partners.home.mendix.com.
+2. Click on your picture in the top right corner.
+3. Select **Partner Admin** from the dropdown menu.
 
-For technical support or questions, contact partnerfinder@mendix.com
+## Setting Up Your Profile
+
+Access the Profile page and add the following information:
+
+* Your public website
+* Your partner logo
+* Your contact information:
+    * Email address
+    * Phone number
+    * Headquarters location
+* Your organization's description
+* Mendix-related professional and managed services
+* Industry-specific competencies and experience
+* Service areas where you operate
+
+## Adding Admins
+
+Every Profile needs an Admin. Follow these steps to add one:
+
+1. Navigate to the **Admins** page.
+2. Click **Invite Member**.
+3. Enter the email address of the Mendix user you want to invite.
+
+{{% alert color="info" %}}Invited Admins must have an active Mendix account before they can be added.{{% /alert %}}
+
+## Publishing Projects
+
+Follow these steps to publish projects to your Partner Profile:
+
+1. Access the **Projects** tab.
+2. Click **Add Projects** in the top right corner.
+3. On the project editing page, add these pieces of information:
+
+   * Project Summary, such as title, industry, and timeframe
+   * Client information
+   * Business value metrics
+   * Project details
+   * Team member information (optional)
+
+If you already had projects in the old partner profile, they can be automatically imported into your new profile by using the migration button.
+
+{{% alert color="info" %}}Ensure you have customer approval for publishing project references.{{% /alert %}}
+
+For technical support or questions, contact partnerfinder@mendix.com.
+
+## Read More
+
+* [Mendix Profile](/community-tools/mendix-profile/)
+* [Mendix Community](/community-tools/mendix-community/)

--- a/content/en/docs/community-tools/how-to-set-up-your-partner-profile.md
+++ b/content/en/docs/community-tools/how-to-set-up-your-partner-profile.md
@@ -7,188 +7,53 @@ aliases:
     - /developerportal/community-tools/how-to-set-up-your-partner-profile/
 ---
 
-## Introduction
-
-The purpose of the Partner Profile is to provide the Mendix community and customers with a transparent overview of each partner company's knowledge, skills, experience, reviews, and culture. The profile is a simple and clear way for each partner to present themselves through an aggregated view of the developers in the organization, including the number of certified developers. It is also possible to add projects, customer reviews, contact information, a company video, and a description to each profile.
-
-This how-to teaches you how to do the following:
-
-* Set up and edit the Mendix Partner Profile
-* Add projects to the profile
-* Add developers to the profile
-
-## Prerequisites
-
-Before starting this how-to, make sure you have completed the following prerequisite:
-
-* Have a Mendix Profile (register [here](https://www.mendix.com/try-now/?utm_source=documentation&utm_medium=community&utm_campaign=signup) and see [Mendix Profile](/community-tools/mendix-profile/))
-
-## Signing In to the Partner Profile
-
-To sign in to the Partner Profile, edit it, and make it public, follow these steps:
-
-1. Sign in to your own Mendix Profile [here](https://developer.mendixcloud.com/openid/login?immediate=true&continuation=link/ownprofile/). Now Mendix knows who you are and which company is attached to your account.
-2. At the top of your Community Profile, you will see your role and company (for example, "Senior Developer at **Finaps**"). When your company is a partner, the company name is clickable. Click your company name to go to its Partner Profile. 
-3. If you are authorized as a Partner Profile Editor, click **Edit Partner Profile** to edit the profile:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/edit-partner-profile.png" class="no-border" >}}
-
-    If you are not authorized to edit the profile but your colleagues are, a list with their email addresses is shown. To gain access to editing the profile, you can contact them so that they can add you as an editor (for details, see the [Changing the Profile Editor](#editors) section). If none of your colleagues are authorized, click **Feedback** on the right side of the screen and submit a feedback item to gain access.<br>
-
-4. Once you are in edit mode, click the form field to edit the Partner Profile:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/edit-profile-field.png" class="no-border" >}}
-    
-    For details about editing, start with the [Editing the Overview](#editing) section below.<br>
-
-5. After you have finished editing, you can make the profile public so that the Mendix community and customers can view it. To do this, simply click **Save and Exit**:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/close-edit.png"  width="343px" class="no-border" >}}
-
-## Editing the Partner Profile Header
-
-### Header Elements
-
-The header of your Partner Profile has important contact details about your company:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/header.png"   width="400"  class="no-border" >}}
-
-You must complete the **Address** and **Email Address** fields before you can make your Partner Profile public (the email address will allow customers to contact you via the **Contact us** button). So, click **Edit Profile** and add this information to the header:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/address.png"   width="550"  class="no-border" >}}
-
-### Capability Levels {#capability}
-
-The header also displays whether the company is **Authorized**, **Expert**, or **Professional**. These capability levels are defined as follows:
-
-* **Authorized** — this type of partner has qualified and certified resources to support customers with Mendix initiatives 
-* **Platform** — this type of partner can support an enterprise in its successful positioning and adoption of the Mendix Platform with all elements of the Mendix "4 P's" (portfolio, people, process, and platform; for details, see [How to Implement Bimodal IT: Focus on the 4 P’s](https://www.mendix.com/blog/how-to-implement-bimodal-it-focus-on-the-4-ps/))
-* **Global** — this type of partner can help an enterprise with large scale programs spanning multiple countries or regions across the globe
-
-A capability level is determined through an assessment of your company's delivery expertise, project references, and Mendix Developer Certification levels. For more information, please contact your Mendix Customer Success Manager.
-
-## Editing the Overview {#editing}
-
-Follow these steps to edit the most important fields on your Partner Profile:
-
-1. Add a **Summary Title** and a company **Summary**:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/summary.png" class="no-border" >}}
-
-2. Add a company **Video** (YouTube or Vimeo) or **Project**:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/video.png"  class="no-border" >}}
-
-    Selecting **Project** will link a project that you have added on the **Projects** tab of the Partner Profile (for more details, see the [Adding Projects](#projects) section below).<br>
-
-3. Add your company's focus **Industries**. These will be used in the filter options on the **Meet our partners** page so that Mendix customers can search for partners in a specific industry.
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/industries.png" class="no-border" >}}
-
-4. Select the **Types of Service** your company provides:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/service.png" class="no-border" >}}
-
-5. Under **Skills**, add the types of skills your company team members can perform:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/skills.png" class="no-border" >}}
-
-    For more information on company team members, see the [Editing Team Members](#team) section.
-
-6. In **Geographical Focus**, add the countries where your company is active and/or has coverage. This will be used in the filter option on the **Meet our partners** page so that Mendix customers can search for partners in a specific country.
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/geo-focus.png" class="no-border" >}}
-
-{{% alert color="info" %}}
-If you're missing an input option (for example, an industry or skill), click **Feedback** on the right side of the screen and let us know!
-{{% /alert %}}
-
-## Adding Projects {#projects}
-
-To add a project to your Partner Profile, go to the **Projects** tab and click **Add Project**:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/add-project.png" class="no-border" >}}
-
-This will open the project editor. There are tips in the editor for what you should enter in each field:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/project-editor.png" class="no-border" >}}
-
-All of the fields in the project editor must be filled out before submitting the project. Click **Submit** to save and submit your project:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/project-buttons.png"   width="245px"  class="no-border" >}}
-
-{{% alert color="warning" %}}
-All projects are reviewed by Mendix upon submission. After approval, the project will be shown in the **Published** project section.
-{{% /alert %}}
-
-Published projects are listed in the **Published** projects section, where the following buttons are available for each published project:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/published.png"   width="600"  class="no-border" >}}
-
-* Arrow buttons – moves the project up or down in the list of projects on your Partner Profile's **Projects** tab
-* **View** – opens the published project so you can view it
-* **Edit** – opens the project editor so you can make more edits
-* **Delete** – deletes the project
-
-If you do not want to publish a project right away, click **Save as draft** in the project editor. The project draft will be available in the **Unpublished** projects section for you to finish later where the following buttons are available for each project draft:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/unpublished.png"   width="450"  class="no-border" >}}
-
-* **Edit** – opens the project editor so you can make more edits on the draft
-* **Add Comment** — opens a dialog box where you can add a comment on the project draft; comments can be viewed in the **Unpublished** projects section
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/project-comment.png"   width="550"  class="no-border" >}}
-
-* **Delete** – deletes the project draft
-
-## Editing Team Members {#team}
-
-This section presents information on adding the most valuable assets of your company: your certified Mendix developers. Before you can add a developer to the Partner Profile, their Mendix Profile needs to be set to public (for details on how to do this, see the [Profile](/community-tools/mendix-profile/user-settings/#profile) section of *Mendix Profile*.
-
-To add developers to the Partner Profile, follow these steps:
-
-1. Go to the **Developers** tab, where all the certified Mendix developers in your company are shown:
-
-    {{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/team-members.png"   width="550"  class="no-border" >}}
-
-    You can use the **Sort by**, **Search**, and **Certification Level** features to find a specific team member.
-
-2. Select the active team members within your organization whose certifications you want to be visible on your Partner Profile by clicking **Add to profile**. The certification of each developer added to the profile will be visible in the statistics in the profile header, where numbers for **Rapid Developers**, **Advanced Developers**, **Expert Developers**, total **Mx Developers** (all developers added to the profile), and total **Mx Developers** (all existing developers) are displayed.
-
-    Only the certifications and points of the added developers will be counted in the Partner Profile. The highest rank of certification will be added to the overview.
-
-{{% alert color="info" %}}
-Make sure you offboard and deactivate the developers who no longer work at your company through [Control Center](/control-center/).
-{{% /alert %}}
-
-## Editing Testimonials
-
-On the **Testimonials** tab, all the testimonials on your company and projects are available. These testimonials are approved by your company's Profile Editor before they are displayed on the profile. 
-
-You can do further editing to the testimonials with the following buttons:
-
-{{< figure src="/attachments/community-tools/how-to-set-up-your-partner-profile/testimonials.png"   width="250"  class="no-border" >}}
-
-* **Edit** – opens the testimonial editor, where you can edit details of the testimonial
-* **Delete** – deletes the testimonial
-* **Show on profile** – displays the testimonial on your company's Partner Profile
-
-{{% alert color="warning" %}}
-Providing accurate testimonials is an important part of participating in the Mendix community, as is respecting the testimonials that have been given. So, while you are able to edit the details of a testimonial about your company, please respect the original intent of the writer of a testimonial that has already been approved by your company's Profile Editor.
-{{% /alert %}}
-
-## Changing the Profile Editor {#editors}
-
-To make a colleague a profile editor, follow these steps:
-
-1. On the Partner Profile, click the **Profile editor(s)** tab.
-2. The **Select profile editor(s)** dialog box displays all the employees of your company. Select the colleague who you want to make a profile editor.
-3. Click **Make Profile Editor**.
-
-## Sorting on the Partners Overview Page
-
-The [Meet Our Partners page](https://developerprofiles.mendix.com/link/partneroverview) is an overview that presents all the partners in the Mendix community. The sorting is based on a combination of the following KPIs:
-
-* Whether your company is Expert (which will get the most weight in sorting), Professional, or Authorized (for more information, see the [Capability Tracks](#capability) section)
-* The total amount of certified developers (note that developers with multiple certifications count as one certified developer)
-* The total number of projects you have published on your Partner Profile
+## 1. Introduction
+The Partner Finder is a platform that allows Mendix partners to showcase their organization, services, and successful customer projects to (potential) clients.
+
+## 2. Prerequisites
+- An active Mendix account
+- Partner status with Mendix 
+- Partner Admin rights (If you need Partner Admin access, please contact your Partner Manager)
+
+## 3. Accessing the Partner Finder
+1. Log in to your Mendix account at https://partners.home.mendix.com
+2. Click on your avatar in the top right corner
+3. Select 'Partner Admin' from the dropdown menu
+
+## 4. Setting Up Your Profile
+### 4.1 Basic Information
+On the Profile Page, you can add the following information:
+1. Public Website and Logo
+2. Contact Information:
+   - Email address
+   - Phone number
+   - Headquarters location
+3. Organization description
+4. Mendix-related professional and managed services
+5. Industry-specific competencies and experience
+6. Service areas where you operate
+
+## 5. Managing Administrators
+### 5.1 Adding Admins
+1. Navigate to the Admins Page
+2. Click on 'Invite Member'
+3. Enter the email address of the Mendix user you want to invite
+
+**Note:** Invited admins must have an active Mendix account before they can be added.
+
+## 6. Publishing Projects
+### 6.1 Adding Project References
+1. Go to the Projects tab
+2. Click "Add Projects" in the top-right corner
+3. On the Project Editing Page, provide:
+   - Project Summary (title, industry, timeframe)
+   - Client information
+   - Business value metrics
+   - Project details
+   - Team member information (optional)
+
+### 6.2 Project Guidelines
+- Did you already have projects available in the old partner profile (Mendix Developers - Meet Our Partners)? These can be automatically imported into your new profile by using the migration button.
+- Ensure you have customer approval for publishing project references
+
+For technical support or questions, contact partnerfinder@mendix.com


### PR DESCRIPTION
The parter finder & profile has been completely revamped. This describes how to set up a partner profile in the new way. 

Btw: this is part of the Community Section, but I would like to have a dedicated Partner section as a main section in the documentation. How can this be done?