### PR TITLE
Add infrastructure cost estimation tools to Mendix on Azure docs

### DIFF
--- a/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
@@ -23,34 +23,34 @@ To deploy Mendix on Azure, make sure you have the following available:
 
 Deploying Mendix on Azure provisions infrastructure resources on your Azure subscription, including Azure Kubernetes Service (AKS), PostgreSQL Flexible Server, networking components, storage, and monitoring services. These resources incur charges from Microsoft based on Azure's consumption-based pricing model.
 
-To help you estimate and plan for these infrastructure costs, Mendix provides two complementary tools:
+To help you estimate and plan for these infrastructure costs, Mendix provides the two complementary tools described in the following sections: Interactive Cost Calculator and Azure Pricing Calculator Estimate.
 
 ### Interactive Cost Calculator
 
 The [Mendix on Azure Infrastructure Cost Calculator](https://mxonazure-infra-calculator.mendix.technology) is a custom-built tool that provides:
 
-- **Real-time pricing** from Azure Retail Prices API
-- **T-shirt sizing helpers** based on Mendix Cloud specifications (XS21 through XXXXL21-5XLDB)
-- **Automatic recommendations** for compute (AKS) and database (PostgreSQL) configurations
-- **Multi-region and multi-currency support** for accurate cost projections
-- **Monthly and annual cost estimates** including all infrastructure components
+* Real-time pricing from the Azure Retail Prices API
+* T-shirt sizing helpers based on Mendix Cloud specifications (XS21 through XXXXL21-5XLDB)
+* Automatic recommendations for compute (AKS) and database (PostgreSQL) configurations
+* Multi-region and multi-currency support for accurate cost projections
+* Monthly and annual cost estimates, including all infrastructure components
 
 This calculator is ideal for quickly exploring different sizing options and understanding how your application requirements translate to Azure infrastructure costs.
 
 ### Azure Pricing Calculator Estimate
 
-The [Azure Pricing Calculator Estimate](https://azure.com/e/35816032bbc246358b5c75c03b608c63) is a pre-configured estimate in Microsoft's official Azure Pricing Calculator that:
+The [Azure Pricing Calculator Estimate](https://azure.com/e/35816032bbc246358b5c75c03b608c63) is a preconfigured estimate in Microsoft's official Azure Pricing Calculator that:
 
-- Provides a **baseline infrastructure configuration** matching the Mendix on Azure deployment architecture
-- Can be **customized and shared** with stakeholders for review and approval
-- Serves as a **cost verification tool** for procurement and budgeting
-- Includes **detailed breakdowns** by resource type and region
+* Provides a baseline infrastructure configuration matching the Mendix on Azure deployment architecture
+* Can be customized and shared with stakeholders for review and approval
+* Serves as a cost verification tool for procurement and budgeting
+* Includes detailed breakdowns by resource type and region
 
 {{% alert color="info" %}}
-We recommend using both tools during your planning phase: start with the interactive calculator to explore sizing options based on your application requirements, then verify your estimates against the official Azure Pricing Calculator for stakeholder communication and procurement approval.
+Mendix recommends using both tools during your planning phase: start with the interactive calculator to explore sizing options based on your application requirements, then verify your estimates against the official Azure Pricing Calculator for stakeholder communication and procurement approval.
 {{% /alert %}}
 
-For more information about the specific Azure resources deployed by Mendix on Azure, see [Architecture](/developerportal/deploy/mendix-on-azure/mx-azure-architecture/).
+For more information about the specific Azure resources deployed by Mendix on Azure, refer to [Architecture](/developerportal/deploy/mendix-on-azure/architecture/).
 
 ## Deploying the Mendix on Azure offering from Azure Marketplace
 

--- a/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
@@ -19,6 +19,39 @@ To deploy Mendix on Azure, make sure you have the following available:
     * Owner role assigned on the target subscription (temporary elevated Privileged Identity Management - PIM - access does not suffice)
 * In case you want to integrate the Mendix on Azure environment into your existing corporate network, be sure to consider the [network configuration options](/developerportal/deploy/mendix-on-azure/configuration/#networking-settings) that cannot be changed after initial environment deployment
 
+## Estimating Infrastructure Costs {#estimating-costs}
+
+Deploying Mendix on Azure provisions infrastructure resources on your Azure subscription, including Azure Kubernetes Service (AKS), PostgreSQL Flexible Server, networking components, storage, and monitoring services. These resources incur charges from Microsoft based on Azure's consumption-based pricing model.
+
+To help you estimate and plan for these infrastructure costs, Mendix provides two complementary tools:
+
+### Interactive Cost Calculator
+
+The [Mendix on Azure Infrastructure Cost Calculator](https://mxonazure-infra-calculator.mendix.technology) is a custom-built tool that provides:
+
+- **Real-time pricing** from Azure Retail Prices API
+- **T-shirt sizing helpers** based on Mendix Cloud specifications (XS21 through XXXXL21-5XLDB)
+- **Automatic recommendations** for compute (AKS) and database (PostgreSQL) configurations
+- **Multi-region and multi-currency support** for accurate cost projections
+- **Monthly and annual cost estimates** including all infrastructure components
+
+This calculator is ideal for quickly exploring different sizing options and understanding how your application requirements translate to Azure infrastructure costs.
+
+### Azure Pricing Calculator Estimate
+
+The [Azure Pricing Calculator Estimate](https://azure.com/e/35816032bbc246358b5c75c03b608c63) is a pre-configured estimate in Microsoft's official Azure Pricing Calculator that:
+
+- Provides a **baseline infrastructure configuration** matching the Mendix on Azure deployment architecture
+- Can be **customized and shared** with stakeholders for review and approval
+- Serves as a **cost verification tool** for procurement and budgeting
+- Includes **detailed breakdowns** by resource type and region
+
+{{% alert color="info" %}}
+We recommend using both tools during your planning phase: start with the interactive calculator to explore sizing options based on your application requirements, then verify your estimates against the official Azure Pricing Calculator for stakeholder communication and procurement approval.
+{{% /alert %}}
+
+For more information about the specific Azure resources deployed by Mendix on Azure, see [Architecture](/developerportal/deploy/mendix-on-azure/mx-azure-architecture/).
+
 ## Deploying the Mendix on Azure offering from Azure Marketplace
 
 To deploy the solution, perform the following steps:


### PR DESCRIPTION
## Summary

This PR adds documentation about Mendix on Azure infrastructure cost estimation tools to help customers plan and budget for their deployments.

## Changes

- Added new 'Estimating Infrastructure Costs' section to the 'Deploying Mendix on Azure' page
- Documented the interactive cost calculator at https://mxonazure-infra-calculator.mendix.technology
- Documented the Azure Pricing Calculator estimate at https://azure.com/e/35816032bbc246358b5c75c03b608c63
- Positioned content in the planning phase (after Prerequisites, before Deployment steps)
- Explained the complementary nature of both tools

## Motivation

Customers currently lack clear guidance on estimating Azure infrastructure costs before deploying Mendix on Azure. This documentation helps them:
- Understand that deployment will incur Azure charges
- Use T-shirt sizing to estimate resource requirements
- Obtain real-time pricing estimates
- Share estimates with stakeholders for approval

## Related Issues

- MXFORAZURE-576: Increase transparency on cost impact of deploying Mendix on Azure
- MXFORAZURE-581: Refer to Azure Pricing Calculator in documentation

## Checklist

- [x] Content follows existing documentation style and formatting
- [x] Links are valid and use HTTPS
- [x] Info alert used for guidance
- [x] Cross-reference to Architecture page included
- [x] Section ID anchor added for deep linking