### PR TITLE
Revise Git merging instructions for *.mpr* files

### DIFF
--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro/_index.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro/_index.md
@@ -331,9 +331,9 @@ The second method should be used if the first method is not possible for some re
 
 #### Merging Using Git in the Command Line
 
-Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format). External tooling can't correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
+Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format). External tools cannot correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
 
-On the roadmap we're planning to introduce a separate command as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) to allow merging on the command line.
+In a future release, we are planning to introduce a separate command as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) to allow merging on the command line.
 
 ### Branching Best-Practices {#branching-best-practices}
 

--- a/content/en/docs/refguide/version-control/using-version-control-in-studio-pro/_index.md
+++ b/content/en/docs/refguide/version-control/using-version-control-in-studio-pro/_index.md
@@ -331,36 +331,9 @@ The second method should be used if the first method is not possible for some re
 
 #### Merging Using Git in the Command Line
 
-For merging *.mpr* files using Git in the command line to work, it is necessary to attach *mx.exe* merge to Git as a driver.
+Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format). External tooling can't correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
 
-When doing a **git merge** operation on two branches in the command line, Git attempts to merge the binaries of *.mpr* files, which does not work. You need to apply Studio Pro merge algorithm and that is where *mx.exe* as a driver is needed.
-
-Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
-
-```text
-[core]
-  attributesfile = ~/.gitattributes
-[merge "custom"]
-  name = custom merge driver for specific files
-  driver = [MX.EXE_PATH] merge %O %A %B
-```
-
-`[MX.EXE_PATH]` should be replaced by the *mx.exe* path with only forward slashes pointing to a drive using `/C/` instead of `C:/`.
-
-You can also configure the Git driver locally per repository using the following commands:
-
-```text
-git config merge.custom.name "custom merge driver for specific files"
-git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
-```
-
-After setting up the driver either locally or globally, create a *.gitattributes* file in the same folder with the following contents:
-
-```text
-*.mpr merge=custom
-```
-
-Save the files and now when **git merge** is run and it involves *.mpr* files, the *mx.exe* merge will run Studio Pro merge algorithm before Git finishes the merge.
+On the roadmap we're planning to introduce a separate command as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) to allow merging on the command line.
 
 ### Branching Best-Practices {#branching-best-practices}
 

--- a/content/en/docs/refguide10/version-control/using-version-control-in-studio-pro/_index.md
+++ b/content/en/docs/refguide10/version-control/using-version-control-in-studio-pro/_index.md
@@ -331,36 +331,9 @@ The second method should be used if the first method is not possible for some re
 
 #### Merging Using Git in the Command Line
 
-For merging *.mpr* files using Git in the command line to work, it is necessary to attach *mx.exe* merge to Git as a driver.
+Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format), which is the default format as of Studio Pro 10.22. External tooling can't correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
 
-When doing a **git merge** operation on two branches in the command line, Git attempts to merge the binaries of *.mpr* files, which does not work. You need to apply Studio Pro merge algorithm and that is where *mx.exe* as a driver is needed.
-
-Navigate to the *.gitconfig* file in C:/Users/[USER_NAME] and add the following:
-
-```text
-[core]
-  attributesfile = ~/.gitattributes
-[merge "custom"]
-  name = custom merge driver for specific files
-  driver = [MX.EXE_PATH] merge %O %A %B
-```
-
-`[MX.EXE_PATH]` should be replaced by the *mx.exe* path with only forward slashes pointing to a drive using `/C/` instead of `C:/`.
-
-You can also configure the Git driver locally per repository using the following commands:
-
-```text
-git config merge.custom.name "custom merge driver for specific files"
-git config merge.custom.driver "[MX.EXE_PATH] merge %O %A %B"
-```
-
-After setting up the driver either locally or globally, create a *.gitattributes* file in the same folder with the following contents:
-
-```text
-*.mpr merge=custom
-```
-
-Save the files and now when **git merge** is run and it involves *.mpr* files, the *mx.exe* merge will run Studio Pro merge algorithm before Git finishes the merge.
+Within Mendix 11 a command as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) will be introduced to allow merging on the command line.
 
 ### Branching Best-Practices {#branching-best-practices}
 

--- a/content/en/docs/refguide10/version-control/using-version-control-in-studio-pro/_index.md
+++ b/content/en/docs/refguide10/version-control/using-version-control-in-studio-pro/_index.md
@@ -331,9 +331,9 @@ The second method should be used if the first method is not possible for some re
 
 #### Merging Using Git in the Command Line
 
-Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format), which is the default format as of Studio Pro 10.22. External tooling can't correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
+Merging using Git in the command line or a third-party tool is not supported after the introduction of [MPRv2](/refguide/troubleshoot-repository-size/#mpr-format), which is the default format as of Studio Pro 10.22. External tools cannot correctly merge the *.mpr* and *.mxunit* files, which can lead to a corrupted branch.
 
-Within Mendix 11 a command as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) will be introduced to allow merging on the command line.
+For Mendix 11, a command will be introduced as part of the [mx Command-Line Tool](/refguide/mx-command-line-tool/) to allow merging on the command line.
 
 ### Branching Best-Practices {#branching-best-practices}
 


### PR DESCRIPTION
Updated merging instructions for Git in the command line to reflect the limitations with *.mpr* files and the need for the *mx.exe* driver. Removed outdated configuration steps and clarified the use of the mx Command-Line Tool for future merging capabilities.