### PR TITLE
[UIA-1213] Add reference to the releases of the Private PDF Document Generation Service

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/modules/document-generation/private-service.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/document-generation/private-service.md
@@ -60,9 +60,9 @@ The following artifact is available for installing the service:
 Follow these steps to install the service through Docker:
 
 1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`.
-2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`. This creates a Docker container, which is exposed on port `8085`.
+2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`. This creates a Docker container, which is exposed on port `8085`.    
 
-{{% alert color="info" %}}The `<tag>` component must be replaced with the version of the service, such as `1.0.0`. You can find all versions and the release notes in the Marketplace Services release notes for the [Private PDF Document Generation Service](/releasenotes/marketplace/private-service/).{{% /alert %}}
+The `<tag>` component must be replaced with the version of the service, such as `1.0.0`. You can find all versions and their release notes in the [Private PDF Document Generation Service Release Notes](/releasenotes/marketplace/private-service/).
 
 ### Isolation
 

--- a/content/en/docs/marketplace/platform-supported-content/modules/document-generation/private-service.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/document-generation/private-service.md
@@ -59,8 +59,10 @@ The following artifact is available for installing the service:
 
 Follow these steps to install the service through Docker:
 
-1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:1.0.0`.
-2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:1.0.0`. This creates a Docker container, which is exposed on port `8085`.
+1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`.
+2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`. This creates a Docker container, which is exposed on port `8085`.
+
+{{% alert color="info" %}}The `<tag>` component must be replaced with the version of the service, such as `1.0.0`. You can find all versions and the release notes in the Marketplace Services release notes for the [Private PDF Document Generation Service](/releasenotes/marketplace/private-service/).{{% /alert %}}
 
 ### Isolation
 


### PR DESCRIPTION
- Added note to explain and reference the new section for the release notes of the Private PDF Document Generation service.
- Removed the static version in the commands