### PR TITLE
Add aliases to Mendix Native Mobile Builder notes

### DIFF
--- a/content/en/docs/releasenotes/mobile/mendix-native-mobile-builder.md
+++ b/content/en/docs/releasenotes/mobile/mendix-native-mobile-builder.md
@@ -2,6 +2,8 @@
 title: "Mendix Native Mobile Builder Release Notes"
 linktitle: "Mendix Native Mobile Builder"
 url: /releasenotes/mobile/mendix-native-mobile-builder/
+aliases:
+    - /releasenotes/mobile/mendix-mobile-native-builder
 weight: 11
 description: "Mendix Native Mobile Builder release notes."
 #This document is mapped to the landing page, update the link there if renaming or moving the doc file.


### PR DESCRIPTION
Added aliases to accommodate a wrong url in the Mendix Native Mobile Builder.