### PR TITLE
Document new nanoflow list parameter behavior

### DIFF
--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/_index.md
@@ -34,4 +34,3 @@ Below presents a list of main differences between microflows and nanoflows:
 * Because nanoflows use JavaScript libraries and microflows use Java libraries, there can sometimes be slight differences in the way [expressions](/refguide/expressions/) are executed.
 * When used in nanoflow activities, expressions do not support the following objects and variables: `$latestSoapFault`, `$latestHttpResponse`, `$currentSession`, `$currentUser`, `$currentDeviceType`.
 * Nanoflows are not run inside a transaction. So, if an error occurs in a nanoflow, it will not roll back any previous changes.
-* <a id="list-changes-in-sub-nanoflows"></a>Changes done to the lists in a sub-nanoflow are not reflected in the original nanoflow.

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
@@ -52,7 +52,7 @@ The type of the parameter that is read-only. For more information on possible ty
 
 The **Edit parameter value** button allows you to edit the argument value. For each parameter of the nanoflow, you have to supply an argument of the same type. The values of the arguments are expressed using [expressions](/refguide/expressions/).
 
-If a list parameter in the called nanoflow uses **Shared**, adding or removing items is only reflected in the caller when the argument is passed as a direct list variable. If the argument is an expression, the expression is evaluated first and changes are not reflected in the caller.
+If a [list parameter](/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow#list-parameters) in the called nanoflow uses **Shared**, adding or removing items is only reflected in the caller when the argument is passed as a direct list variable. If the argument is an expression, the expression is evaluated first and changes are not reflected in the caller.
 
 ### Return Type
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
@@ -52,6 +52,8 @@ The type of the parameter that is read-only. For more information on possible ty
 
 The **Edit parameter value** button allows you to edit the argument value. For each parameter of the nanoflow, you have to supply an argument of the same type. The values of the arguments are expressed using [expressions](/refguide/expressions/).
 
+If a list parameter in the called nanoflow uses **Shared**, adding or removing items is only reflected in the caller when the argument is passed as a direct list variable. If the argument is an expression, the expression is evaluated first and changes are not reflected in the caller.
+
 ### Return Type
 
 This read-only property indicates whether you will retrieve a variable, object or list. 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/activities/client-activities/nanoflow-call.md
@@ -52,7 +52,7 @@ The type of the parameter that is read-only. For more information on possible ty
 
 The **Edit parameter value** button allows you to edit the argument value. For each parameter of the nanoflow, you have to supply an argument of the same type. The values of the arguments are expressed using [expressions](/refguide/expressions/).
 
-If a [list parameter](/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow#list-parameters) in the called nanoflow uses **Shared**, adding or removing items is only reflected in the caller when the argument is passed as a direct list variable. If the argument is an expression, the expression is evaluated first and changes are not reflected in the caller.
+If a [list parameter](/refguide/nanoflow/#list-parameters) in the called nanoflow uses **Shared**, adding or removing items is only reflected in the caller when the argument is passed as a direct list variable. If the argument is an expression, the expression is evaluated first and changes are not reflected in the caller.
 
 ### Return Type
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
@@ -23,6 +23,17 @@ Nanoflow properties consist of the following sections:
 
 The return type defines what information the nanoflow returns. The caller of the nanoflow gets a result of this type. For information on possible return types, see [Data Types](/refguide/data-types/).
 
+#### List Parameters
+
+This property determines how list parameters are passed to the nanoflow.
+
+The following options are available:
+
+* **Shared** - adding or removing items in the called nanoflow is reflected in the caller. This aligns nanoflow behavior with microflows.
+* **Isolated (legacy)** - the called nanoflow works with a separate list, so adding or removing items is not reflected in the caller. This option is deprecated and will be removed in Mendix 12.
+
+Default: *Shared*
+
 ### Common Section {#common}
 
 #### Name

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
@@ -29,8 +29,8 @@ This property determines how list parameters are passed to the nanoflow.
 
 The following options are available:
 
-* **Shared** - adding or removing items in the called nanoflow is reflected in the caller. This aligns nanoflow behavior with microflows.
-* **Isolated (legacy)** - the called nanoflow works with a separate list, so adding or removing items is not reflected in the caller. This option is deprecated and will be removed in Mendix 12.
+* **Shared** - adding or removing items in the called nanoflow is reflected in the caller. This aligns nanoflow behavior with that of microflows.
+* **Isolated (legacy)** - the called nanoflow works with a separate list. So adding or removing items is not reflected in the caller. This option is deprecated and will be removed in Mendix 12.
 
 Default: *Shared*
 

--- a/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
+++ b/content/en/docs/refguide/modeling/application-logic/microflows-and-nanoflows/nanoflows/nanoflow.md
@@ -23,7 +23,7 @@ Nanoflow properties consist of the following sections:
 
 The return type defines what information the nanoflow returns. The caller of the nanoflow gets a result of this type. For information on possible return types, see [Data Types](/refguide/data-types/).
 
-#### List Parameters
+#### List Parameters {#list-parameters}
 
 This property determines how list parameters are passed to the nanoflow.
 


### PR DESCRIPTION
## Summary
- document the new nanoflow `List Parameters` property and the `Shared` / `Isolated (legacy)` behavior
- clarify that shared list changes only propagate back to the caller when a direct list variable is passed to a called nanoflow
- remove the outdated overview statement that sub-nanoflow list changes are never reflected

## Version
- this behavior is introduced in Mendix Studio Pro 11.9