### PR TITLE
Add Pattern Letters `YYYY` to Documentation

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
+++ b/content/en/docs/refguide/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
@@ -21,8 +21,9 @@ The following pattern letters can be used to parse and format Date and time valu
 | `LL`     | Month in year, digit with leading zero           | 01                        |
 | `LLL`    | Month in year, abbreviated (standalone)          | Nov                       |
 | `LLLL`   | Month in year (standalone)                       | November                  |
-| `yy`     | Year, two digits                                 | 01                        |
-| `yyyy`   | Year, four digits                                | 2001                      |
+| `yy`     | Calendar year, two digits                        | 01                        |
+| `yyyy`   | Calendar year, four digits                       | 2022                      |
+| `YYYY`   | ISO week-numbering year, four digits: <br/>`YYYY` shows the year based on the ISO week the date falls in, where week 1 is the first week containing at least four days of the new year. For example, 2024-12-31 is in ISO week 1 of 2025, so `YYYY` returns 2025, while `yyyy` returns 2024. | 2022 |
 | `G`      | Era designator                                   | AD                        |
 | `E`      | Day name in week, abbreviated                    | Tue                       |
 | `EEEE`   | Day name in week                                 | Tuesday                   |

--- a/content/en/docs/refguide10/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
+++ b/content/en/docs/refguide10/modeling/application-logic/expressions/parse-and-format-date-function-calls.md
@@ -21,8 +21,9 @@ The following pattern letters can be used to parse and format Date and time valu
 | `LL`     | Month in year, digit with leading zero           | 01                        |
 | `LLL`    | Month in year, abbreviated (standalone)          | Nov                       |
 | `LLLL`   | Month in year (standalone)                       | November                  |
-| `yy`     | Year, two digits                                 | 01                        |
-| `yyyy`   | Year, four digits                                | 2001                      |
+| `yy`     | Calendar year, two digits                        | 01                        |
+| `yyyy`   | Calendar year, four digits                       | 2022                      |
+| `YYYY`   | ISO week-numbering year, four digits: <br/>`YYYY` shows the year based on the ISO week the date falls in, where week 1 is the first week containing at least four days of the new year. For example, 2024-12-31 is in ISO week 1 of 2025, so `YYYY` returns 2025, while `yyyy` returns 2024. | 2022 |
 | `G`      | Era designator                                   | AD                        |
 | `E`      | Day name in week, abbreviated                    | Tue                       |
 | `EEEE`   | Day name in week                                 | Tuesday                   |


### PR DESCRIPTION
Document the difference between `yyyy` and `YYYY` in terms of date formatting