### PR TITLE
Update Maia for Microflows documentation regarding destructive operations

### DIFF
--- a/content/en/docs/refguide/modeling/mendix-ai-assistance/maia-make/maia-for-microflows.md
+++ b/content/en/docs/refguide/modeling/mendix-ai-assistance/maia-make/maia-for-microflows.md
@@ -28,13 +28,13 @@ To achieve the best results when using Maia to generate microflows, consider the
 
 ## Limitations
 
-### Limitations on Destructive Operations
+### Destructive Operations
 
 Maia for Microflows can create objects and flows and change simple ("primitive") settings, but it has limitations on deleting elements and replacing complex configuration settings.
 
-**Studio Pro 11.9 and above** – Maia can delete flows and microflow objects. However, it cannot change activity types or replace complex configuration settings.
+In Studio Pro 11.9 and above, Maia can delete flows and microflow objects. However, it cannot change activity types or replace complex configuration settings.
 
-**Studio Pro 11.8** – Maia cannot delete objects or flows. For existing objects, Maia can change variable names, move objects, or reconnect flows, but it cannot delete objects or flows, or change the activity types.
+In Studio Pro 11.8, Maia cannot delete objects or flows. For existing objects, Maia can change variable names, move objects, or reconnect flows, but it cannot delete objects or flows, or change the activity types.
 
 ### Variability in Results
 

--- a/content/en/docs/refguide/modeling/mendix-ai-assistance/maia-make/maia-for-microflows.md
+++ b/content/en/docs/refguide/modeling/mendix-ai-assistance/maia-make/maia-for-microflows.md
@@ -28,9 +28,13 @@ To achieve the best results when using Maia to generate microflows, consider the
 
 ## Limitations
 
-### Destructive Operations Are Not Supported
+### Limitations on Destructive Operations
 
-Maia for Microflows can create objects and flows and change simple ("primitive") settings, but it cannot delete objects or replace complex configuration settings. For example, for existing objects, Maia can change variable names, move objects, or reconnect flows, but it cannot delete objects or flows, or change the activity types.
+Maia for Microflows can create objects and flows and change simple ("primitive") settings, but it has limitations on deleting elements and replacing complex configuration settings.
+
+**Studio Pro 11.9 and above** – Maia can delete flows and microflow objects. However, it cannot change activity types or replace complex configuration settings.
+
+**Studio Pro 11.8** – Maia cannot delete objects or flows. For existing objects, Maia can change variable names, move objects, or reconnect flows, but it cannot delete objects or flows, or change the activity types.
 
 ### Variability in Results
 


### PR DESCRIPTION
This PR updates the Limitations section of Maia for Microflows since Maia can now delete flows and microflow objects.