### PR TITLE
Adding the new Usercentrics package for marketing & legal compliance

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -30,11 +30,6 @@ disableKinds = ["taxonomy", "term"]
     quality = 75
     anchor = "smart"
 
-[services]
-    [services.googleAnalytics]
-        # Marketing Google Tag ID
-        id = 'UA-163813-1'
-
 # Language configuration
 
 [languages]
@@ -161,7 +156,7 @@ replacements = "github.com/FortAwesome/Font-Awesome -> ., github.com/twbs/bootst
         sidebar_menu_truncate = 100
         
     # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
-    # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
+    # This feature used to depend on [services.googleAnalytics],but that is now become obsolete.
     # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
     # add "hide_feedback: true" to the page's front matter.
     [params.ui.feedback]

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -9,7 +9,8 @@
 		{{ end }}
 	</header>
 	{{ .Content }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) .Site.Config.Services.GoogleAnalytics.ID) }}
+	<!-- Olu: removed checking for .Site.Config.Services.GoogleAnalytics.ID as part of the conditions -->
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,5 +1,6 @@
 <!-- Include mx-dock on all pages-->
 <div>{{ partial "mx-dock.html" . }}</div>
+
 <!-- Add analytics as defined by Marketing -->
 {{- if eq hugo.Environment "production" -}}<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-QJG4"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -8,6 +9,7 @@
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-QJG4');</script>{{- end -}}
+
 <!-- To make images clickable and zoomable as pop-ups -->
 
 <script src='{{ "js/medium-zoom.js" | relURL }}'></script>
@@ -27,3 +29,8 @@
     }
   });
 </script>
+
+<!-- Olu: Added analytics as defined by Marketing/Legal. Read more here: https://github.com/mendix-web/mendix-analytics-package. You need access from the Mendix Web team -->
+<script src='{{ "js/analytics-packages/datalayer-tracking.js" | relURL }}'></script>
+<script src='{{ "js/analytics-packages/usercentrics-consent.js" | relURL }}'></script>
+

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,3 +1,10 @@
+<!-- Olu: Added analytics as defined by Marketing/Legal. Read more here: https://github.com/mendix-web/mendix-analytics-package. You need access from the Mendix Web team -->
+{{- if eq hugo.Environment "production" -}}
+<script src="https://assets.adobedtm.com/5dfc7d97c6fb/f76097206fad/launch-a8be6e5af390.min.js" async></script> {{- end -}}
+
+{{- if eq hugo.Environment "development" -}}
+<script src="https://assets.adobedtm.com/5dfc7d97c6fb/f76097206fad/launch-ef5f6245245b-staging.min.js" async></script> {{- end -}}
+
 <!-- Not using Docsy Algolia - nothing needs to go here-->
 {{- with .Site.Params.search.algolia -}}
 <!-- stylesheet for algolia docsearch -->
@@ -8,11 +15,7 @@
 {{- else -}}
     <link rel="canonical" href="{{ .Permalink }}">
 {{- end -}}
-<!-- MvM: Add Javascript for Cookie management - requested by Marketing/Legal -->
-<script id="usercentrics-cmp" src="https://app.usercentrics.eu/browser-ui/latest/loader.js" data-settings-id="Fhgux2LDfg_YUL" async></script>
-<script type="application/javascript" src="https://privacy-proxy.usercentrics.eu/latest/uc-block.bundle.js"
->
-</script>
+
 <!-- MvM: Add Javascript for Japanese translation -->
 <!-- MvM: Only if page has a title --> 
 {{- with .Params.title -}}

