### PR TITLE
Add disclaimer on dashes in organization name

### DIFF
--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -84,9 +84,9 @@ The generator will ask you a few questions during setup. Answer the questions by
 * End-to-end tests: **No**
 
 {{% alert color="warning" %}}
-At this time the **Organization Name** cannot include a dash "`-`" character. This will result in an  error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
+Currently, **Organization Name** cannot include a dash "-" character. Dashes in the organization name will result in an error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
 
-To fix this in an existing widget, modify the `packagePath` property of its `package.json` file and rebuild the widget.
+To fix this in an existing widget, modify the `packagePath` property of its **package.json** file and rebuild the widget.
 {{% /alert %}}
 
 {{< figure src="/attachments/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="The Mendix Widget generator with the prompts answered according to the list above." class="no-border" >}}

--- a/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -83,6 +83,12 @@ The generator will ask you a few questions during setup. Answer the questions by
 * Unit tests: **No**
 * End-to-end tests: **No**
 
+{{% alert color="warning" %}}
+At this time the **Organization Name** cannot include a dash "`-`" character. This will result in an  error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
+
+To fix this in an existing widget, modify the `packagePath` property of its `package.json` file and rebuild the widget.
+{{% /alert %}}
+
 {{< figure src="/attachments/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="The Mendix Widget generator with the prompts answered according to the list above." class="no-border" >}}
 
 As part of the widget scaffolding, the generator builds the widget for the first time. You can do this yourself by running `npm run build` inside your widget's directory.

--- a/content/en/docs/howto10/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto10/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -83,6 +83,12 @@ The generator will ask you a few questions during setup. Answer the questions by
 * Unit tests: **No**
 * End-to-end tests: **No**
 
+{{% alert color="warning" %}}
+Currently, **Organization Name** cannot include a dash "-" character. Dashes in the organization name will result in an error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
+
+To fix this in an existing widget, modify the `packagePath` property of its **package.json** file and rebuild the widget.
+{{% /alert %}}
+
 {{< figure src="/attachments/howto10/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="The Mendix Widget generator with the prompts answered according to the list above." class="no-border" >}}
 
 As part of the widget scaffolding, the generator builds the widget for the first time. You can do this yourself by running `npm run build` inside your widget's directory.

--- a/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto8/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -97,7 +97,13 @@ The generator will ask you a few questions during setup. Answer the questions by
 * Unit tests: **No**
 * End-to-end tests: **No**
 
-    {{< figure src="/attachments/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="mx generator" class="no-border" >}}
+{{% alert color="warning" %}}
+Currently, **Organization Name** cannot include a dash "-" character. Dashes in the organization name will result in an error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
+
+To fix this in an existing widget, modify the `packagePath` property of its **package.json** file and rebuild the widget.
+{{% /alert %}}
+
+{{< figure src="/attachments/howto/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="mx generator" class="no-border" >}}
 
 Note that whenever it is required to reinstall NPM package dependencies inside the scaffolded widget development project with an NPM version of 7 or higher, make sure to run the installation script with an extra flag: `npm install --legacy-peer-deps`.
 

--- a/content/en/docs/howto9/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
+++ b/content/en/docs/howto9/extensibility/pluggable-widgets/create-a-pluggable-widget-one.md
@@ -85,7 +85,13 @@ The generator will ask you a few questions during setup. Answer the questions by
 * Unit tests: **No**
 * End-to-end tests: **No**
 
-    {{< figure src="/attachments/howto9/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="mx generator" class="no-border" >}}
+{{% alert color="warning" %}}
+Currently, **Organization Name** cannot include a dash "-" character. Dashes in the organization name will result in an error when running your app, asking to check if the widgets "were  generated with the latest version of the pluggable-widgets-tools and are ES6 modules."
+
+To fix this in an existing widget, modify the `packagePath` property of its **package.json** file and rebuild the widget.
+{{% /alert %}}
+
+{{< figure src="/attachments/howto9/extensibility/pluggable-widgets/create-a-pluggable-widget-one/generatorblack-new.png" alt="mx generator" class="no-border" >}}
 
 Note that whenever it is required to reinstall NPM package dependencies inside the scaffolded widget development app with an NPM version of 7 or higher, make sure to run the installation script with an extra flag: `npm install --legacy-peer-deps`.
 


### PR DESCRIPTION
Widgets generated with a dash in their organization name are not loaded correctly by Studio Pro. We are working on a proper solution, but to avoid confusion in the mean time we want to add this disclaimer to the widget building guide.

While this is the most relevant part of the docs to add this information, we are a bit afraid that people running into this problem might not be looking here. So we include exact phrasing from the error to help search engines to direct them here.

mendix/widgets-tools#137