### PR TITLE
Add support for self signed certificate

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/services/private-service.md
+++ b/content/en/docs/marketplace/platform-supported-content/services/private-service.md
@@ -63,13 +63,13 @@ The following artifact is available for installing the service:
 Follow these steps to install the service through Docker:
 
 {{% alert color="info" %}}
-If you are using a self-signed certificate in your environment, skip the below steps and see [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate).
+If you are using a self-signed certificate in your environment, skip these steps and refer to the [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate) section.
 {{% /alert %}}
 
 1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:latest`.
 2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:latest`. This creates a Docker container, which is exposed on port `8085`.    
 
-The `latest` tag will use the most recent released version of the service. If you would like to use a specific version, replace `latest` tag with the desired version, such as `1.0.0`. You can find all versions and their release notes in the [Private PDF Document Generation Service Release Notes](/releasenotes/marketplace/private-service/).
+    The `latest` tag allows you to use the most recent released version of the service. If you want to use a specific version, replace `latest` with the desired version, such as `1.0.0`. You can find all versions and their release notes in the [Private PDF Document Generation Service Release Notes](/releasenotes/marketplace/private-service/).
 
 #### Setting Up a Health Check (Optional)
 
@@ -118,15 +118,15 @@ When using Docker to run the image, add the configuration using the provided env
 |----------------------|---------------|-------------|
 | `MAX_DOCUMENT_SIZE` | `25000000` (25 MB) | The maximum size for PDF documents generated using the service. When a PDF exceeds this file size, the request is aborted. |
 | `MAX_PAGE_RENDERING_TIME` | `30000` (30 seconds) | The maximum time to wait for the page to finish loading and rendering. If loading the page exceeds this time, a [Wait for Content](/appstore/modules/document-generation/#wait-for-content-exception) exception is sent to the module. |
-| `ACCEPT_INSECURE_CERTIFICATES` | `false` | <p> Allows the use of untrusted certificates, such as when using self-signed certificates.</p> <p> **Warning:** This disables certificate validation, and allows the use of invalid certificates. Be aware of any resulting security risks.</p> <p> Alternatively, for better security, you can provide your certificates to the service, see [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate).</p>|
+| `ACCEPT_INSECURE_CERTIFICATES` | `false` | <p> Allows the use of untrusted certificates, such as when using self-signed certificates.</p> <p> **Warning:** This disables certificate validation, and allows the use of invalid certificates. Be aware of any resulting security risks. Alternatively, for better security, you can provide your certificates to the service. For details, refer to the [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate) section.</p>|
 
 ### Importing a Self-Signed Certificate {#importing-a-self-signed-certificate}
 
-If your environment uses a self-signed certificate, you can extend the PDF Document Generation service Docker image to trust this certificate. This is required for secure communication when the service needs to connect to endpoints using your custom CA.
+If your environment uses a self-signed certificate, you can extend the PDF Document Generation service Docker image to trust this certificate. This is required for secure communication when the service needs to connect to endpoints using your custom Certificate Authority (CA).
 
 Follow these steps:
 
-1. **Create a Dockerfile** (for example, `Dockerfile.import-cert`) with the following content:
+1. Create a Docker file, such as `Dockerfile.import-cert`, with the following content:
 
     ```dockerfile
     FROM private-cloud.registry.mendix.com/mendix/document-generation-service:latest
@@ -166,23 +166,23 @@ Follow these steps:
     CMD [ "node", "bundle.js" ]
     ```
 
-1. **Build the Docker image** with your certificate:
+1. Build the Docker image with your certificate:
+
     ```bash
     docker build -f Dockerfile.import-cert --build-arg CERT_FILE_PATH=<path-to-your-ca.crt> -t document-generation-service-with-cert .
     ```
 
-1. **Run the container** as usual:
+1. Run the container as usual:
+
     ```bash
     docker run -p 8085:8085 --name document-generation-service-with-cert
     ```
 
-    **Note:** Replace `<path-to-your-ca.crt>` with the path to your self-signed certificate `.crt` or `.pem` file.
+    Replace `<path-to-your-ca.crt>` with the path to your self-signed certificate's `.crt` or `.pem` file.
 
-This approach ensures the service trusts your self-signed certificate for secure connections.
+This approach ensures that the service trusts your self-signed certificate for secure connections.
 
-{{% alert color="info" %}}
-If this self-signed certificate is all you need for the service to trust, Then it's best to disable the flag `ACCEPT_INSECURE_CERTIFICATES` by setting the value to `false`.
-{{% /alert %}}
+If you only need the service to trust this self-signed certificate, Mendix recommends setting the `ACCEPT_INSECURE_CERTIFICATES` variable to `false`.
 
 ## Configuring your Mendix Apps
 

--- a/content/en/docs/marketplace/platform-supported-content/services/private-service.md
+++ b/content/en/docs/marketplace/platform-supported-content/services/private-service.md
@@ -63,13 +63,13 @@ The following artifact is available for installing the service:
 Follow these steps to install the service through Docker:
 
 {{% alert color="info" %}}
-If you are using a self-signed certificate in your environment, skip the below step and see [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate).
+If you are using a self-signed certificate in your environment, skip the below steps and see [Importing a Self-Signed Certificate](#importing-a-self-signed-certificate).
 {{% /alert %}}
 
-1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`.
-2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:<tag>`. This creates a Docker container, which is exposed on port `8085`.    
+1. Pull the Docker image using the following command: `docker pull private-cloud.registry.mendix.com/mendix/document-generation-service:latest`.
+2. Run the Docker container using the following command: `docker run -p 8085:8085 --name document-generation private-cloud.registry.mendix.com/mendix/document-generation-service:latest`. This creates a Docker container, which is exposed on port `8085`.    
 
-The `<tag>` component must be replaced with the version of the service, such as `1.0.0`. You can find all versions and their release notes in the [Private PDF Document Generation Service Release Notes](/releasenotes/marketplace/private-service/).
+The `latest` tag will use the most recent released version of the service. If you would like to use a specific version, replace `latest` tag with the desired version, such as `1.0.0`. You can find all versions and their release notes in the [Private PDF Document Generation Service Release Notes](/releasenotes/marketplace/private-service/).
 
 #### Setting Up a Health Check (Optional)
 


### PR DESCRIPTION
### Changes:

- Added section with Dockerfile to enable customers to import their own self-signed certificate to the service.
- Change the `<tag>` with `latest` to recommend using the latest version of the service. also for easier setup.