### PR TITLE
Updated MxOK ingress documentation (no release date)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/_index.md
@@ -77,7 +77,7 @@ OpenShift Routes remain a suitable choice if meet your current needs and you do 
 
 ## Known Issues
 
-* Application load balancers do not work correctly with HTTP2 WebSockets.
+* AWS Application Load Balancers do not work correctly with HTTP2 WebSockets.
 
     As a workaround, you can use HTTP1 as the ingress backend protocol: `alb.ingress.kubernetes.io/backend-protocol-version: HTTP1`
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -69,17 +69,19 @@ In this way, you can configure the following settings:
 * Specify the name of an existing TLS certificate secret.
 * Provide TLS Certificate and Private Key values directly in the environment specification.
 
-## Configuring HTTP headers
+## Configuring HTTP Headers
 
-### Configuring headers in NGINX Ingress
+You can configure HTTP headers for NGINX Ingress and for Mendix Runtime. For more information, refer to the following sections.
 
-For NGINX Ingress, you can set headers in a namespace which will further be propagated across all apps in that namespace by using a configuration snippet in the OperatorConfiguration object. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
+### Configuring Headers in NGINX Ingress
+
+For NGINX Ingress, you can use a configuration snippet in the `OperatorConfiguration` object to set headers in a namespace. The headers that you set are then further propagated across all apps in that namespace. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/advanced-headers.png" class="no-border" >}}
 
-Mendix only supports unencrypted HTTP between the Ingress controller and the app. However, there is no higher level of security with service-to-service encryption and policy controls. In such situation, integrating Ingress controllers with Istio Service Mesh or Linkerd can help you manage both external traffic entering your Kubernetes cluster (by using an Ingress Controller) and internal traffic between services (by using Istio or Linkerd).
+Mendix only supports unencrypted HTTP between the Ingress controller and the app. However, there is no higher level of security with service-to-service encryption and policy controls. In such situations, integrating Ingress controllers with Istio Service Mesh or Linkerd can help you manage both external traffic entering your Kubernetes cluster (by using an Ingress Controller) and internal traffic between services (by using Istio or Linkerd).
 
-Istio Service Mesh and Linkerd help manage service-to-service communication within a Kubernetes cluster. It provides features such as the following:
+Istio Service Mesh and Linkerd help manage service-to-service communication within a Kubernetes cluster. It provides the following features:
 
 * Traffic management (for example, canary releases)
 * Service discovery
@@ -93,11 +95,11 @@ In an Istio- or Linkerd-enabled Kubernetes cluster, an Ingress controller can be
 AWS Application Load Balancer and Azure Application Gateway Ingress Controller only work with Istio.
 {{% /alert %}}
 
-### Configuring headers in the Mendix Runtime
+### Configuring Headers in the Mendix Runtime
 
-Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external ingress controller.
+Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external Ingress controller.
 
