### PR TITLE
Update distributing-native-apps.md

### DIFF
--- a/content/en/docs/refguide/mobile/distributing-mobile-apps/distributing-native-apps.md
+++ b/content/en/docs/refguide/mobile/distributing-mobile-apps/distributing-native-apps.md
@@ -59,7 +59,6 @@ The downloaded *ios_development.cer* and *private.key* file must now be packaged
 2. Convert the downloaded certificate to *pem* format with this command: `"C:\OpenSSL\bin\openssl.exe" x509 -in "C:\ios_development.cer" -inform der -out "C:\ios_development.pem"`.
 3. Package your private key and certificate. The command will ask you for a password for the package: `"C:\OpenSSL\bin\openssl.exe" pkcs12 -export -inkey "C:\private.key" -in "C:\ios_development.pem" -out "C:\key_and_certificate.p12"`. The same password will be used later by the Mendix Native Mobile Builder.
 
-The resulting *key_and_certificate.p12* will be used by the Mendix Native Mobile Builder to sign your apps.
 
 ### Creating the Required Distribution Profile
 


### PR DESCRIPTION
Certificates cannot be uploaded in NBUI anymore. So removed the "certificate will be used by the Mendix Native Mobile Builder to sign your apps." part.