### PR TITLE
Documented how to enhance persistent mode in the browser file storage (OPFS)

### DIFF
--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
@@ -140,12 +140,12 @@ Datagrids can not have columns with attributes from related entities in offline 
 
 Attribute paths can not be used in sort orderings in offline apps.
 
-## Enhancing persistent mode in file storage
+## Enhancing persistent mode in file storage {#persistent-mode}
 
 When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS).
-The OPFS can operate in two modes: 'persistent' and 'best-effort'. The 'persistent' mode is preferable because it offers
-greater storage capacity and better data durability. While 'persistent' mode is used by default, a browser may opt for
-'best-effort' mode if it assesses the site's importance as low. This assessment is made based on internal browser heuristics,
+The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers
+greater storage capacity and better data durability. While **persistent** mode is used by default, a browser may opt for
+**best-effort** mode if it assesses the site's importance as low. This assessment is made based on internal browser heuristics,
 which include:
 * The level of site engagement
 * Whether the site has been bookmarked
@@ -155,5 +155,5 @@ To enhance the likelihood of operating the OPFS in 'persistent' mode, consider t
 * Bookmark the site
 * Enable notifications for the site
 
-Firefox does not utilize heuristics but instead displays a popup requesting permission to use 'persistent' mode.
-To proceed, simply click 'Allow' in the popup.
+Firefox does not utilize heuristics but instead displays a popup requesting permission to use **persistent** mode.
+To proceed, simply click **Allow** in the popup.

--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
@@ -142,7 +142,7 @@ Attribute paths can not be used in sort orderings in offline apps.
 
 ## Enhancing Persistent Mode in File Storage {#persistent-mode}
 
-When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS). The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers greater storage capacity and better data durability. While **persistent** mode is used by default, a browser may opt for **best-effort** mode if it assesses the site's importance as low. This assessment is made based on internal browser metrics, which include the following:
+When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS). The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers greater storage capacity and better data durability. While **persistent** mode is used by default, a browser may opt for **best-effort** mode if it assesses the site's importance as low. This assessment is made based on internal browser heuristics, which include the following:
 * The level of site engagement
 * Whether the site has been bookmarked
 * Whether permission for site notifications has been granted
@@ -151,5 +151,4 @@ To enhance the likelihood of operating the OPFS in 'persistent' mode, consider t
 * Bookmark the site
 * Enable notifications for the site
 
-Firefox does not utilize heuristics but instead displays a popup requesting permission to use **persistent** mode.
-To proceed, simply click **Allow** in the popup.
+Firefox does not utilize heuristics but instead displays a popup requesting permission to use **persistent** mode. To proceed, simply click **Allow** in the popup.

--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
@@ -139,3 +139,21 @@ Datagrids can not have columns with attributes from related entities in offline 
 ### Attribute Paths in Sort Orders
 
 Attribute paths can not be used in sort orderings in offline apps.
+
+## Enhancing persistent mode in file storage
+
+When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS).
+The OPFS can operate in two modes: 'persistent' and 'best-effort'. The 'persistent' mode is preferable because it offers
+greater storage capacity and better data durability. While 'persistent' mode is used by default, a browser may opt for
+'best-effort' mode if it assesses the site's importance as low. This assessment is made based on internal browser heuristics,
+which include:
+* The level of site engagement
+* Whether the site has been bookmarked
+* Whether permission for site notifications has been granted
+
+To enhance the likelihood of operating the OPFS in 'persistent' mode, consider taking the following actions:
+* Bookmark the site
+* Enable notifications for the site
+
+Firefox does not utilize heuristics but instead displays a popup requesting permission to use 'persistent' mode.
+To proceed, simply click 'Allow' in the popup.

--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
@@ -142,11 +142,7 @@ Attribute paths can not be used in sort orderings in offline apps.
 
 ## Enhancing Persistent Mode in File Storage {#persistent-mode}
 
-When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS).
-The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers
-greater storage capacity and better data durability. While **persistent** mode is used by default, a browser may opt for
-**best-effort** mode if it assesses the site's importance as low. This assessment is made based on internal browser heuristics,
-which include:
+When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS). The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers greater storage capacity and better data durability. While **persistent** mode is used by default, a browser may opt for **best-effort** mode if it assesses the site's importance as low. This assessment is made based on internal browser metrics, which include the following:
 * The level of site engagement
 * Whether the site has been bookmarked
 * Whether permission for site notifications has been granted

--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/best-practices.md
@@ -140,7 +140,7 @@ Datagrids can not have columns with attributes from related entities in offline 
 
 Attribute paths can not be used in sort orderings in offline apps.
 
-## Enhancing persistent mode in file storage {#persistent-mode}
+## Enhancing Persistent Mode in File Storage {#persistent-mode}
 
 When using offline profiles, files are stored locally on a user's device in the browser Origin Private File System (OPFS).
 The OPFS can operate in two modes: **persistent** and **best-effort**. The **persistent** mode is preferable because it offers


### PR DESCRIPTION
Recently, an improvement was added to the code related to the browser file storage (Origin Private File System (OPFS)), which is used for offline profiles. Now we run OPFS in a 'persistent' mode. However, a browser can decide to switch back to 'best-effort' mode under certain conditions. In this PR, we added documentation on how to enhance the likelihood of operating the OPFS in 'persistent' mode.

P.S. I am not sure if I placed the new section on the proper page. Please let me know if I need to move it somewhere.