-This allows specifying security headers such as `Content-Security-Policy` with any ingress controller, not just NGINX Ingress.
+This allows specifying security headers such as `Content-Security-Policy` with any Ingress controller, not just NGINX Ingress.
 
 To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting on the [Runtime Tab](/developerportal/deploy/private-cloud-deploy/#runtime-tab) (for Connected environments) or in the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
 
@@ -105,7 +107,7 @@ The `Headers` Custom Runtime Setting accepts a JSON map where the keys are heade
 
 The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` values.
 
-For example, here's an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
+The following is an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
 
 ```json
 {

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -75,7 +75,7 @@ You can configure HTTP headers for NGINX Ingress and for Mendix Runtime. For mor
 
 ### Configuring Headers in NGINX Ingress
 
-For NGINX Ingress, you can use a configuration snippet in the `OperatorConfiguration` object to set headers in a namespace. The headers that you set are then further propagated across all apps in that namespace. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
+For NGINX Ingress (from F5 Networks), you can use a configuration snippet in the `OperatorConfiguration` object to set headers in a namespace. The headers that you set are then further propagated across all apps in that namespace. Alternatively, you can configure headers for individual app environments by adding the `nginx.org/location-snippets` annotation in the Mendix on Kubernetes Portal.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/advanced-headers.png" class="no-border" >}}
 
@@ -101,21 +101,7 @@ Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, witho
 
 This allows specifying security headers such as `Content-Security-Policy` with any Ingress controller, not just NGINX Ingress.
 
-To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting on the [Runtime Tab](/developerportal/deploy/private-cloud-deploy/#runtime-tab) (for Connected environments) or in the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
-
-The `Headers` Custom Runtime Setting accepts a JSON map where the keys are header names and values are header values.
-
-The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` values.
-
-The following is an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
-
-```json
-{
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-    "X-Frame-Options": "SAMEORIGIN",
-    "Content-Security-Policy": "script-src 'nonce-{{ NONCE }}'"
-}
-```
+To set headers, use the [Network Tab](/developerportal/deploy/private-cloud-deploy/#network-tab) (for Connected environments) or the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
 
 ## Istio Service Mesh Integration with Ingress Controller
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -69,7 +69,9 @@ In this way, you can configure the following settings:
 * Specify the name of an existing TLS certificate secret.
 * Provide TLS Certificate and Private Key values directly in the environment specification.
 
-## Configuring Headers in NGINX Ingress
+## Configuring HTTP headers
+
+### Configuring headers in NGINX Ingress
 
 For NGINX Ingress, you can set headers in a namespace which will further be propagated across all apps in that namespace by using a configuration snippet in the OperatorConfiguration object. Alternatively, you can configure headers for individual app environments by adding the `nginx.ingress.kubernetes.io/configuration-snippet` annotation in the Mendix on Kubernetes Portal.
 
@@ -91,7 +93,29 @@ In an Istio- or Linkerd-enabled Kubernetes cluster, an Ingress controller can be
 AWS Application Load Balancer and Azure Application Gateway Ingress Controller only work with Istio.
 {{% /alert %}}
 
-### Istio Service Mesh Integration with Ingress Controller
+### Configuring headers in the Mendix Runtime
+
+Starting from Mendix 10.24.1, the Mendix Runtime can set headers natively, without relying on an external ingress controller.
+
+This allows specifying security headers such as `Content-Security-Policy` with any ingress controller, not just NGINX Ingress.
+
+To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Runtime Setting on the [Runtime Tab](/developerportal/deploy/private-cloud-deploy/#runtime-tab) (for Connected environments) or in the [.spec.runtime.customConfiguration field](/developerportal/deploy/private-cloud-operator/#edit-cr) in the MendixApp CR.
+
+The `Headers` Custom Runtime Setting accepts a JSON map where the keys are header names and values are header values.
+
+The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` valuues.
+
+For example, here's an example value of the `Headers` Custom Runtime Setting that can be usedhow to specify a few typical security headers:
+
+```json
+{
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Content-Security-Policy": "script-src 'nonce-{{ NONCE }}'"
+}
+```
+
+## Istio Service Mesh Integration with Ingress Controller
 
 To integrate the Istio Service Mesh with an Ingress Controller, perform the following steps:
 
@@ -111,7 +135,6 @@ To integrate the Istio Service Mesh with an Ingress Controller, perform the foll
 6. In Istio, configure a [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) resource to allow traffic through the ingress gateway.
 7. Define a [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) to route traffic from the gateway to a service in the mesh.
 
-#### Configuring the Istio Service Mesh in the Mxpc-cli Tool
 
 To configure the Istio Service Mesh for Mendix on Kubernetes, set up the following settings:
 
@@ -124,7 +147,7 @@ To configure the Istio Service Mesh for Mendix on Kubernetes, set up the followi
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/advanced-istio.png" class="no-border" >}}
 
-### Installing Linkerd
+## Installing Linkerd
 
 To install Linkerd, perform the following steps:
 
@@ -141,7 +164,7 @@ To install Linkerd, perform the following steps:
     kubectl annotate {namespace} linkerd.io/inject=enabled
     ```
 
-#### Configuring Linkerd Ingress in the Mxpc-cli Tool
+### Configuring Linkerd Ingress in the Mxpc-cli Tool
 
 To configure Linkerd for Mendix on Kubernetes, set up the following settings:
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-advanced-ingress-settings.md
@@ -103,9 +103,9 @@ To set headers, use the [Headers](/refguide/custom-settings/#Headers) Custom Run
 
 The `Headers` Custom Runtime Setting accepts a JSON map where the keys are header names and values are header values.
 
-The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` valuues.
+The `Content-Security-Policy` header supports [additional custom handling](/refguide/configuration/#headers) to process `nonce` values.
 
-For example, here's an example value of the `Headers` Custom Runtime Setting that can be usedhow to specify a few typical security headers:
+For example, here's an example value of the `Headers` Custom Runtime Setting that can be used how to specify a few typical security headers:
 
 ```json
 {

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
@@ -272,29 +272,30 @@ To configure AGIC for Mendix on Kubernetes, perform the following steps:
 
 4. Optional: To set up TLS certificates, see [Appgw ssl certificate](https://azure.github.io/application-gateway-kubernetes-ingress/features/appgw-ssl-certificate/).
 
-### HAProxy Ingress Controller
+### Traefik Ingress Controller
+
+Traefik is a cloud-native reverse proxy and a load balancer. When deployed as an Ingress Controller in Kubernetes, it manages HTTP and HTTPS traffic to services running within the cluster. It automatically discovers services using Kubernetes' native APIs, based on Kubernetes Ingress resources and other configurations. One of the main advantages of using Traefik is its built-in [Let's Encrypt](https://doc.traefik.io/traefik/https/acme/) support.
+
+#### Installing Traefik
+
+For information about installing the Traefik Ingress Controller, see [Traefik & Kubernetes](https://doc.traefik.io/traefik/providers/kubernetes-ingress/).
 
 {{% alert color="info" %}}
-This section documents how to use the [HAProxy Kubernetes Ingress Controller](https://github.com/haproxytech/kubernetes-ingress).
+Traefik uses 2 types of providers: CRDs or Kubernetes Ingress. Ensure that you install Kubernetes Ingress one, as it is the only one supported by Mendix on Kubernetes.
 {{% /alert %}}
 
-#### Installing HAProxy Ingress Controller
+#### Configuring Traefik in the Mxpc-cli Tool
 
-For more information about the recommended installation process, see [installation instructions for your platform](https://www.haproxy.com/documentation/kubernetes-ingress/community/installation/).
-
-##### Configuring HAProxy Ingress in the Mxpc-cli Tool
-
-To configure HAProxy Ingress for Mendix on Kubernetes, set up the following settings:
-
+To configure Traefik for Mendix on Kubernetes, set up the following settings:
 * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
-* **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
-* **Ingress Path** - Select `/` from the dropdown.
+* **Ingress Domain Name** - Provide the domain name which was registered for Traefik
+* **Ingress Path** - Set to `/*`.
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
 * **Custom Ingress Class** - Set to **enabled**.
-* **Ingress Class Name** - Enter **haproxy**. This setting requires Custom Ingress Class to be enabled.
+* **Ingress Class Name** - Enter **traefik**. This setting requires Custom Ingress Class to be enabled.
 * **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
 
-Additionally, you can add HAProxy-specific annotations to the **Ingress** section of your configuration. The following section shows example annotations. Adjust them as needed based on your specific requirements.
+{{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/configure-traefik.png" class="no-border" >}}
 
 ### Istio Ingress Controller
 
@@ -312,11 +313,11 @@ Istio is a feature-rich system with many configuration options. To validate an I
 
 #### Configuring Istio in the Mxpc-cli Tool
 
-To configure Traefik for Mendix on Kubernetes, set up the following settings:
+To configure Istio for Mendix on Kubernetes, set up the following settings:
 
 * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
 * **Ingress Domain Name** - Provide the domain name which was registered for Istio
-* **Ingress Path** - Set to `/*`. 
+* **Ingress Path** - Set to `/*`.
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
 * **Custom Ingress Class** - Set to **enabled**.
 * **Ingress Class Name** - Enter **istio**. This setting requires Custom Ingress Class to be enabled.

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
@@ -24,23 +24,27 @@ To ensure proper routing, the DNS server must be configured to direct all subdom
 
 The following sections describe the installation and configuration of various supported Ingress Controllers.
 
-### NGINX Ingress Controller
-
-The [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) is an open-source solution that leverages NGINX as a reverse proxy and load balancer to manage Kubernetes Ingress resources.
+### NGINX Ingress Controller (F5)
 
 {{% alert color="info" %}}
-NGINX path based routing is supported for Operator version 2.19.0 and newer, and Mendix version 10.3.0 and newer. To support this feature, NGINX Ingress uses `nginx.ingress.kubernetes.io/rewrite-target/(.*)` in the ingress path.
+This section documents how to use the [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks).
 {{% /alert %}}
 
-#### Installing NGINX
+{{% alert color="info" %}}
+NGINX path based routing is supported for Operator version 2.19.0 and newer, and Mendix version 10.3.0 and newer. To support this feature, NGINX Ingress uses `nginx.org/rewrite-target=/$1` annotation that rewrites a `(.*)` regular expresion in the ingress path.
+{{% /alert %}}
 
-The recommended way to install NGINX is [Helm](https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/installation-with-helm/). Alternatively, you can also install NGINX with a [manifest](https://kubernetes.github.io/ingress-nginx/deploy/).
+#### Installing NGINX Ingress Controller
 
-##### Configuring NGINX in the Mxpc-cli Tool
+The recommended way to install NGINX is [Helm](https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/installation-with-helm/).
+
+Some cloud providers might offer NGINX Ingress as a managed service.
+
+##### Configuring NGINX Ingress in the Mxpc-cli Tool
 
 To configure NGINX for Mendix on Kubernetes, set up the following settings:
 
-* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply. 
+* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
 * **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
 * **Ingress Path** - Optional. You can use this option to specify the Ingress path. The default value is `/`.
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
@@ -49,6 +53,63 @@ To configure NGINX for Mendix on Kubernetes, set up the following settings:
 * **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/configure-nginx.png" class="no-border" >}}
+
+Additionally, you can add NGINX-specific annotations to the **Ingress** section of your configuration. The following section shows example annotations. Adjust them as needed based on your specific requirements.
+
+```text
+apiVersion: privatecloud.mendix.com/v1alpha1
+kind: OperatorConfiguration
+# ...
+# omitted lines for brevity
+# ...
+spec:
+  # Endpoint (Network) configuration
+  endpoint:
+    type: ingress
+    ingress:
+      annotations:
+        # Example: allow uploads of files up to 500MB in size
+        nginx.org/client-max-body-size: 500m
+        # Example: rewrite path for path-based routing
+        nginx.org/rewrite-target: /$1
+        # Example: enable regular expressions for path-based routing
+        nginx.org/path-regex: case_sensitive
+      # The following parameters are already configured by mxpc-cli
+      domain: mendix.example.com
+      enableTLS: true
+      ingressClassName: nginx
+      # Set the path to "/(.*)" when using path-based routing
+      # When not using path-based routing, set the path to "/"
+      path: "/(.*)"
+      pathType: ImplementationSpecific
+# ...
+# omitted lines for brevity
+# ...
+```
+
+### HAProxy Ingress Controller
+
+{{% alert color="info" %}}
+This section documents how to use the [HAProxy Kubernetes Ingress Controller](https://github.com/haproxytech/kubernetes-ingress).
+{{% /alert %}}
+
+#### Installing HAProxy Ingress Controller
+
+For more information about the recommended installation process, see [installation instructions for your platform](https://www.haproxy.com/documentation/kubernetes-ingress/community/installation/).
+
+##### Configuring HAProxy Ingress in the Mxpc-cli Tool
+
+To configure HAProxy Ingress for Mendix on Kubernetes, set up the following settings:
+
+* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
+* **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
+* **Ingress Path** - Select `/` from the dropdown.
+* **Enable TLS** - Enable or disable TLS for your app's Ingress.
+* **Custom Ingress Class** - Set to **enabled**.
+* **Ingress Class Name** - Enter **haproxy**. This setting requires Custom Ingress Class to be enabled.
+* **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
+
+Additionally, you can add HAProxy-specific annotations to the **Ingress** section of your configuration. The following section shows example annotations. Adjust them as needed based on your specific requirements.
 
 ### AWS Load Balancer Ingress Controller
 
@@ -74,7 +135,7 @@ To configure the AWS Load Balancer for Mendix on Kubernetes, perform the followi
 
 1. Set up the following settings:
 
-    * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply. 
+    * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
     * **Ingress Domain Name** - Provide the domain name which which was registered for AWS Load Balancer.
     * **Ingress Path** - Set to `/*`. 
     * **Enable TLS** -  Set to **disabled**. In AWS Load Balancer, TLS is enabled through annotations.
@@ -157,7 +218,7 @@ To configure AGIC for Mendix on Kubernetes, perform the following steps:
 
 1. Set up the following settings:
 
-    * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply. 
+    * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
     * **Ingress Domain Name** - Provide the domain name which which was registered for AGIS.
     * **Ingress Path** - Set to `/*`. 
     * **Enable TLS** -  Enable or disable TLS for your app's Ingress.
@@ -211,28 +272,80 @@ To configure AGIC for Mendix on Kubernetes, perform the following steps:
 
 4. Optional: To set up TLS certificates, see [Appgw ssl certificate](https://azure.github.io/application-gateway-kubernetes-ingress/features/appgw-ssl-certificate/).
 
-### Traefik Ingress Controller
-
-Traefik is a cloud-native reverse proxy and a load balancer. When deployed as an Ingress Controller in Kubernetes, it manages HTTP and HTTPS traffic to services running within the cluster. It automatically discovers services using Kubernetes' native APIs, based on Kubernetes Ingress resources and other configurations. One of the main advantages of using Traefik is its built-in [Let's Encrypt](https://doc.traefik.io/traefik/https/acme/) support.
-
-#### Installing Traefik
-
-For information about installing the Traefik Ingress Controller, see [Traefik & Kubernetes](https://doc.traefik.io/traefik/providers/kubernetes-ingress/).
+### HAProxy Ingress Controller
 
 {{% alert color="info" %}}
-Traefik uses 2 types of providers: CRDs or Kubernetes Ingress. Ensure that you install Kubernetes Ingress one, as it is the only one supported by Mendix on Kubernetes.
+This section documents how to use the [HAProxy Kubernetes Ingress Controller](https://github.com/haproxytech/kubernetes-ingress).
 {{% /alert %}}
 
-#### Configuring Traefik in the Mxpc-cli Tool
+#### Installing HAProxy Ingress Controller
+
+For more information about the recommended installation process, see [installation instructions for your platform](https://www.haproxy.com/documentation/kubernetes-ingress/community/installation/).
+
+##### Configuring HAProxy Ingress in the Mxpc-cli Tool
+
+To configure HAProxy Ingress for Mendix on Kubernetes, set up the following settings:
+
+* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
+* **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
+* **Ingress Path** - Select `/` from the dropdown.
+* **Enable TLS** - Enable or disable TLS for your app's Ingress.
+* **Custom Ingress Class** - Set to **enabled**.
+* **Ingress Class Name** - Enter **haproxy**. This setting requires Custom Ingress Class to be enabled.
+* **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
+
+Additionally, you can add HAProxy-specific annotations to the **Ingress** section of your configuration. The following section shows example annotations. Adjust them as needed based on your specific requirements.
+
+### Istio Ingress Controller
+
+Istio is a well-known service mesh that includes a simple [ingress contoller](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+
+#### Installing Istio
+
+To install Istio, follow the official [installation instructions](https://istio.io/latest/docs/overview/quickstart/).
+
+You will also need to install an Istio [IngressClass](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+
+{{% alert color="info" %}}
+Istio is a feature-rich system with many configuration options. To validate an Istio configuration, it's highly recommended to test with a simple (non-Mendix) app to validate configuration.
+{{% /alert %}}
+
+#### Configuring Istio in the Mxpc-cli Tool
 
 To configure Traefik for Mendix on Kubernetes, set up the following settings:
 
-* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply. 
-* **Ingress Domain Name** - Provide the domain name which was registered for Traefik
+* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
+* **Ingress Domain Name** - Provide the domain name which was registered for Istio
 * **Ingress Path** - Set to `/*`. 
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
 * **Custom Ingress Class** - Set to **enabled**.
-* **Ingress Class Name** - Enter **traefik**. This setting requires Custom Ingress Class to be enabled.
+* **Ingress Class Name** - Enter **istio**. This setting requires Custom Ingress Class to be enabled.
 * **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
 
-{{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/configure-traefik.png" class="no-border" >}}
+### DEPRECATED NGINX Ingress Controller
+
+{{% alert color="warning" %}}
+The [Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) will be supported [until March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/).
+
+We recommend switching to another ingress controller.
+The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set.
+In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks would only require renaming ingress annotations.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+NGINX path based routing is supported for Operator version 2.19.0 and newer, and Mendix version 10.3.0 and newer. To support this feature, NGINX Ingress uses `nginx.ingress.kubernetes.io/rewrite-target=/$1` annotation that rewrites a `(.*)` regular expresion in the ingress path.
+{{% /alert %}}
+
+##### Configuring the NGINX in the Mxpc-cli Tool
+
+To configure the *deprecated* NGINX ingress controller with Mendix on Kubernetes, set up the following settings:
+
+* **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
+* **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
+* **Ingress Path** - Optional. You can use this option to specify the Ingress path. The default value is `/`.
+* **Enable TLS** - Enable or disable TLS for your app's Ingress.
+* **Custom Ingress Class** - Set to **enabled**.
+* **Ingress Class Name** - Enter **nginx**. This setting requires Custom Ingress Class to be enabled.
+* **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
+
+{{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/configure-nginx.png" class="no-border" >}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/networking/private-cloud-ingress.md
@@ -299,38 +299,36 @@ To configure Traefik for Mendix on Kubernetes, set up the following settings:
 
 ### Istio Ingress Controller
 
-Istio is a well-known service mesh that includes a simple [ingress contoller](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+Istio is a service mesh that includes a simple [ingress contoller](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
 
 #### Installing Istio
 
-To install Istio, follow the official [installation instructions](https://istio.io/latest/docs/overview/quickstart/).
+To install Istio, follow the [installation instructions](https://istio.io/latest/docs/overview/quickstart/).
 
-You will also need to install an Istio [IngressClass](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+Ensure that you also install an [Istio IngressClass](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
 
 {{% alert color="info" %}}
-Istio is a feature-rich system with many configuration options. To validate an Istio configuration, it's highly recommended to test with a simple (non-Mendix) app to validate configuration.
+Istio is a feature-rich system with many configuration options. To validate an Istio configuration, it is highly recommended to test with a simple (non-Mendix) app to validate configuration.
 {{% /alert %}}
 
 #### Configuring Istio in the Mxpc-cli Tool
 
-To configure Istio for Mendix on Kubernetes, set up the following settings:
+To configure Istio for Mendix on Kubernetes, configure the following settings:
 
 * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
 * **Ingress Domain Name** - Provide the domain name which was registered for Istio
 * **Ingress Path** - Set to `/*`.
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
 * **Custom Ingress Class** - Set to **enabled**.
-* **Ingress Class Name** - Enter **istio**. This setting requires Custom Ingress Class to be enabled.
+* **Ingress Class Name** - Enter **istio**. This setting requires **Custom Ingress Class** to be enabled.
 * **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
 
-### DEPRECATED NGINX Ingress Controller
+### NGINX Ingress Controller (Deprecated)
 
 {{% alert color="warning" %}}
 The [Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) will be supported [until March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/).
 
-We recommend switching to another ingress controller.
-The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set.
-In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks would only require renaming ingress annotations.
+We recommend switching to another Ingress controller. The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set. In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks only requires renaming Ingress annotations.
 {{% /alert %}}
 
 {{% alert color="info" %}}
@@ -339,14 +337,14 @@ NGINX path based routing is supported for Operator version 2.19.0 and newer, and
 
 ##### Configuring the NGINX in the Mxpc-cli Tool
 
-To configure the *deprecated* NGINX ingress controller with Mendix on Kubernetes, set up the following settings:
+To configure the deprecated NGINX ingress controller with Mendix on Kubernetes, set up the following settings:
 
 * **Ingress Type** - Select **kubernetes-ingress**; this option configures the Ingress according to the additional domain name you supply.
 * **Ingress Domain Name** - Provide the domain name which you want to set for the Ingress resource file.
 * **Ingress Path** - Optional. You can use this option to specify the Ingress path. The default value is `/`.
 * **Enable TLS** - Enable or disable TLS for your app's Ingress.
 * **Custom Ingress Class** - Set to **enabled**.
-* **Ingress Class Name** - Enter **nginx**. This setting requires Custom Ingress Class to be enabled.
+* **Ingress Class Name** - Enter **nginx**. This setting requires **Custom Ingress Class** to be enabled.
 * **Set Ingress Class as Annotation** - Set to **disabled**. This option adds the legacy `kubernetes.io/ingress.class` annotation to set the Ingress class, instead of using the Ingress class name.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-cluster/private-cloud-networking/configure-nginx.png" class="no-border" >}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -354,11 +354,7 @@ Mendix on Kubernetes will use the existing ingress controller.
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-The [Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) will be supported [until March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/).
-
-We recommend switching to another ingress controller.
-The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set.
-In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks would only require renaming ingress annotations.
+The [Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) will be supported [until March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). We recommend switching to another Ingress controller. The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set. In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks only requires renaming Ingress annotations.
 {{% /alert %}}
 
 ### OpenShift Route

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -354,12 +354,11 @@ Mendix on Kubernetes will use the existing ingress controller.
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-We strongly recommend using the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/), even if other Ingress controllers or OpenShift Routes are available. You may need to check which of the [several versions of the NGINX Ingress Controller](https://www.nginx.com/blog/guide-to-choosing-ingress-controller-part-4-nginx-ingress-controller-options/#NGINX-vs.-Kubernetes-Community-Ingress-Controller) is installed in your cluster. Mendix recommends the "community version".
+The [Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) will be supported [until March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/).
 
-NGINX Ingress can be used to deny access to sensitive URLs, add HTTP headers, enable compression, and cache static content.
-NGINX Ingress is fully compatible with [cert-manager](https://cert-manager.io/), removing the need to manually manage TLS certificates. In addition, NGINX Ingress can use a [Linkerd](https://linkerd.io/) Service Mesh to encrypt network traffic between the Ingress Controller and the Pod running a Mendix app.
-
-These features will likely be required once your application is ready for production.
+We recommend switching to another ingress controller.
+The [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project (F5 Networks) has a similar feature set.
+In most cases, switching from the deprecated Kubernetes controller to controller from F5 Networks would only require renaming ingress annotations.
 {{% /alert %}}
 
 ### OpenShift Route
@@ -386,11 +385,14 @@ It is also possible to provide a custom TLS configuration for individual environ
 
 Mendix on Kubernetes is compatible with the following ingress controllers:
 
-* [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
+* [NGINX Ingress Controller](https://github.com/nginx/kubernetes-ingress) from the NGINX project
 * [Traefik](https://traefik.io/traefik/)
+* [Istio Kubernetes Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/)
+* [HAProxy Kubernetes Ingress Controller](https://github.com/haproxytech/kubernetes-ingress)
 * [AWS Application Load Balancer](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
 * [Ingress for External Application Load Balancer](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb)
 * [Azure Application Gateway Ingress Controller](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)
+* [Deprecated Kubernetes Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) from the Kubernetes project - ⚠️ supported only until March 2026
 
 For ingress, it is possible to do the following:
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,14 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
+### November ???, 2025
+
+#### Documentation Improvements
+
+* We have updated documentation on setting HTTP(S) headers.
+   The instructions now include a new Mendix 10.24.1 Runtime feature allowing to set custom headers directly in the Mendix Runtime, without having to configure the ingress controller.
+   For more information, see [Advanced Ingress Settings in Mendix on Kubernetes](developerportal/deploy/private-cloud-cluster/private-cloud-ingress-settings/advanced/).
+
 ### November 7, 2025
 
 #### Portal Hotfix

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,14 +12,6 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2025
 
-### November ???, 2025
-
-#### Documentation Improvements
-
-* We have updated documentation on setting HTTP(S) headers.
-   The instructions now include a new Mendix 10.24.1 Runtime feature allowing to set custom headers directly in the Mendix Runtime, without having to configure the ingress controller.
-   For more information, see [Advanced Ingress Settings in Mendix on Kubernetes](developerportal/deploy/private-cloud-cluster/private-cloud-ingress-settings/advanced/).
-
 ### November 7, 2025
 
 #### Portal Hotfix


### PR DESCRIPTION
Kubernetes announced [deprecation of the NGINX Ingress controller](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) around March 2026. It was listed as a "recommended" option, and some customers asked for a recommended migration path.

There's an alternative NGINX Ingress controller (from the NGINX project, F5 Networks) that will remain supported and maintained.

* Removed recommendation to use the deprecated ingress controller. There's no recommendation to use a specific ingress controller anymore.
* Added the F5 NGINX Ingress controller to the list of supported ingress controllers (tried to explain the difference between them)
* Added other ingress controllers that were tested to be compatible with MxOK.

These changes are not linked with any releases and can be reviewed and published at a convenient time.

Some of the changes from https://github.com/mendix/docs/pull/10385 are included into this PR.