### PR TITLE
Fix 9.24 release note for Node.js upgrade

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/9/9.24.md
+++ b/content/en/docs/releasenotes/studio-pro/9/9.24.md
@@ -19,7 +19,7 @@ This is the [LTS](/releasenotes/studio-pro/lts-mts/#lts) version 9 release for a
 
 ### Improvements
     
-* We updated the bundled Node.js from v20 to v22.
+* We updated the bundled Node.js from v16 to v22.
 
 ### Fixes
     


### PR DESCRIPTION
Hi,
I just noticed that I made a mistake for the 9.24 release note, which is correct by this MR. For all other versions of Studio Pro, the release note is correct, as Node.js was updated from v20 to v22.