### PR TITLE
Oncommit webhook info update

### DIFF
--- a/content/en/docs/deployment/general/webhooks.md
+++ b/content/en/docs/deployment/general/webhooks.md
@@ -162,9 +162,7 @@ Make sure to use the correct key names when using this payload information to ca
 ## Teamserver Push (Git)
 
 {{% alert color="info" %}}
-This webhook is not visible for newly created apps. It is only visible for existing apps.
-
-For apps where the webhook is visible, do not delete it; deleting it would cause pipeline run failures for pipelines that rely on the Teamserver push (Git) trigger type.
+This webhook is not visible to first-time pipeline users. For existing pipeline users who can view this webhook, do not delete it. Deleting it causes failures for pipelines that rely on the Teamserver push (Git) trigger.
 {{% /alert %}}
 
 When you push a model change to the [Git Team Server](/developerportal/general/team-server/), and the webhook responds to the event **Teamserver push (Git)**, request content is sent to the configured endpoint. The request content contains a payload with the following format:

--- a/content/en/docs/deployment/general/webhooks.md
+++ b/content/en/docs/deployment/general/webhooks.md
@@ -162,7 +162,9 @@ Make sure to use the correct key names when using this payload information to ca
 ## Teamserver Push (Git)
 
 {{% alert color="info" %}}
-This webhook is not visible to first-time pipeline users. For existing pipeline users who can view this webhook, do not delete it. Deleting it causes failures for pipelines that rely on the Teamserver push (Git) trigger.
+This webhook is not visible to first-time pipeline users. 
+
+For existing pipeline users who can view this webhook, do not delete it. Deleting it causes failures for pipelines that rely on the Teamserver push (Git) trigger.
 {{% /alert %}}
 
 When you push a model change to the [Git Team Server](/developerportal/general/team-server/), and the webhook responds to the event **Teamserver push (Git)**, request content is sent to the configured endpoint. The request content contains a payload with the following format:

--- a/content/en/docs/deployment/general/webhooks.md
+++ b/content/en/docs/deployment/general/webhooks.md
@@ -161,6 +161,12 @@ Make sure to use the correct key names when using this payload information to ca
 
 ## Teamserver Push (Git)
 
+{{% alert color="info" %}}
+This webhook is not visible for newly created apps. It is only visible for existing apps.
+
+For apps where the webhook is visible, do not delete it; deleting it would cause pipeline run failures for pipelines that rely on the Teamserver push (Git) trigger type.
+{{% /alert %}}
+
 When you push a model change to the [Git Team Server](/developerportal/general/team-server/), and the webhook responds to the event **Teamserver push (Git)**, request content is sent to the configured endpoint. The request content contains a payload with the following format:
 
 ```json

--- a/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
@@ -321,7 +321,7 @@ Pipeline failure notifications only send if the user who triggered the pipeline 
 
 Pipelines time out if they run for more than three hours. In other words, if the operations in your pipeline cumulatively take longer than three hours to complete, then the pipeline will fail.
 
-To trigger pipelines based on Teamserver push (Git), Mendix automatically creates a webhook on your behalf. You can see this webhook if you click **Webhooks** in the [navigation pane](/developerportal/#navigation-pane). Do not delete this webhook; deleting it would cause pipeline run failures for pipelines that rely on the Teamserver push (Git) trigger type.
+To trigger pipelines based on [Teamserver push (Git)](/developerportal/deploy/webhooks/#teamserver-push-git), Mendix automatically creates a webhook on your behalf.
 
 ### Known Issues and Limitations
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
@@ -321,7 +321,10 @@ Pipeline failure notifications only send if the user who triggered the pipeline 
 
 Pipelines time out if they run for more than three hours. In other words, if the operations in your pipeline cumulatively take longer than three hours to complete, then the pipeline will fail.
 
-To trigger pipelines based on [Teamserver push (Git)](/developerportal/deploy/webhooks/#teamserver-push-git), Mendix automatically creates a webhook on your behalf. This webhook is not visible for newly created apps. For existing apps, you can view this webhook by clicking **Webhooks** in the [navigation pane](/developerportal/#navigation-pane). Do not delete this webhook; deleting it would cause pipeline run failures for pipelines that rely on the Teamserver push (Git) trigger type.
+Mendix automatically creates a webhook on your behalf to trigger pipelines based on [Teamserver push (Git)](/developerportal/deploy/webhooks/#teamserver-push-git):
+
+* This webhook is not visible to first-time pipeline users. 
+* For existing pipeline users, you can view this webhook by clicking **Webhooks** in the [navigation pane](/developerportal/#navigation-pane). Do not delete this webhook. Deleting it causes failures for pipelines that rely on the Teamserver push (Git) trigger.
 
 ### Known Issues and Limitations
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/pipelines.md
@@ -321,7 +321,7 @@ Pipeline failure notifications only send if the user who triggered the pipeline 
 
 Pipelines time out if they run for more than three hours. In other words, if the operations in your pipeline cumulatively take longer than three hours to complete, then the pipeline will fail.
 
-To trigger pipelines based on [Teamserver push (Git)](/developerportal/deploy/webhooks/#teamserver-push-git), Mendix automatically creates a webhook on your behalf.
+To trigger pipelines based on [Teamserver push (Git)](/developerportal/deploy/webhooks/#teamserver-push-git), Mendix automatically creates a webhook on your behalf. This webhook is not visible for newly created apps. For existing apps, you can view this webhook by clicking **Webhooks** in the [navigation pane](/developerportal/#navigation-pane). Do not delete this webhook; deleting it would cause pipeline run failures for pipelines that rely on the Teamserver push (Git) trigger type.
 
 ### Known Issues and Limitations
 


### PR DESCRIPTION
Based on a recent change, the webhook created by pipelines for the "On commit" trigger will not be visible on the webhooks page for new apps - the webhook will still be visible for legacy apps. Thus making the current info stale.

This PR fixes that.