### PR TITLE
Revise Linux deployment warning in documentation

### DIFF
--- a/content/en/docs/deployment/on-premises-design/linux.md
+++ b/content/en/docs/deployment/on-premises-design/linux.md
@@ -7,7 +7,7 @@ aliases:
     - /developerportal/deploy/unix-like/
 ---
 
-{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for [Mendix Runtimes supported versions](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/).  We will not add support for any other versions.  {{% /alert %}}
+{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for the [supported versions of Mendix Runtime](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/).  We will not add support for any other versions of Debian.  {{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/deployment/on-premises-design/linux.md
+++ b/content/en/docs/deployment/on-premises-design/linux.md
@@ -7,7 +7,7 @@ aliases:
     - /developerportal/deploy/unix-like/
 ---
 
-{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for the [supported versions of Mendix Runtime](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/).  We will not add support for any other versions of Debian.  {{% /alert %}}
+{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for the [Mendix Runtime version 9, 10, and 11](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/).  We will not add support for any other versions of the Mendix Runtime.  {{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/deployment/on-premises-design/linux.md
+++ b/content/en/docs/deployment/on-premises-design/linux.md
@@ -7,7 +7,7 @@ aliases:
     - /developerportal/deploy/unix-like/
 ---
 
-{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for Mendix Runtime versions 7, 8, and 9. We will not add support for any other versions.  {{% /alert %}}
+{{% alert color="warning" %}} Linux deployment is only supported on Debian 10 (buster) for [Mendix Runtimes supported versions](https://docs.mendix.com/releasenotes/studio-pro/lts-mts/).  We will not add support for any other versions.  {{% /alert %}}
 
 ## Introduction
 


### PR DESCRIPTION
Updated warning message to include a link to supported Mendix Runtime versions. We have checked internally and, according to our tests, M2EE can run Mx 10 and Mendix 11.

I do not have permission to edit in https://github.com/mendix/m2ee-tools/blob/master/doc/README.md I want to have the same message there too, please.