### PR TITLE
Toolchoice & OpenAI Document Chat

### DIFF
--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/aws/amazon-bedrock.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/aws/amazon-bedrock.md
@@ -232,12 +232,12 @@ Some capabilities of the chat completions operations are currently only availabl
 
 All [tool choice types](/appstore/modules/genai/genai-for-mx/commons/#enum-toolchoice) of GenAI Commons for the [Tools: Set Tool Choice](/appstore/modules/genai/genai-for-mx/commons/#set-toolchoice) action are supported. For API mapping reference, see the table below:
 
-| GenAI Commons (Mendix) | Amazon Bedrock                |
-| -----------------------| ----------------------------- |
-| auto                   | auto                          |                     
-| any                    | any                           |
-| none                   | tools removed from request    |
-| tool                   | tool                          |
+| GenAI Commons (Mendix) | Amazon Bedrock |
+| --- | --- |
+| Auto | Auto |                     
+| Any | Any |
+| None | Tools removed from request |
+| Tool | Tool |
 
 #### RetrieveAndGenerate {#retrieve-and-generate}
 

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/aws/amazon-bedrock.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/aws/amazon-bedrock.md
@@ -228,6 +228,17 @@ Some capabilities of the chat completions operations are currently only availabl
 
 * **Document Chat** - This operation supports the ability to chat with documents for [supported models](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html). To send a document to the model add a `FileCollection` with a `System.FileDocument` to the `Message` using the [Files: Initialize Collection with File](/appstore/modules/genai/genai-for-mx/commons/#initialize-filecollection) or the [Files: Add to Collection](/appstore/modules/genai/genai-for-mx/commons/#add-file-to-collection) operation. For Document Chat, it is not supported to create a `FileContent` from an URL using the above mentioned operations; Please use the `System.FileDocument` option. Make sure to set the `FileType` attribute to **document**.
 
+##### Tool Choice
+
+All [tool choice types](/appstore/modules/genai/genai-for-mx/commons/#enum-toolchoice) of GenAI Commons for the [Tools: Set Tool Choice](/appstore/modules/genai/genai-for-mx/commons/#set-toolchoice) action are supported. For API mapping reference, see the table below:
+
+| GenAI Commons (Mendix) | Amazon Bedrock                |
+| -----------------------| ----------------------------- |
+| auto                   | auto                          |                     
+| any                    | any                           |
+| none                   | tools removed from request    |
+| tool                   | tool                          |
+
 #### RetrieveAndGenerate {#retrieve-and-generate}
 
 The `Retrieve and Generate` activity can be used for conversations leveraging Retrieval Augmented Generation through a knowledge base. This operation corresponds to the *RetrieveAndGenerate* microflow.

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/_index.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/_index.md
@@ -71,8 +71,7 @@ Mendix connectors offer direct support for the following models:
 |--------------|---------------------|---------------------|-------------------|-----------|-------------------------|
 | Mendix Cloud GenAI | Anthropic Claude 3.5 Sonnet | Chat Completions | text, image, document | text | Function calling |
 | | Cohere Embed English, Cohere Embed Multilingual | Embeddings | text | embeddings | |
-| Azure / OpenAI | gpt-3.5-turbo | Chat completions | text | text | Function calling |
-| | gpt-4, gpt-4-turbo, gpt-4o, gpt-4o mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4.5-preview | Chat completions | text, image | text | Function calling |
+| Azure / OpenAI | gpt-4, gpt-4-turbo, gpt-4o, gpt-4o mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4.5-preview | Chat completions | text, image, document (OpenAI only) | text | Function calling |
 | | DALL·E 2, DALL·E 3, gpt-image-1 | Image generation | text | image | |
 | | text-embedding-ada-002, text-embedding-3-small, text-embedding-3-large     | Embeddings | text | embeddings| |
 | Amazon Bedrock | Amazon Titan Text G1 - Express, Amazon Titan Text G1 - Lite, Amazon Titan Text G1 - Premier | Chat Completions | text, document (except Titan Premier) | text | |
@@ -104,4 +103,4 @@ In addition to the models listed above, you can also connect to other models by 
 
 * To connect to other [foundation models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-features.html) and implement them in your app, use the [Amazon Bedrock connector](/appstore/modules/aws/amazon-bedrock/).
 * To connect to [Snowflake Cortex LLM](https://docs.snowflake.com/en/sql-reference/functions/complete-snowflake-cortex) functions, [configure the Snowflake REST SQL connector for Snowflake Cortex Analyst](/appstore/connectors/snowflake/snowflake-rest-sql/#cortex-analyst).
-* To implement your connector compatible with the other components, use the [GenAI Commons](/appstore/modules/genai/commons/) interface.
+* To implement your connector compatible with the other components, use the [GenAI Commons](/appstore/modules/genai/commons/) interface and follow the how-to [Build Your Own GenAI Connector](/appstore/modules/genai/how-to/byo-connector/).

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
@@ -254,6 +254,17 @@ The **Documentation** pane displays the documentation for the currently selected
 
     {{< figure src="/attachments/appstore/platform-supported-content/modules/technical-reference/doc-pane.png" >}}
 
+### Tool Choice
+
+All [tool choice types](/appstore/modules/genai/genai-for-mx/commons/#enum-toolchoice) of GenAI Commons for the [Tools: Set Tool Choice](/appstore/modules/genai/genai-for-mx/commons/#set-toolchoice) action are supported. For API mapping reference, see the table below:
+
+| GenAI Commons (Mendix) | Amazon Bedrock                |
+| -----------------------| ----------------------------- |
+| auto                   | auto                          |                     
+| any                    | any                           |
+| none                   | tools removed from request    |
+| tool                   | tool                          |
+
 ## Implementing GenAI with the Showcase App
 
 For more guidance on how to use microflows in your logic, Mendix recommends downloading the [GenAI Showcase App](https://marketplace.mendix.com/link/component/220475), which demonstrates a variety of example use cases and applies almost all of the Mendix Cloud GenAI operations. The starter apps in the [Mendix Components](/appstore/modules/genai/#mendix-components) list can also be used as inspiration or simply adapted for a specific use case.

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
@@ -161,7 +161,7 @@ For [Chat Completions (without history)](/appstore/modules/genai/genai-for-mx/co
 In the entire conversation, you can pass up to five documents that are smaller than 4.5 MB each. The following file types are accepted: PDF, CSV, DOC, DOCX, XLS, XLSX, HTML, TXT, and MD.
 
 {{% alert color="info" %}}
-Note that the model uses the file name when analyzing documents, which could make it vulnerable to prompt injection. Depending on your use case, you may choose to modify the file's name before adding it to the request.
+The model uses the file name when analyzing documents, which may introduce a potential vulnerability to prompt injection. To reduce this risk, consider modifying file names before including them in the request.
 {{% /alert %}}
 
 ### Knowledge Base Operations

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/mendix-cloud-genai/Mx GenAI Connector.md
@@ -161,9 +161,7 @@ For [Chat Completions (without history)](/appstore/modules/genai/genai-for-mx/co
 In the entire conversation, you can pass up to five documents that are smaller than 4.5 MB each. The following file types are accepted: PDF, CSV, DOC, DOCX, XLS, XLSX, HTML, TXT, and MD.
 
 {{% alert color="info" %}}
-When adding a document to the `FileCollection`, you can optionally use the `TextContent` parameter to pass the file name. Ensure the file name excludes its extension before passing it to the file collection.
-
-Note that the model uses the file name when analyzing documents, which could make it vulnerable to prompt injection. Depending on your use case, you may choose to modify the string or not pass it at all.
+Note that the model uses the file name when analyzing documents, which could make it vulnerable to prompt injection. Depending on your use case, you may choose to modify the file's name before adding it to the request.
 {{% /alert %}}
 
 ### Knowledge Base Operations

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
@@ -219,6 +219,20 @@ When you use Azure OpenAI, it is recommended to set the optional `MaxTokens` inp
 
 For more information on vision, see [OpenAI](https://platform.openai.com/docs/guides/vision) and [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/gpt-with-vision) documentation.
 
+#### Document Chat {#chatcompletions-document}
+
+Document chat enables the model to interpret and analyze PDF documents, allowing them to answer questions and perform tasks related to the content. To use document chat, an optional [FileCollection](/appstore/modules/genai/genai-for-mx/commons/#filecollection) containing one or multiple documents must be sent along with a single message.
+
+For [Chat Completions (without history)](/appstore/modules/genai/genai-for-mx/commons/#chat-completions-without-history), `OptionalFileCollection` is an optional input parameter. For [Chat completions (with history)](/appstore/modules/genai/genai-for-mx/commons/#chat-completions-with-history), a `FileCollection` can optionally be added to individual user messages using [Add Message to Request](/appstore/modules/genai/genai-for-mx/commons/#chat-add-message-to-request).
+
+In the entire conversation, you can pass up 100 pages across multiple files and a maximum of 32MB. Currently, processing multiple files with OpenAI is not always guaranteed and can lead to unexpected behavior (e.g., only using one document).
+
+{{% alert color="info" %}}
+Azure OpenAI does not support the use of file input at the moment.
+
+Note that the model uses the file name when analyzing documents, which could make it vulnerable to prompt injection. Depending on your use case, you may choose to modify the string or not pass it at all.
+{{% /alert %}}
+
 #### Image Generations {#image-generations-configuration}
 
 OpenAI also provides image generation capabilities which can be invoked using this connector module. The `OpenAIDeployedModel` entity is compatible with the [image generation operation from GenAI Commons](/appstore/modules/genai/genai-for-mx/commons/#generate-image).
@@ -257,11 +271,11 @@ OpenAI-specific exposed microflow actions to construct requests via drag-and-dro
 
 This microflow changes the `ResponseFormat` of the `OpenAIRequest_Extension` object, which will be created for a `Request` if not present. This describes the format that the chat completions model must output. The default behavior for OpenAI's models currently is `Text`. This operation must be used to enable JSON mode by providing the value `JSONObject` as input.
 
-#### Files: Initialize Collection with OpenAI File {#initialize-filecollection}
+#### Files: Initialize Collection with OpenAI Image {#initialize-filecollection}
 
 This microflow initializes a new `FileCollection` and adds a new `FileDocument` or URL. Optionally, the `Image Detail` or a description using `TextContent` can be passed.
 
-#### Files: Add OpenAI File to Collection {#add-file}
+#### Files: Add OpenAI Image to Collection {#add-file}
 
 This microflow adds a new `FileDocument` or URL to an existing `FileCollection`. Optionally, the `Image Detail` or a description using `TextContent` can be passed.
 

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
@@ -221,16 +221,16 @@ For more information on vision, see [OpenAI](https://platform.openai.com/docs/gu
 
 #### Document Chat {#chatcompletions-document}
 
-Document chat enables the model to interpret and analyze PDF documents, allowing them to answer questions and perform tasks related to the content. To use document chat, an optional [FileCollection](/appstore/modules/genai/genai-for-mx/commons/#filecollection) containing one or multiple documents must be sent along with a single message.
+Document chat enables the model to interpret and analyze PDF documents, allowing it to answer questions and perform tasks based on the document content. To use document chat, you can send an optional [FileCollection](/appstore/modules/genai/genai-for-mx/commons/#filecollection) containing one or more documents along with a single message.
 
 For [Chat Completions (without history)](/appstore/modules/genai/genai-for-mx/commons/#chat-completions-without-history), `OptionalFileCollection` is an optional input parameter. For [Chat completions (with history)](/appstore/modules/genai/genai-for-mx/commons/#chat-completions-with-history), a `FileCollection` can optionally be added to individual user messages using [Add Message to Request](/appstore/modules/genai/genai-for-mx/commons/#chat-add-message-to-request).
 
-In the entire conversation, you can pass up 100 pages across multiple files and a maximum of 32MB. Currently, processing multiple files with OpenAI is not always guaranteed and can lead to unexpected behavior (e.g., only using one document).
+You can send up to 100 pages across multiple files, with a maximum combined size of 32 MB per conversation.  Currently, processing multiple files with OpenAI is not always guaranteed and can lead to unexpected behavior (for example, only one file being processed).
 
 {{% alert color="info" %}}
-Azure OpenAI does not support the use of file input at the moment.
+Azure OpenAI does not currently support file input.
 
-Note that the model uses the file name when analyzing documents, which could make it vulnerable to prompt injection. Depending on your use case, you may choose to modify the string or not pass it at all.
+Note that the model uses the file name when analyzing documents, which may introduce a potential vulnerability to prompt injection. To reduce this risk, consider modifying the string or not passing it at all.
 {{% /alert %}}
 
 #### Image Generations {#image-generations-configuration}
@@ -304,7 +304,6 @@ All [tool choice types](/appstore/modules/genai/genai-for-mx/commons/#enum-toolc
 | any                    | required|
 | none                   | none    |
 | tool                   | tool    |
-
 
 ## GenAI showcase Application {#showcase-application}
 

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/external-platforms/openai.md
@@ -280,6 +280,18 @@ The **Documentation** pane displays the documentation for the currently selected
 
     {{< figure src="/attachments/appstore/platform-supported-content/modules/technical-reference/doc-pane.png" >}}
 
+### Tool Choice
+
+All [tool choice types](/appstore/modules/genai/genai-for-mx/commons/#enum-toolchoice) of GenAI Commons for the [Tools: Set Tool Choice](/appstore/modules/genai/genai-for-mx/commons/#set-toolchoice) action are supported. For API mapping reference, see the table below:
+
+| GenAI Commons (Mendix) | OpenAI  |
+| -----------------------| ------- |
+| auto                   | auto    |
+| any                    | required|
+| none                   | none    |
+| tool                   | tool    |
+
+
 ## GenAI showcase Application {#showcase-application}
 
 For more inspiration or guidance on how to use those microflows in your logic, Mendix recommends downloading the [GenAI Showcase App](https://marketplace.mendix.com/link/component/220475), which demonstrates a variety of example use cases.

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/genai-commons.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/genai-commons.md
@@ -141,8 +141,9 @@ This is a file in a collection of files that belongs to a message. Each instance
 | `FileContent` | Depending on the `ContentType`, this is either a URL or the base64-encoded file data. |
 | `ContentType` | This describes the type of file data. Supported content types are either URL or base64-encoded file data. For more information, see the [ENUM_ContentType](#enum-contenttype) section.
 | `FileType` | Currently only images and documents are supported file types. In general, not all file types might be supported by all AI providers or models. For more information, see the [ENUM_FileType](#enum-filetype).
-| `TextContent` | An optional text content describing the file content or giving it a specific name. This can be used to refer to specific files in the prompt of the message. | 
+| `TextContent` | An optional text content describing the file content. | 
 | `FileExtension` | Extension of the file, e.g. *png* or *pdf*. Note that this attribute may only be filled if the ContentType equals *Base64* and can be empty. | 
+| `FileName` | If a FileDocument is added, the Filename is extracted automatically. | 
 
 #### `ToolCollection` {#toolcollection}
 

--- a/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/genai-commons.md
+++ b/content/en/docs/appstore/use-content/platform-supported-content/modules/genai/reference-guide/genai-commons.md
@@ -143,7 +143,7 @@ This is a file in a collection of files that belongs to a message. Each instance
 | `FileType` | Currently only images and documents are supported file types. In general, not all file types might be supported by all AI providers or models. For more information, see the [ENUM_FileType](#enum-filetype).
 | `TextContent` | An optional text content describing the file content. | 
 | `FileExtension` | Extension of the file, e.g. *png* or *pdf*. Note that this attribute may only be filled if the ContentType equals *Base64* and can be empty. | 
-| `FileName` | If a FileDocument is added, the Filename is extracted automatically. | 
+| `FileName` | If a FileDocument is added, the `Filename` is extracted automatically. | 
 
 #### `ToolCollection` {#toolcollection}
 


### PR DESCRIPTION
Added tables for tool choice in each connector to show how the GenAICommons values are mapped to the respective APIs.

For OpenAI, we added document chat as capability and renamed a few actions. The new capabilities are added to the general GenAI page.