### PR TITLE
Clarified which Mendix Runtime versions use AWS SDK v2 in MxOK (small correction, no release date)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
@@ -147,7 +147,7 @@ If the commands return a *not found* response, your environment database and blo
 
 #### S3 Bucket Region Might Need to Be Set Manually
 
-In Studio Pro version 11.6, the AWS S3 library was updated from version 1 to version 2. This new AWS library version can no longer automatically detect an S3 bucket's region from its endpoint address, and needs the bucket endpoint to be specified manually. The AWS S3 library is also updated in the latest LTS versions of Studio Pro.
+In Studio Pro version 11.6, the AWS S3 library was updated from version 1 to version 2. This new AWS library version can no longer automatically detect an S3 bucket's region from its endpoint address, and needs the bucket endpoint to be specified manually. The AWS S3 library is also updated in the latest LTS versions of Studio Pro: 9.24.41 (or later) and 10.24.14 (or later)
 
 Mendix Operator 2.25 (or later versions) will automatically recognise an S3 bucket's region from its endpoint address:
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
@@ -147,7 +147,12 @@ If the commands return a *not found* response, your environment database and blo
 
 #### S3 Bucket Region Might Need to Be Set Manually
 
-In Studio Pro version 11.6, the AWS S3 library was updated from version 1 to version 2. This new AWS library version can no longer automatically detect an S3 bucket's region from its endpoint address, and needs the bucket endpoint to be specified manually. The AWS S3 library is also updated in the latest LTS versions of Studio Pro: 9.24.41 (or later) and 10.24.14 (or later)
+In Studio Pro version 11.6, the AWS S3 library was updated from version 1 to version 2. This new AWS library version can no longer automatically detect an S3 bucket's region from its endpoint address, and needs the bucket endpoint to be specified manually.
+
+The AWS S3 library is also updated in the latest LTS versions of Studio Pro:
+
+* 9.24.41 (or later)
+* 10.24.14 (or later).
 
 Mendix Operator 2.25 (or later versions) will automatically recognise an S3 bucket's region from its endpoint address:
 
@@ -157,7 +162,7 @@ the Operator uses `<region>` as the S3 region name.
 
 In some scenarios (legacy or custom S3 endpoints), this autodetection might not work correctly. In this case, you can manually specify the S3 bucket region by setting the [com.mendix.storage.s3.Region](/refguide/custom-settings/#commendixstorages3Region) Custom Runtime Setting. A manually specified `com.mendix.storage.s3.Region` will override the autodetected bucket region.
 
-Mendix Operator versions 2.24.2 (and older) does not autodetect S3 bucket regions. To use Mendix 11.6 (or the latest LTS versions), manually set the `com.mendix.storage.s3.Region` custom Runtime setting. You can also consider upgrading to Mendix Operator 2.25.0 or newer.
+Mendix Operator versions 2.24.2 (and older) does not autodetect S3 bucket regions. To use Mendix versions with version 2 of the AWS S3 library, manually set the `com.mendix.storage.s3.Region` custom Runtime setting. You can also consider upgrading to Mendix Operator 2.25.0 or newer.
 
 This issue does not affect [Azure Blob Storage](#blob-azure) or [ephemeral](#blob-ephemeral) data storage plans.
 


### PR DESCRIPTION
This change clarifies which Mendix Runtime versions use AWS SDK v2 and need the `com.mendix.storage.s3.Region` workaround.
It's not linked to any release and can be published at any convenient time.