### PR TITLE
Update Dynatrace docs to reflect the Kubernetes reality

### DIFF
--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
@@ -59,9 +59,9 @@ What Dynatrace calls "dimensions," other monitoring tools call "tags." The Mendi
 
 For metrics that are pushed to Dynatrace, Mendix attaches these default dimensions:
 
-* `app` – The environment ID of your Mendix environment
+* `app` - The environment ID of your Mendix environment
 * `pod_name` - The instance to which the metrics belong (available only in Kubernetes deployments)
-* `instance_index` – Instance index that the metrics belong to (available only in Cloud Foundry deployments)
+* `instance_index` - The instance index to which the metrics (available only in Cloud Foundry deployments)
 
 #### Extra Dimensions
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
@@ -60,7 +60,8 @@ What Dynatrace calls "dimensions," other monitoring tools call "tags." The Mendi
 For metrics that are pushed to Dynatrace, Mendix attaches these default dimensions:
 
 * `app` – The environment ID of your Mendix environment
-* `instance_index` – Instance index that the metrics belong to
+* `pod_name` - The instance to which the metrics belong (available only in Kubernetes deployments)
+* `instance_index` – Instance index that the metrics belong to (available only in Cloud Foundry deployments)
 
 #### Extra Dimensions
 

--- a/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/monitoring-with-apm/dynatrace-metrics.md
@@ -61,7 +61,7 @@ For metrics that are pushed to Dynatrace, Mendix attaches these default dimensio
 
 * `app` - The environment ID of your Mendix environment
 * `pod_name` - The instance to which the metrics belong (available only in Kubernetes deployments)
-* `instance_index` - The instance index to which the metrics (available only in Cloud Foundry deployments)
+* `instance_index` - The instance index to which the metrics belong (available only in Cloud Foundry deployments)
 
 #### Extra Dimensions
 


### PR DESCRIPTION
Includes information about the instance identifier for Cloud Foundry and Kubernetes.
The `instance_index` dimension does not exist on Kubernetes. It is being replaced by the `pod_name`.