### PR TITLE
Add release note for autocomplete behaviour in oql editor for view entity

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/11/11.1.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.1.md
@@ -125,7 +125,7 @@ weight: 99
 * When upgrading to a data widgets module version 3.0.0 or above, we fixed conversion issues affecting both grid-wide filtering configurations (when filter widgets were wrapped in containers) and drop-down filter settings for associations on Data grid 2 columns during widget updates.
 * We fixed an error that appeared when trying to use the [Radio buttons](/refguide/radio-buttons/) widget.
 * We introduced a set of pre-commit checks to ensure generated content is up to date before committing. This prevents generated content from being updated without any user input after committing, which limited the user from completing other version control operations (like a **Pull** from the server).
-* We improved autocomplete behaviour in OQL document editor to ensure relevant suggestions appear even when typing in the middle of a sentence, enhancing the writing flow and making autocomplete more practical for real-world editing scenarios.
+* We improved the autocomplete behavior in the OQL document editor to ensure relevant suggestions appear even when typing in the middle of a sentence, enhancing the writing flow and making autocomplete more useful in real-world editing scenarios.
 
 ### Breaking Changes
 

--- a/content/en/docs/releasenotes/studio-pro/11/11.1.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.1.md
@@ -125,6 +125,7 @@ weight: 99
 * When upgrading to a data widgets module version 3.0.0 or above, we fixed conversion issues affecting both grid-wide filtering configurations (when filter widgets were wrapped in containers) and drop-down filter settings for associations on Data grid 2 columns during widget updates.
 * We fixed an error that appeared when trying to use the [Radio buttons](/refguide/radio-buttons/) widget.
 * We introduced a set of pre-commit checks to ensure generated content is up to date before committing. This prevents generated content from being updated without any user input after committing, which limited the user from completing other version control operations (like a **Pull** from the server).
+* We improved autocomplete behaviour in OQL document editor to ensure relevant suggestions appear even when typing in the middle of a sentence, enhancing the writing flow and making autocomplete more practical for real-world editing scenarios.
 
 ### Breaking Changes
 


### PR DESCRIPTION
This was a release note for auto completion improvement that was not merged on time 
[DUX-496](https://mendix.atlassian.net/browse/DUX-496)