### PR TITLE
Mendix on Kubernetes 2.26.1 release notes (planned for release on Thursday, April 9)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
@@ -158,6 +158,8 @@ Mendix Operator 2.25 (or later versions) will automatically recognise an S3 buck
 
 * If the bucket endpoint has a `<subdomains>.<region>.amazonaws.com` format (or `<subdomains>.<region>.amazonaws.com.<suffix>` format for AWS China regions),
 the Operator uses `<region>` as the S3 region name.
+* If the bucket has a `<bucketname>.s3.amazonaws.com` [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format, Mendix Operator 2.26.1 (or later versions) will detect the bucket region with a [HeadBucket call](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html#API_HeadBucket_ResponseSyntax).
+   In case the HeadBucket call fails, the Mendix Operator will use the default `us-east-1` region (only for bucket endpoints that match the `<bucketname>.s3.amazonaws.com` _Legacy global endpoint_ format).
 * If the S3 bucket endpoint does not match this format, the Mendix Operator will use a default `us-east-1` region, as this works with most S3-compatible buckets like [Minio](#blob-minio) and [Google Cloud Storage](#blob-gcp-storage-bucket).
 
 In some scenarios (legacy or custom S3 endpoints), this autodetection might not work correctly. In this case, you can manually specify the S3 bucket region by setting the [com.mendix.storage.s3.Region](/refguide/custom-settings/#commendixstorages3Region) Custom Runtime Setting. A manually specified `com.mendix.storage.s3.Region` will override the autodetected bucket region.

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
@@ -156,11 +156,9 @@ The AWS S3 library is also updated in the latest LTS versions of Studio Pro:
 
 Mendix Operator 2.25 (or later versions) will automatically recognise an S3 bucket's region from its endpoint address:
 
-* If the bucket endpoint has a `<subdomains>.<region>.amazonaws.com` format (or `<subdomains>.<region>.amazonaws.com.<suffix>` format for AWS China regions),
-the Operator uses `<region>` as the S3 region name.
-* If the bucket has a `<bucketname>.s3.amazonaws.com` [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format, Mendix Operator 2.26.1 (or later versions) will detect the bucket region with a [HeadBucket call](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html#API_HeadBucket_ResponseSyntax).
-   In case the HeadBucket call fails, the Mendix Operator will use the default `us-east-1` region (only for bucket endpoints that match the `<bucketname>.s3.amazonaws.com` _Legacy global endpoint_ format).
-* If the S3 bucket endpoint does not match this format, the Mendix Operator will use a default `us-east-1` region, as this works with most S3-compatible buckets like [Minio](#blob-minio) and [Google Cloud Storage](#blob-gcp-storage-bucket).
+* If the bucket endpoint has a `<subdomains>.<region>.amazonaws.com` format (or `<subdomains>.<region>.amazonaws.com.<suffix>` format for AWS China regions), the Operator uses `<region>` as the S3 region name.
+* For buckets that use the `<bucketname>.s3.amazonaws.com` [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format, Mendix Operator 2.26.1 (or later versions) detects the bucket region with a [HeadBucket call](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html#API_HeadBucket_ResponseSyntax). If the call fails, the Mendix Operator uses the default `us-east-1` region instead.
+* If the S3 bucket endpoint does not match this format, the Mendix Operator uses a default `us-east-1` region, as this works with most S3-compatible buckets (for example, [Minio](#blob-minio) and [Google Cloud Storage](#blob-gcp-storage-bucket)).
 
 In some scenarios (legacy or custom S3 endpoints), this autodetection might not work correctly. In this case, you can manually specify the S3 bucket region by setting the [com.mendix.storage.s3.Region](/refguide/custom-settings/#commendixstorages3Region) Custom Runtime Setting. A manually specified `com.mendix.storage.s3.Region` will override the autodetected bucket region.
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -36,8 +36,8 @@ If deploying to Red Hat OpenShift, you need to specify that specifically when cr
 
 Mendix on Kubernetes Operator `v2.*.*` is the latest version which officially supports:
 
-* Kubernetes versions 1.19 through 1.34
-* OpenShift 4.6 through 4.20
+* Kubernetes versions 1.19 through 1.35
+* OpenShift 4.6 through 4.21
 
 {{% alert color="warning" %}}
 Kubernetes 1.22 is a [new release](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/) which removes support for several deprecated APIs and features.

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,18 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2026
 
+### April 7, 2026
+
+#### Mendix Operator v2.26.1 {#2.26.1}
+
+* We have improved AWS S3 region detection for bucket endpoints using the [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format.
+* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
+* We have updated the list of supported platforms to include Kubernetes 1.35 and OpenShift 4.21.
+
+#### License Manager CLI v0.10.9 {#0.10.9}
+
+* We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
+
 ### April 2, 2026
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,7 +12,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2026
 
-### April 7, 2026
+### April 9, 2026
 
 #### Mendix Operator v2.26.1 {#2.26.1}
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -16,7 +16,7 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 #### Mendix Operator v2.26.1 {#2.26.1}
 
-* We have improved AWS S3 region detection for bucket endpoints using the [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format.
+* We have improved the AWS S3 region detection for bucket endpoints using the [Legacy global endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) format.
 * We have updated components to use the latest dependency versions in order to improve security score ratings for container images.
 * We have updated the list of supported platforms to include Kubernetes 1.35 and OpenShift 4.21.
 


### PR DESCRIPTION
We're planning to release a new version of the MxOK Operator next week (on Thursday or possibly later).

This is a small bugfix/patch release with no major changes.