### PR TITLE
Release notes Mx4PC 2.21.3 (planned for release around May 23)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -965,7 +965,7 @@ If your app works without issues when read-only root filesystem is enabled, it i
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-In Mendix Operator versions 2.21.0, 2.21.1 and 2.21.2, enabling the `runtimeReadOnlyRootFilesystem` option causes the `model/resources` directory to be empty. If your app (or a Marketplace module such as SAML) uses the `model/resources` directory for resources such as configuration data, consider upgrading to Mendix Operator 2.21.3 (or a later version), which is not affected by this issue.
+Enabling the `runtimeReadOnlyRootFilesystem` option causes the `model/resources` directory to be empty. If your app (or a Marketplace module such as SAML) uses the `model/resources` directory for resources such as configuration data, consider moving those resources to another location (for example, `model/userlib`) or loading them from FileDocument entities.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -965,7 +965,7 @@ If your app works without issues when read-only root filesystem is enabled, it i
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Enabling the `runtimeReadOnlyRootFilesystem` option causes the `model/resources` directory to be empty. If your app (or a Marketplace module such as SAML) uses the `model/resources` directory for resources such as configuration data, consider moving those resources to another location (for example, `model/userlib`) or loading them from FileDocument entities.
+In Mendix Operator versions 2.21.0, 2.21.1 and 2.21.2, enabling the `runtimeReadOnlyRootFilesystem` option causes the `model/resources` directory to be empty. If your app (or a Marketplace module such as SAML) uses the `model/resources` directory for resources such as configuration data, consider upgrading to Mendix Operator 2.21.3 (or a later version), which is not affected by this issue.
 {{% /alert %}}
 
 ### GKE Autopilot Workarounds {#gke-autopilot-workarounds}

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -10,7 +10,7 @@ beta: true
 {{% alert color="warning" %}}
 Private Cloud License Manager is currently in beta. For more information, see [Beta Releases](/releasenotes/beta-features/).
 
-We highly recommend to upgrade to the latest available version, as newer versions contain bugfixes and improvements to ensure that all apps get a valid, non-expired license.
+Mendix highly recommends that you upgrade to the latest available version to ensure that all apps get a valid, non-expired license. Newer versions contain bugfixes and improvements.
 {{% /alert %}}
 
 ## Introduction

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -9,6 +9,8 @@ beta: true
 
 {{% alert color="warning" %}}
 Private Cloud License Manager is currently in beta. For more information, see [Beta Releases](/releasenotes/beta-features/).
