### PR TITLE
Release Note for History Web pane timeouts fix

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/11/11.9.md
+++ b/content/en/docs/releasenotes/studio-pro/11/11.9.md
@@ -159,6 +159,7 @@ We changed how Studio Pro stores Marketplace identity data for widgets. This dat
 * We fixed an issue where deleting a duplicate navigation profile deleted the wrong duplicate profile.
 * We fixed an issue where mxbuild incorrectly reported that the modern web client bundler stopped unexpectedly, while the React client bundler completed normally without errors.
 * We fixed an issue where an Oops pop-up window appeared when copying button widgets with parameter arguments to page templates or building blocks, and when creating page templates or building blocks from pages or widgets containing such buttons.
+* We fixed History Web pane timeouts for large repositories and eliminated refresh commit history errors
 
 ### Deprecations
     


### PR DESCRIPTION
Fixed History Web pane timeouts for large repositories and eliminated refresh commit history errors.