### PR TITLE
[MOO-1818] Update Air-Gapped Development Prerequisites for PMP (10.22+ Support)

### DIFF
--- a/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
@@ -53,10 +53,6 @@ For building:
 
 In some situations, it can be beneficial to designate a single machine for building native mobile apps or outsourcing the process to a partner.
 
-{{% alert color="warning" %}}
-Building native mobile apps is not supported on the [Private Mendix Platform](/private-mendix-platform/).
-{{% /alert %}}
-
 ## Getting the Make It Native App {#get-min-app}
 
 {{% alert color="info" %}}

--- a/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
@@ -55,6 +55,7 @@ In some situations, it can be beneficial to designate a single machine for build
 
 {{% alert color="warning" %}}
 Building native mobile apps is not supported on the [Private Mendix Platform](/private-mendix-platform/).
+Starting from version 10.22, native mobile builds are supported for PMP, including air-gapped environments with custom repository mirror support.
 {{% /alert %}}
 
 ## Getting the Make It Native App {#get-min-app}

--- a/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
@@ -54,8 +54,9 @@ For building:
 In some situations, it can be beneficial to designate a single machine for building native mobile apps or outsourcing the process to a partner.
 
 {{% alert color="warning" %}}
-Building native mobile apps is not supported on the [Private Mendix Platform](/private-mendix-platform/).
-Starting from version 10.22, native mobile builds are supported for PMP, including air-gapped environments with custom repository mirror support.
+Building native mobile apps is not supported for [Private Mendix Platform](/private-mendix-platform/) version 10.21 and older.
+
+In version 10.22 and newer, the Platform supports native mobile builds, including air-gapped environments with custom repository mirror support.
 {{% /alert %}}
 
 ## Getting the Make It Native App {#get-min-app}


### PR DESCRIPTION
This PR updates the air-gapped development prerequisites documentation to reflect the new support for native mobile builds on the Private Mendix Platform (PMP) starting from version 10.22. It adds a note clarifying that native mobile apps can be built on PMP 10.22 or later, including support for air-gapped environments and custom repository mirrors.