--- a/static/js/analytics-packages/datalayer-tracking.js
+++ b/static/js/analytics-packages/datalayer-tracking.js
@@ -1,0 +1,76 @@
+/**
+ * DataLayer Management and Analytics Tracking
+ *
+ * Centralizes dataLayer initialization and provides consistent API
+ * for all analytics tracking across the site.
+ *
+ * @version 2.0.0 - Production optimized
+ */
+
+// Initialize dataLayer as early as possible
+window.dataLayer = window.dataLayer || [];
+
+/**
+ * Unified dataLayer push function
+ * @param {Object} data - Data to push to dataLayer
+ * @param {string} source - Source identifier (optional, for internal tracking)
+ */
+window.pushToDataLayer = function (data, source) {
+	if (window.dataLayer) {
+		window.dataLayer.push(data);
+	}
+};
+
+/**
+ * Legacy pusher function for backwards compatibility
+ * Provides consistent interface for pushing consent and tracking data
+ * @param {Object} payload - Data payload to push to dataLayer
+ */
+window.pusher = function (payload) {
+	if (typeof window.pushToDataLayer === 'function') {
+		window.pushToDataLayer(payload, 'legacy-pusher');
+	} else {
+		window.dataLayer.push(payload);
+	}
+};
+
+/**
+ * Track various clicks and page events in Google Analytics
+ */
+document.addEventListener('DOMContentLoaded', function () {
+	// Track PDF downloads - ensure PDFs aren't crawled by search engines
+	const pdfLinks = document.querySelectorAll('a[href*="pdf"]');
+	pdfLinks.forEach(function (link) {
+		link.setAttribute('rel', 'nofollow');
+		link.addEventListener('click', function () {
+			pushToDataLayer(
+				{
+					event: 'PDFClick',
+					clickedHREF: this.getAttribute('href'),
+				},
+				'pdf-tracking'
+			);
+		});
+	});
+
+	// Track signin clicks
+	const signinLinks = document.querySelectorAll("a[href*='home.mendix.com']");
+	signinLinks.forEach(function (link) {
+		link.addEventListener('click', function () {
+			pushToDataLayer(
+				{
+					event: 'SigninClick',
+				},
+				'signin-tracking'
+			);
+		});
+	});
+
+	// Send virtual page view when document is ready
+	pushToDataLayer(
+		{
+			event: 'virtual_page_view',
+		},
+		'page-view'
+	);
+});

