### PR TITLE
[SOLP-3302] Remove mx.exe git-merge section from refguide.

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool/merge.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool/merge.md
@@ -26,9 +26,9 @@ These are the `OPTIONS`:
 | `--help` | | Shows help for the `mx diff` command and exits. |
 | `--loose-version-check` | `-l` | Makes the version check loose (meaning, it auto-converts if possible before diffing). |
 
-`BASE` is the first *.mpr* file, which is used as a base in comparison. 
+`BASE` is the first *.mpr* file, which is used as a base in comparison.
 
-`MINE` is the second *.mpr* file, which is used as the changed version in comparison. The output will contain the changes that are in this file against the base. 
+`MINE` is the second *.mpr* file, which is used as the changed version in comparison. The output will contain the changes that are in this file against the base.
 
 {{% alert color="info" %}}
 For example, if the `BASE` *.mpr* has Microflow1 and the `MINE` *.mpr* does not have it, Microflow1 will be listed as deleted in the output file. If you swap the `BASE` and `MINE` parameters and compare again, Microflow1 will be listed as added.{{% /alert %}}
@@ -95,14 +95,14 @@ This command works differently than the normal version-controlled merges you can
 
 ### Conflicts
 
-If there are conflicts during the merge, resolve them by opening the app in Studio Pro and selecting **Version Control** > [Merge Changes Here](/refguide/version-control-menu/#merge-changes-here). 
+If there are conflicts during the merge, resolve them by opening the app in Studio Pro and selecting **Version Control** > [Merge Changes Here](/refguide/version-control-menu/#merge-changes-here).
 
 The reason for this is that conflict resolution is a complex process that has two requirements:
 
 * The app has to be version-controlled
 * Your Git repository has to be in the merge state (Studio Pro does this when you click **Merge Changes Here**)
 
-This merge state is needed for Studio Pro to know what your current branch is and which branch you are trying to merge into it. This way, when you are trying to resolve the conflict using the `THEIRS` document, Studio Pro can download the document from the branch and put it into your current app. 
+This merge state is needed for Studio Pro to know what your current branch is and which branch you are trying to merge into it. This way, when you are trying to resolve the conflict using the `THEIRS` document, Studio Pro can download the document from the branch and put it into your current app.
 
 So, if you run this command from the command line specifying the three *.mpr* files but the result has conflicts, you will not be able to resolve the conflicts in the `MINE` app using the `THEIRS` documents by just opening the app in Studio Pro. Instead, you need to configure Git to use `mx merge` as a [merge driver](#merge-git-driver) for the *.mpr* files and trigger the merge from the Git command line (so the repository is put in the merge state for Studio Pro to be able to pick it up after the command is complete).
 
@@ -139,9 +139,9 @@ Studio Pro configures the merge driver for an app with the name **studiopro** wh
 
 This section outlines the necessary configuration to enable the [mx merge](#merge) command as a merge driver in Git. With this configuration, you can merge one branch into another using third-party version control tools and the Git command line.
 
-Normally, when you are merging branches with Git, it compares the file changes in both branches. If a certain file has been changed in both branches, this triggers a conflict. If conflicting files are text files, Git attempts to resolve it automatically (very often successfully). 
+Normally, when you are merging branches with Git, it compares the file changes in both branches. If a certain file has been changed in both branches, this triggers a conflict. If conflicting files are text files, Git attempts to resolve it automatically (very often successfully).
 
-However, if the conflicting files are Mendix apps, the conflict occurs in two .mpr files. Both the files and the conflict itself are more complex, which is why Studio Pro is needed to resolve them. 
+However, if the conflicting files are Mendix apps, the conflict occurs in two .mpr files. Both the files and the conflict itself are more complex, which is why Studio Pro is needed to resolve them.
 
 For such cases, Git provides an option to delegate conflict resolution for specific file types to an external tool. The `mx merge` command is designed to work with this mechanism, allowing Git to attempt merging the *.mpr* files as Studio Pro would. If conflicts remain, you can open Studio Pro and resolve them manually.
 
@@ -209,69 +209,3 @@ Now, if you open you app on the **Main** branch, you should see the following:
 {{% alert color="info" %}}
 When you get a different output, the custom merge drive is not configured correctly. Abort the merge using the command `$git merge --abort` and close the Git command line tool before making changes to the configuration. Changes made to the configuration *config* and *.gitattributes* files are picked up by reopening the Git command line tool.
 {{% /alert %}}
-
-## mx git-merge Command {#git-merge}
-
-The `mx git-merge` command performs a three-way merge of two *.mpr* files by  considering their common ancestor (base).
-The command is suitable for both [MPRv2 Format](/refguide/troubleshoot-repository-size/#mpr-format) and the [MPRv1 Format](/refguide/troubleshoot-repository-size/#mpr-format).  
-
-{{% alert color="warning" %}}
-The command should be used as a **merge driver** and not as a standalone command like [mx merge](#merge).
-{{% /alert %}}
-
-The input is three *.mpr* files: `BASE`, `MINE`, `THEIRS`, and three labels: `BASE_COMMIT`, `MINE_COMMIT` and `THEIRS_COMMIT` which are their respective revisions.
-
-### Usage
-
-{{% alert color="info" %}}
-Studio Pro configures the merge driver for an app with the name **studiopro** when  opening it in Studio Pro.
-{{% /alert %}}
-
-This section outlines the necessary configuration to enable the `mx git-merge` command as a merge driver in Git. With this configuration, you can merge one branch into another using third-party version control tools and the Git command line.
-
-Normally, when you are merging branches with Git, it compares the file changes in both branches. If a certain file has been changed in both branches, this triggers a conflict. If conflicting files are text files, Git attempts to resolve it automatically (very often successfully). 
-
-However, if the conflicting files are Mendix apps, the conflict occurs in two *.mpr* files. Both the files and the conflict itself are more complex, which is why Studio Pro is needed to resolve them.
-
-For such cases, Git provides an option to delegate conflict resolution for specific file types to an external tool. The `mx git-merge` command is designed to work with this mechanism, allowing Git to attempt merging the *.mpr* files as Studio Pro would. If conflicts remain, you can open Studio Pro and resolve them manually.
-
-{{% alert color="warning" %}}
-Currently `mx git-merge` supports merging MPRv2 with MPRv2 and MPRv1 with MPRv1. Merging MPRv2 with MPRv1 or MPRv1 with MPRv2 should be done in Studio Pro.
-{{% /alert %}} 
-
-### config File {#git-merge-config}
-
-Add the lines below to the *config* file located in the *.git* folder of your app.
-
-At the end of the file, add a `[merge "custommpr"]` block like in the example below:
-
-```ini
-[merge "custommpr"]
-    name = custom merge driver for MPR files
-    driver = [MX.EXE_PATH] git-merge %O %A %B %S %X %Y
-```
-
-and a `[merge "custommprcontent"]` block like this
-
-```ini
-[merge "custommprcontent"]
-    name = custom merge driver for mxunit files
-    driver = true
-```
-
-Replace `[MX.EXE_PATH]` with a full path to your *mx.exe* file in the Unix format (for example, `'/C/Program Files/Mendix/10.21.0.63213/modeler/mx.exe'`).
-
-{{% alert color="info" %}}
-The *.git* folder is a hidden folder in your computer file management system. You can view it when hidden items are visible.
-{{% /alert %}}
-
-With the `custommprcontent` merge driver you specify that all *.mxunit* files will be preserved from the default git merge driver. As all conflict are resolved inside the mx tool, there is no need to solve any conflicts in *.mxunit* separately -- mx tool does it together with resolving the mpr file conflict. The only side effect is that modified and deleted files remain unstaged. They should be staged manually using the git add command or within Studio Pro when committing the merge result.
-
-### attributes File
-
-Create the `attributes` file in *info* folder of *.git* directory of your app. Add the following line to instruct Git to use `[merge "custommpr"]` and `[merge "custommprcontent"]` drivers from the [config](#git-merge-config) section of this document for merging *.mpr* and *.mxunit* files.
-
-```ini
-*.mpr     merge=custommpr
-*.mxunit  merge=custommprcontent
-```

--- a/content/en/docs/refguide/version-control/version-control-troubleshooting/repository-size.md
+++ b/content/en/docs/refguide/version-control/version-control-troubleshooting/repository-size.md
@@ -10,7 +10,7 @@ description: "Explains consequences and root cause of a large repository size an
 
 In case you are experiencing performance issues when cloning or pulling your app, this may be caused by a large repository size. This document explains why your repository may be large, how Git handles it, and what you can do about this issue.
 
-## Causes of a Large Repository 
+## Causes of a Large Repository
 
 There are several reasons why your repository may be large. The most common reasons for a Mendix app are the following:
 
@@ -46,16 +46,16 @@ Version control systems like Git do not store a full copy of a document for ever
 MPRv2 was released in Studio Pro 10.18.0 as [Public Beta](/releasenotes/beta-features/). In Studio Pro 10.21.0, MPRv2 was released for General Availability (GA) and is automatically used for new apps.
 {{% /alert %}}
 
-Studio Pro 10.18 introduced a new version of the *.mpr* format: MPRv2. The key difference is that all documents, such as microflows, are no longer stored as part of the *.mpr* file but as separate files in the *mprcontents* directory. The *.mpr* file functions as an index file pointing to all the different files on disk. 
+Studio Pro 10.18 introduced a new version of the *.mpr* format: MPRv2. The key difference is that all documents, such as microflows, are no longer stored as part of the *.mpr* file but as separate files in the *mprcontents* directory. The *.mpr* file functions as an index file pointing to all the different files on disk.
 
-This means that when you change one document, for example, a page, only a small file representing that page will change on disk. This allows Git to calculate an efficient delta and results in a more appropriate repository growth compared to MPRv1. Functionally there is no differences between the split (v2) or the combined (v1) format inside Studio Pro. 
+This means that when you change one document, for example, a page, only a small file representing that page will change on disk. This allows Git to calculate an efficient delta and results in a more appropriate repository growth compared to MPRv1. Functionally there is no differences between the split (v2) or the combined (v1) format inside Studio Pro.
 
 {{% alert color="info" %}}
 Collaborating within one app on MPRv1 and MPRv2 branches is possible. To limit repository growth as much as possible, Mendix recommends migrating the most active branches to MPRv2 the first.
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Merging MPRv2 apps using the command line with `git merge` or using third-party tools is only supported from Studio Pro 10.21.0 and above. Hybrid merges involving both MPRv1 and MPRv2 formats are not supported.
+Merging using the command line with `git merge` or by using third-party tools is not yet supported for MPRv2.
 {{% /alert %}}
 
 #### Converting MPR Storage Format {#convert}
@@ -85,7 +85,7 @@ As the Mendix model is stored in a single file, this threshold can be exceeded b
 
 ### Working with a Large Repository Size
 
-When cloning an app, the default behavior of Git is to download the full history. As Mendix uses different folders on disk for different branches, downloading full history is done for each branch. To mitigate that, Mendix uses local cloning for subsequent branch downloads. When cloning a new branch, data from a local branch you already have is used to reduce data that needs to be downloaded. 
+When cloning an app, the default behavior of Git is to download the full history. As Mendix uses different folders on disk for different branches, downloading full history is done for each branch. To mitigate that, Mendix uses local cloning for subsequent branch downloads. When cloning a new branch, data from a local branch you already have is used to reduce data that needs to be downloaded.
 
 Starting from Studio Pro 10.12 it is possible to prevent downloading the full history, by changing the [Clone type](/refguide/clone-type/) to use partial clones. A partial clone downloads all data for a specific revision without downloading the contents of all historical commits.
 
@@ -121,13 +121,13 @@ Uncommitted work, or work committed to branches that have not been merged to the
 
 #### Deciding on the Cleanup
 
-The cleanup is intended to shrink your repository size to mitigate performance issues. We advise to first check whether you and your team are affected by performance issues, as that largely depends on your situation. 
+The cleanup is intended to shrink your repository size to mitigate performance issues. We advise to first check whether you and your team are affected by performance issues, as that largely depends on your situation.
 
 To conclude whether the situation is acceptable for you, follow these steps:
 
 * Ensure the Git app you are downloading is not yet on your machine
 * Download the branch through Studio Pro, while manually measuring how long the download takes
-  
+
 The first download of a branch on a device is a good indication of the maximum waiting time you or your team member can experience. Subsequent branch downloads use data that is already available locally and will, therefore, be a lot faster.
 
 If the download time was acceptable, or if you have a process where team members do not change often and they do not have to download an app for the first time, you can skip the cleanup.
@@ -178,7 +178,7 @@ Force pushing your results to the server is a separate step, in a separate scrip
 
 If you are using Mendix Team Server as your Git version control server, you can follow the steps below:
 
-* Ensure you have configured a Personal Access Token to use it as described in the [Authenticating to Team Server](/refguide/using-version-control-in-studio-pro/#authenticating) section in *Using Version Control in Studio Pro*. 
+* Ensure you have configured a Personal Access Token to use it as described in the [Authenticating to Team Server](/refguide/using-version-control-in-studio-pro/#authenticating) section in *Using Version Control in Studio Pro*.
 * Run the second script.
     * When prompted, enable force pushing.
     * Conduct the force push.
@@ -186,7 +186,7 @@ If you are using Mendix Team Server as your Git version control server, you can 
 
 ##### Other Git Platforms
 
-When using another Git platform than Mendix Team Server, such as GitHub or Azure Devops, you can typically enable force pushing in a portal. 
+When using another Git platform than Mendix Team Server, such as GitHub or Azure Devops, you can typically enable force pushing in a portal.
 
 {{% alert color="warning" %}}
 Force pushing allows to make destructive changes to the repository, which can easily lead to unrecoverable errors. We recommend you to give these permissions to as few users as strictly necessary.
@@ -200,7 +200,7 @@ You can follow these steps:
 
 #### Handling Local Copies
 
-After the results of the cleanup are pushed to the server all local clones need to be reset. This means that each developer of your team who has the project on disk and CI pipelines that have cached data need to get a fresh clone. 
+After the results of the cleanup are pushed to the server all local clones need to be reset. This means that each developer of your team who has the project on disk and CI pipelines that have cached data need to get a fresh clone.
 
 For developers on your team this means they have to ensure Studio Pro can no longer find their local folders. The **sp-reset** tool, shipped together with the Cleanup tool, can be used. Alternatively, they can rename their folders of the app to *old*.
 
@@ -222,7 +222,7 @@ We recommend doing the following:
 * Check the local repo location, it should be up-to-date and there should be no uncommitted changes
 * Check your git config settings, especially any setting that involves encoding or text conversions: run `git config --list --show-origin`.
 * Consider moving your local repo, so that its folder has a shorter name
-  
+
 When reaching out to Mendix Support, please include:
 
 * App/Projects ID for your app


### PR DESCRIPTION
removing git-merge command and information about merge driver support for MPRv2