### PR TITLE
Clarify that the backup snapshot file format used by Mendix on Azure is identical to the backup snapshot file format used in the public Mendix Cloud

### DIFF
--- a/content/en/docs/deployment/mx-azure/mx-azure-backups.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-backups.md
@@ -11,6 +11,8 @@ Mendix on Azure integrates backup and restore functionality that allows you to c
 
 Backup snapshots include both the database and the file documents associated with the Mendix app environment.
 
+The backup snapshot file format used by Mendix on Azure is identical to the backup snapshot file format used in the public Mendix Cloud. This allows for easy migration of app data between these deployment options.
+
 ## Enabling Backups
 
 To start using backups, select **Try new Backup and Restore** on the **Backups** page in the Mendix for Kubernetes portal.


### PR DESCRIPTION
Clarify that the backup snapshot file format used by Mendix on Azure is identical to the backup snapshot file format used in the public Mendix Cloud