### PR TITLE
Refine 3D Viewer Licensing Section (Usage, Deployment, Trial Token)

### DIFF
--- a/content/en/docs/partners/siemens/3d-viewer/_index.md
+++ b/content/en/docs/partners/siemens/3d-viewer/_index.md
@@ -78,13 +78,22 @@ For more information about the requirements for other releases, see the releases
 
 ### Obtaining a License Token {#obtain-license-token}
 
-3D Viewer is a **premium** Siemens product and requires a valid **purchase and commercial license** for production use.
+3D Viewer is a premium Siemens product which requires a valid purchase and commercial license for production use.
 
-- You can use 3D Viewer **without** a license in your **local development environment** with [Mendix Studio Pro](/releasenotes/studio-pro/), for more details see [Run Locally or Preview](/deployment/#run-locally-or-preview/).
+You can use 3D Viewer without a license in your local development environment with [Mendix Studio Pro](/releasenotes/studio-pro/). For details, refer to [Run Locally or Preview](/deployment/#run-locally-or-preview/).
+However, a license is required to deploy your application to any server environment. This includes:
 
-- A license is **required** to deploy your application to any **server environment**. This includes [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/) as well as all self-managed or [on-premises](/developerportal/deploy/on-premises-design/) infrastructures(such as [Kubernetes](/developerportal/deploy/private-cloud/), [Docker](/developerportal/deploy/docker-deploy/), [Azure](/developerportal/deploy/mendix-on-azure/), [SAP BTP](/developerportal/deploy/sap-cloud-platform/) etc.), for more details see [Deploying Apps](/deployment/).
+* [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/)
+* Self-managed or [on-premises](/developerportal/deploy/on-premises-design/) infrastructures, such as:    
 
-To request a **trial license token**, click the **Contact Us** button on the [3D Viewer Marketplace page](https://marketplace.mendix.com/link/component/118345) or send an email to MX3DViewerHelp.sisw@siemens.com.
+    * [Kubernetes](/developerportal/deploy/private-cloud/)
+    * [Docker](/developerportal/deploy/docker-deploy/)
+    * [Azure](/developerportal/deploy/mendix-on-azure/)
+    * [SAP BTP](/developerportal/deploy/sap-cloud-platform/)
+    
+For details, refer to [Deploying Apps](/deployment/).
+
+To request a trial license token, click the **Contact Us** button on the [3D Viewer Marketplace page](https://marketplace.mendix.com/link/component/118345) or send an email to MX3DViewerHelp.sisw@siemens.com.
 
 Once you have obtained a license token, configure it as described in [Configuring the License Token](#configure-license-token).
 
@@ -325,6 +334,8 @@ The **Toolbar** widgets do not require additional configuration. Simply place th
 | Tool Bar Item Snapshot | Provides the ability to take a snapshot of the current Viewer and save the snapshot to a local machine. |
 
 ### Configuring the License Token {#configure-license-token}
+
+Follow this guidance to configure a license token depending on your environment.
 
 #### For an App Deployed in Mendix Cloud
 

--- a/content/en/docs/partners/siemens/3d-viewer/_index.md
+++ b/content/en/docs/partners/siemens/3d-viewer/_index.md
@@ -80,7 +80,7 @@ For more information about the requirements for other releases, see the releases
 
 3D Viewer is a premium Siemens product which requires a valid purchase and commercial license for production use.
 
-You can use 3D Viewer without a license in your local development environment with [Mendix Studio Pro](/releasenotes/studio-pro/). For details, refer to [Run Locally or Preview](/deployment/#run-locally-or-preview/).
+You can use 3D Viewer without a license in your local development environment with [Mendix Studio Pro](/releasenotes/studio-pro/). For details, refer to [Run Locally or Preview](/deployment/#run-locally-or-preview).
 However, a license is required to deploy your application to any server environment. This includes:
 
 * [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/)

--- a/content/en/docs/partners/siemens/3d-viewer/_index.md
+++ b/content/en/docs/partners/siemens/3d-viewer/_index.md
@@ -78,9 +78,15 @@ For more information about the requirements for other releases, see the releases
 
 ### Obtaining a License Token {#obtain-license-token}
 
-3D Viewer is a premium Mendix product that is subject to a purchase and subscription fee. You can deploy 3D Viewer locally or in a Mendix Free App for free. However, to deploy the 3D Viewer on the cloud, you need to get a license token which you will need when you configure it as described in [Configuring the License Token](#configure-license-token), below.
+3D Viewer is a **premium** Siemens product and requires a valid **purchase and commercial license** for production use.
 
-You can request a license token by clicking the **Contact Us** button on the [3D Viewer](https://marketplace.mendix.com/link/component/118345) Marketplace page.
+- You can use 3D Viewer **without** a license in your **local development environment** with [Mendix Studio Pro](/releasenotes/studio-pro/), for more details see [Run Locally or Preview](/deployment/#run-locally-or-preview/).
+
+- A license is **required** to deploy your application to any **server environment**. This includes [Mendix Cloud](/developerportal/deploy/mendix-cloud-deploy/) as well as all self-managed or [on-premises](/developerportal/deploy/on-premises-design/) infrastructures(such as [Kubernetes](/developerportal/deploy/private-cloud/), [Docker](/developerportal/deploy/docker-deploy/), [Azure](/developerportal/deploy/mendix-on-azure/), [SAP BTP](/developerportal/deploy/sap-cloud-platform/) etc.), for more details see [Deploying Apps](/deployment/).
+
+To request a **trial license token**, click the **Contact Us** button on the [3D Viewer Marketplace page](https://marketplace.mendix.com/link/component/118345) or send an email to MX3DViewerHelp.sisw@siemens.com.
+
+Once you have obtained a license token, configure it as described in [Configuring the License Token](#configure-license-token).
 
 ### Installing the Component in Your App
 
@@ -320,8 +326,6 @@ The **Toolbar** widgets do not require additional configuration. Simply place th
 
 ### Configuring the License Token {#configure-license-token}
 
-You can deploy 3D Viewer locally or in a Mendix Free App for free. However, to deploy 3D Viewer on the cloud, it will need to be licensed, and you need to obtain a license token as described in [Obtaining a License Token](#obtain-license-token), above, and then configure it as follows:
-
 #### For an App Deployed in Mendix Cloud
 
 If you deploy your app in Mendix Cloud, configure the license token in the [Mendix Portal](/developerportal/deploy/environments-details/).
@@ -330,7 +334,7 @@ Before you deploy your app, configure the app **Constants** in the deployment pa
 
 {{< figure src="/attachments/partners/siemens/3d-viewer/licensetoken-cloudportal.jpg" alt="licensetoken-cloudportal" class="no-border" >}}
 
-If you have already deployed your app, change the existing **LicenseToken** constant value on the **Model Options** tab and restart the app.
+If you have already deployed your app, change the existing **LicenseToken** constant value on the **[Model Options](/developerportal/deploy/environments-details/#model-options)** tab and restart the app.
 
 {{< figure src="/attachments/partners/siemens/3d-viewer/licensetoken-envdetails.jpg" alt="licensetoken-envdetails" class="no-border" >}}
 


### PR DESCRIPTION
Refine 3D Viewer Licensing Section (Usage, Deployment, Trial Token)

- Clarifying when a commercial license is required for production deployments.
- Explaining that 3D Viewer can be used without a license in local development with Mendix Studio Pro.
- Adding instructions for requesting a trial license token (Marketplace “Contact Us” or support email).
- Refining the section on obtaining and configuring the license token for all deployment environments (Mendix Cloud, Private Cloud, On-Premises).
- Improving overall readability, structure, and consistency of the licensing content.