+
+We highly recommend to upgrade to the latest available version, as newer versions contain bugfixes and improvements to ensure that all apps get a valid, non-expired license.
 {{% /alert %}}
 
 ## Introduction

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -36,8 +36,8 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix for Private Cloud Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.32
-* OpenShift 4.6 through 4.17
+* Kubernetes versions 1.19 through 1.33
+* OpenShift 4.6 through 4.18
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -27,7 +27,7 @@ For information on the current status of deployment to Mendix for Private Cloud 
 #### Mendix Operator v2.21.3 {#2.21.3}
 
 * We fixed an issue where an overlapping `/tmp/mendix/img` path could cause issues with some Marketplace components, for example [Azure Application Insights](https://marketplace.mendix.com/link/component/108303). (Ticket 248704)
-* We added support for updating license expiration dates when a newer license is available in PCLM. (Ticket 249344)
+* We updated the license refresh mechanism to automatically refresh expired licenses from PCLM. (Ticket 249344)
 * Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### May 08, 2025

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -20,8 +20,6 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 #### Mendix Operator v2.21.3 {#2.21.3}
 
-* We have addressed an issue with accessing contents of the `model/resources` directory when using the [read-only root filesystem feature](/developerportal/deploy/private-cloud-cluster/#readonlyrootfs).
-  Starting from this version, the contents of `model/resources` will be available for use by the app (in read-only mode) even when the **Read-Only Root Filesystem** feature is enabled.
 * We fixed an issue where an ovelapping `/tmp/mendix/img` path could cause issues with some Marketplace components such as [Azure Application Insights](https://marketplace.mendix.com/link/component/108303) (Ticket 248704).
 * We've added support for updating license expiration dates when a newer license is available in PCLM (Ticket 249344).
 * Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -172,7 +172,7 @@ This issue has been fixed in Mendix Operator [version 2.21.1](#2.21.1).
 #### Mendix Operator v2.20.1 {#2.20.1}
 
 * We have updated the m2ee-sidecar lifecycle to no longer stop the Mendix Runtime if a `ping` times out or fails; an app will now only be restarted by the liveness probe (Ticket 230648).
-* We have adjusted AWS STS token expiration for envrionments using IRSA, which should prevent occasional *SQLState: 28000 Error code: 0 Message: "FATAL: PAM authentication failed for user …", retrying...(1/4)* errors (Ticket 234454).
+* We have adjusted AWS STS token expiration for environments using IRSA, which should prevent occasional *SQLState: 28000 Error code: 0 Message: "FATAL: PAM authentication failed for user …", retrying...(1/4)* errors (Ticket 234454).
 * We have switched the log format to JSON for the `build`, `database` and `file` pods, to help with parsing the logs and automatically assigning log levels and timestamps.
 * We have updated a library used to validate licenses to the latest non-alpha version.
 * We have updated documentation that OpenShift 4.17 and Postgres 17 are supported by the Mendix Operator.
@@ -183,7 +183,7 @@ This issue has been fixed in Mendix Operator [version 2.21.1](#2.21.1).
 
 At present, a Technical Contact can only be assigned to one application at a time instead of multiple applications. If an individual who is already a Technical Contact for an existing application creates another application, they are automatically assigned as the Technical Contact for the new application. However, this results in their removal as the Technical Contact for the previous application. 
 
-Additionally, being assigned as a Technical Contact grants the individual administrator-level access across all namespaces where environments are created. Consequently, in this scenario, the individual gaina administrator access to the namespaces for both applications with created environments.
+Additionally, being assigned as a Technical Contact grants the individual administrator-level access across all namespaces where environments are created. Consequently, in this scenario, the individual grants administrator access to the namespaces for both applications with created environments.
 
 We are working on a fix, which is expected to be available in next release. Once the fix is available, make sure to check your applications and assign the Technical Contact accordingly.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -14,6 +14,9 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ### May 23, 2025
 
+In today's release, we've addressed an issue with updating expired licenses in PCLM and the Mendix Operator.
+If you're using the Mendix Operator with PCLM, it's **highly recommended** to upgrade Mendix Operator to version 2.21.3 (or later) and PCLM to version 0.10.3 (or later).
+
 #### License Manage CLI v0.10.3
 
 * We've added support for uploading license bundles with an extended license expiration date (Ticket 249344).

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -14,12 +14,17 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ### May 23, 2025
 
+#### License Manage CLI v0.10.3
+
+* We've added support for uploading license bundles with an extended license expiration date (Ticket 249344).
+
 #### Mendix Operator v2.21.3 {#2.21.3}
 
 * We have addressed an issue with accessing contents of the `model/resources` directory when using the [read-only root filesystem feature](/developerportal/deploy/private-cloud-cluster/#readonlyrootfs).
   Starting from this version, the contents of `model/resources` will be available for use by the app (in read-only mode) even when the **Read-Only Root Filesystem** feature is enabled.
-* Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 * We fixed an issue where an ovelapping `/tmp/mendix/img` path could cause issues with some Marketplace components such as [Azure Application Insights](https://marketplace.mendix.com/link/component/108303) (Ticket 248704).
+* We've added support for updating license expiration dates when a newer license is available in PCLM (Ticket 249344).
+* Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### May 08, 2025
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,15 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ## 2025
 
+### May 23, 2025
+
+#### Mendix Operator v2.21.3 {#2.21.3}
+
+* We have addressed an issue with accessing contents of the `model/resources` directory when using the [read-only root filesystem feature](/developerportal/deploy/private-cloud-cluster/#readonlyrootfs).
+  Starting from this version, the contents of `model/resources` will be available for use by the app (in read-only mode) even when the **Read-Only Root Filesystem** feature is enabled.
+* Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
+* We fixed an issue where an ovelapping `/tmp/mendix/img` path could cause issues with some Marketplace components such as [Azure Application Insights](https://marketplace.mendix.com/link/component/108303) (Ticket 248704).
+
 ### May 08, 2025
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -14,17 +14,20 @@ For information on the current status of deployment to Mendix for Private Cloud 
 
 ### May 23, 2025
 
-In today's release, we've addressed an issue with updating expired licenses in PCLM and the Mendix Operator.
-If you're using the Mendix Operator with PCLM, it's **highly recommended** to upgrade Mendix Operator to version 2.21.3 (or later) and PCLM to version 0.10.3 (or later).
+#### Fixes
+
+* We addressed an issue with updating expired licenses in PCLM and the Mendix Operator.
+
+    If you are using the Mendix Operator with PCLM, it is **highly recommended** that you upgrade Mendix Operator to version 2.21.3 or above and PCLM to version 0.10.3 or above.
 
 #### License Manage CLI v0.10.3
 
-* We've added support for uploading license bundles with an extended license expiration date (Ticket 249344).
+* We added support for uploading license bundles with an extended license expiration date. (Ticket 249344)
 
 #### Mendix Operator v2.21.3 {#2.21.3}
 
-* We fixed an issue where an ovelapping `/tmp/mendix/img` path could cause issues with some Marketplace components such as [Azure Application Insights](https://marketplace.mendix.com/link/component/108303) (Ticket 248704).
-* We've added support for updating license expiration dates when a newer license is available in PCLM (Ticket 249344).
+* We fixed an issue where an overlapping `/tmp/mendix/img` path could cause issues with some Marketplace components, for example [Azure Application Insights](https://marketplace.mendix.com/link/component/108303). (Ticket 248704)
+* We added support for updating license expiration dates when a newer license is available in PCLM. (Ticket 249344)
 * Upgrading to Mendix Operator v2.21.3 from a previous version now restarts environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### May 08, 2025


### PR DESCRIPTION
We're planning to release a minor patch version of the Mendix for Private Cloud Operator and PCLM this week, and this PR contains release notes.