### PR TITLE
Draft: [WTF]: Remove Mx10 references from Mx11 Pluggable Widgets Docs

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-client-apis/_index.md
@@ -2,7 +2,7 @@
 title: "Client APIs"
 linktitle: "Client APIs for Pluggable Widgets"
 url: /apidocs-mxsdk/apidocs/pluggable-widgets-client-apis/
-description: A guide for understanding the client APIs available to pluggable widgets in Mx10.
+description: A guide for understanding the client APIs available to pluggable widgets in Mx11.
 weight: 20
 aliases:
     - /apidocs-mxsdk/apidocs/client-apis-for-pluggable-widgets

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
@@ -480,10 +480,6 @@ Then the Studio Pro UI for the property appears like this:
 
 ### Action {#action}
 
-{{% alert color="info" %}}
-The `defaultType` and `defaultValue` attributes for Action were introduced in Mendix [10.15](/releasenotes/studio-pro/10.15/).
-{{% /alert %}}
-
 The action property type allows a user to configure an action which can do things like call nanoflows, save changes, and open pages.
 
 If a `dataSource` attribute is not specified, the client will receive an `ActionValue` representing the action or `undefined` if the **Do nothing** action was selected.
@@ -767,10 +763,6 @@ Only list datasources are supported, therefore specifying `isList="true"` is req
 
 ##### Data Source Defaults {#data-source-defaults}
 
-{{% alert color="info" %}}
-The `defaultType` and `defaultValue` attributes for datasources were introduced in Mendix [10.16](/releasenotes/studio-pro/10.16/).
-{{% /alert %}}
-
 You can use the `defaultType` and `defaultValue` attributes to configure default data sources for your widget. Unless overridden in Studio Pro, the widget will attempt to configure the data source according to its defaults. Both attributes need to be set for the defaults to be applied.
 
 The format of `defaultValue` depends on the chosen `defaultType`:
@@ -796,10 +788,6 @@ Then the Studio Pro UI for the property appears like this:
 {{< figure src="/attachments/apidocs-mxsdk/apidocs/pluggable-widgets/pluggable-widgets-property-types/datasource.png" class="no-border" >}}
 
 ### Selection {#selection}
-
-{{% alert color="info" %}}
-The property type was introduced in Mendix [10.7](/releasenotes/studio-pro/10.7/).
-{{% /alert %}}
 
 The selection property allows a widget to read and set a selection that can be used in actions, expressions, or a `Listen to` data source of a data view.
 
@@ -866,10 +854,6 @@ Label property allows a pluggable widget to have labeling functionality similar 
 ```
 
 #### setLabel {#setLabel}
-
-{{% alert color="info" %}}
-The `setLabel` attribute was introduced in Mendix [10.5](/releasenotes/studio-pro/10.5/).
-{{% /alert %}}
 
 You can use `setLabel` to specify which properties can be used to set the `Label` property value. 
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/pluggable-widgets-property-types.md
@@ -277,6 +277,10 @@ The user can use the optional attribute [`allowUpload`](#allow-upload) with defa
 
 #### XML Attributes
 
+{{% alert color="info" %}}
+The `allowUpload` attribute was introduced in Mendix [11.8](/releasenotes/studio-pro/11.8/).
+{{% /alert %}}
+
 | Attribute  	| Required | Attribute Type | Description                                                           |
 |---------------|----------|----------------|-----------------------------------------------------------------------|
 | `type`     	| Yes      | String         | Must be `image`                                                       |
@@ -717,6 +721,10 @@ The user can use the optional attribute [`allowUpload`](#allow-upload) with defa
 {{% alert color="info" %}} Editable types are not supported for Native as of now. {{% /alert %}}
 
 #### XML Attributes
+
+{{% alert color="info" %}}
+The `allowUpload` attribute was introduced in Mendix [11.8](/releasenotes/studio-pro/11.8/).
+{{% /alert %}}
 
 | Attribute     | Required | Attribute Type | Description                      |
 |---------------|----------|----------------|----------------------------------|


### PR DESCRIPTION
The Mx11 Pluggable Widgets documentation contained references to 10 and was missing minor-version-specific callouts.