### PR TITLE
Work around Hugo Cascade bug

### DIFF
--- a/content/en/docs/howto10/_index.md
+++ b/content/en/docs/howto10/_index.md
@@ -11,6 +11,8 @@ cascade:
     - notsitemap: true
     - sitemap:
         priority: 0.7
+    - banner: ""
+# Empty banner added to get around bug in Hugo 0.123.0 (https://github.com/gohugoio/hugo/issues/12465) which is not fixed until 0.143.0 (https://github.com/gohugoio/hugo/releases/tag/v0.143.0)
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/en/docs/howto9/_index.md
+++ b/content/en/docs/howto9/_index.md
@@ -12,6 +12,8 @@ cascade:
     - notsitemap: true
     - sitemap:
         priority: 0.3
+    - banner: ""
+# Empty banner added to get around bug in Hugo 0.123.0 (https://github.com/gohugoio/hugo/issues/12465) which is not fixed until 0.143.0 (https://github.com/gohugoio/hugo/releases/tag/v0.143.0)
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.
 ---
 

--- a/content/en/docs/refguide10/_index.md
+++ b/content/en/docs/refguide10/_index.md
@@ -11,6 +11,8 @@ cascade:
     - notsitemap: true
     - sitemap:
         priority: 0.8
+    - banner: ""
+# Empty banner added to get around bug in Hugo 0.123.0 (https://github.com/gohugoio/hugo/issues/12465) which is not fixed until 0.143.0 (https://github.com/gohugoio/hugo/releases/tag/v0.143.0)
 ---
 
 ## Introduction

--- a/content/en/docs/refguide9/_index.md
+++ b/content/en/docs/refguide9/_index.md
@@ -12,6 +12,8 @@ cascade:
     - notsitemap: true
     - sitemap:
         priority: 0.4
+    - banner: ""
+# Empty banner added to get around bug in Hugo 0.123.0 (https://github.com/gohugoio/hugo/issues/12465) which is not fixed until 0.143.0 (https://github.com/gohugoio/hugo/releases/tag/v0.143.0)
 ---
 
 ## Introduction

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -3,11 +3,13 @@
     <!-- Check if the page has a banner: "string" set if yes, display a banner. -->
     <!-- safeHTML means you can include HTML. If you need to escape double quotes, use \" -->
     <!-- For example: banner: "Go <a href=\"/refguide9/moving-from-8-to-9/\">here</a>" -->
-    {{ with .Params.banner}}
-    <div class="pageinfo pageinfo-warning">
-        <p>{{ . | safeHTML }}</p>
+    {{ with .Params.banner }}
+       {{ if ne . "" }}
+            <div class="pageinfo pageinfo-warning">
+             <p>{{ . | safeHTML }}</p>
+        {{ end }}
     </div>
-    {{end}}
+    {{ end }}
 
     <!-- If the page has draft: true set, display the following text as a banner. -->
     {{ with .Params.draft }}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -7,9 +7,9 @@
     {{ with .Params.banner }}
        {{ if ne . "" }}
             <div class="pageinfo pageinfo-warning">
-             <p>{{ . | safeHTML }}</p>
-        {{ end }}
-    </div>
+                <p>{{ . | safeHTML }}</p>
+            </div>
+       {{ end }}
     {{ end }}
 
     <!-- If the page has draft: true set, display the following text as a banner. -->

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -3,6 +3,7 @@
     <!-- Check if the page has a banner: "string" set if yes, display a banner. -->
     <!-- safeHTML means you can include HTML. If you need to escape double quotes, use \" -->
     <!-- For example: banner: "Go <a href=\"/refguide9/moving-from-8-to-9/\">here</a>" -->
+    <!-- Extra check for empty banner added to allow empty banners in front matter to get around bug in Hugo 0.123.0 (https://github.com/gohugoio/hugo/issues/12465) which is not fixed until 0.143.0 (https://github.com/gohugoio/hugo/releases/tag/v0.143.0) -->
     {{ with .Params.banner }}
        {{ if ne . "" }}
             <div class="pageinfo pageinfo-warning">


### PR DESCRIPTION
There is [a bug in Hugo v0.123.0](https://github.com/gohugoio/hugo/issues/12465) which means that cascaded items can leak onto other pages when the directory names are similar.
We are using Hugo v0.126.0
This is not fixed until [v0.143.0](https://github.com/gohugoio/hugo/releases/tag/v0.143.0)

This was causing problems with banners.

This workaround explicitly adds a blank banner to overwrite the incorrect banner and does not display a banner if it is blank. 