### PR TITLE
UPdated release notes for Operator 2.25.1

### DIFF
--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,8 +16,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 #### Mendix Operator v2.25.1 {#2.25.1}
 
-* We've implemented an enhancement to improve how our system parses S3 endpoint URLs by addressing configurations where the S3 endpoint is provided as a hostname without a preceding schema (e.g., my-s3-endpoint.com instead of https://my-s3-endpoint.com).
-
+* We have implemented an enhancement to improve how our system parses S3 endpoint URLs by addressing configurations where the S3 endpoint is provided as a hostname without a preceding schema (e.g., my-s3-endpoint.com instead of https://my-s3-endpoint.com).
 
 ### January 19, 2026
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,13 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2026
 
+### January 22, 2026
+
+#### Mendix Operator v2.25.1 {#2.25.1}
+
+* We've implemented an enhancement to improve how our system parses S3 endpoint URLs by addressing configurations where the S3 endpoint is provided as a hostname without a preceding schema (e.g., my-s3-endpoint.com instead of https://my-s3-endpoint.com).
+
+
 ### January 19, 2026
 
 #### Mendix Operator v2.25.0 {#2.25.0}


### PR DESCRIPTION
As reported by PMP, they have a number of environments where the S3 endpoint is just a hostname, without a schema.

In that case, Go's `url.Parse` will return an empty string hostname; in those cases, the hostname will be in `endpointURL.Path`.

This implementation prepends a placeholder schema, so that `url.Parse` can use its built-in hostname and path validation.