### PR TITLE
Release notes for Mx4PC (MxOK) Operator 2.23.0, planned for release around August 27

### DIFF
--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -104,6 +104,13 @@ This percentage can be adjusted by providing a custom value in Custom JVM Option
 
 ### Operator License
 
+{{% alert color="info" %}}
+Mendix Operator versions **before** 2.23.0 require an Operator licence.
+Starting from Operator version 2.23.0, Operator licenses are no longer needed.
+
+A valid subscription and support contract is still necessary to be receive technical support.
+{{% /alert %}}
+
 Mendix on Kubernetes is a premium offering from Mendix, and you will need an additional license to use it for your applications. This **Operator license** allows you to manage Mendix apps in your cluster through the Mendix Operator and, optionally, the Mendix Gateway Agent.
 
 You need one license for each namespace you want to manage.

--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -105,8 +105,7 @@ This percentage can be adjusted by providing a custom value in Custom JVM Option
 ### Operator License
 
 {{% alert color="info" %}}
-Mendix Operator versions **before** 2.23.0 require an Operator licence.
-Starting from Operator version 2.23.0, Operator licenses are no longer needed.
+Mendix Operator versions older than 2.23.0 require an Operator licence. Starting from Operator version 2.23.0, Operator licenses are no longer needed.
 
 A valid subscription and support contract is still necessary to be receive technical support.
 {{% /alert %}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -540,9 +540,9 @@ An app will return a successful health check status if all of these conditions a
 {{% /alert %}}
 
 {{% alert color="info" %}}
-Starting from Mendix Operator 2.23.0, environments running in `leaderless` mode will use the Mendix Runtime's built-in liveness and readiness checks.
+Starting from Mendix Operator 2.23.0, environments running in `leaderless` mode use the Mendix Runtime's built-in liveness and readiness checks.
 
-When another **runtimeLeaderSelection** mode is used (default, unspecified `assigned` mode or `none`), the healthcheck microflow will be used, as described above.
+When another **runtimeLeaderSelection** mode is used (default, unspecified `assigned` mode, or `none`), the healthcheck microflow is used, as described above.
 {{% /alert %}}
 
 #### Customize Liveness Probe to Resolve Crash Loopback Scenarios

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -417,7 +417,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /m2ee-sidecar/v1/healthz
+            path: /m2ee-sidecar/v1/livez
             port: 8800
             scheme: HTTP
           initialDelaySeconds: 60
@@ -427,8 +427,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: mendix-app
+            path: /m2ee-sidecar/v1/readyz
+            port: 8800
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 1
@@ -539,6 +539,12 @@ An app will return a successful health check status if all of these conditions a
 3. If the Runtime is `running`, and a healthcheck microflow is configured, the healthcheck microflow needs to return a `healthy` state. If there is no `check_health` microflow configured, or the Runtime's state is not `running`, this condition is ignored.
 {{% /alert %}}
 
+{{% alert color="info" %}}
+Starting from Mendix Operator 2.23.0, environments running in `leaderless` mode will use the Mendix Runtime's built-in liveness and readiness checks.
+
+When another **runtimeLeaderSelection** mode is used (default, unspecified `assigned` mode or `none`), the healthcheck microflow will be used, as described above.
+{{% /alert %}}
+
 #### Customize Liveness Probe to Resolve Crash Loopback Scenarios
 
 The `liveness probe` informs the cluster whether the pod is dead or alive. If the pod fails to respond to the liveness probe, the pod will be restarted (this is called a `crash loopback`).
@@ -555,7 +561,7 @@ Let us now analyze the `liveness probe` section from the application deployment 
 livenessProbe:
   failureThreshold: 3
   httpGet:
-    path: /m2ee-sidecar/v1/healthz
+    path: /m2ee-sidecar/v1/readyz
     port: 8800
     scheme: HTTP
   initialDelaySeconds: 60

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy.md
@@ -356,9 +356,7 @@ You can get an Operator license from [Mendix Support](https://support.mendix.com
 {{% /alert %}}
 
 {{% alert color="info" %}}
-Starting from version 2.23.0, the Operator no longer performs Operator license checks.
-
-The Operator will show as **Licensed Operator** even when no Operator license is installed.
+Starting from version 2.23.0, the Operator no longer performs Operator license checks. The Operator shows as **Licensed Operator** even when no Operator license is installed.
 
 Environments still need subscription secrets to remove Mendix Runtime trial limitations from the app.
 {{% /alert %}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy.md
@@ -169,7 +169,7 @@ All environments are defined as production environments, which means that [secur
     You can also filter the environment by the namespace name, environment ID, and environment name.
 
 {{% alert color="info" %}}
-If the Operator managing the environment is licensed, **Licensed Operator** is displayed. If the Operator is not licensed, the display shows **Trial Operator**.
+If the Operator managing the environment has a valid license attached, **Licensed Operator** is displayed. If the Operator has no valid license, the display shows **Trial Operator**.
 {{% /alert %}}
 
 ### Deploying the Deployment Package{#deploy-package}
@@ -353,6 +353,14 @@ The word **Licensed Operator** shows that the Operator managing that environment
 The Operator license is independent from a Mendix Runtime license. The Operator license allows you to manage Mendix apps in your cluster, while the Mendix Runtime license (configured through a [Subscription Secret](#license-mendix)) removes trial restrictions from a Mendix App itself.
 
 You can get an Operator license from [Mendix Support](https://support.mendix.com), together with instructions on how to configure it.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+Starting from version 2.23.0, the Operator no longer performs Operator license checks.
+
+The Operator will show as **Licensed Operator** even when no Operator license is installed.
+
+Environments still need subscription secrets to remove Mendix Runtime trial limitations from the app.
 {{% /alert %}}
 
 ##### Service Account

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -229,7 +229,10 @@ You must make the following changes:
 * **environmentVariables** - Set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable.
 * **clientCertificates** - Specify client certificates to be used for TLS calls to Web Services and REST services.
 * **runtimeMetricsConfiguration** - Specify how metrics should be collected. Any non-empty values override the [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration`. Refer to [Monitoring Environments in Mendix on Kubernetes](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment.
-* **runtimeLeaderSelection** - Specify how the leader replica should be selected. Valid options are `assigned` (default mode; the `master` deployment will run one leader replica) and `none` (do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, make sure to consult with Mendix Expert Services before using this feature).
+* **runtimeLeaderSelection** - Specify how the leader replica should be selected. Valid options are
+  * `assigned` (default mode) - the `master` deployment will run one leader replica, while the `worker` deployment will run all additional replicas;
+  * `none` - do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
+  * `leaderless` - a mode where the nodes dynamically choose a leader (**in preview**, requires Mendix Runtime 10.24 or higher, and Mendix Operator 2.23 or higher)
 * **customPodLabels** - Specify additional pod labels. Avoid using labels that start with the `privatecloud.mendix.com/` prefix.
     * **general** - Specify additional labels for all pods of the app.
 * **deploymentStrategy** - Specify parameters for the deployment strategy. For more information, see the reduced downtime deployment documentation.

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -232,7 +232,7 @@ You must make the following changes:
 * **runtimeLeaderSelection** - Specify how the leader replica should be selected. The following options are available:
     * `assigned` (default mode) - The `master` deployment runs one leader replica, while the `worker` deployment runs all additional replicas.
     * `none` - Do not run any leader replicas, `master` deployment is scaled down to zero. This mode requires a specific infrastructure configuration. Contact Mendix Expert Services before using this feature.
-    * `leaderless` - A mode where the nodes dynamically choose a leader. This feature is in preview mode. It requires Mendix Runtime 10.24 or higher, and Mendix Operator 2.23 or higher.
+    * `leaderless` - A mode where the nodes dynamically choose a leader. This feature is in preview mode. It requires Mendix Runtime 10.24 or newer, and Mendix Operator 2.23 or newer.
 * **customPodLabels** - Specify additional pod labels. Avoid using labels that start with the `privatecloud.mendix.com/` prefix.
     * **general** - Specify additional labels for all pods of the app.
 * **deploymentStrategy** - Specify parameters for the deployment strategy. For more information, see the reduced downtime deployment documentation.

--- a/content/en/docs/deployment/private-cloud/private-cloud-operator.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-operator.md
@@ -229,10 +229,10 @@ You must make the following changes:
 * **environmentVariables** - Set the environment variables for the Mendix app container, and JVM arguments through the `JAVA_TOOL_OPTIONS` environment variable.
 * **clientCertificates** - Specify client certificates to be used for TLS calls to Web Services and REST services.
 * **runtimeMetricsConfiguration** - Specify how metrics should be collected. Any non-empty values override the [default values](/developerportal/deploy/private-cloud-cluster/#customize-runtime-metrics) from `OperatorConfiguration`. Refer to [Monitoring Environments in Mendix on Kubernetes](/developerportal/deploy/private-cloud-monitor/) for details on how to monitor your environment.
-* **runtimeLeaderSelection** - Specify how the leader replica should be selected. Valid options are
-  * `assigned` (default mode) - the `master` deployment will run one leader replica, while the `worker` deployment will run all additional replicas;
-  * `none` - do not run any leader replicas, `master` deployment is scaled down to zero; this mode requires a specific infrastructure configuration, please consult with Mendix Expert Services before using this feature)
-  * `leaderless` - a mode where the nodes dynamically choose a leader (**in preview**, requires Mendix Runtime 10.24 or higher, and Mendix Operator 2.23 or higher)
+* **runtimeLeaderSelection** - Specify how the leader replica should be selected. The following options are available:
+    * `assigned` (default mode) - The `master` deployment runs one leader replica, while the `worker` deployment runs all additional replicas.
+    * `none` - Do not run any leader replicas, `master` deployment is scaled down to zero. This mode requires a specific infrastructure configuration. Contact Mendix Expert Services before using this feature.
+    * `leaderless` - A mode where the nodes dynamically choose a leader. This feature is in preview mode. It requires Mendix Runtime 10.24 or higher, and Mendix Operator 2.23 or higher.
 * **customPodLabels** - Specify additional pod labels. Avoid using labels that start with the `privatecloud.mendix.com/` prefix.
     * **general** - Specify additional labels for all pods of the app.
 * **deploymentStrategy** - Specify parameters for the deployment strategy. For more information, see the reduced downtime deployment documentation.

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -37,7 +37,7 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 Mendix on Kubernetes Operator `v2.*.*` is the latest version which officially supports:
 
 * Kubernetes versions 1.19 through 1.33
-* OpenShift 4.6 through 4.18
+* OpenShift 4.6 through 4.19
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.

--- a/content/en/docs/deployment/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
@@ -126,7 +126,7 @@ These dependency CRs include `StorageInstance`, `Build`, and `Endpoint` CRs. Eac
 Once all dependencies are processed (report their status as Ready), the Operator will process the `Runtime` CR.
 
 {{% alert color="info" %}}
-Starting from version 2.23.0 of the Mendix Operator, the Operator no longer waits for the `Endpoint` CR and updates the `Runtime` CR before the `Endpoint` is created.
+Starting from version 2.23.0 of the Mendix Operator, the Operator no longer waits for the `Endpoint` CR. Instead, it updates the `Runtime` CR before the `Endpoint` is created.
 
 In addition, if a `Build` CR has failed or is processing changes, the Operator will process some changes in the `Runtime` CR, as long as the previous build is available.
 {{% /alert %}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02.md
@@ -125,6 +125,12 @@ These dependency CRs include `StorageInstance`, `Build`, and `Endpoint` CRs. Eac
 
 Once all dependencies are processed (report their status as Ready), the Operator will process the `Runtime` CR.
 
+{{% alert color="info" %}}
+Starting from version 2.23.0 of the Mendix Operator, the Operator no longer waits for the `Endpoint` CR and updates the `Runtime` CR before the `Endpoint` is created.
+
+In addition, if a `Build` CR has failed or is processing changes, the Operator will process some changes in the `Runtime` CR, as long as the previous build is available.
+{{% /alert %}}
+
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-technical-appendix/private-cloud-technical-appendix-02/crd-controller-hierarchy.png" class="no-border" >}}
 
 Any time a CR's status is changed, the Operator will propagate it to the `MendixApp` CR. The Agent will receive events any time the `MendixApp` CR changes its status.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -27,6 +27,10 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
 * We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
 * We removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside--mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
+* We updated internal handling logic for the `MendixApp`, `Build` and `Runtime` CRD controllers (Ticket 251404).
+  * The `Build` controller now only checks pod attributes that are necessary to complete a build.
+  * The `MendixApp` and `Runtime` controllers now allow processing of some chnages if a build fails.
+    For example, it's possible to start an environment or change the **MxAdmin** password even when the build fails - in this case, the previous build will be used instead.
 * When enabling the *Prevent data deletion* option, Mendix 9.6 (or newer) apps will no longer try to delete files from unreferenced *System.FileDocument*, so that Mendix apps would be able to run without permissions to delete files.
 * We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
 * We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -26,6 +26,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
 * We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
+* When enabling the *Prevent data deletion* option, Mendix 9.6 (or newer) apps will no longer try to delete files from unreferenced *System.FileDocument*, so that Mendix apps would be able to run without permissions to delete files.
 * We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
 * We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.
 * We have deprecated support for Tencent COS storage.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -27,6 +27,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
 * We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
 * We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
+* We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.
 * We have deprecated support for Tencent COS storage.
 * If an app pod crashes or restarts, the MendixApp CR will show the reason for the restart and the Mendix Runtime's UNIX exit code.
 * Upgrading to Mendix Operator v2.23.0 from a previous version will restart environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -26,6 +26,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
 * We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
+* We removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside--mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
 * When enabling the *Prevent data deletion* option, Mendix 9.6 (or newer) apps will no longer try to delete files from unreferenced *System.FileDocument*, so that Mendix apps would be able to run without permissions to delete files.
 * We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
 * We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -36,6 +36,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.
 * We have deprecated support for Tencent COS storage.
 * If an app pod crashes or restarts, the MendixApp CR will show the reason for the restart and the Mendix Runtime's UNIX exit code.
+* We have addressed a rare bug where the Agent sometimes crashed with a panic when a network connection is lost.
 * Upgrading to Mendix Operator v2.23.0 from a previous version will restart environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### August 7, 2025

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,31 +12,33 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
-### August ???, 2025
+### August 29, 2025
 
 #### Mendix Operator v2.23.0 {#2.23.0}
 
-* We added a  new `leaderless` deployment mode for the `runtimeLeaderSelection` option. This mode is currently in preview.
-   * This is a new option that can be used, in addition of the current `assigned` and `none` modes.
-   * Setting `runtimeLeaderSelection` to `leaderless` will only use one Deployment instead of `master` and `worker`. Mendix Runtime nodes will decide which one gets to run any exclusive task.
-   * This mode uses a simplified Java launch process and uses a more efficient way of generating JSON logs.
-   * To use `leaderless` mode, the Mendix app needs to be based on Mendix 10.24 or a higher version.
-* We have adjusted the Runtime liveness and readiness probes; in `leaderless` deployment mode, the Mendix Runtime's built-in self-test will be used for the liveness and readiness probes.
-* We have addressed a few redundant API calls to reduce API calls in a few scenarios.
-* We fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
+* In addition to the current `assigned` and `none` modes, we have added a new `leaderless` deployment mode for the `runtimeLeaderSelection` option. This mode is currently in preview.
+
+    Setting `runtimeLeaderSelection` to `leaderless` uses only one Deployment instead of `master` and `worker`. Mendix Runtime nodes decide which one gets to run any exclusive task. The mode uses a simplified Java launch process and uses a more efficient way of generating JSON logs. To use `leaderless` mode, the Mendix app needs to be based on Mendix 10.24 or a higher version.
+  
+* We have adjusted the Runtime liveness and readiness probes. In `leaderless` deployment mode, the Mendix Runtime's built-in self-test is now used for the liveness and readiness probes.
+* We have addressed a few redundant API calls to reduce API calls in a small number of scenarios.
+* We have fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
-* We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
-* We removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside--mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
+* To provide clearer error messages and more relevant context, we have improved the logging of some startup and other errors.
+* We have removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside--mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
 * We updated internal handling logic for the `MendixApp`, `Build` and `Runtime` CRD controllers (Ticket 251404).
-  * The `Build` controller now only checks pod attributes that are necessary to complete a build.
-  * The `MendixApp` and `Runtime` controllers now allow processing of some chnages if a build fails.
-    For example, it's possible to start an environment or change the **MxAdmin** password even when the build fails - in this case, the previous build will be used instead.
-* When enabling the *Prevent data deletion* option, Mendix 9.6 (or newer) apps will no longer try to delete files from unreferenced *System.FileDocument*, so that Mendix apps would be able to run without permissions to delete files.
+
+    * The `Build` controller now only checks pod attributes that are necessary to complete a build.
+    * The `MendixApp` and `Runtime` controllers now allow processing of some chnages if a build fails.
+
+        For example, it is possible to start an environment or change the **MxAdmin** password even when the build fails - in this case, the previous build will be used instead.
+
+* When enabling the **Prevent data deletion** option, Mendix 9.6 (or newer) apps will no longer try to delete files from unreferenced *System.FileDocument*, so that Mendix apps would be able to run without permissions to delete files.
 * We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
 * We have updated documentation that OpenShift 4.19 is supported by the Mendix Operator.
 * We have deprecated support for Tencent COS storage.
-* If an app pod crashes or restarts, the MendixApp CR will show the reason for the restart and the Mendix Runtime's UNIX exit code.
-* We have addressed a rare bug where the Agent sometimes crashed with a panic when a network connection is lost.
+* If an app pod crashes or restarts, the MendixApp CR now shows the reason for the restart and the Mendix Runtime's UNIX exit code.
+* We have addressed a rare bug where the Agent sometimes crashed with a panic when a network connection was lost.
 * Upgrading to Mendix Operator v2.23.0 from a previous version will restart environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
 
 ### August 7, 2025

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -25,7 +25,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We have fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
 * We have added a workaround to improve handling of bucket prefixes containing `/` characters.
 * To provide clearer error messages and more relevant context, we have improved the logging of some startup and other errors.
-* We have removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside--mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
+* We have removed license checks from the Mendix Operator. Starting version 2.23.0 of the Mendix Opeartor, only Runtime licenses are required (to remove [trial restrictions](/developerportal/deploy/licensing-apps-outside-mxcloud/) from the Mendix Runtime). The Operator will show its status as **Licensed** even when no Operator license is applied.
 * We updated internal handling logic for the `MendixApp`, `Build` and `Runtime` CRD controllers (Ticket 251404).
 
     * The `Build` controller now only checks pod attributes that are necessary to complete a build.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,25 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
+### August ???, 2025
+
+#### Mendix Operator v2.23.0 {#2.23.0}
+
+* We added a new, **preview** mode for the `runtimeLeaderSelection` option - a `leaderless` deployment mode.
+   * This is a new option that can be used, in addition of the current `assigned` and `none` modes.
+   * Setting `runtimeLeaderSelection` to `leaderless` will only use one Deployment instead of `master` and `worker`. Mendix Runtime nodes will decide which one gets to run any exclusive task.
+   * This mode uses a simplified Java launch process and uses a more efficient way of generating JSON logs.
+   * To use `leaderless` mode, the Mendix app needs to be based on Mendix 10.24 or a higher version.
+* We have adjusted the Runtime liveness and readiness probes; in `leaderless` deployment mode, the Mendix Runtime's built-in self-test will be used for the liveness and readiness probes.
+* We have addressed a few redundant API calls to reduce API calls in a few scenarios.
+* We fixed an issue when a Prometheus metrics scaper would reject metrics from Mendix 11 apps.
+* We have added a workaround to improve handling of bucket prefixes containing `/` characters.
+* We have improved logging of some startup and other errors - to provide clearer error messages and more relevant context.
+* We have updated components to use Go 1.24 and the latest dependency versions in order to improve security score ratings for container images.
+* We have deprecated support for Tencent COS storage.
+* If an app pod crashes or restarts, the MendixApp CR will show the reason for the restart and the Mendix Runtime's UNIX exit code.
+* Upgrading to Mendix Operator v2.23.0 from a previous version will restart environments managed by that version of the Operator. Environments with two or more replicas and a **PreferRolling** update strategy are restarted without downtime.
+
 ### August 7, 2025
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,7 +16,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 #### Mendix Operator v2.23.0 {#2.23.0}
 
-* We added a new, **preview** mode for the `runtimeLeaderSelection` option - a `leaderless` deployment mode.
+* We added a  new `leaderless` deployment mode for the `runtimeLeaderSelection` option. This mode is currently in preview.
    * This is a new option that can be used, in addition of the current `assigned` and `none` modes.
    * Setting `runtimeLeaderSelection` to `leaderless` will only use one Deployment instead of `master` and `worker`. Mendix Runtime nodes will decide which one gets to run any exclusive task.
    * This mode uses a simplified Java launch process and uses a more efficient way of generating JSON logs.


### PR DESCRIPTION
We're planning to release a new MxOnKubernertes Operator in the second half of next week, most likely on or after August 27 (we need to complete testing and prepare the release).

This PR contains updated release notes and documentation changes for the new version of the Operator.