### PR TITLE
Add note about AppleDouble in MxBuild docs

### DIFF
--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -36,6 +36,13 @@ For details on the system requirements for MxBuild, see [System Requirements](/r
 The examples used in this document are for Windows, except when specifically mentioned otherwise.
 {{% /alert %}}
 
+{{% alert color="info" %}}
+Note for MXbuild and macOS users:
+
+If you are using the macOS version of Studio Pro and you store your project files on an external drive not formatted using the Apple File System, macOS can generate hidden files and folders that can make Windows versions of Studio Pro or MxBuild not work as expected.
+{{% /alert %}}
+
+
 ## Command Line
 
 To build your package, specify the Mendix app file (*.mpr*) for which you want to build the deployment package (*.mda*) on the command-line. The file name may be preceded by a relative or absolute path. The app file should be located inside a Mendix app directory.

--- a/content/en/docs/refguide/general/mxbuild.md
+++ b/content/en/docs/refguide/general/mxbuild.md
@@ -36,8 +36,8 @@ For details on the system requirements for MxBuild, see [System Requirements](/r
 The examples used in this document are for Windows, except when specifically mentioned otherwise.
 {{% /alert %}}
 
-{{% alert color="info" %}}
-Note for MXbuild and macOS users:
+{{% alert color="warning" %}}
+For MxBuild and macOS users:
 
 If you are using the macOS version of Studio Pro and you store your project files on an external drive not formatted using the Apple File System, macOS can generate hidden files and folders that can make Windows versions of Studio Pro or MxBuild not work as expected.
 {{% /alert %}}

--- a/content/en/docs/refguide10/general/mxbuild.md
+++ b/content/en/docs/refguide10/general/mxbuild.md
@@ -36,6 +36,12 @@ For details on the system requirements for MxBuild, see [System Requirements](/r
 The examples used in this document are for Windows, except when specifically mentioned otherwise.
 {{% /alert %}}
 
+{{% alert color="info" %}}
+Note for MXbuild and macOS users:
+
+If you are using the macOS version of Studio Pro and you store your project files on an external drive not formatted using the Apple File System, macOS can generate hidden files and folders that can make Windows versions of Studio Pro or MxBuild not work as expected.
+{{% /alert %}}
+
 ## Command Line
 
 To build your package, specify the Mendix app file (*.mpr*) for which you want to build the deployment package (*.mda*) on the command-line. The file name may be preceded by a relative or absolute path. The app file should be located inside a Mendix app directory.

--- a/content/en/docs/refguide10/general/mxbuild.md
+++ b/content/en/docs/refguide10/general/mxbuild.md
@@ -36,8 +36,8 @@ For details on the system requirements for MxBuild, see [System Requirements](/r
 The examples used in this document are for Windows, except when specifically mentioned otherwise.
 {{% /alert %}}
 
-{{% alert color="info" %}}
-Note for MXbuild and macOS users:
+{{% alert color="warning" %}}
+For MxBuild and macOS users:
 
 If you are using the macOS version of Studio Pro and you store your project files on an external drive not formatted using the Apple File System, macOS can generate hidden files and folders that can make Windows versions of Studio Pro or MxBuild not work as expected.
 {{% /alert %}}


### PR DESCRIPTION
On this story we add a note about possible file incompatibilities due to AppleDouble for mx11 and mx10, I've placed it on the MxBuild file after the example alarm, but feel free to move it to a more convenient spot. 

This change is not tied to any particular release and it can be merged at your earliest convenience :)