### PR TITLE
[WTF-2318]: Default Parameter Argument Mappings

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -2,7 +2,7 @@
 title: "Client APIs"
 linktitle: "Client APIs for Pluggable Widgets"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/
-description: A guide for understanding the client APIs available to pluggable widgets in Mx10.
+description: A guide for understanding the client APIs available to pluggable widgets.
 weight: 20
 aliases:
     - /apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/pluggable-widgets-client-apis-list-values.md
@@ -1,7 +1,7 @@
 ---
 title: "List Values"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/
-description: A guide to understanding the list of objects for the datasource property in Mx10.
+description: A guide to understanding the list of objects for the datasource property.
 ---
 
 ## Introduction

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
@@ -484,6 +484,8 @@ If a `dataSource` attribute is not specified, the client will receive an `Action
 
 When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListActionValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listactionvalue). For more information, see the [Datasource](#datasource) section below.
 
+Action properties can be preconfigured using the `defaultValue` and `defaultType` attributes. This is particularly useful when the widget is intended to be used with a specific microflow, nanoflow, or page. When the property [exposes action variables](#action-xml-elements), they are automatically mapped to parameters of matching name and type.
+
 #### XML Attributes {#xml-attributes}
 
 | Attribute      | Required | Attribute Type | Description                                                                                             |
@@ -496,7 +498,7 @@ When a `dataSource` attribute is specified and configured by the user, it is pas
 
 #### XML Elements {#action-xml-elements}
 
-`<actionVariables>` — Defines variables a widget provides when calling [execute() on an ActionValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#execute). The variables are made available in Studio Pro when configuring [Call a Microflow](/refguide/on-click-event/#call-microflow) and [Call a Nanoflow](/refguide/on-click-event/#call-nanoflow) actions.
+`<actionVariables>` — Defines variables a widget provides when calling [execute() on an ActionValue](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#execute). The variables are made available in Studio Pro when configuring [Call a Microflow](/refguide/on-click-event/#call-microflow) and [Call a Nanoflow](/refguide/on-click-event/#call-nanoflow) actions. Action variables are automatically mapped to parameters of the same name (`key`) and type.
 
 `<actionVariable>` (required one or more) — Represents a primitive value provided by the widget as an argument when calling `ActionValue.execute()`. The variable is defined by the following attributes:
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
@@ -480,7 +480,7 @@ Then the Studio Pro UI for the property appears like this:
 
 The action property type allows a user to configure an action which can do things like call nanoflows, save changes, and open pages.
 
-If a `dataSource` attribute is not specified, the client will receive an `ActionValue` representing the action or `undefined` if the **Do nothing** action was selected.
+If a `dataSource` attribute is not specified, the client will receive an [`ActionValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/#actionvalue) representing the action or `undefined` if the **Do nothing** action was selected.
 
 When a `dataSource` attribute is specified and configured by the user, it is passed as a [`ListActionValue`](/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#listactionvalue). For more information, see the [Datasource](#datasource) section below.
 

--- a/content/en/docs/refguide/modeling/pages/on-click-event.md
+++ b/content/en/docs/refguide/modeling/pages/on-click-event.md
@@ -223,7 +223,7 @@ Set the **Nanoflow** property to specify a [nanoflow](/refguide/nanoflow/) that 
 
 You can either select an existing nanoflow or create a new nanoflow by clicking the **New** button from the **Select Nanoflow** dialog box.
 
-**Nanoflow arguments** specify the values that are passed as parameters when the nanoflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the **Nanoflow** is set, arguments are automatically filled for parameters with clear candidate variables. For example, because the name of the variable matches that of the parameter, or only one variable of the parameter's type is available.
+**Nanoflow arguments** specify the values that are passed as parameters when the nanoflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the **Nanoflow** is set, arguments are automatically filled for parameters with matching candidate variables. Specifically, if the name of the variable matches that of the parameter, or only one variable of the parameter's type is available, then arguments for those parameters will be filled with those candidate values automatically.
 
 If there is nothing to pass to the new nanoflow, then a dialog box is shown where you can only specify the name of the nanoflow.
 

--- a/content/en/docs/refguide/modeling/pages/on-click-event.md
+++ b/content/en/docs/refguide/modeling/pages/on-click-event.md
@@ -138,7 +138,7 @@ This duplicates the [Microflow](#microflow) specified above.
 
 ##### Microflow Arguments
 
-**Microflow arguments** specify the values that are passed as parameters when the microflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the [**Microflow**](#microflow) is set, arguments are automatically filled for parameters with clear candidate variables. For example, because the name of the variable matches that of the parameter, or only one variable of the parameter's type is available.
+**Microflow arguments** specify the values that are passed as parameters when the microflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the [**Microflow**](#microflow) is set, arguments are automatically filled for parameters with matching candidate variables. Specifically, if the name of the variable matches that of the parameter, or only one variable of the parameter's type is available, then arguments for those parameters will be filled with those candidate values automatically.
 
 ##### Microflow Call Type
 

--- a/content/en/docs/refguide/modeling/pages/on-click-event.md
+++ b/content/en/docs/refguide/modeling/pages/on-click-event.md
@@ -138,9 +138,7 @@ This duplicates the [Microflow](#microflow) specified above.
 
 ##### Microflow Arguments
 
-**Microflow arguments** are automatically configured based on the parameters of the selected microflow and the available arguments. In general arguments are taken from any enclosing data widget. If the data widget enclosing the widget calling a microflow is inside another (nested) data widget, then objects from that data widget and any others in which it is nested can also be passed.
-
-If the microflow is triggered within a grid and has an object list parameter, the objects which are passed in the list depend on the selection mode of the grid. Simple multi-selection allows for either all rows or selection, and defaults to selection. This can be configured via the drop-down menu in the microflow settings page. A grid with single selection always passes all rows to the microflow.
+**Microflow arguments** specify the values that are passed as parameters when the microflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the [**Microflow**](#microflow) is set, arguments are automatically filled for parameters with clear candidate variables. For example, because the name of the variable matches that of the parameter, or only one variable of the parameter's type is available.
 
 ##### Microflow Call Type
 
@@ -225,7 +223,7 @@ Set the **Nanoflow** property to specify a [nanoflow](/refguide/nanoflow/) that 
 
 You can either select an existing nanoflow or create a new nanoflow by clicking the **New** button from the **Select Nanoflow** dialog box.
 
-When creating a new nanoflow, a dialog box is shown where you can set the name and select parameters for the new nanoflow. You can choose the data view, snippet, page parameter, or available selection from which the parameter must be created in the new nanoflow.
+**Nanoflow arguments** specify the values that are passed as parameters when the nanoflow is called. Each argument can be defined using an expression or by choosing a variable that is available on the page. Variables are exposed by the widget itself, surrounding data widgets, a widget with selection, page variables, and page parameters. When the **Nanoflow** is set, arguments are automatically filled for parameters with clear candidate variables. For example, because the name of the variable matches that of the parameter, or only one variable of the parameter's type is available.
 
 If there is nothing to pass to the new nanoflow, then a dialog box is shown where you can only specify the name of the nanoflow.
 


### PR DESCRIPTION
Microflow and Nanoflow calls now automatically assign variables to parameters that have matching names. This MR updates relevant sections.

It also includes some small bonus improvements.

Up for discussion: I removed the description of the selection behavior for Data Grid 1, as it is incompatible with React Client and is no longer included in the Blank App template for new apps in 11. The behavior is still present, but will only work for apps that are upgraded to 11 from an earlier version, include Data Grid 1, and have not migrated to React Client.