### PR TITLE
add ticket 261700 entry to 10.24.10 and remove from 10.24.11

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/10/10.24.md
+++ b/content/en/docs/releasenotes/studio-pro/10/10.24.md
@@ -38,6 +38,7 @@ This is the [LTS](/releasenotes/studio-pro/lts-mts/#lts) version 10 release for 
 * We fixed an issue where the React client would not get bundled when deploying for Eclipse. (Ticket 258470)
 * We fixed an issue with Offline PWAs when using the React client where changes to the application would not be shown to the user without clearing the cache. (Ticket 260673)
 * We fixed a "no such column" error when synchronizing a file or image derived entity which itself is derived by another entity with an offline synchronization mode. (Ticket 261700)
+* We fixed a "no such column" error from a "CREATE INDEX" query when upgrading an offline app that has an association added to an entity. (Ticket 261700)
 * We fixed an issue in the Studio Pro XPath constraint parser with the treatment of `true` and `false` . These are now treated the same as their function equivalents (`true()` and `false()` respectively).
 * We fixed a memory leak that occurred when editing an action of a Microflow.
 * We fixed an issue in offline apps that could result in data validations of microflow calls not being properly handled.


### PR DESCRIPTION
This fix was added to 10.24.10 due to an urgent customer request, but originally was planned for 10.24.11.
Therefore, release note reflects 10.24.11 but the fix is actually at 10.24.10. 

Also [this other PR](https://github.com/mendix/docs/pull/10304) to be reviewed @MarkvanMents 