### PR TITLE
Update supported databases in system requirements

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -216,12 +216,12 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
-* [MariaDB](/refguide/mysql/): 10.4, 10.5, 10.6, 10.11, 11.4
+* [MariaDB](/refguide/mysql/): 10.6, 10.11, 11.4, 11.8
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
-* [MySQL](/refguide/mysql/): 8.0, 8.4
+* [MySQL](/refguide/mysql/): 8.4
 * [Oracle Database](/refguide/oracle/): 19, 21c
-* PostgreSQL: 12, 13, 14, 15, 16, 17
+* PostgreSQL: 13, 14, 15, 16, 17
 * [SAP HANA](/refguide/saphana/): 2.00.076.00.1705400033
 
 {{% alert color="warning" %}}

--- a/content/en/docs/refguide10/installation/system-requirements.md
+++ b/content/en/docs/refguide10/installation/system-requirements.md
@@ -240,12 +240,12 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
-* [MariaDB](/refguide10/mysql/): 10.4, 10.5, 10.6, 10.11, 11.4
+* [MariaDB](/refguide10/mysql/): 10.6, 10.11, 11.4, 11.8
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
-* [MySQL](/refguide10/mysql/): 8.0, 8.4
+* [MySQL](/refguide10/mysql/): 8.4
 * [Oracle Database](/refguide10/oracle/): 19, 21c
-* PostgreSQL: 12, 13, 14, 15, 16, 17
+* PostgreSQL: 13, 14, 15, 16, 17
 * [SAP HANA](/refguide10/saphana/): 2.00.076.00.1705400033
 
 {{% alert color="warning" %}}

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -102,14 +102,13 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
-* [IBM DB2](/refguide8/db2/) 11.5 for Linux, Unix, and Windows
-* [MariaDB](/refguide8/mysql/) 10.4, 10.5, 10.6, 10.11
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/) 2019, 2022
-* [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017) v12 compatibility mode 140 or higher
-* [MySQL](/refguide8/mysql/) 8.0
-* [Oracle Database](/refguide8/oracle/) 19, 21c
-* PostgreSQL 12, 13, 14, 15, 16
-* [SAP HANA](/refguide8/saphana/) 2.00.040.00.1545918182
+* [MariaDB](/refguide8/mysql/): 10.6, 10.11, 11.4, 11.8
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
+* [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
+* [MySQL](/refguide8/mysql/): 8.4
+* [Oracle Database](/refguide8/oracle/): 19, 21c
+* PostgreSQL: 13, 14, 15, 16, 17
+* [SAP HANA](/refguide8/saphana/): 2.00.076.00.1705400033
 
 {{% alert color="warning" %}}
 Each app should have its own database. Mendix apps cannot share data by sharing the same database. 

--- a/content/en/docs/refguide8/general/system-requirements.md
+++ b/content/en/docs/refguide8/general/system-requirements.md
@@ -102,6 +102,7 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
+* [IBM DB2](/refguide8/db2/) 11.5 for Linux, Unix, and Windows
 * [MariaDB](/refguide8/mysql/): 10.6, 10.11, 11.4, 11.8
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -203,6 +203,7 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
+* [IBM DB2](/refguide8/db2/) 11.5 for Linux, Unix, and Windows
 * [MariaDB](/refguide9/mysql/): 10.6, 10.11, 11.4, 11.8
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -203,14 +203,13 @@ Mendix tries to support the most recent and patched database server versions fro
 
 Current support:
 
-* [MariaDB](/refguide9/mysql/): 10.4, 10.5, 10.6, 10.11
+* [MariaDB](/refguide9/mysql/): 10.6, 10.11, 11.4, 11.8
 * [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
-* [MySQL](/refguide9/mysql/): 8.0
+* [MySQL](/refguide9/mysql/): 8.4
 * [Oracle Database](/refguide9/oracle/): 19, 21c
-* PostgreSQL: 12, 13, 14, 15, 16
-* [SAP HANA](/refguide9/saphana/): 2.00.040.00.1545918182
-* [IBM DB2](/refguide9/db2/): 11.5 for Linux, Unix, and Windows (please note that support for DB2 is deprecated and will be removed in Studio Pro 10)
+* PostgreSQL: 13, 14, 15, 16, 17
+* [SAP HANA](/refguide9/saphana/): 2.00.076.00.1705400033
 
 {{% alert color="warning" %}}
 Each app must have its own database. Mendix apps cannot share data by sharing the same database.


### PR DESCRIPTION
To be published with 11.2 release

MariaDB 10.5 and MySQL 8.0 will be announced as to be dropped, but it should be safe to already remove them from the requirements as they are not supported by the vendors.