### PR TITLE
[MOO-1948] - Fix feedback widget documentation

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/modules/mendix-feedback.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/mendix-feedback.md
@@ -50,7 +50,7 @@ Typically, feedback module usage has the following flow:
 
 * This module is compatible with Studio Pro 9.18.6 or higher.
 * [Atlas Core](https://marketplace.mendix.com/link/component/117187) is required to apply the styling.
-* In native mobile apps, some of the feedback metadata such as username, email address, and document name will be hard-coded, as they cannot be retrieved dynamically (to address this you can use the [Native Feedback widget](/appstore/modules/native-mobile-resources/) instead, located in [Native Mobile Resources](https://marketplace.mendix.com/link/component/109513)).
+* In native mobile apps, some of the feedback metadata, such as username, email address, and document name, will be hard-coded, as it cannot be retrieved dynamically.
 
 ## Installation
 


### PR DESCRIPTION
**Problem**: The current documentation suggests using the Native Feedback widget as a solution for hard-coded metadata in native mobile apps:
> In native mobile apps, some of the feedback metadata such as username, email address, and document name will be hard-coded, as they cannot be retrieved dynamically (to address this you can use the [Native Feedback widget](https://docs.mendix.com/appstore/modules/native-mobile-resources/) instead, located in [Native Mobile Resources](https://marketplace.mendix.com/link/component/109513)).

**Issue**: This recommendation is misleading because the Native Feedback widget from Native Mobile Resources also has the same limitation - it has [hard-coded metadata](https://github.com/mendix/native-widgets/blob/main/packages/pluggableWidgets/feedback-native/src/utils/sprintrApi.ts#L16).

**Solution**: Removed the parenthetical recommendation text since native feedback widget has the same metadata limitation. The documentation now accurately states the limitation without suggesting an ineffective workaround.