### PR TITLE
Correct reference to Microflow section

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/workflows/workflow-elements/multi-user-task.md
+++ b/content/en/docs/refguide/modeling/application-logic/workflows/workflow-elements/multi-user-task.md
@@ -64,7 +64,7 @@ In case **Target users using** (an XPath or a microflow) results in an empty lis
 
 Specifies the expression used to assign the multi-user task. This option is displayed only when the [Target users using](#target-users) is set to **XPath**. Click **Edit** to edit the [XPath constraint](/refguide/xpath-constraints/).
 
-#### Microflow
+#### Microflow {#microflow-targeting}
 
 Specifies the microflow used to assign the multi-user task. This option is displayed only when the [Target users using](#target-users) is set to **Microflow**.
 


### PR DESCRIPTION
In the table in 2.4.2 Decision Method there's a hyper-link to the Microflow section.

However, there are 2 headings named microflow and even though the second one is tagged as `#microflow` the hyper-link refers to the first, which is incorrect.

I've now tagged the first one differently, but I have no means to verify that/if this actually fixes the problem.