### PR TITLE
Corrected History Pane release note

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/11/11.4.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.4.md
@@ -15,7 +15,8 @@ weight: 96
 
 * In the experimental Java API `OqlStatement`, the  [`UPDATE`](/refguide/oql-statements/#oql-update) statement can now also update associations.
 * We introduced the [batch conversion](/refguide/mendix-client/batch-conversion/) capability in Studio Pro so you can convert old widgets no longer supported by the [React client](/refguide/mendix-client/react/).
-* We added the [History pane](/refguide/view-menu/#history-pane) as a beta feature. This allows you to find changes and navigate to modified documents without closing the history view. 
+* We added the [History pane](/refguide/view-menu/#history-pane) as a beta feature. This allows you to find changes and navigate to modified documents without closing the history view. In addition to local history, we now also show commits that have been pushed to the same branch on the server which you have not pulled yet.<br />
+You can open the History Pane via View > History. To make it your default history view, update the setting in the New Features preferences.
 
 #### New Fetch Options
 

--- a/content/en/docs/releasenotes/studio-pro/11/11.4.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.4.md
@@ -15,8 +15,7 @@ weight: 96
 
 * In the experimental Java API `OqlStatement`, the  [`UPDATE`](/refguide/oql-statements/#oql-update) statement can now also update associations.
 * We introduced the [batch conversion](/refguide/mendix-client/batch-conversion/) capability in Studio Pro so you can convert old widgets no longer supported by the [React client](/refguide/mendix-client/react/).
-* We added the [History pane](/refguide/view-menu/#history-pane) as a beta feature. This allows you to find changes and navigate to modified documents without closing the history view. In addition to local history, we now also show commits that have been pushed to the same branch on the server which you have not pulled yet.<br />
-You can open the History Pane via View > History. To make it your default history view, update the setting in the New Features preferences.
+* We added the [History pane](/refguide/view-menu/#history-pane) as a beta feature. This allows you to find changes and navigate to modified documents without closing the history view. In addition to local history, you can also now see commits that have been pushed to the same branch on the server that you have not pulled yet. You can open the History Pane by clicking **View** > **History**. 
 
 #### New Fetch Options
 


### PR DESCRIPTION
Expanded the description of the History pane feature to include server commits and usage instructions.