### PR TITLE
Enhance tracing documentation with Grafana support

### DIFF
--- a/content/en/docs/refguide/runtime/monitoring-mendix-runtime.md
+++ b/content/en/docs/refguide/runtime/monitoring-mendix-runtime.md
@@ -649,3 +649,27 @@ This configuration will produce logs similar to these:
 This will write logs to standard output in simple text format.
 
 [//]: # (<!-- markdownlint-enable no-duplicate-heading -->)
+
+### Request to Create New Log Subscriber in Open Telemetry Format
+
+```json
+{
+  "action": "create_log_subscriber",
+  "params": {
+    "type": "opentelemetry",
+    "name": "OpenTelemetrySubscriber",
+    "autosubscribe": "INFO"
+  }
+}
+```
+
+### Example Response
+
+```json
+{
+  "feedback": {},
+  "result": 0
+}
+```
+
+This will send logs to the registered OpenTelemetry collector. See [Tracing](/refguide/tracing-in-runtime/) for a guide on how to enable OpenTelemetry.

--- a/content/en/docs/refguide/runtime/monitoring-mendix-runtime.md
+++ b/content/en/docs/refguide/runtime/monitoring-mendix-runtime.md
@@ -553,7 +553,7 @@ For that you need to do three things:
 
  [//]: # (<!-- markdownlint-disable no-duplicate-heading -->)
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -579,7 +579,7 @@ If the `feedback` is not empty use the name of your current log subscriber in th
 {"action": "remove_log_subscriber", "params": {"name": "ConsoleLogSubscriber"}}
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -590,7 +590,7 @@ If the `feedback` is not empty use the name of your current log subscriber in th
 
 It is possible to have multiple log subscribers running simultaneously, if several log subscribers were created then each of them will be writing the same log lines. 
 
-### Request to Create New Log Subscriber in Json Format
+### Request to Create New Log Subscriber in JSON Format
 
 ```json
 {
@@ -607,7 +607,7 @@ It is possible to have multiple log subscribers running simultaneously, if sever
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -616,7 +616,7 @@ It is possible to have multiple log subscribers running simultaneously, if sever
 }
 ```
 
-This will write logs to standard output in Json format. If you need to add extra static fields to tag logs then you can add them into `tags`, in this example `ddtags` and `service` are added.
+This will write logs to standard output in JSON format. If you need to add extra static fields to tag logs then you can add them into `tags`, in this example `ddtags` and `service` are added.
 This configuration will produce logs similar to these:
 
 ```json
@@ -637,7 +637,7 @@ This configuration will produce logs similar to these:
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -650,7 +650,7 @@ This will write logs to standard output in simple text format.
 
 [//]: # (<!-- markdownlint-enable no-duplicate-heading -->)
 
-### Request to Create New Log Subscriber in Open Telemetry Format
+### Request to Create New Log Subscriber in Open Telemetry Format {#new-log-sub-opentelemetry}
 
 ```json
 {
@@ -663,7 +663,7 @@ This will write logs to standard output in simple text format.
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -50,7 +50,15 @@ You can filter out specific traces using the `mendix.tracing.filter` system prop
 
 ### Testing
 
-You can test the tracing using [Jaeger](https://www.jaegertracing.io/). For example, you can use the all-in-one binary or Docker image. Jaeger will listen to endpoint `http://localhost:4318/v1/traces` by default.
+You can test the tracing using [Jaeger](https://www.jaegertracing.io/) or [Grafana](https://grafana.com).
+
+For Jaeger, you can use the all-in-one binary or Docker image. Jaeger will listen to endpoint `http://localhost:4318/v1/traces` by default.
+
+For Grafana, you can use the all-in-one Docker image `grafana/otel-lgtm`. After starting it with below command it will listen to the endpoint `http://localhost:4318/v1/traces`.
+
+```
+docker run --name otel-grafana -d -p 3000:3000 -p 4317:4317 -p 4318:4318 grafana/otel-lgtm
+```
 
 Alternatively, you can set up the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/), which will also listen to the default endpoint and can be configured to send to backends which support OpenTelemetry. Check with your APM vendor to confirm that OpenTelemetry is supported. The free online collector configuration tool [OTelBin](https://github.com/dash0hq/otelbin) can help with collector configuration.
 
@@ -137,3 +145,10 @@ To use the OpenTelemetry Collector with Datadog, follow these steps:
 1. Install the OpenTelemetry Collector by following the official [installation guide](https://opentelemetry.io/docs/collector/installation/).
 2. Install the `otelcol_contrib` package instead of `otelcol` to include Datadog support. 
 3. Run the collector with the [appropriate configuration](https://docs.datadoghq.com/opentelemetry/setup/collector_exporter/install/#2---configure-the-datadog-exporter-and-connector) adapted for Datadog.
+
+## Include Metrics and Logs in OpenTelemetry
+
+You can also collect metrics data (CPU load, memory, etc.) and logs with OpenTelemetry.
+
+* Please see [Metrics](https://docs.mendix.com/refguide/metrics/#opentelemetry) for a guide on how to setup Metrics with OpenTelemetry.
+* Please see [Monitoring Mendix Runtime](https://docs.mendix.com/refguide/monitoring-mendix-runtime/#request-to-create-new-log-subscriber-in-otel-format) for a guide on how to setup Logs with OpenTelemetry.

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -150,5 +150,5 @@ To use the OpenTelemetry Collector with Datadog, follow these steps:
 
 You can also collect metrics data (CPU load, memory, etc.) and logs using OpenTelemetry.
 
-* See the [OpenTelemetry](/refguide/metrics/#opentelemetry) section of *Metrics* for a guide on how to setup Metrics with OpenTelemetry.
-* See [Request to Create New Log Subscriber in Open Telemetry Format](/refguide/monitoring-mendix-runtime/#new-log-sub-opentelemetry) in *Monitoring Mendix Runtime* for a guide on how to setup Logs with OpenTelemetry.
+* See the [OpenTelemetry](/refguide/metrics/#opentelemetry) section of *Metrics* for a guide on how to setup metrics with OpenTelemetry.
+* See [Request to Create New Log Subscriber in Open Telemetry Format](/refguide/monitoring-mendix-runtime/#new-log-sub-opentelemetry) in *Monitoring Mendix Runtime* for a guide on how to setup logs with OpenTelemetry.

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -150,5 +150,5 @@ To use the OpenTelemetry Collector with Datadog, follow these steps:
 
 You can also collect metrics data (CPU load, memory, etc.) and logs with OpenTelemetry.
 
-* Please see [Metrics](https://docs.mendix.com/refguide/metrics/#opentelemetry) for a guide on how to setup Metrics with OpenTelemetry.
-* Please see [Monitoring Mendix Runtime](https://docs.mendix.com/refguide/monitoring-mendix-runtime/#request-to-create-new-log-subscriber-in-otel-format) for a guide on how to setup Logs with OpenTelemetry.
+* Please see [Metrics](/refguide/metrics/#opentelemetry) for a guide on how to setup Metrics with OpenTelemetry.
+* Please see [Monitoring Mendix Runtime](/refguide/monitoring-mendix-runtime/#request-to-create-new-log-subscriber-in-open-telemetry-format) for a guide on how to setup Logs with OpenTelemetry.

--- a/content/en/docs/refguide/runtime/tracing-in-runtime.md
+++ b/content/en/docs/refguide/runtime/tracing-in-runtime.md
@@ -54,7 +54,7 @@ You can test the tracing using [Jaeger](https://www.jaegertracing.io/) or [Grafa
 
 For Jaeger, you can use the all-in-one binary or Docker image. Jaeger will listen to endpoint `http://localhost:4318/v1/traces` by default.
 
-For Grafana, you can use the all-in-one Docker image `grafana/otel-lgtm`. After starting it with below command it will listen to the endpoint `http://localhost:4318/v1/traces`.
+For Grafana, you can use the all-in-one Docker image `grafana/otel-lgtm`. After starting it with the following command, it will listen to the endpoint `http://localhost:4318/v1/traces`.
 
 ```
 docker run --name otel-grafana -d -p 3000:3000 -p 4317:4317 -p 4318:4318 grafana/otel-lgtm
@@ -69,7 +69,7 @@ The following settings are supported by the Mendix runtime. See [Configure the S
 You can configure the Java Agent through system properties which can be added to the **Extra JVM parameters** field (for example, `-Dotel.exporter.otlp.traces.endpoint`), or set through environment variables. 
 
 | Name | Description | Default |
-|------|-------------|---------|
+| ---- | ----------- | ------- |
 | `otel.service.name` | The name of the service. | `runtimelauncher` |
 | `otel.resource.attributes` | Extra resource attributes to include in every span. Example: `attribute1=value1,attribute2=value2` | |
 | `otel.traces.exporter` | Comma-separated list of span exporters. Supported values are: `otlp`, `console`, `logging-otlp`, and `none`. | `otlp` |
@@ -148,7 +148,7 @@ To use the OpenTelemetry Collector with Datadog, follow these steps:
 
 ## Include Metrics and Logs in OpenTelemetry
 
-You can also collect metrics data (CPU load, memory, etc.) and logs with OpenTelemetry.
+You can also collect metrics data (CPU load, memory, etc.) and logs using OpenTelemetry.
 
-* Please see [Metrics](/refguide/metrics/#opentelemetry) for a guide on how to setup Metrics with OpenTelemetry.
-* Please see [Monitoring Mendix Runtime](/refguide/monitoring-mendix-runtime/#request-to-create-new-log-subscriber-in-open-telemetry-format) for a guide on how to setup Logs with OpenTelemetry.
+* See the [OpenTelemetry](/refguide/metrics/#opentelemetry) section of *Metrics* for a guide on how to setup Metrics with OpenTelemetry.
+* See [Request to Create New Log Subscriber in Open Telemetry Format](/refguide/monitoring-mendix-runtime/#new-log-sub-opentelemetry) in *Monitoring Mendix Runtime* for a guide on how to setup Logs with OpenTelemetry.


### PR DESCRIPTION
Updated the tracing documentation to include Grafana as an option alongside Jaeger, and provided Docker setup instructions for both tools. Added information on collecting metrics and logs with OpenTelemetry.