### PR TITLE
Add guidance to not rename mpr files when using version control

### DIFF
--- a/content/en/docs/developerportal/general/settings/_index.md
+++ b/content/en/docs/developerportal/general/settings/_index.md
@@ -27,13 +27,13 @@ These tabs are only available for users with the **App Settings** permission:
 * **History**
 * **Story Archive**
 
-## Page Header
+## Page Header {#settings-page-header}
 
 The page header displays the following information:
 
 * The app image – You can change the image by clicking it.
 * The app name – You can change the name of the app by clicking the pencil icon next to it.    
-    Renaming the app in the Mendix Portal does not rename it in Studio Pro. The app name in Studio Pro is tied to its *.mpr* file. However, changing the name of the *.mpr* file is not supported, and we strongly advise against it. For more information, refer to the [MPR Format](/refguide/version-control/#mpr-format) section in *Version Control*. 
+    Renaming the app in the Mendix Portal does not rename it in Studio Pro. The app name in Studio Pro is tied to its *.mpr* file. However, changing the name of the *.mpr* file is not supported, and we strongly advise against it. For more information, refer to the [Mendix MPR Storage ](/refguide/version-control/#mpr-format) section in *Version Control*. 
 * The company that owns the app.
 * The **Watch** / **Stop Watching** toggle – You can enable or disable notifications for this app.
 

--- a/content/en/docs/developerportal/general/settings/_index.md
+++ b/content/en/docs/developerportal/general/settings/_index.md
@@ -15,14 +15,6 @@ aliases:
 
 The **Settings** page in the [navigation pane](/developerportal/#navigation-pane) of **Apps** presents an overview of your app.
 
-On the top of the page, you can see the image of the app, the app name, and the company that owns the app. You can also find the **Watch** / **Stop Watching** toggle, which enables or disables notifications for this app.
-
-{{< figure src="/attachments/developerportal/general/settings/general-information.png"  class="no-border" >}}
-
-{{% alert color="info" %}}
-Only users with the **App Settings** permission can edit the image and the app name.
-{{% /alert %}}
-
 The **Settings** page always contains the following tabs:
 
 * **General**
@@ -34,6 +26,22 @@ These tabs are only available for users with the **App Settings** permission:
 * **Project Management**
 * **History**
 * **Story Archive**
+
+## Page Header
+
+The page header displays the following information:
+
+* The app image – You can change the image by clicking it.
+* The app name – You can change the name of the app by clicking the pencil icon next to it.    
+    Renaming the app in the Mendix Portal does not automatically rename it in Studio Pro. Refer to [Version Control](/refguide/version-control/#mpr-format) in the Studio Pro guide for information on renaming the *.mpr* file.
+* The company that owns the app.
+* The **Watch** / **Stop Watching** toggle – You can enable or disable notifications for this app.
+
+{{< figure src="/attachments/developerportal/general/settings/general-information.png"  class="no-border" >}}
+
+{{% alert color="info" %}}
+Only users with the **App Settings** permission can edit the image and the app name.
+{{% /alert %}}
 
 ## General {#general}
 

--- a/content/en/docs/developerportal/general/settings/_index.md
+++ b/content/en/docs/developerportal/general/settings/_index.md
@@ -33,7 +33,7 @@ The page header displays the following information:
 
 * The app image – You can change the image by clicking it.
 * The app name – You can change the name of the app by clicking the pencil icon next to it.    
-    Renaming the app in the Mendix Portal does not automatically rename it in Studio Pro. Refer to [Version Control](/refguide/version-control/#mpr-format) in the Studio Pro guide for information on renaming the *.mpr* file.
+    Renaming the app in the Mendix Portal does not rename it in Studio Pro. The app name in Studio Pro is tied to its *.mpr* file. However, changing the name of the *.mpr* file is not supported, and we strongly advise against it. For more information, refer to the [MPR Format](/refguide/version-control/#mpr-format) section in *Version Control*. 
 * The company that owns the app.
 * The **Watch** / **Stop Watching** toggle – You can enable or disable notifications for this app.
 

--- a/content/en/docs/refguide/version-control/_index.md
+++ b/content/en/docs/refguide/version-control/_index.md
@@ -103,7 +103,8 @@ You can convert *.mpr* to a new [MPRv2 storage format](/refguide/troubleshoot-re
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored. This includes renaming the *.mpr* file itself. Renaming the App by renaming the *.mpr* file is not supported. Renaming your App when using version control is only supported via Sprintr.
+Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored. 
+This includes renaming the *.mpr* file itself. Renaming the app by renaming the *.mpr* file is not supported. Renaming your app when using version control is only supported via Mendix Portal. For more information, see the [Page Header](/developerportal/collaborate/general-settings/#settings-page-header) section in *Settings*. 
 {{% /alert %}}
 
 ## Branches {#branches}

--- a/content/en/docs/refguide/version-control/_index.md
+++ b/content/en/docs/refguide/version-control/_index.md
@@ -103,7 +103,7 @@ You can convert *.mpr* to a new [MPRv2 storage format](/refguide/troubleshoot-re
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored.
+Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored. This includes renaming the *.mpr* file itself. Renaming the App by renaming the *.mpr* file is not supported. Renaming your App when using version control is only supported via Sprintr.
 {{% /alert %}}
 
 ## Branches {#branches}

--- a/content/en/docs/refguide/version-control/_index.md
+++ b/content/en/docs/refguide/version-control/_index.md
@@ -104,7 +104,7 @@ You can convert *.mpr* to a new [MPRv2 storage format](/refguide/troubleshoot-re
 
 {{% alert color="warning" %}}
 Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored. 
-This includes renaming the *.mpr* file itself. Renaming the app by renaming the *.mpr* file is not supported. Renaming your app when using version control is only supported via Mendix Portal. For more information, see the [Page Header](/developerportal/collaborate/general-settings/#settings-page-header) section in *Settings*. 
+This includes renaming the *.mpr* file itself. Renaming the app by renaming the *.mpr* file is not supported. Renaming your app when using version control is only supported via the Mendix Portal. For more information, see the [Page Header](/developerportal/collaborate/general-settings/#settings-page-header) section in *Settings*. 
 {{% /alert %}}
 
 ## Branches {#branches}

--- a/content/en/docs/refguide10/version-control/_index.md
+++ b/content/en/docs/refguide10/version-control/_index.md
@@ -103,7 +103,8 @@ Studio Pro 10.18 introduced a public beta to convert *.mpr* to a new [MPRv2 stor
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored.
+Manually modifying files belonging to the *.mpr* storage format such as the *.mpr* file or the *mprcontents* directory (for example, when resolving file conflicts through third-party tooling), will lead to a corrupted state. To recover from a corrupted state a previous commit will need to be restored. 
+This includes renaming the *.mpr* file itself. Renaming the app by renaming the *.mpr* file is not supported. Renaming your app when using version control is only supported via the Mendix Portal. For more information, see the [Page Header](/developerportal/collaborate/general-settings/#settings-page-header) section in *Settings*. 
 {{% /alert %}}
 
 ## Branches {#branches}


### PR DESCRIPTION
We do not support renaming the mpr file when you are using Git version control. This should be clear from the documentation.

I added some comments to make this more clear.