### PR TITLE
Clarify that XPath constraints could be case-sensitive

### DIFF
--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-contains.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-contains.md
@@ -1,12 +1,17 @@
 ---
 title: "XPath contains"
+linktitle: "contains"
 url: /refguide/xpath-contains/
 weight: 16
 ---
 
 ## Overview
 
-The `contains()` function tests whether a string attribute contains a specific string (case-insensitive) as a sub-string.
+The `contains()` function tests whether a string attribute contains a specific string as a sub-string.
+
+{{% alert color="info" %}}
+String comparisons in XPath constraints are generally case-insensitive, but this can depend on the collation setting for some databases. See [Case-Sensitive Database Behavior](/refguide/case-sensitive-database-behavior/) for more information.
+{{% /alert %}}
 
 ## Example
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath day-from-dateTime"
+linktitle: "day-from-dateTime"
 url: /refguide/xpath-day-from-datetime/
 weight: 8
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-day-of-year-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath day-of-year-from-dateTime"
+linktitle: "day-of-year-from-dateTime"
 url: /refguide/xpath-day-of-year-from-datetime/
 weight: 13
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-ends-with.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-ends-with.md
@@ -1,12 +1,17 @@
 ---
 title: "XPath ends-with"
+linktitle: "ends-with"
 url: /refguide/xpath-ends-with/
 weight: 18
 ---
 
 ## Overview
 
-The `ends-with()` function checks whether a string attribute ends with a specific string (case-insensitive) as a sub-string.
+The `ends-with()` function checks whether a string attribute ends with a specific string as a sub-string.
+
+{{% alert color="info" %}}
+String comparisons in XPath constraints are generally case-insensitive, but this can depend on the collation setting for some databases. See [Case-Sensitive Database Behavior](/refguide/case-sensitive-database-behavior/) for more information.
+{{% /alert %}}
 
 ## Example
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-false.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-false.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath false"
+linktitle: "false"
 url: /refguide/xpath-false/
 weight: 2
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-hours-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath hours-from-dateTime"
+linktitle: "hours-from-dateTime"
 url: /refguide/xpath-hours-from-datetime/
 weight: 9
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-length.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-length.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath length"
+linktitle: "length"
 url: /refguide/xpath-length/
 weight: 4
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-minutes-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath minutes-from-dateTime"
+linktitle: "minutes-from-dateTime"
 url: /refguide/xpath-minutes-from-datetime/
 weight: 10
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-month-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath month-from-dateTime"
+linktitle: "month-from-dateTime"
 url: /refguide/xpath-month-from-datetime/
 weight: 7
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-not.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-not.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath not"
+linktitle: "not"
 url: /refguide/xpath-not/
 weight: 3
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-quarter-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath quarter-from-dateTime"
+linktitle: "quarter-from-dateTime"
 url: /refguide/xpath-quarter-from-datetime/
 weight: 12
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-seconds-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath seconds-from-dateTime"
+linktitle: "seconds-from-dateTime"
 url: /refguide/xpath-seconds-from-datetime/
 weight: 11
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-starts-with.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-starts-with.md
@@ -1,12 +1,17 @@
 ---
 title: "XPath starts-with"
+linktitle: "starts-with"
 url: /refguide/xpath-starts-with/
 weight: 17
 ---
 
 ## Overview
 
-The `starts-with()` function tests whether a string attribute starts with a specific string (case-insensitive) as a sub-string.
+The `starts-with()` function tests whether a string attribute starts with a specific string as a sub-string.
+
+{{% alert color="info" %}}
+String comparisons in XPath constraints are generally case-insensitive, but this can depend on the collation setting for some databases. See [Case-Sensitive Database Behavior](/refguide/case-sensitive-database-behavior/) for more information.
+{{% /alert %}}
 
 ## Example
 

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-string-length.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-string-length.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath string-length"
+linktitle: "string-length"
 url: /refguide/xpath-string-length/
 weight: 5
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-true.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-true.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath true"
+linktitle: "true"
 url: /refguide/xpath-true/
 weight: 1
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-week-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath week-from-dateTime"
+linktitle: "week-from-dateTime"
 url: /refguide/xpath-week-from-datetime/
 weight: 14
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-weekday-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath weekday-from-dateTime"
+linktitle: "weekday-from-dateTime"
 url: /refguide/xpath-weekday-from-datetime/
 weight: 15
 ---

--- a/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
+++ b/content/en/docs/refguide/modeling/xpath/xpath-constraints/xpath-constraint-functions/xpath-year-from-datetime.md
@@ -1,5 +1,6 @@
 ---
 title: "XPath year-from-dateTime"
+linktitle: "year-from-dateTime"
 url: /refguide/xpath-year-from-datetime/
 weight: 6
 ---


### PR DESCRIPTION
There are some circumstances when XPath constraints on strings will be case-sensitive, although these are rare.

Also improved the navigation by removing redundant "XPath " from every entryl.