--- a/static/js/analytics-packages/usercentrics-consent.js
+++ b/static/js/analytics-packages/usercentrics-consent.js
@@ -1,0 +1,184 @@
+/**
+ * Usercentrics Cookie Consent Management
+ *
+ * Handles Cookie Monster consent events and Google Consent Mode v2 integration.
+ *
+ * Note: Usercentrics and Cookie Monster are loaded by Adobe Launch.
+ * This script only sets up event listeners to respond to consent changes.
+ *
+ * Adobe Launch loads:
+ * - Usercentrics banner (settings ID: xUbnOnjLm)
+ * - Cookie Monster script
+ * - Environment-specific configurations
+ *
+ * @version 2.0.0 - Production optimized
+ */
+
+window.UserCentrics = {
+	/**
+	 * Initialize Cookie Monster listeners
+	 */
+	init() {
+		// Ensure dataLayer exists
+		window.dataLayer = window.dataLayer || [];
+
+		// Create gtag function for Google Consent Mode v2
+		this.createGtagFunction();
+
+		// Wait for Cookie Monster to be available (loaded by Adobe Launch)
+		this.waitForCookieMonster();
+	},
+
+	/**
+	 * Wait for Cookie Monster to load (from Adobe Launch)
+	 */
+	waitForCookieMonster() {
+		const self = this;
+		const maxAttempts = 50; // 5 seconds max
+		let attempts = 0;
+
+		const checkCookieMonster = setInterval(() => {
+			attempts++;
+
+			if (window.cookieMonster) {
+				clearInterval(checkCookieMonster);
+				self.setupCookieListeners();
+				self.restoreSavedConsent();
+				self.dispatchReadyEvent();
+			} else if (attempts >= maxAttempts) {
+				clearInterval(checkCookieMonster);
+			}
+		}, 100);
+	},
+
+	/**
+	 * Create gtag function for Google Consent Mode v2 communication
+	 */
+	createGtagFunction() {
+		window.dataLayer = window.dataLayer || [];
+		if (typeof window.gtag !== 'function') {
+			window.gtag = function () {
+				window.dataLayer.push(arguments);
+			};
+		}
+	},
+
+	/**
+	 * Set up Usercentrics consent change listeners
+	 * Listens to UC_UI_CMP_EVENT for all consent changes (accept/reject/save)
+	 */
+	setupCookieListeners() {
+		const self = this;
+
+		// Listen for all Usercentrics consent events
+		window.addEventListener('UC_UI_CMP_EVENT', (event) => {
+			if (event.detail) {
+				const { type } = event.detail;
+
+				// Handle all consent-changing events
+				if (
+					type === 'ACCEPT_ALL' ||
+					type === 'DENY_ALL' ||
+					type === 'SAVE'
+				) {
+					self.updateAllConsentStates();
+				}
+			}
+		});
+	},
+
+	/**
+	 * Restore saved consent preferences on page load
+	 * Uses polling to wait for Cookie Monster to load consent data
+	 */
+	restoreSavedConsent() {
+		const self = this;
+
+		// Check if user has previously saved consent
+		if (window.cookieMonster.hasInteracted()) {
+			// Poll until Cookie Monster has loaded the consent data
+			let attempts = 0;
+			const maxAttempts = 10; // 1 second max
+
+			const checkReady = setInterval(() => {
+				attempts++;
+
+				// Test if data is loaded by checking if required cookies return true
+				const dataLoaded =
+					window.cookieMonster.permitted('reqd') === true;
+
+				if (dataLoaded || attempts >= maxAttempts) {
+					clearInterval(checkReady);
+					self.updateAllConsentStates();
+				}
+			}, 100);
+		}
+	},
+
+	/**
+	 * Update all consent states in GTM based on current Cookie Monster permissions
+	 */
+	updateAllConsentStates() {
+		// Check Targeting cookies
+		const targPermitted = window.cookieMonster.permitted('targ');
+		gtag('consent', 'update', {
+			ad_storage: targPermitted ? 'granted' : 'denied',
+			ad_user_data: targPermitted ? 'granted' : 'denied',
+			ad_personalization: targPermitted ? 'granted' : 'denied',
+			personalization_storage: targPermitted ? 'granted' : 'denied',
+		});
+
+		// Check Performance cookies
+		const perfPermitted = window.cookieMonster.permitted('perf');
+		gtag('consent', 'update', {
+			analytics_storage: perfPermitted ? 'granted' : 'denied',
+		});
+
+		// Check Functional cookies
+		const fnctPermitted = window.cookieMonster.permitted('fnct');
+		gtag('consent', 'update', {
+			functionality_storage: fnctPermitted ? 'granted' : 'denied',
+		});
+
+		// Push custom dataLayer event for GTM triggers
+		// This allows GTM to fire tags conditionally based on consent state
+		window.dataLayer.push({
+			event: 'consent_update',
+			consent_state: {
+				ad_storage: targPermitted ? 'granted' : 'denied',
+				ad_user_data: targPermitted ? 'granted' : 'denied',
+				ad_personalization: targPermitted ? 'granted' : 'denied',
+				personalization_storage: targPermitted ? 'granted' : 'denied',
+				analytics_storage: perfPermitted ? 'granted' : 'denied',
+				functionality_storage: fnctPermitted ? 'granted' : 'denied',
+			},
+		});
+	},
+
+	/**
+	 * Dispatch custom event when Cookie Monster is ready
+	 */
+	dispatchReadyEvent() {
+		window.cookieMonsterReady = true;
+
+		if (typeof CustomEvent !== 'undefined') {
+			const event = new CustomEvent('cookieMonsterReady', {
+				detail: {
+					version: window.cookieMonster.VERSION || 'unknown',
+					engine: window.cookieMonster.ENGINE || 'unknown',
+				},
+			});
+			document.dispatchEvent(event);
+		}
+	},
+};
+
+/**
+ * Auto-initialize when DOM is ready
+ */
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', () => UserCentrics.init());
+} else {
+	// DOM already loaded
+	UserCentrics.init();
+}


### PR DESCRIPTION
## Notable Changes:
- Added 2 new packages (datalayer.js & usercentrics.js)
- Removed reference to the UA-ID and removed it as a condition to display the feedback UI
  - This was done because the UA ID is now obsolete, and the feedback is now tracked via the GA tags
- Removed the obsolete Usercentrics script and updated the file with the latest from Marketing & legal
  - New scripts react based on development/production environment
  - Usercentrics will not load in the local build if the local machine host points to localhost