### PR TITLE
Remove entity access rules editor option from new features tab docs

### DIFF
--- a/content/en/docs/refguide/modeling/menus/edit-menu/preferences-dialog.md
+++ b/content/en/docs/refguide/modeling/menus/edit-menu/preferences-dialog.md
@@ -267,16 +267,6 @@ When the **Do not show antivirus exclusion notifications** setting is enabled, S
 
 ## New Features Tab {#new-features}
 
-### Access Rules Editor
-
-This option allows you to disable the new editor in the *Access rules* tab of the entity properties dialog and return to the version which was available in Studio Pro 10 or enable the new editor if it has been disabled.
-
-{{% alert color="warning" %}}
-This option will be removed before the GA version of Mendix 11.0.
-{{% /alert %}}
-
-For more information, see [Defining Access Rules Using the New Editor](/refguide10/access-rules/#new-editor) section of the Mendix 10 documentation *Access Rules*.
-
 ### App Explorer
 
 Select this option to use the modernized version of the App Explorer. You must restart Studio Pro to use this feature.


### PR DESCRIPTION
As of Mendix 11 beta 2, the old entity access rules editor is removed, which also means the setting to toggle between the old and the modernized editor is removed. The docs are updated to reflect this change.