### PR TITLE
Add Oracle 23 to system requirements and remove SQL Server 2019

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -228,10 +228,10 @@ Mendix tries to support the most recent and patched database server versions fro
 Current support:
 
 * [MariaDB](/refguide/mysql/): 10.6, 10.11, 11.4, 11.8
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
 * [MySQL](/refguide/mysql/): 8.4
-* [Oracle Database](/refguide/oracle/): 19, 21c
+* [Oracle Database](/refguide/oracle/): 19, 21c, 23ai
 * PostgreSQL: 13, 14, 15, 16, 17
 * [SAP HANA](/refguide/saphana/): 2.00.076.00.1705400033
 

--- a/content/en/docs/refguide10/installation/system-requirements.md
+++ b/content/en/docs/refguide10/installation/system-requirements.md
@@ -241,10 +241,10 @@ Mendix tries to support the most recent and patched database server versions fro
 Current support:
 
 * [MariaDB](/refguide10/mysql/): 10.6, 10.11, 11.4, 11.8
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
 * [MySQL](/refguide10/mysql/): 8.4
-* [Oracle Database](/refguide10/oracle/): 19, 21c
+* [Oracle Database](/refguide10/oracle/): 19, 21c, 23ai
 * PostgreSQL: 13, 14, 15, 16, 17
 * [SAP HANA](/refguide10/saphana/): 2.00.076.00.1705400033
 

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -205,10 +205,10 @@ Current support:
 
 * [IBM DB2](/refguide8/db2/) 11.5 for Linux, Unix, and Windows
 * [MariaDB](/refguide9/mysql/): 10.6, 10.11, 11.4, 11.8
-* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2019, 2022
+* [Microsoft SQL Server](/developerportal/deploy/mendix-on-windows-microsoft-sql-server/): 2022
 * [Azure SQL](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017): v12 compatibility mode 140 or higher
 * [MySQL](/refguide9/mysql/): 8.4
-* [Oracle Database](/refguide9/oracle/): 19, 21c
+* [Oracle Database](/refguide9/oracle/): 19, 21c, 23ai
 * PostgreSQL: 13, 14, 15, 16, 17
 * [SAP HANA](/refguide9/saphana/): 2.00.076.00.1705400033
 


### PR DESCRIPTION
Requires team review.

Toe be published with 11.4 release.