### PR TITLE
Enhance offline-first documentation on synchronization

### DIFF
--- a/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/synchronization.md
+++ b/content/en/docs/refguide/mobile/building-efficient-mobile-apps/offlinefirst-data/synchronization.md
@@ -111,6 +111,18 @@ If you have custom widgets or JavaScript actions which use an entity that cannot
 
 For each entity the **Synchronization mode** is shown. A default is automatically determined by analyzing the model, but can be overridden by the developer in which case the setting will appear in boldface. 
 
+When an entity is configured with one of the **Online**, **Nothing (clear data)**, **Nothing (preserve data)**, or **Never** synchronization modes, the Mendix Runtime will reject any synchronization request from a client that attempts to upload changes for that entity. This prevents unintended data modifications on the server and makes your application more secure.                                                                                                                                         
+If a client attempts to synchronize changes for a restricted entity, those changes are blocked and a synchronization error is recorded on the server. You can inspect these errors via the `System.SynchronizationError` entity.                                                                                                                                                                                                                        
+**Compatibility Mode** — When you migrate an entity from All Objects or By XPath to **Online**, **Nothing**, or **Never**, older versions of your offline app may still attempt to synchronize changes for that entity. To prevent those clients from receiving synchronization errors during the migration period, you can enable **Compatibility Mode** for the entity by selecting the checkbox in the synchronization configuration.                                                                                                  
+
+When **Compatibility Mode** is enabled for an entity:
+
+* The runtime accepts synchronization requests from clients for that entity, regardless of the configured synchronization mode.
+* The entity behaves as if it were still set to **All Objects**.
+                                                                                                                     
+When you are confident that all old clients have updated to the latest version, you should disable Compatibility Mode by deselecting the checkbox.                                                                                                                                                                                                     
+When you change an entity's synchronization mode to **Online**, **Nothing**, or **Never** in Studio Pro, **Compatibility Mode** is automatically enabled to avoid breaking existing clients.
+
 ### Limitations
 
 Please be aware of the following limitation affecting synchronization: 

--- a/content/en/docs/refguide8/mobile/offline-first.md
+++ b/content/en/docs/refguide8/mobile/offline-first.md
@@ -111,6 +111,17 @@ If you have custom widgets or JavaScript actions which use an entity that cannot
 
 For each entity the **Synchronization mode** is shown. A default is automatically determined by analyzing the model, but can be overridden by the developer in which case the setting will appear in boldface.
 
+When an entity is configured with the Online, Nothing (clear data), Nothing (preserve data), or Never synchronization mode, the Mendix runtime will reject any synchronization request from a client that attempts to upload changes for that entity. This prevents unintended data modifications on the server and makes your application more secure.                                                                                                                                         
+If a client attempts to synchronize changes for a restricted entity, those changes are blocked and a synchronization error is recorded on the server. You can inspect these errors via the System.SynchronizationError entity.                                                                                                                                                                                                                        
+**Compatibility Mode** - When you migrate an entity from All Objects or By XPath to Online, Nothing, or Never, older versions of your offline app may still attempt to synchronize changes for that entity. To prevent those clients from receiving synchronization errors during the migration period, you can enable Compatibility Mode for the entity by selecting the checkbox in the synchronization configuration.                                                                                                  
+
+When Compatibility Mode is enabled for an entity:
+* The runtime accepts synchronization requests from clients for that entity, regardless of the configured synchronization mode.
+* The entity behaves as if it were still set to All Objects.
+                                                                                                                     
+When you are confident that all old clients have updated to the latest version, you should disable Compatibility Mode by deselecting the checkbox.                                                                                                                                                                                                     
+When you change an entity's synchronization mode to Online, Nothing, or Never in Studio Pro, Compatibility Mode is automatically enabled to avoid breaking existing clients.
+
 ### Limitations
 
 Running multiple synchronization processes at the same time is not supported, regardless the of the type (**full** or **selective**). For more information, see the [Limitations](/refguide8/synchronize/#limitations) section of the *Synchronize Reference Guide*.

--- a/content/en/docs/refguide8/mobile/offline-first.md
+++ b/content/en/docs/refguide8/mobile/offline-first.md
@@ -111,17 +111,6 @@ If you have custom widgets or JavaScript actions which use an entity that cannot
 
 For each entity the **Synchronization mode** is shown. A default is automatically determined by analyzing the model, but can be overridden by the developer in which case the setting will appear in boldface.
 
-When an entity is configured with the Online, Nothing (clear data), Nothing (preserve data), or Never synchronization mode, the Mendix runtime will reject any synchronization request from a client that attempts to upload changes for that entity. This prevents unintended data modifications on the server and makes your application more secure.                                                                                                                                         
-If a client attempts to synchronize changes for a restricted entity, those changes are blocked and a synchronization error is recorded on the server. You can inspect these errors via the System.SynchronizationError entity.                                                                                                                                                                                                                        
-**Compatibility Mode** - When you migrate an entity from All Objects or By XPath to Online, Nothing, or Never, older versions of your offline app may still attempt to synchronize changes for that entity. To prevent those clients from receiving synchronization errors during the migration period, you can enable Compatibility Mode for the entity by selecting the checkbox in the synchronization configuration.                                                                                                  
-
-When Compatibility Mode is enabled for an entity:
-* The runtime accepts synchronization requests from clients for that entity, regardless of the configured synchronization mode.
-* The entity behaves as if it were still set to All Objects.
-                                                                                                                     
-When you are confident that all old clients have updated to the latest version, you should disable Compatibility Mode by deselecting the checkbox.                                                                                                                                                                                                     
-When you change an entity's synchronization mode to Online, Nothing, or Never in Studio Pro, Compatibility Mode is automatically enabled to avoid breaking existing clients.
-
 ### Limitations
 
 Running multiple synchronization processes at the same time is not supported, regardless the of the type (**full** or **selective**). For more information, see the [Limitations](/refguide8/synchronize/#limitations) section of the *Synchronize Reference Guide*.


### PR DESCRIPTION
Added details about synchronization modes and Compatibility Mode for entities.

As a part of this improvement- https://mendix.atlassian.net/browse/OFF-816 we made following changes  - We introduced a stricter requirements check on the server synchronization API's for offline apps. This prevents entities from synchronizing changes when they are configured with the synchronization modes Online, Nothing, or Never. To allow older offline clients having an All Objects or By XPath synchronization mode to still synchronize while the new app version has the entity configured with an Online, Nothing, or Never synchronization mode, we added a Compatibility mode checkbox. 

We are aiming to add following details in this document : 

- Accessing objects via sync apis is no longer possible for the sync modes online / nothing / never which makes applications more secure (unless the checkbox is checked)

- Explain that the checkbox should be checked to migrate from all objects / by xpath to nothing / never / online to make sure old clients can still work

- Once all old clients are updated, the checkbox should be disabled.

Please if you feel any better place for this details.


