### PR TITLE
Add deprecation notice for Native Mobile AR module

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/modules/native-mobile-ar.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/native-mobile-ar.md
@@ -1,9 +1,14 @@
 ---
 title: "Native Mobile AR"
+deprecated: true
 url: /appstore/modules/native-mobile-ar/
 description: "Describes the Native Mobile AR module, which is available in the Mendix Marketplace."
 #If moving or renaming this doc file, implement a temporary redirect and let the respective team know they should update the URL in the product. See Mapping to Products for more details. 
 ---
+
+{{% alert color="warning" %}}
+As of Mendix version 10.24, the Native Mobile AR module is deprecated and will not receive further updates.
+{{% /alert %}}
 
 ## Introduction
 


### PR DESCRIPTION
This PR updates the Native Mobile AR module documentation to reflect its deprecation as of Mendix version 10.24.