### PR TITLE
Added documentation about pagination parameters in PCLM (no release date)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -498,8 +498,7 @@ Where:
 * `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list license usage in batches.
 
 {{% alert color="info" %}}
-To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
-This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go. This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
 {{% /alert %}}
 
 Which would reply with something similar to this:

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -334,11 +334,10 @@ mx-pclm-cli license runtime list \
 ```
 
 * `<custom-ca-cert-path>` - is only required if the PCLM server is configured with a custom certificate. Otherwise it is optional.
-* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list licenses in batches.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and the licenses to be listed in batches.
 
 {{% alert color="info" %}}
-To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
-This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go. This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
 {{% /alert %}}
 
 You will receive the result in the following format:

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -328,10 +328,18 @@ mx-pclm-cli license runtime list \
    -s <pclm-http-url> \
    -u <admin-user> \
    -p <admin-password> \
-   -t <custom-ca-cert-path>
+   -t <custom-ca-cert-path> \
+   --page <page-number> \
+   --limit <max-licenses-per-page>
 ```
 
 * `<custom-ca-cert-path>` - is only required if the PCLM server is configured with a custom certificate. Otherwise it is optional.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list licenses in batches.
+
+{{% alert color="info" %}}
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
+This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+{{% /alert %}}
 
 You will receive the result in the following format:
 
@@ -354,10 +362,18 @@ mx-pclm-cli license operator list \
    -s <pclm-http-url> \
    -u <admin-user> \
    -p <admin-password> \
-   -t <custom-ca-cert-path>
+   -t <custom-ca-cert-path> \
+   --page <page-number> \
+   --limit <max-licenses-per-page>
 ```
 
 * `<custom-ca-cert-path>` - is only required if the PCLM server is configured with a custom certificate. Otherwise it is optional.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list licenses in batches.
+
+{{% alert color="info" %}}
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
+This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+{{% /alert %}}
 
 You will receive the result in the following format:
 
@@ -470,7 +486,9 @@ You can see which licenses are currently used by which environments and operator
 mx-pclm-cli license list-usage -s <pclm-http-url> \
     -u <admin-user> \
     -p <admin-password> \
-    -t <custom-ca-cert-path>
+    -t <custom-ca-cert-path> \
+   --page <page-number> \
+   --limit <max-licenses-per-page>
 ```
 
 Where:
@@ -479,6 +497,12 @@ Where:
 * `<admin-user>` – is a user of type *admin* which can update users, default: `administrator` (overrides the config file)
 * `<admin-password>` – is the password for the chosen *admin* user (overrides the config file)
 * `<custom-ca-cert-path>` - is optional. Required only if the PCLM server is configured with custom cert.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list license usage in batches.
+
+{{% alert color="info" %}}
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
+This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+{{% /alert %}}
 
 Which would reply with something similar to this:
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -334,7 +334,7 @@ mx-pclm-cli license runtime list \
 ```
 
 * `<custom-ca-cert-path>` - is only required if the PCLM server is configured with a custom certificate. Otherwise it is optional.
-* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and the licenses to be listed in batches.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow the licenses to be listed in batches.
 
 {{% alert color="info" %}}
 To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go. This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
@@ -367,11 +367,10 @@ mx-pclm-cli license operator list \
 ```
 
 * `<custom-ca-cert-path>` - is only required if the PCLM server is configured with a custom certificate. Otherwise it is optional.
-* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow to list licenses in batches.
+* `<page-number>` specifies the page number to load, in case the number of licenses exceeds `<max-licenses-per-page>`. These parameters are optional and allow the licenses to be listed in batches.
 
 {{% alert color="info" %}}
-To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go.
-This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
+To get a full list of licenses with one command, use `--page 0 --limit 10000` to load 10000 licenses in one go. This can be useful when using a text editor to check if licenses are loaded correctly, or when collecting data for a support case.
 {{% /alert %}}
 
 You will receive the result in the following format:


### PR DESCRIPTION
This change extends documentation about already existing features and is not linked to any release - and can be published at any convenient time.

PCLM supports pagination when listing licenses - and by default loads 100 licenses per page. Customers need to load licenses page by page, running `mx-pclm-cli` multiple times with a `--page 0`, `--page 1` and so on, until all the pages have been listed.

This makes it difficult for customers to get a full license usage overview.

* Documented what the `--page` and `--limit` arguments do (they already exist, just weren't documented)
* Added a recommendation to set `--limit 10000` to load all licenses in one go (most environments have much less licenses)