### PR TITLE
Restore banner front matter and allow HTML in banner

### DIFF
--- a/content/en/docs/community-tools/contribute-to-mendix-docs/indentation-spacing-test.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/indentation-spacing-test.md
@@ -2,7 +2,7 @@
 title: "Indentation and Spacing Test"
 url: /developerportal/community-tools/indentation-spacing-test/
 draft: true
-banner: "Go <a href=\"/refguide9/moving-from-8-to-9/\">here</a>"
+banner: "Banner with a link to <a href=\"#spacing\">spacing</a>"
 description: "Various test cases for rendering of indents and spaces. Use this page to test how spacing and indents will render with various elements and shortcodes. Linting has been disabled for this file."
 ---
 

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/indentation-spacing-test.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/indentation-spacing-test.md
@@ -2,6 +2,7 @@
 title: "Indentation and Spacing Test"
 url: /developerportal/community-tools/indentation-spacing-test/
 draft: true
+banner: "Go <a href=\"/refguide9/moving-from-8-to-9/\">here</a>"
 description: "Various test cases for rendering of indents and spaces. Use this page to test how spacing and indents will render with various elements and shortcodes. Linting has been disabled for this file."
 ---
 

--- a/content/en/docs/howto/_index.md
+++ b/content/en/docs/howto/_index.md
@@ -11,12 +11,9 @@ cascade:
     - mendix_version: 11
     - sitemap:
         priority: 0.7
+    - banner: "Mendix 11 is currently in Beta. For more information about Beta releases and features, see <a href=\"/releasenotes/beta-features/\">Beta Releases</a>."
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
-
-{{% alert color="warning" %}}
-Mendix 11 is currently in Beta. For more information about Beta releases and features, see [Beta Releases](/releasenotes/beta-features/).
-{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/howto8/_index.md
+++ b/content/en/docs/howto8/_index.md
@@ -8,7 +8,7 @@ description_list: true
 cascade:
     - content_type: "Studio Pro 8"
     - mendix_version: 8
-    - banner_8: true
+    - banner: "If you would like to upgrade to a newer <a href=\"/releasenotes/studio-pro/lts-mts/#lts\">long-term support version</a> of Studio Pro, see <a href=\"/refguide9/moving-from-8-to-9/\">Moving from Mendix Studio Pro 8 to 9</a>."
     - old_content: true
     - hide_feedback: true
     - notsitemap: true

--- a/content/en/docs/refguide/_index.md
+++ b/content/en/docs/refguide/_index.md
@@ -11,11 +11,8 @@ cascade:
     - mendix_version: 11
     - sitemap:
         priority: 0.8
+    - banner: "Mendix 11 is currently in Beta. For more information about Beta releases and features, see <a href=\"/releasenotes/beta-features/\">Beta Releases</a>."
 ---
-
-{{% alert color="warning" %}}
-Mendix 11 is currently in Beta. For more information about Beta releases and features, see [Beta Releases](/releasenotes/beta-features/).
-{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide8/_index.md
+++ b/content/en/docs/refguide8/_index.md
@@ -8,7 +8,7 @@ description_list: true
 cascade:
     - content_type: "Studio Pro 8"
     - mendix_version: 8
-    - banner_8: true
+    - banner: "If you would like to upgrade to a newer <a href=\"/releasenotes/studio-pro/lts-mts/#lts\">long-term support version</a> of Studio Pro, see <a href=\"/refguide9/moving-from-8-to-9/\">Moving from Mendix Studio Pro 8 to 9</a>."
     - old_content: true
     - hide_feedback: true
     - notsitemap: true

--- a/content/en/docs/releasenotes/studio-pro/11/_index.md
+++ b/content/en/docs/releasenotes/studio-pro/11/_index.md
@@ -9,11 +9,8 @@ simple_list: true
 beta: true
 cascade:
     - numberless_headings: true
+    - banner: "Mendix 11 is currently in Beta. For more information about Beta releases and features, see <a href=\"/releasenotes/beta-features/\">Beta Releases</a>."
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details.
 ---
-
-{{% alert color="warning" %}}
-Mendix 11 is currently in Beta. For more information about Beta releases and features, see [Beta Releases](/releasenotes/beta-features/).
-{{% /alert %}}
 
 These are the release notes for Mendix Studio Pro 11:

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,18 +1,14 @@
-<!-- MODIFICATION FOR MENDIX DOCS-->
+<!-- MODIFICATION FOR MENDIX DOCS -->
 
-    <!-- If the page has banner_7: true set, display the following text as a banner. -->
-    {{ with .Params.banner_7 }}
+    <!-- Check if the page has a banner: "string" set if yes, display a banner. -->
+    <!-- safeHTML means you can include HTML. If you need to escape double quotes, use \" -->
+    <!-- For example: banner: "Go <a href=\"/refguide9/moving-from-8-to-9/\">here</a>" -->
+    {{ with .Params.banner}}
     <div class="pageinfo pageinfo-warning">
-        <p>Mendix 7 is no longer supported unless you have <a href="/support/#extended-support">Extended Support</a>. Mendix 7 documentation will remain available until July 2024.</p>
-        <p>To upgrade to a supported version, see <a href="/refguide8/moving-from-7-to-8/">Moving from Desktop Modeler Version 7 to Studio Pro 8</a>.</p>
+        <p>{{ . | safeHTML }}</p>
     </div>
-    {{ end }}
-    <!-- If the page has banner_8: true set, display the following text as a banner. -->
-    {{ with .Params.banner_8 }}
-    <div class="pageinfo pageinfo-info">
-        <p>If you would like to upgrade to a newer <a href="/releasenotes/studio-pro/lts-mts/#lts">long-term support version</a> of Studio Pro, see <a href="/refguide9/moving-from-8-to-9/">Moving from Mendix Studio Pro 8 to 9</a>.</p>
-    </div>
-    {{ end }}
+    {{end}}
+
     <!-- If the page has draft: true set, display the following text as a banner. -->
     {{ with .Params.draft }}
     <div class="pageinfo pageinfo-warning">


### PR DESCRIPTION
Banners were removed in #7642 and replaced with specific text. This was because we couldn't find a way to put HTML (e.g. links) into the text.

By using the `safeHTML` filter, Hugo will keep the HTML and so banners can have richer text.