### PR TITLE
Update Studio Pro prerequisites (.NET 10 Upgrade)

### DIFF
--- a/content/en/docs/refguide/installation/install.md
+++ b/content/en/docs/refguide/installation/install.md
@@ -46,7 +46,11 @@ If you run into problems installing Studio Pro, one workaround is to restart you
 
 The prerequisites are the following:
 
-* [Microsoft .NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (Mendix recommends using version 8.0.10 or above)
+* Microsoft .NET Desktop Runtime
+
+    | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
+    | --- | --- |
+    | [.NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) <br/> Mendix recommends using version 8.0.10 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.0 or above |
 
 * [Eclipse Temurin JDK 21 (x64 or ARM64)](https://adoptium.net/temurin/releases/?version=21)
 
@@ -77,9 +81,13 @@ It is possible to prepare the prerequisite installers beforehand so the setup pr
 3. Create a folder in the same location where the Mendix Studio Pro installer was moved. Name this folder *Dependencies*.
 4. Download the prerequisites listed in the **[Troubleshooting](#troubleshooting)** section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
-   1. Microsoft .NET Desktop Runtime 8.0.x
-      * On x64, rename *windowsdesktop-runtime-8.0.10-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
-      * On ARM64, rename *windowsdesktop-runtime-8.0.10-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
+   1. Microsoft .NET Desktop Runtime
+      * For Studio Pro versions 11.0.0 through 11.6.2, rename the Microsoft .NET Desktop Runtime 8.0.x
+        * On x64, rename *windowsdesktop-runtime-8.0.10-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
+        * On ARM64, rename *windowsdesktop-runtime-8.0.10-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
+      * For Studio Pro versions 11.6.3 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
+         * On x64, rename *windowsdesktop-runtime-10.0.0-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
+         * On ARM64, rename *windowsdesktop-runtime-10.0.0-win-arm64.exe* to *windowsdesktop-runtime-10.0-arm64.exe*
    2. Eclipse Temurin JDK
       * Rename the Java Development Kit 21 *msi*
         * On x64, rename *OpenJDK21U-jdk_x64_windows_hotspot_21.0.5_11.msi* to *adoptiumjdk_21_x64.msi*

--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -37,7 +37,12 @@ If you were using Parallels and enabled port forwarding, but then upgraded and w
 
 The following frameworks are required. They will be installed automatically by the Studio Pro installer, if necessary:
 
-* Microsoft .NET Desktop Runtime 8.0.x (x64) and all applicable Windows security patches
+* Microsoft .NET Desktop Runtime (x64) and all applicable Windows security patches
+
+    | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
+    | --- | --- |
+    | .NET 8 Desktop Runtime | .NET 10 Desktop Runtime |
+
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
 * A Java Developer Kit (JDK) version 11, 17, or 21 - if not yet installed on your machine, Mendix will install 'Eclipse Temurin JDK 21 (x64 or ARM64)'
 * Gradle version 8.5 or above - if Gradle is not yet installed on your machine, Mendix will install Gradle version 8.5
@@ -47,7 +52,12 @@ The following frameworks are required. They will be installed automatically by t
 
 When you are running Studio Pro on a Parallels virtual machine on an ARM64 device (for example, an M1 Mac), you need the following dependencies in addition to the x64 version listed above:
 
-* Microsoft .NET Desktop Runtime 8.0.x (ARM64)
+* .NET Desktop Runtime (arm64)
+
+    | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
+    | --- | --- |
+    | .NET 8 Desktop Runtime | .NET 10 Desktop Runtime |
+
 * Microsoft Edge WebView2 Evergreen Runtime (ARM64)
 
 {{% alert color="info" %}}
@@ -320,7 +330,12 @@ Developing native mobile apps with Mendix comes with special requirements explai
 
 MxBuild is a Windows, Linux, and macOS command-line tool that can be used to build a Mendix Deployment Package. For more information, see [MxBuild](/refguide/mxbuild/).
 
-* .NET 8
+* .NET
+
+    | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
+    | --- | --- |
+    | .NET 8 | .NET 10 |
+
 * JDK 21
 
 ## mx Command-Line Tool {#mxtool}

--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -52,7 +52,7 @@ The following frameworks are required. They will be installed automatically by t
 
 When you are running Studio Pro on a Parallels virtual machine on an ARM64 device (for example, an M1 Mac), you need the following dependencies in addition to the x64 version listed above:
 
-* .NET Desktop Runtime (arm64)
+* .NET Desktop Runtime (ARM64)
 
     | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
     | --- | --- |


### PR DESCRIPTION
We are upgrading Studio Pro 11.6.3 and 11.7.0 onwards to work with .NET 10. 
We also need to make this a release note.