### PR TITLE
11.6: Update information about one way navigability display

### DIFF
--- a/content/en/docs/refguide/modeling/domain-model/associations/association-properties.md
+++ b/content/en/docs/refguide/modeling/domain-model/associations/association-properties.md
@@ -82,7 +82,7 @@ One-way navigable associations are associations that allow navigation to associa
 
 You can retrieve data from all other domain model associations in both directions.
 
-One-way navigable associations are represented by an icon next to the association name showing the direction of its navigability.
+One-way navigable associations are represented by an icon next to the association name showing the direction of its navigability. In Mendix versions below 11.6.0, they are also shown with a dashed arrow.
 
 ### On Delete Behavior {#delete-behavior}
 

--- a/content/en/docs/refguide/modeling/domain-model/associations/association-properties.md
+++ b/content/en/docs/refguide/modeling/domain-model/associations/association-properties.md
@@ -82,7 +82,7 @@ One-way navigable associations are associations that allow navigation to associa
 
 You can retrieve data from all other domain model associations in both directions.
 
-One-way navigable associations are represented by a dashed arrow in Domain model editor. An icon shows the direction of its navigability.
+One-way navigable associations are represented by an icon next to the association name showing the direction of its navigability.
 
 ### On Delete Behavior {#delete-behavior}
 


### PR DESCRIPTION
From 11.6 onwards one way navigable associations no longer show as a dotted line, they will only have an icon showing it's direction