### PR TITLE
Add a release note for the fix reversing an association’s direction.

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/11/11.8.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.8.md
@@ -99,7 +99,7 @@ This ensures your app uses the current ISO 639 standard and avoids future compat
 - We fixed an issue where a long-running after startup microflow caused other nodes to assume that the node had crashed. (Ticket 269993)
 - We fixed an issue where, when downloading a widget from the Marketplace or updating a widget via the widget updater, the widget MPK file would become corrupted. This corruption led to an error dialog appearing in Studio Pro when attempting to read the widget package. (Ticket 270889, 271134)
 - We fixed an issue where deleting an external object with a local association to it that uses the direct association storage format would fail with an exception.
-- We fixed an issue where reversing an association’s direction via the context menu did not function correctly in the Domain Model editor.
+- We fixed an issue where reversing an association’s direction via the context menu in the Domain Model editor did not function correctly.
 - We fixed an issue in workflow user tasks, where having no fallback outcome in majority or threshold criteria with a single outcome would prevent the runtime from starting.
 - We fixed an issue in the modernized app explorer where pressing the <kbd>Del</kbd> key in the search input would trigger document deletion instead of text deletion.
 - We fixed an issue in the modernized app explorer where the version number of an add-on module would not show.

--- a/content/en/docs/releasenotes/studio-pro/11/11.8.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.8.md
@@ -99,6 +99,7 @@ This ensures your app uses the current ISO 639 standard and avoids future compat
 - We fixed an issue where a long-running after startup microflow caused other nodes to assume that the node had crashed. (Ticket 269993)
 - We fixed an issue where, when downloading a widget from the Marketplace or updating a widget via the widget updater, the widget MPK file would become corrupted. This corruption led to an error dialog appearing in Studio Pro when attempting to read the widget package. (Ticket 270889, 271134)
 - We fixed an issue where deleting an external object with a local association to it that uses the direct association storage format would fail with an exception.
+- We fixed an issue where reversing an association’s direction via the context menu did not function correctly in the Domain Model editor.
 - We fixed an issue in workflow user tasks, where having no fallback outcome in majority or threshold criteria with a single outcome would prevent the runtime from starting.
 - We fixed an issue in the modernized app explorer where pressing the <kbd>Del</kbd> key in the search input would trigger document deletion instead of text deletion.
 - We fixed an issue in the modernized app explorer where the version number of an add-on module would not show.


### PR DESCRIPTION
Add a release note for the fix that resolves the issue where reversing an association’s direction did not work.