### PR TITLE
Update Studio 9/10/11 Pro prerequisites and requirements (.NET 10 Upgrade)

### DIFF
--- a/content/en/docs/refguide/installation/install.md
+++ b/content/en/docs/refguide/installation/install.md
@@ -50,7 +50,7 @@ The prerequisites are the following:
 
     | Studio Pro 11.0.0 - 11.6.2 | Studio Pro 11.6.3 and above |
     | --- | --- |
-    | [.NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) <br/> Mendix recommends using version 8.0.10 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.0 or above |
+    | [.NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) <br/> Mendix recommends using version 8.0.10 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.3 or above |
 
 * [Eclipse Temurin JDK 21 (x64 or ARM64)](https://adoptium.net/temurin/releases/?version=21)
 
@@ -86,8 +86,8 @@ It is possible to prepare the prerequisite installers beforehand so the setup pr
         * On x64, rename *windowsdesktop-runtime-8.0.10-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-8.0.10-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
       * For Studio Pro versions 11.6.3 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
-         * On x64, rename *windowsdesktop-runtime-10.0.0-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
-         * On ARM64, rename *windowsdesktop-runtime-10.0.0-win-arm64.exe* to *windowsdesktop-runtime-10.0-arm64.exe*
+         * On x64, rename *windowsdesktop-runtime-10.0.3-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
+         * On ARM64, rename *windowsdesktop-runtime-10.0.3-win-arm64.exe* to *windowsdesktop-runtime-10.0-arm64.exe*
    2. Eclipse Temurin JDK
       * Rename the Java Development Kit 21 *msi*
         * On x64, rename *OpenJDK21U-jdk_x64_windows_hotspot_21.0.5_11.msi* to *adoptiumjdk_21_x64.msi*

--- a/content/en/docs/refguide10/installation/install.md
+++ b/content/en/docs/refguide10/installation/install.md
@@ -100,19 +100,19 @@ It is possible to prepare the prerequisite installers beforehand so the setup pr
 4. Download the prerequisites listed in the **[Troubleshooting](https://docs.mendix.com/refguide9/install/#troubleshooting)** section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
    1. Microsoft .NET Desktop Runtime
-      * For Studio Pro versions 10.0.0 through 10.10.0, rename the Microsoft .NET Desktop Runtime 6.0.x
+      * For Studio Pro versions 10.0.0 - 10.10.0, rename the Microsoft .NET Desktop Runtime 6.0.x
         * On x64, rename *windowsdesktop-runtime-6.0.35-win-x64.exe* to *windowsdesktop-runtime-6.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-6.0.35-win-arm64.exe* to *windowsdesktop-runtime-6.0-arm64.exe*
-      * For Studio Pro versions 10.11.0 through 10.24.15, rename the Microsoft .NET Desktop Runtime 8.0.x
+      * For Studio Pro versions 10.11.0 - 10.24.15, rename the Microsoft .NET Desktop Runtime 8.0.x
         * On x64, rename *windowsdesktop-runtime-8.0.10-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-8.0.10-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
       * For Studio Pro versions 10.24.16 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
         * On x64, rename *windowsdesktop-runtime-10.0.3-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-10.0.3-win-arm64.exe* to *windowsdesktop-runtime-10.0-arm64.exe*
    2. Eclipse Temurin JDK (x64)
-      * For Studio Pro versions 10.0.0 through 10.10.0, rename the Java Development Kit 11 (x64) *msi* 
+      * For Studio Pro versions 10.0.0 - 10.10.0, rename the Java Development Kit 11 (x64) *msi* 
         * For example, *OpenJDK11U-jdk_x64_windows_hotspot_11.0.20.1_1.msi* to *adoptiumjdk_11_x64.msi*
-      * For Studio Pro versions 10.11.0 through 10.18.0, rename the Java Development Kit 21 (x64) *msi* 
+      * For Studio Pro versions 10.11.0 - 10.18.0, rename the Java Development Kit 21 (x64) *msi* 
         * For example, *OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.msi* to *adoptiumjdk_21_x64.msi*
       * For Studio Pro versions 10.12.11 and 10.18.1 and above, rename the Java Development Kit 21 *msi*
         * On x64, rename *OpenJDK21U-jdk_x64_windows_hotspot_21.0.5_11.msi* to *adoptiumjdk_21_x64.msi*

--- a/content/en/docs/refguide10/installation/install.md
+++ b/content/en/docs/refguide10/installation/install.md
@@ -50,9 +50,9 @@ The prerequisites are the following:
 
 * Microsoft .NET Desktop Runtime
 
-    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 and above |
-    | --- | --- |
-    | [.NET Desktop Runtime 6.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) <br/> Mendix recommends using version 6.0.35 or above | [.NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) <br/> Mendix recommends using version 8.0.10 or above |
+    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 - 10.24.15 | Studio Pro 10.24.16 and above |
+    | --- | --- | --- |
+    | [.NET Desktop Runtime 6.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) <br/> Mendix recommends using version 6.0.35 or above | [.NET Desktop Runtime 8.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) <br/> Mendix recommends using version 8.0.10 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.3 or above |
 
 * Eclipse Temurin JDK (x64) (see [JDK Installation](/refguide10/jdk-installation/) if you want to install another version of the JDK). Mendix version 10.8.0 and 10.0.9 supports JDK 11 and 17. Mendix version 10.10.0 supports JDK 11, 17, and 21, but installer still installs JDK 11.
 
@@ -103,9 +103,12 @@ It is possible to prepare the prerequisite installers beforehand so the setup pr
       * For Studio Pro versions 10.0.0 through 10.10.0, rename the Microsoft .NET Desktop Runtime 6.0.x
         * On x64, rename *windowsdesktop-runtime-6.0.35-win-x64.exe* to *windowsdesktop-runtime-6.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-6.0.35-win-arm64.exe* to *windowsdesktop-runtime-6.0-arm64.exe*
-      * For Studio Pro versions 10.11.0 and above, rename the Microsoft .NET Desktop Runtime 8.0.x
+      * For Studio Pro versions 10.11.0 through 10.24.15, rename the Microsoft .NET Desktop Runtime 8.0.x
         * On x64, rename *windowsdesktop-runtime-8.0.10-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
         * On ARM64, rename *windowsdesktop-runtime-8.0.10-win-arm64.exe* to *windowsdesktop-runtime-8.0-arm64.exe*
+      * For Studio Pro versions 10.24.16 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
+        * On x64, rename *windowsdesktop-runtime-10.0.3-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
+        * On ARM64, rename *windowsdesktop-runtime-10.0.3-win-arm64.exe* to *windowsdesktop-runtime-10.0-arm64.exe*
    2. Eclipse Temurin JDK (x64)
       * For Studio Pro versions 10.0.0 through 10.10.0, rename the Java Development Kit 11 (x64) *msi* 
         * For example, *OpenJDK11U-jdk_x64_windows_hotspot_11.0.20.1_1.msi* to *adoptiumjdk_11_x64.msi*

--- a/content/en/docs/refguide10/installation/system-requirements.md
+++ b/content/en/docs/refguide10/installation/system-requirements.md
@@ -41,9 +41,9 @@ The following frameworks are required. They will be installed automatically by t
 
 * Microsoft .NET desktop runtime (x64) and all applicable Windows security patches
 
-    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 and above |
-    | --- | --- |
-    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime |
+    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 - 10.24.15 | Studio Pro 10.24.16 and above |
+    | --- | --- | --- |
+    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime | .NET 10 Desktop Runtime |
     
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
 * A Java Developer Kit (JDK) version 11, 17, or 21 - if not yet installed on your machine, Mendix will install 'Eclipse Temurin JDK 21 (x64 or ARM64)'
@@ -56,9 +56,9 @@ When you are running Studio Pro on a Parallels virtual machine on an ARM64 devic
 
 * .NET Desktop Runtime (arm64)
 
-    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 and above |
-    | --- | --- |
-    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime |
+    | Studio Pro 10.0.0 - 10.10.0 | Studio Pro 10.11.0 - 10.24.15 | Studio Pro 10.24.16 and above |
+    | --- | --- | --- |
+    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime | .NET 10 Desktop Runtime |
 
 * Microsoft Edge WebView2 Evergreen Runtime (arm64)
 

--- a/content/en/docs/refguide9/general/install.md
+++ b/content/en/docs/refguide9/general/install.md
@@ -61,7 +61,8 @@ Sometimes you can run into problems when installing Studio Pro. One work-around 
 
 The prerequisites are the following:
 
-* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 - 9.24.41 | Studio Pro 9.24.42 and above |
+* Microsoft .NET Desktop Runtime
+    | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 - 9.24.41 | Studio Pro 9.24.42 and above |
     | --- | --- | --- |
     |  [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – Mendix recommends using version 6.0.6 or above | [Microsoft .NET Desktop Runtime 8.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) – Mendix recommends using version 8.0.14 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.3 or above |
     
@@ -102,9 +103,9 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 4. Download the prerequisites listed in the [Troubleshooting](#troubleshooting) section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
    * Microsoft .NET Desktop Runtime
-      * For Studio Pro versions 9.0.0 through 9.24.33, rename the Microsoft .NET Desktop Runtime 6.0.x
+      * For Studio Pro versions 9.0.0 - 9.24.33, rename the Microsoft .NET Desktop Runtime 6.0.x
         * Rename the Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe*
-      * For Studio Pro versions 9.24.34 through 9.24.41, rename the Microsoft .NET Desktop Runtime 8.0.x
+      * For Studio Pro versions 9.24.34 - 9.24.41, rename the Microsoft .NET Desktop Runtime 8.0.x
         * Rename *windowsdesktop-runtime-8.0.14-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
       * For Studio Pro versions 9.24.42 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
         * Rename *windowsdesktop-runtime-10.0.3-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*

--- a/content/en/docs/refguide9/general/install.md
+++ b/content/en/docs/refguide9/general/install.md
@@ -61,9 +61,9 @@ Sometimes you can run into problems when installing Studio Pro. One work-around 
 
 The prerequisites are the following:
 
-* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
-    | --- | --- |
-    |  [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – Mendix recommends using version 6.0.6 or above | [Microsoft .NET Desktop Runtime 8.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) – Mendix recommends using version 8.0.14 or above |
+* | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 - 9.24.41 | Studio Pro 9.24.42 and above |
+    | --- | --- | --- |
+    |  [Microsoft .NET Desktop Runtime 6.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) – Mendix recommends using version 6.0.6 or above | [Microsoft .NET Desktop Runtime 8.0.x](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) – Mendix recommends using version 8.0.14 or above | [.NET Desktop Runtime 10.0.x (x64 or ARM64)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) <br/> Mendix recommends using version 10.0.3 or above |
     
 * Java JDK
 
@@ -101,6 +101,13 @@ It is possible to prepare the prerequisite installers beforehand, so that the Me
 3. Create a folder with the name **Dependencies** in the same location where the Mendix Studio Pro installer was placed.
 4. Download the prerequisites listed in the [Troubleshooting](#troubleshooting) section above and move them into the **Dependencies** folder.
 5. Rename the following dependencies:
+   * Microsoft .NET Desktop Runtime
+      * For Studio Pro versions 9.0.0 through 9.24.33, rename the Microsoft .NET Desktop Runtime 6.0.x
+        * Rename the Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe*
+      * For Studio Pro versions 9.24.34 through 9.24.41, rename the Microsoft .NET Desktop Runtime 8.0.x
+        * Rename *windowsdesktop-runtime-8.0.14-win-x64.exe* to *windowsdesktop-runtime-8.0-x64.exe*
+      * For Studio Pro versions 9.24.42 and above, rename the Microsoft .NET Desktop Runtime 10.0.x
+        * Rename *windowsdesktop-runtime-10.0.3-win-x64.exe* to *windowsdesktop-runtime-10.0-x64.exe*
     * The Microsoft .NET Desktop Runtime 6.0.x executable (*dotnet.exe*) to *windowsdesktop-runtime-6.0-x64.exe*
     * The Java Development Kit 11, 17 or 21 (x64) *msi* (for example, *OpenJDK17U-jdk_x64_windows_hotspot_17.0.10_7.msi*) to one of the following, depending on the Studio Pro version:
         * *adoptiumjdk_21_x64.msi* – for versions 9.24.34 and above

--- a/content/en/docs/refguide9/general/system-requirements.md
+++ b/content/en/docs/refguide9/general/system-requirements.md
@@ -22,9 +22,9 @@ The following frameworks are required. They will be installed automatically by t
 
 * Microsoft .NET desktop runtime (x64) and all applicable Windows security patches
 
-    | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
-    | --- | --- |
-    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime |
+    | Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 - 9.24.41 | Studio Pro 9.24.42 and above |
+    | --- | --- | --- |
+    | .NET 6 Desktop Runtime | .NET 8 Desktop Runtime | .NET 10 Desktop Runtime |
     
 * Microsoft Visual C++ 2015 Redistributable Package (x64)
 * Microsoft Visual C++ 2019 Redistributable Package (x64)
@@ -40,9 +40,9 @@ The following frameworks are required. They will be installed automatically by t
 
 If you are running Studio Pro on an ARM64 device (for example, an M1 Mac), you need the following version of .NET in addition to the x64 version listed above:
 
-| Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34 and above |
-| --- | --- |
-| .NET 6 Desktop Runtime (arm64) | .NET 8 Desktop Runtime (arm64) |
+| Studio Pro 9.0.0 - 9.24.33 | Studio Pro 9.24.34  - 9.24.41 | Studio Pro 9.24.42 and above |
+| --- | --- | --- |
+| .NET 6 Desktop Runtime (arm64) | .NET 8 Desktop Runtime (arm64) | .NET 10 Desktop Runtime (arm64) |
 
 {{% alert color="info" %}}
 You can choose which JDK is used for building and running locally via the **Edit** > **Preferences** menu item in Studio Pro.


### PR DESCRIPTION
We are upgrading Studio Pro 10.24.16 and onwards, and 9.24.42 and onwards to work with .NET 10.