### PR TITLE
Release notes for Mx4PC/MxOK  2.23.1 (planned for September 17)

### DIFF
--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,14 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
+### September 17
+
+#### Mendix Operator v2.23.1 {#2.23.1}
+
+* We've updated storage provisioners that create Azure Workload identitites - to correctly detect and handle _Cannot validate Microsoft Entra ID user ... because the OID isn't found in the tenant_ errors.
+  * After creating a new workload identity, it might take some time before the workload identity (user) becomes fully functional; this error is not an issue (just a temporary status) and in this situation the Mendix Operator can just retry after waiting for some time.
+  * Azure changed the error text and older Operator versions might not correct this error.
+
 ### September 4, 2025
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
-### September 17
+### September 16, 2025
 
 #### Mendix Operator v2.23.1 {#2.23.1}
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,9 +16,11 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 #### Mendix Operator v2.23.1 {#2.23.1}
 
-* We've updated storage provisioners that create Azure Workload identitites - to correctly detect and handle _Cannot validate Microsoft Entra ID user ... because the OID isn't found in the tenant_ errors.
-  * After creating a new workload identity, it might take some time before the workload identity (user) becomes fully functional; this error is not an issue (just a temporary status) and in this situation the Mendix Operator can just retry after waiting for some time.
-  * Azure changed the error text and older Operator versions might not correct this error.
+* We have updated storage provisioners that create Azure Workload identitites. This update helps ensure that errors like *Cannot validate Microsoft Entra ID user ... because the OID isn't found in the tenant* are detected and handled correctly.
+
+    After creating a new workload identity, it might take some time before the workload identity (user) becomes fully functional. This error is not an issue (just a temporary status) and in this situation the Mendix Operator can just retry after waiting for some time.
+
+  Because Microsoft Azure previously changed the error text, older Mendix Operator versions might not correct this error.
 
 ### September 4, 2025
 


### PR DESCRIPTION
We're planning to release a small patch for Mendix on Kubernetes (Mx4PC) this Wednesday.

Azure changed the text of an error message and our custom error handler now no longer detects an error that needs custom handling.
This release will update the Operator to reliably detect the new (updated) error message text.