### PR TITLE
Fix links that point to outdated pages about the model-sdk.

### DIFF
--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/domain-model-metamodel.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/domain-model-metamodel.md
@@ -21,10 +21,10 @@ The entities can also relate to each other through generalizations. Finally, you
 | Studio Pro Guide | Model SDK API Docs |
 | --- | --- |
 | [Domain Model](/refguide/domain-model/) | TypeScript module [domainmodels](https://apidocs.rnd.mendix.com/modelsdk/latest/modules/domainmodels.html)  |
-| [Entities](/refguide/entities/) | [DomainModel](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.domainmodel.html) |
-| [Attributes](/refguide/attributes/) | [Entity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html) |
-| [Associations](/refguide/associations/) | [Association](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.association.html) |
-| | [Attribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.attribute.html) |
+| [Entities](/refguide/entities/) | [DomainModel](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.DomainModel.html) |
+| [Attributes](/refguide/attributes/) | [Entity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Entity.html) |
+| [Associations](/refguide/associations/) | [Association](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Association.html) |
+| | [Attribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Attribute.html) |
 
 ## Attributes
 
@@ -40,9 +40,9 @@ Entities can have multiple attributes. Each attribute has a specific type.
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Attributes](/refguide/attributes/) | Property [`attributes`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html#attributes) of entity  |
-| | [Attribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.attribute.html) |
-| | [AttributeType](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.attributetype.html) |
+| [Attributes](/refguide/attributes/) | Property [`attributes`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Entity.html#attributes) of entity  |
+| | [Attribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Attribute.html) |
+| | [AttributeType](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.AttributeType.html) |
 
 ## Generalization Relationships
 
@@ -56,10 +56,10 @@ An `Entity` instance has a `generalization` property with which to define this r
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Entities](/refguide/entities/) | Property [`generalization`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html#generalization) of Entity |
-| | [GeneralizationBase](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.generalizationbase.html) |
-| | [Generalization](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.generalization.html) |
-| | [NoGeneralization](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.nogeneralization.html) |
+| [Entities](/refguide/entities/) | Property [`generalization`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Entity.html#generalization) of Entity |
+| | [GeneralizationBase](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.GeneralizationBase.html) |
+| | [Generalization](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Generalization.html) |
+| | [NoGeneralization](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.NoGeneralization.html) |
 
 ## Access Rules
 
@@ -72,9 +72,9 @@ To secure access to the data in a Mendix app, you can define access rules for en
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
 | [Access rules](/refguide/access-rules/) | Property [`accessRules`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html#accessrules) of Entity |
-| | [AccessRule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.accessrule.html) |
-| | Property [`xpathConstraint`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.accessrule.html#xpathconstraint) of AccessRule |
-| | [ModuleRole](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/security.modulerole.html) |
+| | [AccessRule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.AccessRule.html) |
+| | Property [`xpathConstraint`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.AccessRule.html#xPathConstraint) of AccessRule |
+| | [ModuleRole](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/security.ModuleRole.html) |
 
 ## Validation Rules
 
@@ -86,9 +86,9 @@ For each attribute of an entity, it is possible to define a validation rule. The
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Validation Rules](/refguide/validation-rules/) | Property [`validationRules`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html#validationrules) of Entity |
-| | [ValidationRule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.validationrule.html) |
-| | [RuleInfo](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.ruleinfo.html) |
+| [Validation Rules](/refguide/validation-rules/) | Property [`validationRules`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Entity.html#validationRules) of Entity |
+| | [ValidationRule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.ValidationRule.html) |
+| | [RuleInfo](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.RuleInfo.html) |
 
 ## Indexes
 
@@ -100,6 +100,6 @@ An entity can have multiple indexes. Each index consists of a set of indexed att
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Indexes](/refguide/indexes/) | Property [`indexes`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.entity.html#indexes) of Entity |
-| | [Index](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.index.html) |
-| | [IndexedAttribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.indexedattribute.html) |
+| [Indexes](/refguide/indexes/) | Property [`indexes`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Entity.html#indexes) of Entity |
+| | [Index](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.Index.html) |
+| | [IndexedAttribute](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/domainmodels.IndexedAttribute.html) |

--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/microflows-metamodel.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/microflows-metamodel.md
@@ -17,9 +17,9 @@ Microflows have parameters, a return type (the return value is defined in an obj
 Studio Pro Guide | Model SDK API docs
 --- | --- |
 The [Microflows](/refguide/microflows/) overview page | The [`microflows`](https://apidocs.rnd.mendix.com/modelsdk/latest/modules/microflows.html) package
-[Microflow](/refguide/microflow/), technical information on properties of a microflow | [Microflow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflow.html)
-[Rule](/refguide/rules/) | [Rule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.rule.html)
-[Parameter](/refguide/parameter/) | [MicroflowParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowparameter.html)
+[Microflow](/refguide/microflow/), technical information on properties of a microflow | [Microflow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Microflow.html)
+[Rule](/refguide/rules/) | [Rule](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Rule.html)
+[Parameter](/refguide/parameter/) | [MicroflowParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowParameter.html)
 
 ### Microflow and Rule Structure
 
@@ -33,8 +33,8 @@ For example, a simple microflow could consist of a start event, a single activit
 
 Studio Pro Guide | Model SDK API docs
 --- | --- |
-[Activities](/refguide/activities/) | [MicroflowObjectCollection](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowobjectcollection.html)
-[Sequence Flow](/refguide/sequence-flow/) | [SequenceFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sequenceflow.html)
+[Activities](/refguide/activities/) | [MicroflowObjectCollection](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowObjectCollection.html)
+[Sequence Flow](/refguide/sequence-flow/) | [SequenceFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SequenceFlow.html)
 
 ### Microflow Objects
 
@@ -48,10 +48,10 @@ There are several types of objects that can be added to a microflow. One type is
 
 Studio Pro Guide | Model SDK API docs
 --- | --- |
-[Activities](/refguide/activities/) | [MicroflowParameterObject](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowparameterobject.html), [Activity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.activity.html)
-[Start](/refguide/start-event/) and [End](/refguide/end-event/) events | [StartEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.startevent.html), [EndEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.endevent.html)
-[Loop](/refguide/loop/)s, with [Break](/refguide/break-event/) and [Continue](/refguide/continue-event/) events | [LoopedActivity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.loopedactivity.html), [BreakEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.breakevent.html), [ContinueEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.continueevent.html)
-[Annotation](/refguide/annotation/) | [Annotation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.annotation.html)
+[Activities](/refguide/activities/) | [MicroflowParameterObject](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowParameterObject.html), [Activity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Activity.html)
+[Start](/refguide/start-event/) and [End](/refguide/end-event/) events | [StartEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.StartEvent.html), [EndEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.EndEvent.html)
+[Loop](/refguide/loop/)s, with [Break](/refguide/break-event/) and [Continue](/refguide/continue-event/) events | [LoopedActivity](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.LoopedActivity.html), [BreakEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.BreakEvent.html), [ContinueEvent](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ContinueEvent.html)
+[Annotation](/refguide/annotation/) | [Annotation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Annotation.html)
 
 ### Flows {#flows}
 
@@ -69,11 +69,11 @@ Annotation flows are used to connect annotations to other microflow objects.
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | ---  |
-| [Sequence Flow](/refguide/sequence-flow/) | [Flow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.flow.html) |
-| [Annotation flow](/refguide/annotation/#annotation-flow) | [SequenceFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sequenceflow.html) |
-| |[AnnotationFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.annotationflow.html) |
-| |Properties [`origin`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.flow.html#origin) and [`destination`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.flow.html#destination) of Flow |
-| |[CaseValue](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.casevalue.html) and its inheritance hierarchy |
+| [Sequence Flow](/refguide/sequence-flow/) | [Flow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Flow.html) |
+| [Annotation flow](/refguide/annotation/#annotation-flow) | [SequenceFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SequenceFlow.html) |
+| |[AnnotationFlow](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AnnotationFlow.html) |
+| |Properties [`origin`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Flow.html#origin) and [`destination`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Flow.html#destination) of Flow |
+| |[CaseValue](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CaseValue.html) and its inheritance hierarchy |
 
 ### Decisions
 
@@ -92,13 +92,13 @@ A decision conditionally splits on either an expression or a rule. In case of a 
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- | 
-| [Decision](/refguide/decision/) |[ExclusiveSplit](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.exclusivesplit.html) |
-| [Object Type Decision](/refguide/object-type-decision/) |[InheritanceSplit](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.inheritancesplit.html) |
-| [Merge](/refguide/merge/) |[ExclusiveMerge](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.exclusivemerge.html) |
-| [Rules](/refguide/rules/) |[ExpressionSplitCondition](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.expressionsplitcondition.html) |
-| |[RuleSplitCondition](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.rulesplitcondition.html) |
-| |[RuleCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.rulecall.html) |
-| |[RuleCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.rulecallparametermapping.html) |
+| [Decision](/refguide/decision/) |[ExclusiveSplit](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ExclusiveSplit.html) |
+| [Object Type Decision](/refguide/object-type-decision/) |[InheritanceSplit](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.InheritanceSplit.html) |
+| [Merge](/refguide/merge/) |[ExclusiveMerge](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ExclusiveMerge.html) |
+| [Rules](/refguide/rules/) |[ExpressionSplitCondition](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ExpressionSplitCondition.html) |
+| |[RuleSplitCondition](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RuleSplitCondition.html) |
+| |[RuleCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RuleCall.html) |
+| |[RuleCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RuleCallParameterMapping.html) |
 
 ## Microflow Activities
 
@@ -114,9 +114,9 @@ Object attributes can be updated with a change action, both in a create action a
 
 Studio Pro Guide | Model SDK API docs
 --- | --- |
-[Create Object](/refguide/create-object/) |[CreateObjectAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.createobjectaction.html) and [ChangeObjectAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.changeobjectaction.html) ([ChangeMembersAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.changemembersaction.html), [MemberChange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.memberchange.html))
-[Change Object](/refguide/change-object/) | [DeleteAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.deleteaction.html)
-[Rollback Object](/refguide/rollback-object/) |[CommitAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.commitaction.html) and [RollbackAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.rollbackaction.html)
+[Create Object](/refguide/create-object/) |[CreateObjectAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CreateObjectAction.html) and [ChangeObjectAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ChangeObjectAction.html) ([ChangeMembersAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ChangeMembersAction.html), [MemberChange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MemberChange.html))
+[Change Object](/refguide/change-object/) | [DeleteAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.DeleteAction.html)
+[Rollback Object](/refguide/rollback-object/) |[CommitAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CommitAction.html) and [RollbackAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RollbackAction.html)
 
 ### Retrieving Objects
 
@@ -128,11 +128,11 @@ A retrieve action is either an association-based retrieve or a database-based re
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Retrieve object(s)](/refguide/retrieve-objects/) |[RetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.retrievesource.html) |
-| [XPath](/refguide/xpath/) constraints |[AssociationRetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.associationretrievesource.html) |
-| |[DatabaseRetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.databaseretrievesource.html) |
-| |[Range](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.range.html), [ConstantRange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.constantrange.html) and [CustomRange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.customrange.html) |
-| |[SortItemList](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sortitemlist.html) and [SortItem](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sortitem.html) |
+| [Retrieve object(s)](/refguide/retrieve-objects/) |[RetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RetrieveSource.html) |
+| [XPath](/refguide/xpath/) constraints |[AssociationRetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AssociationRetrieveSource.html) |
+| |[DatabaseRetrieveSource](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.DatabaseRetrieveSource.html) |
+| |[Range](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Range.html), [ConstantRange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ConstantRange.html) and [CustomRange](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CustomRange.html) |
+| |[SortItemList](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SortItemList.html) and [SortItem](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SortItem.html) |
 
 ### Microflow Calls
 
@@ -144,9 +144,9 @@ Microflows can call other microflows by defining a mapping of expressions to par
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Microflow](/refguide/microflow-call/) |[MicroflowCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowcallaction.html) |
-| |[MicroflowCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowcall.html) |
-| |[MicroflowCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.microflowcallparametermapping.html) |
+| [Call Microflow](/refguide/microflow-call/) |[MicroflowCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowCallAction.html) |
+| |[MicroflowCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowCall.html) |
+| |[MicroflowCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MicroflowCallParameterMapping.html) |
 
 ### Web Client Activities
 
@@ -158,11 +158,11 @@ Microflows can trigger behavior in the browser: showing and closing pages, showi
 
 Studio Pro Guide | Model SDK API docs
 --- | --- |
-[Show Page](/refguide/show-page/) and [Show Home Page](/refguide/show-home-page/) |[ShowPageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.showpageaction.html) and [ShowHomePageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.showhomepageaction.html)
-[Close Page](/refguide/close-page/) |[CloseFormAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.closeformaction.html)
-[Show Message](/refguide/show-message/) |[ShowMessageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.showmessageaction.html)
-[Validation Feedback](/refguide/validation-feedback/) |[ValidationFeedbackAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.validationfeedbackaction.html)
-[Download File](/refguide/download-file/) |[DownloadFileAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.downloadfileaction.html)
+[Show Page](/refguide/show-page/) and [Show Home Page](/refguide/show-home-page/) |[ShowPageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ShowPageAction.html) and [ShowHomePageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ShowHomePageAction.html)
+[Close Page](/refguide/close-page/) |[CloseFormAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CloseFormAction.html)
+[Show Message](/refguide/show-message/) |[ShowMessageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ShowMessageAction.html)
+[Validation Feedback](/refguide/validation-feedback/) |[ValidationFeedbackAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ValidationFeedbackAction.html)
+[Download File](/refguide/download-file/) |[DownloadFileAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.DownloadFileAction.html)
 
 ### App Service Calls
 
@@ -174,10 +174,10 @@ An app service call action points to a specific app service action (which is par
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| | [AppServiceCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.appservicecallaction.html) |
-| |[AppServiceAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/appservices.appserviceaction.html) |
-| |[AppServiceCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.appservicecallparametermapping.html) |
-| |[AppServiceActionParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/appservices.appserviceactionparameter.html) |
+| | [AppServiceCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AppServiceCallAction.html) |
+| |[AppServiceAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/appservices.AppServiceAction.html) |
+| |[AppServiceCallParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AppServiceCallParameterMapping.html) |
+| |[AppServiceActionParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/appservices.AppServiceActionParameter.html) |
 
 ### Web Service Calls
 
@@ -191,9 +191,9 @@ See the following diagrams for details on the HTTP configuration, request handli
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Web Service](/refguide/call-web-service-action/) |[WebServiceCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.webservicecallaction.html) |
-| |[HttpConfiguration](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.httpconfiguration.html) |
-| |[RequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.requesthandling.html) and [ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.resulthandling.html) |
+| [Call Web Service](/refguide/call-web-service-action/) |[WebServiceCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.WebServiceCallAction.html) |
+| |[HttpConfiguration](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.HttpConfiguration.html) |
+| |[RequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RequestHandling.html) and [ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ResultHandling.html) |
 
 ### Web Service Calls – Request HTTP Configuration
 
@@ -205,8 +205,8 @@ An HTTP configuration has an optional custom endpoint location, authentication c
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Web Service](/refguide/call-web-service-action/) |[HttpConfiguration](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.httpconfiguration.html) |
-| |[HttpHeaderEntry](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.httpheaderentry.html) |
+| [Call Web Service](/refguide/call-web-service-action/) |[HttpConfiguration](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.HttpConfiguration.html) |
+| |[HttpHeaderEntry](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.HttpHeaderEntry.html) |
 
 ### Web Service Calls – Request Handling
 
@@ -223,11 +223,11 @@ A web service operation request needs to be mapped from Mendix app concepts to t
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Web Service](/refguide/call-web-service-action/) |[RequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.requesthandling.html) |
-| |[SimpleRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.simplerequesthandling.html) - [WebServiceOperationSimpleParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.webserviceoperationsimpleparametermapping.html) |
-| |[AdvancedRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.advancedrequesthandling.html) - [WebServiceOperationAdvancedParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.webserviceoperationadvancedparametermapping.html) |
-| |[MappingRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.mappingrequesthandling.html) |
-| |[CustomRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.customrequesthandling.html) |
+| [Call Web Service](/refguide/call-web-service-action/) |[RequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.RequestHandling.html) |
+| |[SimpleRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SimpleRequestHandling.html) - [WebServiceOperationSimpleParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.WebServiceOperationSimpleParameterMapping.html) |
+| |[AdvancedRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AdvancedRequestHandling.html) - [WebServiceOperationAdvancedParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.WebServiceOperationAdvancedParameterMapping.html) |
+| |[MappingRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.MappingRequestHandling.html) |
+| |[CustomRequestHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CustomRequestHandling.html) |
 
 ### Web Service Calls – Response Handling
 
@@ -239,10 +239,10 @@ The result of a web service operation needs to be mapped to Mendix app concepts 
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Web Service](/refguide/call-web-service-action/) |[ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.resulthandling.html) |
-| |[ImportMappingCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.importmappingcall.html) |
-| |[ImportMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/importmappings.importmapping.html) |
-| |[Range](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.range.html) |
+| [Call Web Service](/refguide/call-web-service-action/) |[ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ResultHandling.html) |
+| |[ImportMappingCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ImportMappingCall.html) |
+| |[ImportMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/importmappings.ImportMapping.html) |
+| |[Range](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Range.html) |
 
 ### Variables
 
@@ -254,8 +254,8 @@ Microflow variables can be created and changed with specific actions. A create v
 
 Studio Pro Guide | Model SDK API docs
 --- | --- |
-[Create Variable](/refguide/create-variable/) |[CreateVariableAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.createvariableaction.html)
-[Change Variable](/refguide/change-variable/) |[ChangeVariableAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.changevariableaction.html)
+[Create Variable](/refguide/create-variable/) |[CreateVariableAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CreateVariableAction.html)
+[Change Variable](/refguide/change-variable/) |[ChangeVariableAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ChangeVariableAction.html)
 
 ### Lists
 
@@ -267,11 +267,11 @@ Lists can be created, changed and deleted with specific actions. List aggregatio
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Create List](/refguide/create-list/) |[CreateListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.createlistaction.html) |
-| [Change List](/refguide/change-list/) |[ChangeListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.changelistaction.html) |
-| [Aggregate List](/refguide/aggregate-list/) |[DeleteAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.deleteaction.html) |
-| [List Operation](/refguide/list-operation/) |[AggregateListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.aggregatelistaction.html) |
-| |[ListOperationAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.listoperationaction.html) and [ListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.listoperation.html) |
+| [Create List](/refguide/create-list/) |[CreateListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.CreateListAction.html) |
+| [Change List](/refguide/change-list/) |[ChangeListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ChangeListAction.html) |
+| [Aggregate List](/refguide/aggregate-list/) |[DeleteAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.DeleteAction.html) |
+| [List Operation](/refguide/list-operation/) |[AggregateListAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.AggregateListAction.html) |
+| |[ListOperationAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ListOperationAction.html) and [ListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ListOperation.html) |
 
 ### Lists – Operations
 
@@ -283,10 +283,10 @@ Lists can be manipulated with different types of operations. Lists can be sorted
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [List Operation](/refguide/list-operation/) |[ListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.listoperation.html) |
-| |[Head](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.head.html) and [Tail](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.tail.html) |
-| |[Sort](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sort.html), [SortItemList](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sortitemlist.html) and [SortItem](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.sortitem.html) |
-| |[Filter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.filter.html) and [Find](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.find.html) |
+| [List Operation](/refguide/list-operation/) |[ListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ListOperation.html) |
+| |[Head](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Head.html) and [Tail](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Tail.html) |
+| |[Sort](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Sort.html), [SortItemList](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SortItemList.html) and [SortItem](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.SortItem.html) |
+| |[Filter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Filter.html) and [Find](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Find.html) |
 
 ### Lists – Binary Operations
 
@@ -298,12 +298,12 @@ Lists can be manipulated with several binary operations, which take two lists as
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [List Operation](/refguide/list-operation/) |[BinaryListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.binarylistoperation.html) |
-| |[Contains](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.contains.html) |
-| |[Intersect](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.intersect.html) |
-| |[ListEquals](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.listequals.html) |
-| |[Subtract](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.subtract.html) |
-| |[Union](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.union.html) |
+| [List Operation](/refguide/list-operation/) |[BinaryListOperation](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.BinaryListOperation.html) |
+| |[Contains](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Contains.html) |
+| |[Intersect](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Intersect.html) |
+| |[ListEquals](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ListEquals.html) |
+| |[Subtract](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Subtract.html) |
+| |[Union](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.Union.html) |
 
 ### Java Action Calls
 
@@ -315,10 +315,10 @@ Java action calls point to a specific Java action and have a parameter mapping w
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Call Java Action](/refguide/call-java-action/) |[JavaAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/javaactions.javaaction.html) |
-| |[JavaActionParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/javaactions.javaactionparameter.html) |
-| |[JavaActionCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.javaactioncallaction.html) |
-| |[JavaActionParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.javaactionparametermapping.html) |
+| [Call Java Action](/refguide/call-java-action/) |[JavaAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/javaactions.JavaAction.html) |
+| |[JavaActionParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/javaactions.JavaActionParameter.html) |
+| |[JavaActionCallAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.JavaActionCallAction.html) |
+| |[JavaActionParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.JavaActionParameterMapping.html) |
 
 ### Logging
 
@@ -330,10 +330,10 @@ Logging actions target a single log node on a specific log level. The log messag
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Log Message](/refguide/log-message/) |[LogMessageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.logmessageaction.html) |
-| |[LogLevel](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.loglevel.html) |
-| |[StringTemplate](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.stringtemplate.html) |
-| |[TemplateArgument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.templateargument.html) |
+| [Log Message](/refguide/log-message/) |[LogMessageAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.LogMessageAction.html) |
+| |[LogLevel](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.LogLevel.html) |
+| |[StringTemplate](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.StringTemplate.html) |
+| |[TemplateArgument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.TemplateArgument.html) |
 
 ### Importing and Exporting XML
 
@@ -347,12 +347,12 @@ XML export actions use a domain-to-XML mapping similar to web service request ma
 
 Model SDK API docs
 
-* [ImportXmlAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.importxmlaction.html)
-* [ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.resulthandling.html)
-* [ExportXmlAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.exportxmlaction.html)
-* [ExportMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/exportmappings.exportmapping.html)
-* [FileDocumentExport](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.filedocumentexport.html)
-* [VariableExport](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.variableexport.html)
+* [ImportXmlAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ImportXmlAction.html)
+* [ResultHandling](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ResultHandling.html)
+* [ExportXmlAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.ExportXmlAction.html)
+* [ExportMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/exportmappings.ExportMapping.html)
+* [FileDocumentExport](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.FileDocumentExport.html)
+* [VariableExport](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.VariableExport.html)
 
 ### Document Generation
 
@@ -364,6 +364,6 @@ Documents are generated from a document template. Such a template has parameters
 
 | Studio Pro Guide | Model SDK API docs |
 | --- | --- |
-| [Generate Document](/refguide/generate-document/) |[GenerateDocumentAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.generatedocumentaction.html) |
-| |[DocumentTemplate](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/documenttemplates.documenttemplate.html) |
-| |[DocumentTemplateParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.documenttemplateparametermapping.html) |
+| [Generate Document](/refguide/generate-document/) |[GenerateDocumentAction](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.GenerateDocumentAction.html) |
+| |[DocumentTemplate](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/documenttemplates.DocumentTemplate.html) |
+| |[DocumentTemplateParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/microflows.DocumentTemplateParameterMapping.html) |

--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/pages-metamodel.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/pages-metamodel.md
@@ -74,9 +74,9 @@ defines where this data comes from. A page variable can either point to a data w
 
 | Studio Pro Guide              | Model SDK API docs                                                                                                   |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| [Snippet](/refguide/snippet/) | [Snippet](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.snippet.html)                                 | 
-|                               | [SnippetCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.snippetcall.html)                         | 
-|                               | [SnippetCallWidget](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.snippetcallwidget.html)             |
+| [Snippet](/refguide/snippet/) | [Snippet](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.Snippet.html)                                 | 
+|                               | [SnippetCall](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.SnippetCall.html)                         | 
+|                               | [SnippetCallWidget](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.SnippetCallWidget.html)             |
 |                               | [SnippetParameter](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.SnippetParameter.html)               |
 |                               | [SnippetParameterMapping](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.SnippetParameterMapping.html) |
 |                               | [PageVariable](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/pages.PageVariable.html)                       |

--- a/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/projects-metamodel.md
+++ b/content/en/docs/apidocs-mxsdk/mxsdk/sdk-refguide/understanding-the-metamodel/projects-metamodel.md
@@ -17,9 +17,9 @@ A Mendix app model starts with a project. A project contains several top-level o
 Studio Pro Guide | Model SDK API docs
 | --- | --- |
 | [App](/refguide/app/) | TypeScript module [projects](https://apidocs.rnd.mendix.com/modelsdk/latest/modules/projects.html) |
-| [Modules](/refguide/modules/) |[Project](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.project.html) |
-| |[Module](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.module.html) |
-| |[ProjectDocument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.projectdocument.html) |
+| [Modules](/refguide/modules/) |[Project](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Project.html) |
+| |[Module](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Module.html) |
+| |[ProjectDocument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.ProjectDocument.html) |
 
 ### Project Documents
 
@@ -48,8 +48,8 @@ A module consists of a domain model, model security settings and zero or more do
 
 Studio Pro Guide | Model SDK API docs
 | --- | --- |
-| [Domain Model](/refguide/domain-model/) | Property [`domainModel`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.module.html#domainmodel) of Project |
-| [Module Security](/refguide/module-security/) | Property [`moduleSecurity`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.module.html#modulesecurity) of Project |
+| [Domain Model](/refguide/domain-model/) | Property [`domainModel`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Module.html#domainModel) of Project |
+| [Module Security](/refguide/module-security/) | Property [`moduleSecurity`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Module.html#moduleSecurity) of Project |
 
 ### Documents
 
@@ -63,9 +63,9 @@ In this sense, Module and Folder behave in the exact same way, and thus inherit 
 
 Studio Pro Guide | Model SDK API docs
 | --- | --- |
-| [Modules](/refguide/modules/) | Property [`modules`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.project.html#modules) of Project |
-| [Module](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.module.html) | |
-| [FolderBase](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.folderbase.html) | |
-| [Folder](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.folder.html) | |
-| [ModuleDocument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.moduledocument.html) | |
-| [Document](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.document.html) | |
+| [Modules](/refguide/modules/) | Property [`modules`](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Project.html#modules) of Project |
+| [Module](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Module.html) | |
+| [FolderBase](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.FolderBase.html) | |
+| [Folder](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Folder.html) | |
+| [ModuleDocument](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.ModuleDocument.html) | |
+| [Document](https://apidocs.rnd.mendix.com/modelsdk/latest/classes/projects.Document.html) | |


### PR DESCRIPTION
This fixes hyperlinks from the Mendix Metamodel sections that point to the Mendix Model SDK pages.

Previously, these links pointed to pages that were no longer being updated.