### PR TITLE
[3D Viewer]: Update 3D Viewer documentation to clarify supported file formats

### DIFF
--- a/content/en/docs/partners/siemens/3d-viewer/_index.md
+++ b/content/en/docs/partners/siemens/3d-viewer/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 ## Introduction
 
-The [3D Viewer](https://marketplace.mendix.com/link/component/118345) service lets you upload, visualize, and operate on 3D files (JT, OBJ, glTF, and STL formats) in your web applications, using Mendix file storage to store models. The app service contains out-of-the-box Java actions, JavaScript actions, [domain models](/refguide/domain-model/), [nanoflows](/refguide/nanoflows/), [microflows](/refguide/microflows/), and a set of 3D widgets that enable you to build apps to work with 3D models. Also included are whole functionalities and integrations that can be very helpful when building your own 3D applications. All you need to do is drag and drop items and configure them.
+The [3D Viewer](https://marketplace.mendix.com/link/component/118345) service lets you upload, visualize, and operate on JT files in your web applications, using Mendix file storage to store models. The app service contains out-of-the-box Java actions, JavaScript actions, [domain models](/refguide/domain-model/), [nanoflows](/refguide/nanoflows/), [microflows](/refguide/microflows/), and a set of 3D widgets that enable you to build apps to work with 3D models. Also included are whole functionalities and integrations that can be very helpful when building your own 3D applications. All you need to do is drag and drop items and configure them.
 
 This app service does the heavy-lifting for you so you do not have to build a 3D-rendering engine from scratch.
 
@@ -63,7 +63,7 @@ The 3D Viewer app service includes a few 3D widgets. These are some limitations 
 
 * One **Container3D** widget can only contain one **Viewer** widget. If multiple Viewer widgets are placed inside a Container3D widget, you will see error message in **Design mode**. 
 * The **Viewer** widget is used to display a 3D model. All other 3D widgets (except the **Uploader** and **Container3D** widgets) need a Viewer widget present on the page to interact with.
-* Currently, supports glTF, STL, OBJ, and JT (JT version 9 and above) formats.
+* Supports JT (JT version 9 and above) format.
 * Before uploading a shattered JT *.zip* file, make sure you are using UTF-8 encode to zip the JT files. For example, if you are using 7-Zip, make sure you enter *cu* in **Parameters**.
 
     {{< figure src="/attachments/partners/siemens/3d-viewer/shatteredjt-utf8.png" alt="shatteredjt-utf8" class="no-border" >}}


### PR DESCRIPTION
Update 3D Viewer documentation to clarify supported file formats : Just keep the **JT** format.