### PR TITLE
Change 'widget' to 'component' in customization.md

### DIFF
--- a/content/en/docs/partners/siemens/teamcenter-bom-component/customization.md
+++ b/content/en/docs/partners/siemens/teamcenter-bom-component/customization.md
@@ -2,12 +2,12 @@
 title: "Advanced Customization Options"
 url: /partners/siemens/bom-widget-customization/
 weight: 3
-description: "Describes the customization capabilities that allow developers to add data from external systems, and how these can be combined into the Teamcenter BOM widget."
+description: "Describes the customization capabilities that allow developers to add data from external systems, and how these can be combined into the Teamcenter BOM component."
 ---
 
 ## Augmenting with Mendix Data
 
-Client columns allow you to display custom data next to Teamcenter properties in the BOM view. The widget calls the following two microflows:
+Client columns allow you to display custom data next to Teamcenter properties in the BOM view. The component calls the following two microflows:
 
 * `CUSTOM_RetrieveClientColumnDefinitions` – Microflow to retrieve the client column definitions: client column name, width, and column order.
 * `CUSTOM_RetrieveClientColumnData` – Microflow to retrieve the additional cell data to display for the BOM lines and client columns. 
@@ -16,7 +16,7 @@ As a developer, you are free to implement this according to your own needs. Addi
 
 ### CUSTOM_RetrieveClientColumnDefinitions
 
-This microflow is invoked by the Teamcenter BOM widget to retrieve the definitions of the client columns to display in the widget.
+This microflow is invoked by the Teamcenter BOM component to retrieve the definitions of the client columns to display in the component.
 
 {{< figure src="/attachments/partners/siemens/teamcenter-bom-component/custom-retrieveclientcolumndefinitions.png">}}
 
@@ -25,7 +25,7 @@ This microflow is invoked by the Teamcenter BOM widget to retrieve the definitio
 * **Object**: `MendixColumnRoot`
 * **Attribute**:
   
-    * `WidgetId` is a unique identifier for the specific Teamcenter BOM widget instance that is making the request. This is useful if your app includes multiple Teamcenter BOM widgets that need to display different columns. You can use this ID to differentiate and return the appropriate data.
+    * `WidgetId` is a unique identifier for the specific Teamcenter BOM component instance that is making the request. This is useful if your app includes multiple Teamcenter BOM components that need to display different columns. You can use this ID to differentiate and return the appropriate data.
 
 {{< figure src="/attachments/partners/siemens/teamcenter-bom-component/domain-model-mendixcolumnroot.png">}}
 
@@ -34,8 +34,8 @@ This microflow is invoked by the Teamcenter BOM widget to retrieve the definitio
 * **Object**: `List of ClientColumn`
 * **Attributes**:
 
-    * `Name` – The name of the client column. This name is used in the UI of the Teamcenter BOM widget as the column title.
-    * `ColumnOrder` – The order of the column within the widget, respectively. Teamcenter columns also have their own order, so this needs to be filled in conjunction. If the order is identical, Teamcenter columns take priority.    
+    * `Name` – The name of the client column. This name is used in the UI of the Teamcenter BOM component as the column title.
+    * `ColumnOrder` – The order of the column within the component, respectively. Teamcenter columns also have their own order, so this needs to be filled in conjunction. If the order is identical, Teamcenter columns take priority.    
     The first column should be object_string, which is already defined.    
     All Mendix client columns must start with `columnOrder 2` and will be displayed before the Teamcenter columns.    
     Mendix columns are sorted based on their `columnOrder` parameter.    
@@ -46,7 +46,7 @@ This microflow is invoked by the Teamcenter BOM widget to retrieve the definitio
 
 ### CUSTOM_RetrieveClientColumnData
 
-This microflow is invoked by the Teamcenter BOM widget to retrieve the data to be rendered in the BOM tree. It gathers cell data for specific BOM lines and any client columns.
+This microflow is invoked by the Teamcenter BOM component to retrieve the data to be rendered in the BOM tree. It gathers cell data for specific BOM lines and any client columns.
 
 {{< figure src="/attachments/partners/siemens/teamcenter-bom-component/custom-retrieveclientcolumndata.png">}}
 
@@ -55,9 +55,9 @@ This microflow is invoked by the Teamcenter BOM widget to retrieve the data to b
 * **Object**: `MendixDataRoot`
 * **Attributes and associations**:
 
-    * `WidgetId` – A unique identifier for the specific Teamcenter BOM widget instance that is making the request. This is useful if your app includes multiple Teamcenter BOM widgets that need to display different data. You can use this ID to differentiate and return the appropriate data.
-    * Associated `MendixDataColumnName` objects – This list specifies which custom columns the widget is configured to display. Each object has a `Name` attribute, representing the identifier of a custom column.
-    * Associated `MendixDataBOMLine` objects – This list contains the specific BOM lines for which the widget requires data. Each object includes attributes such as `ItemId`, `RevisionId`, `RevisionUId`, and `BOMlineUid` to identify the BOM line and its `ItemRevision`.
+    * `WidgetId` – A unique identifier for the specific Teamcenter BOM component instance that is making the request. This is useful if your app includes multiple Teamcenter BOM components that need to display different data. You can use this ID to differentiate and return the appropriate data.
+    * Associated `MendixDataColumnName` objects – This list specifies which custom columns the component is configured to display. Each object has a `Name` attribute, representing the identifier of a custom column.
+    * Associated `MendixDataBOMLine` objects – This list contains the specific BOM lines for which the component requires data. Each object includes attributes such as `ItemId`, `RevisionId`, `RevisionUId`, and `BOMlineUid` to identify the BOM line and its `ItemRevision`.
 
 {{< figure src="/attachments/partners/siemens/teamcenter-bom-component/domain-model-mendixdataroot-with-associations.png">}}
 


### PR DESCRIPTION
Updated references from 'widget' to 'component' in some places of customization documentation.