### PR TITLE
Documented how to add HTTP headers in MxOK (no release date)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/_index.md
@@ -77,7 +77,7 @@ OpenShift Routes remain a suitable choice if meet your current needs and you do 
 
 ## Known Issues
 
-* Application load balancers do not work correctly with HTTP2 WebSockets.
+* AWS Application Load Balancers do not work correctly with HTTP2 WebSockets.
 
     As a workaround, you can use HTTP1 as the ingress backend protocol: `alb.ingress.kubernetes.io/backend-protocol-version: HTTP1`
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -69,17 +69,19 @@ In this way, you can configure the following settings:
 * Specify the name of an existing TLS certificate secret.
 * Provide TLS Certificate and Private Key values directly in the environment specification.
 
-## Configuring HTTP headers
+## Configuring HTTP Headers
 
-### Configuring headers in NGINX Ingress
+You can configure HTTP headers for NGINX Ingress and for Mendix Runtime. For more information, refer to the following sections.
 
-For NGINX Ingress, you can set headers in a namespace which will further be propagated across all apps in that namespace by using a configuration snippet in the OperatorConfiguration object. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
+### Configuring Headers in NGINX Ingress
+
+For NGINX Ingress, you can use a configuration snippet in the `OperatorConfiguration` object to set headers in a namespace. The headers that you set are then further propagated across all apps in that namespace. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/advanced-headers.png" class="no-border" >}}
 
-Mendix only supports unencrypted HTTP between the Ingress controller and the app. However, there is no higher level of security with service-to-service encryption and policy controls. In such situation, integrating Ingress controllers with Istio Service Mesh or Linkerd can help you manage both external traffic entering your Kubernetes cluster (by using an Ingress Controller) and internal traffic between services (by using Istio or Linkerd).
+Mendix only supports unencrypted HTTP between the Ingress controller and the app. However, there is no higher level of security with service-to-service encryption and policy controls. In such situations, integrating Ingress controllers with Istio Service Mesh or Linkerd can help you manage both external traffic entering your Kubernetes cluster (by using an Ingress Controller) and internal traffic between services (by using Istio or Linkerd).
 
-Istio Service Mesh and Linkerd help manage service-to-service communication within a Kubernetes cluster. It provides features such as the following:
+Istio Service Mesh and Linkerd help manage service-to-service communication within a Kubernetes cluster. It provides the following features:
 
 * Traffic management (for example, canary releases)
 * Service discovery
@@ -93,11 +95,11 @@ In an Istio- or Linkerd-enabled Kubernetes cluster, an Ingress controller can be
 AWS Application Load Balancer and Azure Application Gateway Ingress Controller only work with Istio.
 {{% /alert %}}
 
-### Configuring headers in the Mendix Runtime
+### Configuring Headers in the Mendix Runtime
 
-Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external ingress controller.
+Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external Ingress controller.
 
-This allows specifying security headers such as `Content-Security-Policy` with any ingress controller, not just NGINX Ingress.
+This allows specifying security headers such as `Content-Security-Policy` with any Ingress controller, not just NGINX Ingress.
 
 To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting on the [Runtime Tab](/developerportal/deploy/private-cloud-deploy/#runtime-tab) (for Connected environments) or in the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
 
@@ -105,7 +107,7 @@ The `Headers` Custom Runtime Setting accepts a JSON map where the keys are heade
 
 The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` values.
 
-For example, here's an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
+The following is an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
 
 ```json
 {

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -69,7 +69,9 @@ In this way, you can configure the following settings:
 * Specify the name of an existing TLS certificate secret.
 * Provide TLS Certificate and Private Key values directly in the environment specification.
 
-## Configuring Headers in NGINX Ingress
+## Configuring HTTP headers
+
+### Configuring headers in NGINX Ingress
 
 For NGINX Ingress, you can set headers in a namespace which will further be propagated across all apps in that namespace by using a configuration snippet in the OperatorConfiguration object. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
 
@@ -91,7 +93,29 @@ In an Istio- or Linkerd-enabled Kubernetes cluster, an Ingress controller can be
 AWS Application Load Balancer and Azure Application Gateway Ingress Controller only work with Istio.
 {{% /alert %}}
 
-### Istio Service Mesh Integration with Ingress Controller
+### Configuring headers in the Mendix Runtime
+
+Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external ingress controller.
+
+This allows specifying security headers such as `Content-Security-Policy` with any ingress controller, not just NGINX Ingress.
+
+To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting on the [Runtime Tab](/developerportal/deploy/private-cloud-deploy/#runtime-tab) (for Connected environments) or in the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
+
+The `Headers` Custom Runtime Setting accepts a JSON map where the keys are header names and values are header values.
+
+The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` valuues.
+
+For example, here's an example value of the `Headers` Custom Runtime Setting that can be usedhow to specify a few typical security headers:
+
+```json
+{
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Content-Security-Policy": "script-src 'nonce-{{ NONCE }}'"
+}
+```
+
+## Istio Service Mesh Integration with Ingress Controller
 
 To integrate the Istio Service Mesh with an Ingress Controller, perform the following steps:
 
@@ -111,7 +135,6 @@ To integrate the Istio Service Mesh with an Ingress Controller, perform the foll
 6. In Istio, configure a [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) resource to allow traffic through the ingress gateway.
 7. Define a [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) to route traffic from the gateway to a service in the mesh.
 
-#### Configuring the Istio Service Mesh in the Mxpc-cli Tool
 
 To configure the Istio Service Mesh for Mendix on Kubernetes, set up the following settings:
 
@@ -124,7 +147,7 @@ To configure the Istio Service Mesh for Mendix on Kubernetes, set up the followi
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/advanced-istio.png" class="no-border" >}}
 
-### Installing Linkerd
+## Installing Linkerd
 
 To install Linkerd, perform the following steps:
 
@@ -141,7 +164,7 @@ To install Linkerd, perform the following steps:
     kubectl annotate {namespace} linkerd.io/inject=enabled
     ```
 
-#### Configuring Linkerd Ingress in the Mxpc-cli Tool
+### Configuring Linkerd Ingress in the Mxpc-cli Tool
 
 To configure Linkerd for Mendix on Kubernetes, set up the following settings:
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -103,9 +103,9 @@ To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Run
 
 The `Headers` Custom Runtime Setting accepts a JSON map where the keys are header names and values are header values.
 
-The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` valuues.
+The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` values.
 
-For example, here's an example value of the `Headers` Custom Runtime Setting that can be usedhow to specify a few typical security headers:
+For example, here's an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
 
 ```json
 {

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,14 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
+### November ???, 2025
+
+#### Documentation Improvements
+
+* We have updated documentation on setting HTTP(S) headers.
+   The instructions now include a new Mendix 10.24.1 Runtime feature allowing to set custom headers directly in the Mendix Runtime, without having to configure the ingress controller.
+   For more information, see [Advanced Ingress Settings in Mendix on Kubernetes](developerportal/deploy/private-cloud-cluster/private-cloud-ingress-settings/advanced/).
+
 ### November 7, 2025
 
 #### Portal Hotfix


### PR DESCRIPTION
Mendix 10.24.1 added an option to set HTTP headers - this update explains how to use this feature.

It's not linked with any releases and can be reviewed and merged at any convenient time.