### PR TITLE
Add localhost subnet to private connectivity documentation

### DIFF
--- a/content/en/docs/control-center/security/private-connectivity/configure-private-connectivity.md
+++ b/content/en/docs/control-center/security/private-connectivity/configure-private-connectivity.md
@@ -469,6 +469,7 @@ On the **Activities** tab, you can view a log of activities performed on your Pr
 
 The Mendix internal systems operate on the following subnets:
 
+* 127.0.0.1/32
 * 10.10.0.0/16
 * 10.11.0.0/16
 * 172.20.0.0/16


### PR DESCRIPTION
Add localhost subnet to private connectivity documentation to make it explicit users can't use this IP address for pivat connectivity