### PR TITLE
Introduce optional parameters

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
@@ -65,6 +65,12 @@ In the **Documentation** tab, you can find a **Summary** and a **Description**. 
 
 The **Edit External Action Parameter Mapping** dialog allows you to set the value of the parameter you pass to an external action. You can either select a **Variable** from the dropdown field, or write a custom [microflow expression](/refguide/expressions/) that returns a value of the expected type.
 
-Every parameter must have a value specified. When **Can be empty** is true, the selected variable or expression may evaluate to `empty`. When the value cannot be empty, the microflow will throw an error if the value evaluates to `empty`.
+Every parameter must have a value specified unless the service indicates that the parameter is optional (with the `Org.OData.Core.V1.OptionalParameter` annotation).
+
+When the service indicates that a value cannot be empty (with `Nullable="false"`) then the microflow will throw an error if the value evaluates to `empty`.
 
 If you have selected a variable for an entity that has associations, you can select which associations you want to include in the arguments that you call the external action with.
+
+{{% alert color="info" %}}
+The possibility to not specify a value for optional parameters was introduced in Studio Pro 11.4.0.
+{{% /alert %}}

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
@@ -67,7 +67,7 @@ The **Edit External Action Parameter Mapping** dialog allows you to set the valu
 
 Every parameter must have a value specified unless the service indicates that the parameter is optional (with the `Org.OData.Core.V1.OptionalParameter` annotation).
 
-When the service indicates that a value cannot be empty (with `Nullable="false"`) then the microflow will throw an error if the value evaluates to `empty`.
+When the service indicates that a value cannot be empty (with `Nullable="false"`), the microflow will throw an error if the value evaluates to `empty`.
 
 If you have selected a variable for an entity that has associations, you can select which associations you want to include in the arguments that you call the external action with.
 

--- a/content/en/docs/refguide10/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
+++ b/content/en/docs/refguide10/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
@@ -69,7 +69,7 @@ In the **Documentation** tab, you can find a **Summary** and a **Description**. 
 
 The **Edit External Action Parameter Mapping** dialog allows you to set the value of the parameter you pass to an external action. You can either select a **Variable** from the dropdown field, or write a custom [microflow expression](/refguide10/expressions/) that returns a value of the expected type.
 
-Every parameter must have a value specified. When **Can be empty** is true, the selected variable or expression may evaluate to `empty`. When the value cannot be empty, the microflow will throw an error if the value evaluates to `empty`.
+Every parameter must have a value specified. When the service indicates that a value cannot be empty (with `Nullable="false"`) then the microflow will throw an error if the value evaluates to `empty`.
 
 If you have selected a variable for an entity that has associations, you can select which associations you want to include in the arguments that you call the external action with.
 

--- a/content/en/docs/refguide10/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
+++ b/content/en/docs/refguide10/modeling/application-logic/microflows-and-nanoflows/activities/integration-activities/call-external-action.md
@@ -69,7 +69,7 @@ In the **Documentation** tab, you can find a **Summary** and a **Description**. 
 
 The **Edit External Action Parameter Mapping** dialog allows you to set the value of the parameter you pass to an external action. You can either select a **Variable** from the dropdown field, or write a custom [microflow expression](/refguide10/expressions/) that returns a value of the expected type.
 
-Every parameter must have a value specified. When the service indicates that a value cannot be empty (with `Nullable="false"`) then the microflow will throw an error if the value evaluates to `empty`.
+Every parameter must have a value specified. When the service indicates that a value cannot be empty (with `Nullable="false"`), the microflow will throw an error if the value evaluates to `empty`.
 
 If you have selected a variable for an entity that has associations, you can select which associations you want to include in the arguments that you call the external action with.
 


### PR DESCRIPTION
Introduce optional parameters for external actions in Studio Pro 11.4.0.

Also clarify wording for whether parameter values are allowed to evaluate to `empty`.