### PR TITLE
Update _index.md

### DIFF
--- a/content/en/docs/refguide/installation/performance-tips/_index.md
+++ b/content/en/docs/refguide/installation/performance-tips/_index.md
@@ -35,7 +35,7 @@ Additionally, do not run your solution from a USB drive. Copy it to your hard-di
 
 In some exceptional cases, hardware acceleration can cause errors when rendering desktop applications. When this occurs, Mendix recommends enabling software rendering.
 
-To do this, navigate to **Preferences** > **Work Environment** and select [Enable software rendering mode](/refguide/preferences-dialog/#rendering). Then, restart Studio Pro. After restarting, check if you notice improvements. If you do not notice improvements, it is preferable to turn this setting off.
+To do this, navigate to **Preferences** > **Advanced** and select [Enable software rendering mode](/refguide/preferences-dialog/#rendering). Then, restart Studio Pro. After restarting, check if you notice improvements. If you do not notice improvements, it is preferable to turn this setting off.
 
 ### Parallels
 

--- a/content/en/docs/refguide10/installation/performance-tips/_index.md
+++ b/content/en/docs/refguide10/installation/performance-tips/_index.md
@@ -35,7 +35,7 @@ Additionally, do not run your solution from a USB drive. Copy it to your hard-di
 
 In some exceptional cases, hardware acceleration can cause errors when rendering desktop applications. When this occurs, Mendix recommends enabling software rendering.
 
-To do this, navigate to **Preferences** > **Work Environment** and select [Enable software rendering mode](/refguide10/preferences-dialog/#rendering). Then, restart Studio Pro. After restarting, check if you notice improvements. If you do not notice improvements, it is preferable to turn this setting off.
+To do this, navigate to **Preferences** > **Advanced** and select [Enable software rendering mode](/refguide10/preferences-dialog/#rendering). Then, restart Studio Pro. After restarting, check if you notice improvements. If you do not notice improvements, it is preferable to turn this setting off.
 
 ### Parallels
 

--- a/content/en/docs/refguide10/modeling/menus/edit-menu/preferences-dialog.md
+++ b/content/en/docs/refguide10/modeling/menus/edit-menu/preferences-dialog.md
@@ -245,10 +245,6 @@ This option allows user to choose between Studio Pro themes: **Auto (System them
 
 This option sets the default page editor mode that your page opens in: **Structure mode** (the default) or **Design mode**. For more information on page editor modes, see the [Page Editor Modes](/refguide10/page/#page-editor-modes) section in *Page*.
 
-### Rendering {#rendering}
-
-Hardware and driver issues may cause performance problems when running Studio Pro. These issues can appear in form of dialog boxes opening and closing much more slowly than expected, and general slowness of the UI. In case the hardware problems cannot be solved, it is possible to mitigate these issues by turning the **Enable software rendering mode** setting on. Enabling this setting requires a restart of Studio Pro to take effect. Running the application with this setting on may increase the CPU usage.
-
 ### Language {#language}
 
 This option allows you to change the user interface language you work in while using Studio Pro. At this time, English, Japanese, Chinese, Korean, and Brazilian Portuguese (Beta) are supported. You must restart Studio Pro in order to use this feature.
@@ -273,6 +269,12 @@ The closing policy is not applied to tabs with unsaved changes.
 This setting allows you to move forward and backward through your editing history to show the documents you have recently worked on. This feature is enabled by default. 
 
 ## Advanced Tab
+
+### Rendering {#rendering}
+
+Hardware and driver issues may cause performance problems when running Studio Pro. These issues can appear in form of dialog boxes opening and closing much more slowly than expected, and general slowness of the UI. If case the hardware problems cannot be solved, it is possible to mitigate these issues by turning the **Enable software rendering mode** setting on. This option is available for Native UI and Web Content. For Web Content, you can select **Auto**, which enables software rendering mode automatically when running on Parallels or another virtual machine.
+
+Enabling this setting requires a restart of Studio Pro to take effect. Running the application with this setting on may increase the CPU usage.
 
 ### Proxy Server
 


### PR DESCRIPTION
The option is under the Advanced tab, not the Work Environment (at least in 10.24.8).

Sorry this commit/request is far from complete, I wanted to quickly make a change but I now see this mixup is also here: https://docs.mendix.com/refguide10/preferences-dialog/#rendering. I'm assuming that Mx11 doc also need to be updated for both these documents and perhaps also 9. 

One more thing, in 10.24.8, we have two options for Software Rendering: one for Native UI and one for Web Content.