### PR TITLE
Add render-codeblock hook to tell Shutto to ignore translating codeblocks.

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,5 @@
+<!-- MvM - added to prevent Shutto from translating codeblocks -->
+<span data-stt-ignore>
+{{ $result := transform.HighlightCodeBlock . }}
+{{ $result.Wrapped }}
+</span>


### PR DESCRIPTION
Uses documentation here: https://gohugo.io/render-hooks/code-blocks/

With a bit of help from GPT to remind me there was a relevant render hook.