### PR TITLE
feat: behaviour differences when moving to Public Cloud Kubernetes

### DIFF
--- a/content/en/docs/deployment/mendix-cloud-deploy/behavior-of-app.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/behavior-of-app.md
@@ -61,8 +61,8 @@ Therefore, do not assume that an established WebSocket connection will remain op
 
 ## Move to Kubernetes
 
-* Only [supported Mendix versions](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/) are able to move to Kubernetes
+* Only [supported Mendix versions](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/) are able to move to Kubernetes.
 * The platform configures `CF_INSTANCE_INDEX=0` for 1 of the instances to define a leader instance and to make [Community Commons](/appstore/modules/community-commons-function-library/) function `GetCFInstanceIndex` partially backwards compatible. The leader instance will return `0`. All follower instances will return `-1`. We advise to stop using function `GetCFInstanceIndex` as it is Cloud Foundry specific.
-* If your model is using the [SAML module](https://marketplace.mendix.com/link/component/1174) these versions are compatible with Kubernetes:
-    * Mendix 9: Version 3.6.19 and higher
-    * Mendix 10: Version 4.1.0 and higher
+* If your model is using the [SAML module](https://marketplace.mendix.com/link/component/1174), these versions are compatible with Kubernetes:
+    * Mendix 9 – Version 3.6.19 and higher.
+    * Mendix 10 – Version 4.1.0 and higher.

--- a/content/en/docs/deployment/mendix-cloud-deploy/behavior-of-app.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/behavior-of-app.md
@@ -58,3 +58,11 @@ Apps running in Mendix Cloud are subject to certain limitations. These behaviors
 Therefore, do not assume that an established WebSocket connection will remain open indefinitely. To ensure connection stability and prevent unexpected disconnections:
     * Enable periodic keepalive checks (for example, every 25–30 seconds). This ensures the connection remains active and prevents Network Address Translators (NATs) and firewalls from dropping long-idle tunnels.
     * Implement robust reconnection logic to gracefully handle connectivity loss and automatically reestablish dropped connections.
+
+## Move to Kubernetes
+
+* Only [supported Mendix versions](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/) are able to move to Kubernetes
+* The platform configures `CF_INSTANCE_INDEX=0` for 1 of the instances to define a leader instance and to make [Community Commons](/appstore/modules/community-commons-function-library/) function `GetCFInstanceIndex` partially backwards compatible. The leader instance will return `0`. All follower instances will return `-1`. We advise to stop using function `GetCFInstanceIndex` as it is Cloud Foundry specific.
+* If your model is using the [SAML module](https://marketplace.mendix.com/link/component/1174) these versions are compatible with Kubernetes:
+    * Mendix 9: Version 3.6.19 and higher
+    * Mendix 10: Version 4.1.0 and higher


### PR DESCRIPTION
There are some minimal differences in some cases that customers need to be aware of when moving from Public Cloud - Cloud Foundry platform to Kubernetes platform.