### PR TITLE
[WTF-2219] Add missing release notes

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.23.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.23.md
@@ -41,6 +41,7 @@ weight: 77
 
 * In the logic editors, we fixed an issue where a warning was shown for microflows being inaccessible even though they were used in the application. (Tickets 184859, 186059, 215091, 216988)
 * We fixed an issue where having a disabled and detached activity in a microflow caused the microflow to not execute the main flow. (Ticket 243133)
+* We fixed an issue with microflow parameter mappings that caused an error pop-up window. (Ticket 244852)
 * We fixed an issue where, when updating an association from an entity to its own specialization on an instance of the specialization, the association was set in the opposite direction. (Ticket 245140)
 * We fixed the behavior of the `urlEncode` and `urlDecode` functions in the client to align with the runtime. This means that spaces are now correctly encoded as `%20` instead of `+`. `urlDecode` still supports decoding strings containing `+` to ensure backwards compatibility with strings encoded in previous versions. (Ticket 245510)
 * We fixed an issue where a wrong text is shown in a dialog after languages were removed from the app. (Ticket 248967)
@@ -62,4 +63,3 @@ weight: 77
 * We fixed an issue where metadata got corrupted when special characters were present.
 * We fixed an issue where the **Revert change** option was missing for deleted files in the **Changes** pane.
 * We fixed an issue with offline mode, where data sources did not react to updates of attributes used in XPath constraints.
-* We fixed an issue with microflow parameter mappings that caused an Oops dialog. (Ticket 244852)

--- a/content/en/docs/releasenotes/studio-pro/10/10.23.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.23.md
@@ -62,3 +62,4 @@ weight: 77
 * We fixed an issue where metadata got corrupted when special characters were present.
 * We fixed an issue where the **Revert change** option was missing for deleted files in the **Changes** pane.
 * We fixed an issue with offline mode, where data sources did not react to updates of attributes used in XPath constraints.
+* We fixed an issue with microflow parameter mappings that caused an Oops dialog. (Ticket 244852)

--- a/content/en/docs/releasenotes/studio-pro/11/11.0.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.0.md
@@ -186,6 +186,7 @@ For details on upgrading to Studio Pro 11, see [Upgrading from Mendix Studio Pro
 * We fixed an issue where data sources with a default configuration triggered an **Oops** pop-up window when hidden by another property.
 * We fixed an error that occurred when reconfiguring a data source with an invalid expression referring to it.
 * We fixed an issue with editing expressions where the expected type was **Not set** when its target was a page or snippet variable, for example static values for a combo box widget.
+* We fixed an issue with microflow parameter mappings that caused an Oops dialog. (Ticket 244852)
 
 ### Deprecations
 

--- a/content/en/docs/releasenotes/studio-pro/11/11.0.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.0.md
@@ -117,6 +117,7 @@ For details on upgrading to Studio Pro 11, see [Upgrading from Mendix Studio Pro
 * We fixed the <kbd>F9</kbd> View App shortcut. It is used to view the currently running app in the browser. (Ticket 243743)
 * We fixed an issue where the runtime fails to start with a `NullPointerException` if a microflow contained an invalid disabled activity. (Ticket 243931)
 * We fixed an issue in published REST and OData services where calling the service using active session authentication with an expired CSRF token in JavaScript caused the browser to show a Username/Password pop-up window. (Ticket 243407)
+* We fixed an issue with microflow parameter mappings that caused an error pop-up window. (Ticket 244852)
 * In the logic editors, we fixed the displayed data type for cross-module one-to-one associations. (Ticket 245052)
 * We fixed an issue where, when updating an association from an entity to its own specialization on an instance of the specialization, the association was set in the opposite direction. (Ticket 245140)
 * We fixed an issue in the React client where the document title briefly was 'Mendix' during startup instead of the title configured in the application. (Ticket 245280)
@@ -186,7 +187,6 @@ For details on upgrading to Studio Pro 11, see [Upgrading from Mendix Studio Pro
 * We fixed an issue where data sources with a default configuration triggered an **Oops** pop-up window when hidden by another property.
 * We fixed an error that occurred when reconfiguring a data source with an invalid expression referring to it.
 * We fixed an issue with editing expressions where the expected type was **Not set** when its target was a page or snippet variable, for example static values for a combo box widget.
-* We fixed an issue with microflow parameter mappings that caused an Oops dialog. (Ticket 244852)
 
 ### Deprecations
 


### PR DESCRIPTION
The release notes for WTF-2219 were misplaced and thus missed when the release notes were generated for versions 10.23.0 and 11.0.0 Beta 2. This PR adds the missing line to both release notes.