### PR TITLE
Add style guide and improve skills

### DIFF
--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polish
-description: Proofreads documentation and improves clarity, readability, and word choice without changing meaning or reorganizing structure. Simplifies complex sentences, applies style guide standards, and converts passive voice to active voice. Use when the user wants to polish, improve clarity, make more readable, check style guide compliance, improve language, or clean up documentation while preserving its structure.
+description: Proofreads documentation and improves clarity, readability, and word choice without changing meaning or reorganizing structure. Simplifies complex sentences, applies style guide standards, and converts passive voice to active voice. Use when the user wants to polish, improve language and clarity, make more readable, check style guide compliance, or clean up documentation while preserving its structure.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -1,32 +1,39 @@
 ---
 name: polish
-description: Proofreads documentation and improves clarity, readability, and word choice without changing meaning or reorganizing structure. Simplifies complex sentences, applies style guide standards, and converts passive voice to active voice. Use when the user wants to polish, improve clarity, make more readable, or clean up documentation while preserving its structure.
+description: Proofreads documentation and improves clarity, readability, and word choice without changing meaning or reorganizing structure. Simplifies complex sentences, applies style guide standards, and converts passive voice to active voice. Use when the user wants to polish, improve clarity, make more readable, check style guide compliance, improve language, or clean up documentation while preserving its structure.
 user-invocable: true
 disable-model-invocation: false
 ---
 
-> **Skill progression:** This preserves structure. If only basic fixes are needed, use `/proofread`. For deeper reorganization, suggest `/enhance`.
+> **Skill progression:** This does everything `/proofread` does plus clarity improvements and style guide enforcement. If only grammar and spelling fixes are needed, use `/proofread`. For deeper reorganization, suggest `/enhance`.
 
-First, use the Skill tool to invoke the `proofread` skill.
-
-Then immediately continue: improve clarity and readability without changing meaning, structure, or paragraph order:
+Improve clarity and readability without changing meaning, structure, or paragraph order:
 
 **Polish should**:
+* Read Mendix style guides first (in parallel): `grammar-formatting.md`, `terminology.md`, and `product-naming-guide.md` from `/community-tools/contribute-to-mendix-docs/style-guide/`
+* Fix all spelling, grammar, and punctuation errors
+* Add missing alt text to images (use simple, factual descriptions)
+* Ensure required front matter fields are present (title, url, description) and make descriptions concise and action-oriented
+* Fix broken Markdown syntax
+* Fix capitalization and terminology inconsistencies
 * Break up long, complex sentences for better readability
 * Simplify wordy or awkward phrasing
 * Improve word choice (more precise or accessible terms)
 * Change passive voice to active voice where appropriate
-* Make front matter descriptions more concise and action-oriented
-* Apply all style standards from project instructions (tone, formatting, terminology)
 * Remove bold and italics used for emphasis (reword or use alerts if needed)
-* Ensure consistent application of Microsoft Writing Style Guide
+* Apply Mendix style guide standards (overrides the Microsoft Writing Style Guide)
+* Apply Microsoft Writing Style Guide standards, unless they conflict with the Mendix style guide standards
 
 **Polish should NOT**:
 * Move paragraphs or restructure sections (that's `/enhance`)
 * Change technical meaning or accuracy
 * Significantly increase document length
-* Modify code samples (flag issues instead)
+* Change command syntax, code identifiers, variable names, placeholders, or any other text that appears in code formatting (inline backticks or code blocks). Code-formatted text represents literal technical content that must remain unchanged. If you notice an issue with code-formatted text, flag it in the chat but don't edit it directly.
 
 Every edit should serve a clear purpose in making the text easier to read, scan, and understand.
 
-Do not change any code samples directly, but flag any code issues or inconsistencies in the chat.
+Priority order for determining scope:
+1. If the user has selected text in a file (check for `ide_selection` tags), only polish the selected text in that file. Don't polish the entire document.
+2. If there's one open file (check for `ide_opened_file` tags) and no selection, work on the entire file.
+3. If there are multiple open files, list them and ask which to process.
+4. If no files are open, ask for a file path.

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -10,7 +10,7 @@ disable-model-invocation: false
 Improve clarity and readability without changing meaning, structure, or paragraph order:
 
 **Polish should**:
-* Read Mendix style guides first (in parallel): `grammar-formatting.md`, `terminology.md`, and `product-naming-guide.md` from `/community-tools/contribute-to-mendix-docs/style-guide/`
+* Read Mendix style guides first (in parallel): `grammar-formatting.md`, `terminology.md`, and `product-naming-guide.md` from `/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/`
 * Fix all spelling, grammar, and punctuation errors
 * Add missing alt text to images (use simple, factual descriptions)
 * Ensure required front matter fields are present (title, url, description) and make descriptions concise and action-oriented

--- a/.claude/skills/proofread/SKILL.md
+++ b/.claude/skills/proofread/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: proofread
-description: Checks and fixes spelling, grammar, punctuation, basic Markdown formatting, alt text, and required front matter fields. Makes minimal technical corrections without rewording or restructuring. Use when the user asks to proofread, check for errors, fix typos, or perform a light technical review of documentation.
+description: Checks and fixes spelling, grammar, punctuation, basic Markdown formatting, and required front matter fields. Makes minimal corrections without rewording or restructuring. Use when the user asks to proofread, check for spelling and grammar errors, or fix typos.
 user-invocable: true
 disable-model-invocation: false
 ---
 
-> **Skill progression:** This is the lightest touch. If more clarity work is needed, suggest `/polish`. For deeper restructuring, suggest `/enhance`.
+> **Skill progression:** This is the lightest touch. If more clarity and style guide work is needed, suggest `/polish`. For deeper restructuring, suggest `/enhance`.
 
-Proofread the document for technical correctness only. Do NOT rewrite, rephrase, or improve clarity:
+Do NOT rewrite, rephrase, or improve clarity. Proofread only:
 
 * **Spelling**: Fix typos and misspellings
 * **Grammar**: Fix grammatical errors (subject-verb agreement, tense consistency, etc.)
 * **Basic formatting checks**:
-  * Add missing alt text to images (use simple, factual descriptions)
   * Ensure required front matter fields are present (title, url, description)
   * Fix broken Markdown syntax
   * Fix any capitalization and terminology inconsistencies
@@ -23,5 +22,11 @@ Do NOT:
 * Change passive voice to active voice
 * Simplify complex sentences
 * Reorganize content
+
+Priority order for determining scope:
+1. If the user has selected text in a file (check for `ide_selection` tags), only proofread the selected text in that file. Don't proofread the entire document.
+2. If there's one open file (check for `ide_opened_file` tags) and no selection, work on the entire file.
+3. If there are multiple open files, list them and ask which to process.
+4. If no files are open, ask for a file path.
 
 If you notice style or clarity issues that need improvement, finish proofreading first, then suggest the user run `/polish` for those improvements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable-file -->
 
-**Your role**: Edit and review Markdown documentation files under `content/en/docs/` following Microsoft Writing Style Guide and the project-specific conventions below.
+**Your role**: Edit and review Markdown documentation files under `content/en/docs/` following the style guidance and project-specific conventions below.
 
 ## Instruction Precedence
 
@@ -12,8 +12,9 @@ When instructions conflict, follow this order of precedence:
 2. Task-specific prompt files in `.github/prompts/*.prompt.md` (for Copilot) or skills in `.claude/skills/*/SKILL.md` (for Claude) when explicitly referenced or invoked.
 3. Overlay instruction files (for example, `.github/release-notes-instructions.md`) when path-scoped.
 4. This file (`CLAUDE.md`).
-5. Existing conventions in nearby pages within the same folder.
-6. Microsoft Writing Style Guide.
+5. Mendix Style Guide files in `content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/` for detailed grammar, terminology, and formatting rules.
+6. Existing conventions in nearby pages within the same folder.
+7. Microsoft Writing Style Guide.
 
 ### Critical Constraints
 
@@ -73,7 +74,7 @@ Before creating a new file, use Glob to explore the directory structure and unde
 
 ## Style Standards
 
-* **Guiding manual** – Microsoft Writing Style Guide (https://learn.microsoft.com/style-guide/). Apply grammar, inclusive language, terminology, and formatting rules from that document.
+* **Guiding manual** – Mendix-specific style guides (see subsection below) extend and customize the Microsoft Writing Style Guide (https://learn.microsoft.com/style-guide/). Consult the Mendix style guides first for grammar, inclusive language, terminology, and formatting rules; use MSG as fallback for topics not covered by Mendix guides.
 * **Tone** – Clear, concise, active voice; use imperative mood for procedures; second person (you/your) when addressing readers. Keep a conversational, straightforward tone. Present tense. Use American English and write for a global audience. Prefer short, everyday words; avoid or explain jargon. Keep it simple—short sentences and fragments are easier to scan and read, and prune excess words. Avoid marketing language.
 * **Terminology** – Capitalize product names (Mendix, Studio Pro, Developer Portal); use "microflow", "nanoflow", etc. consistently. Never use e.g. or i.e.
 * **Text formatting** – Reserve bold for UI labels, button names, menu items, or other interface text, or for introductions in list items. Don't use italics except to refer to titles and sections. Use wording or alert shortcodes for emphasis; don't use text formatting for emphasis. Use code font only to wrap literal code, filenames, paths, or command-line input. Use `<kbd>` for keyboard shortcuts.
@@ -82,9 +83,19 @@ Before creating a new file, use Glob to explore the directory structure and unde
 * **Indentation** – Four spaces for sub-lists and nested content. Alerts in lists are an exception:  don't indent alert lines but do omit preceding blank line.
 * **Links** – Use absolute paths starting with a leading slash (`/deployment/`). Use descriptive link text such as the page title, not "click here". To link to a heading, add an anchor ID (`{#anchor-id}`) next to the heading and use that ID in the URL (for example, `[Section title](/path/to/page#anchor-id)` to link to a heading in another page or `[Section title](#anchor-id)` to link to a heading in the same page).
 * **Images** – Always include `alt` text (or `alt=""` if decorative). Use W3C guidelines. Reference images with the `figure` shortcode.
-* **Code** – Use fenced code blocks with language specifier.
+* **Code** – Use fenced code blocks with language specifier. Do not modify text that appears in code formatting (inline backticks or code blocks), even to fix apparent inconsistencies or apply naming conventions. 
 
-Project‑specific preferences are documented in the templates and in `community-tools` example pages; consult them for tricky formatting cases.
+### Mendix-Specific Style Guides
+
+For detailed guidance beyond the basics above, consult these Mendix style guide files in `content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/`:
+
+* **`grammar-formatting.md`** – Grammar and formatting rules including acronyms, active/passive voice, alerts, bold/italics, capitalization, contractions, dashes, dates, emphasis, headings, lists, numbers, person, verb tense, keyboard shortcuts, URL handling, and cross-reference conventions. This is the most detailed style reference.
+* **`terminology.md`** – General terminology guidance for common terms, with capitalization and hyphenation rules.
+* **`product-naming-guide.md`** – Reference for Mendix product names and other Mendix terms.
+
+When encountering style questions not covered in this file, read the relevant style guide file above before falling back to the Microsoft Writing Style Guide.
+
+Project‑specific preferences are also documented in the templates; consult them for tricky formatting cases.
 
 ## Tool Usage Guidelines
 

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/_index.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/_index.md
@@ -7,22 +7,8 @@ description: "Comprehensive guidelines on terminology, grammar, formatting, incl
 
 ## Introduction
 
-The Documentation group maintains guidelines on terminology, grammar, formatting, inclusive language, document structuring, and image usage that are applied to the [Mendix Documentation](https://docs.mendix.com/) and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/).
-
-The guidelines can be referenced in these sections:
-
-* [Grammar & Formatting](grammar-formatting/)
-* [Terminology](terminology/)
-* [Inclusive Language](inclusive-language/)
-* [Structuring](structuring/)
-* [Images, Icons, and Videos](images-icons-videos/)
-* [Shortcodes, Markdown, and HTML](shortcodes-markdown-html/)
-* [Front Matter (Metadata)](front-matter/)
-* [Microcopy Guide](microcopy-guide/)
-* [Mendix Product Naming Guide](product-naming-guide/)
+The Documentation group maintains guidelines on terminology, grammar, formatting, inclusive language, document structuring, and image usage that are applied to the [Mendix Documentation](/) and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/).
 
 The tone of the Mendix documentation is conversational, relaxed, and always straight-forward. The tone reflects the Documentation group's values.
 
 Our language conventions are based on American English.
-
-When editing the Evaluation Guide, you can use the WordPress shortcodes described in <https://mendix.atlassian.net/wiki/x/vwB2vg>

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/_index.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Mendix Documentation Style Guide"
+url: /community-tools/contribute-to-mendix-docs/style-guide/
+weight: 10
+description: "Comprehensive guidelines on terminology, grammar, formatting, inclusive language, document structuring, and image usage for Mendix documentation."
+---
+
+## Introduction
+
+The Documentation group maintains guidelines on terminology, grammar, formatting, inclusive language, document structuring, and image usage that are applied to the [Mendix Documentation](https://docs.mendix.com/) and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/).
+
+The guidelines can be referenced in these sections:
+
+* [Grammar & Formatting](grammar-formatting/)
+* [Terminology](terminology/)
+* [Inclusive Language](inclusive-language/)
+* [Structuring](structuring/)
+* [Images, Icons, and Videos](images-icons-videos/)
+* [Shortcodes, Markdown, and HTML](shortcodes-markdown-html/)
+* [Front Matter (Metadata)](front-matter/)
+* [Microcopy Guide](microcopy-guide/)
+* [Mendix Product Naming Guide](product-naming-guide/)
+
+The tone of the Mendix documentation is conversational, relaxed, and always straight-forward. The tone reflects the Documentation group's values.
+
+Our language conventions are based on American English.
+
+When editing the Evaluation Guide, you can use the WordPress shortcodes described in <https://mendix.atlassian.net/wiki/x/vwB2vg>

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/grammar-formatting.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/grammar-formatting.md
@@ -1,0 +1,541 @@
+---
+title: "Grammar & Formatting"
+url: /community-tools/contribute-to-mendix-docs/style-guide/grammar-formatting/
+weight: 20
+description: "Guidelines on grammar, formatting, capitalization, punctuation, lists, headings, and other writing conventions for Mendix documentation."
+---
+
+## Introduction
+
+## Acronyms and Initialisms
+
+Define technical or obscure acronyms and initialisms, and write them out fully the first time before using them throughout the rest of the document.
+
+Add an "s" to make an acronym plural. For example, write "your choice of IDEs" instead of "your choice of IDE's".
+
+## Active and Passive Voice
+
+Use active voice whenever you can. However, you can use passive voice in the following situations:
+
+* To avoid condescending text or blaming the customer, especially in errors, warnings, or notifications
+* To avoid awkward constructions
+* To emphasize the receiver of the action
+
+For more information, see the [Active and Passive Voice](https://docs.microsoft.com/en-us/style-guide/grammar/verbs#active-and-passive-voice) section in *Microsoft Style Guide*.
+
+> Divide your document into as many sections as you want.
+>
+> When the user clicks OK, the transaction is committed.
+
+## Alerts
+
+Use an alert to emphasize or call attention to information that doesn't fit into the flow of text.
+
+In general, alerts should be short (1-2 paragraphs); if you need to write something long or complex in an alert, consider whether it can go into its own subsection with a header instead. Avoid using code blocks, bulleted lists, or numbered lists in an alert unless they are absolutely necessary.
+
+For technical guidance on how to add an alert to the docs, see Shortcodes, Markdown, and HTML.
+
+## Ampersands (&)
+
+Only use ampersands when talking about their use in UI elements, HTML, or programming languages. Otherwise, do not use ampersands in either titles, link titles, headings, or text. Use "and" instead.
+
+For more information, see the [ampersand (&)](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/a/ampersand) section in *Microsoft Style Guide*.
+
+> Click **Save & Close**.
+>
+> Extract and edit the sub-microflow.
+
+## Bold
+
+Use bold for UI text (for example, button names, column names). Do not put UI text in quotation marks.
+
+> If you can't find the toolbox, you can re-open it from the **View** menu.
+>
+> Select **From database** as the **Source**.
+>
+> **Structure mode** and **Design mode**
+
+Do not use bold on text that is hyperlinked for a cross-reference. The formatting for hyperlinking overrides the need to bold or italicize.
+
+It is not necessary to use bold in a hyperlink, the link highlighting is sufficient.
+
+## Button Names
+
+Button names should be capitalized.
+
+Button names should be **bolded** in the documentation.
+
+For toolbar or other buttons, just use the button name ("click **Delete**" instead of "click the **Delete** button", for example).
+
+> Click **Edit** to edit the course start date.
+
+## Capitalization of Mendix Terminology
+
+All guidelines on capitalization of Mendix terminology are listed in the Mendix Product Naming Guide.
+
+We do not capitalize the names of the editors, such as: the microflow editor, the page editor, the domain model editor.
+
+Capitalize external tools and methodologies that are used by the Mendix Platform (for example, Subversion, Scrum, and Sprint).
+
+When referring directly to the UI (for example, in a procedure or how-to), you should directly reflect how the entity is written and capitalized on the UI (and apply **bold** styling).
+
+> The domain model is a data model that describes…
+>
+> Go to the **Domain Model**.
+
+## Colloquialisms
+
+Keep the diversity of end-users in mind and generally avoid using colloquial language.
+
+## Code Snippets
+
+When using a piece of punctuation/code in a sentence, put the item in parentheses after stating its name and add Markdown code formatting (` `).
+
+> Enclose the whole setting value in braces (`{ }`).
+
+## Conditional Adverbs
+
+Avoid the following conditional adverbs in technical writing:
+
+* would
+* could
+* should
+* possibly
+* might
+* actually
+* potentially
+
+These words add uncertainty and cloud the true meaning of sentences. The main exception to this rule is when you are writing about a hypothetical or theoretical scenario. In that case, make it clear to the reader the scenario is **hypothetical** before using words like "could", and make it clear what Mendix actually supports/recommends.
+
+## Contractions
+
+Should not be used. Write "it is" and not "it's."
+
+Do not use a contraction formed from a proper noun and verb (for example, "Mendix'll…").
+
+## Cross-Referencing and Hyperlinks
+
+For technical guidance on links, anchors, and cross-referencing, see Shortcodes, Markdown, and HTML.
+
+### Cross-Reference Text
+
+Write out the full name of the cross-referenced/hyperlinked document (for example, another how-to) and not just, for example, "look at this how-to".
+
+If you make a cross-reference to a how-to when you are outside of a how-to space, you should preface the crosslink with "How to" to add context."
+
+> For more information, see How to Create a Basic Data Layer.
+
+Use these phrases consistently when cross-referencing:
+
+* "For more information,…" **+** "…see {doc}."
+* "For details on…," **+** "…see {doc}."
+
+> For details on microflow expressions, see Triggering Logic Using Microflows.
+
+> For more information, see the [Troubleshooting](https://docs.mendix.com/refguide/install/#troubleshooting) section of *Installing Mendix Studio Pro*.
+>
+> For more information, see the [Installing Studio Pro Offline](https://docs.mendix.com/refguide/install/#offline) section below.
+
+Do not use bold or italics on text that is hyperlinked for a cross-reference. The formatting for hyperlinking overrides the need to bold or italicize.
+
+Only link to URLs that use HTTPS. If you're working with a URL that uses HTTP, check if there's an HTTPS version available instead. If not, considering linking to a different site.
+
+### Cross-Referencing Examples
+
+#### APIs
+
+When cross-referencing an API (like Client or Mendix Runtime) that is hosted on <http://apidocs.rnd.mendix.com> but you are only cross-referencing the index (meaning, the general API or the API in its entirety), use a relative link to our docs page for that API: <https://docs.mendix.com/apidocs-mxsdk/apidocs/> .
+
+When cross-referencing an API method or a specific element of the API that the user needs to be directed to, use a link to <http://apidocs.rnd.mendix.com> . These links need to be updated/maintained per Studio Pro major version (and thus API version).
+
+#### Learning Path
+
+When cross-referencing a learning path, use the formulation below.
+
+> For more information, see the [LP Title Goes Here](link url) learning path.
+
+When linking to a learning path in a "Read More" section, simply link to the path's title text.
+
+When you wish to reference multiple learning paths, make a distinct "Learning Paths" section.
+
+#### Section
+
+When cross-referencing a section of the same document, include "section" outside the link. Do not include the number of the section (because that is too difficult to maintain). You can also include "above" or "below" to help orient the reader in the document.
+
+> For details, see the Installing the Widget section below.
+
+When cross-referencing a section of another document, add the link to the section name and include the italicized name of the full document you are linking to. Do not add the section number (because it may change, so it is difficult to maintain in cross-references).
+
+> For details, see the Creating a New App in the Mendix Desktop Modeler section in *How to Create a Custom Theme with the Mendix UI Framework*.
+
+### Hyperlinks
+
+For static links (to external websites), deep-link the name of the site/page (do not include full URL as the link text unless you want to emphasize how the URL is written).
+
+You can download it for free at [Tortoise SVN](http://tortoisesvn.tigris.org/) (choose version 1.6).
+
+## Dashes
+
+### En Dash
+
+Use an en dash (–) in definitions (do not capitalize the word after the en dash) and [number ranges](https://learn.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/enes).
+
+Use the keyboard shortcut`ALT` + `0150` (or `Option` + `Minus sign` on a Mac)
+
+> Reliable – this handles the sending and retrieving of changes in Subversion.
+
+> 2015–2017
+
+Use an en dash to set off introductory text in list items. If you use introductory text in a list item, make sure all other items in that list have introductory text too. Bold the introductory text if it appears in the UI. For more guidance about list formatting, see <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Lists>.
+
+> * **Decline** – Click this button to reject the request. You can also add a reason. After you decline the request, the submitter will receive a notification.
+> * **Download** – Click this button to download the MPK file of the component.
+
+### Em Dash
+
+Use an em dash (—) to set off a parenthetical phrase with more emphasis than parentheses provide. Don't add spaces around an em dash.
+
+Use the keyboard shortcut `ALT` + `0151` (or `Option` + `Shift` + `Minus sign` on a Mac)
+
+> The information in your page—numbers, formulas, and text—is stored in the database.
+>
+> If you're not sure about the details, look at the illustrations in the wizard—they can help you figure out what type of connection you're using.
+
+## Dates
+
+Dates should be written in the format **month day, year** where:
+
+* month is either the full month in English, or a three-letter abbreviation
+* [day is just the cardinal number](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Numbers) (16) not the ordinal number (16th)
+* year is four digits
+
+> September 25, 2023
+
+## Default Values
+
+Where a property (or other list of possibilities) has a default value, indicate this in one of the following ways.
+
+### Exhaustive Lists
+
+Where every possibility for a value is listed, identify the default value by following the value with the word *default* in italics and enclosed in parentheses. The values should be listed in the order they appear in the UI.
+
+You can put the values in a table.
+
+|  |  |
+| --- | --- |
+| **Value** | **Description** |
+| Small | The pop-up window is small, only a quarter of the screen |
+| Medium *(default)* | The pop-up window is medium-sized, around half the area of the screen |
+| Large | The pop-up window is large and takes up nearly the whole screen |
+
+Or you can put them in a bulleted list.
+
+> • Small – The pop-up window is small, only a quarter of the screen
+>
+> • Medium *(default)* – The pop-up window is medium-sized, around half the area of the screen
+>
+> • Large – The pop-up window is large and takes up nearly the whole screen
+
+### Non-Exhaustive
+
+Where you do not list all the values (for example, for a value which is represented by a number), add the default value as a new paragraph that just consists of "Default: *value*" with the *value* in italics.
+
+> **Size** indicates how much of the screen is taken up by the pop-up as a percentage.
+>
+> Default: *50*
+
+If you are documenting a property in the UI (for example, in a dialog box or wizard) and you are not listing and defining each option but still want to identify the default, add it in parentheses and bold the value (because it is a UI element).
+
+> **Start as** (default: **Collapsed**) – Determines whether the header content starts expanded or collapsed.
+
+## Document Types
+
+Capitalize when the document type is in a full title.
+
+> For details, see How to Create and Deploy Your First App.
+>
+> The Mendix Studio Guide…
+
+Do not capitalize when just talking about the how-tos generally.
+
+Refer to the various parts of the reference guide as "topics."
+
+> The reference guide topics…
+
+## Emphasis
+
+Do not use **bold** for emphasis in regular documentation. An exception is that bold can be used to emphasize product names and technical terms in release notes.
+
+Using *italics* for emphasis was permissible in the past, but because italics is reserved for user input/strings (which should always be in English), this interferes with machine translation (meaning, a word italicized for emphasis may not be translated when it should be). Using italics is no longer permissible for emphasis.
+
+## Entity Names
+
+Do not use single or double quotation marks. You may use italics if a user needs to type the entity name or bold if the name is on the screenshot and you are referring to it.
+
+## File Formats
+
+Capitalize file formats for consistency. This should make file formats consistent with <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Languages> (while covering both options if necessary).
+
+Note that file formats can differ from extensions, and file names and extensions are formatted differently (see below).
+
+> ZIP
+
+In the example above, ZIPis a format, not an extension. This is the way that ZIPshould be used and formatted regularly (because it is more common to refer to this as a format, and the extension can be *.zip* or *.ZIP*).
+
+For example file formats, see [List of File Formats](https://en.wikipedia.org/wiki/List_of_file_formats).
+
+## File Names, Directories, and Extensions
+
+Use lower case and italics for file names, directories, and extensions.
+
+> [*tech-writer.md*](http://tech-writer.md)
+>
+> *.htm*
+
+Note that *.plist* can be both an extension and a (blank) file itself (meaning, it would not have a proper file name).
+
+If you need to use the file extension as a word in a sentence, keep the period preceding the extension. When using an indefinite article ("a" or "an"), use the one that applies to the sound of the first letter of the extension (as though the period is not pronounced as "dot").
+
+> An *.exe* file…
+
+## Folder Names
+
+Bold folder names.
+
+> In the **config** folder.
+
+## Headings and Titles
+
+### Capitalization
+
+Capitalize all words in titles and headings of documents according to title case (meaning, do not capitalize words like a, an, the, at, by, for, in, of, on, to, and, as, but, or, nor, etc.). If there is a phrasal verb used in the title (like "Set Up"), capitalize the preposition as well ("Up").
+
+You can use this [Title Case Converter](https://titlecaseconverter.com/) tool to check your case and capitalize titles (according to the Chicago Manual of Style). Notethat you need to click **Convert** in the tool when checking titles.
+
+### Length
+
+Keep headings short. They should never render as longer than two lines on your laptop screen. Try to keep to a maximum of about 80 characters or 15 words.
+
+### Verb Form in Headings (for How-Tos and Reference Guide Topics)
+
+Use gerunds for conceptual/information topics (the top headings in the document's hierarchy).
+
+> Finding a File
+
+### Verb Form in How-To Titles
+
+Use an infinitive verb (without "to") for titles of how-tos. This way, the full title can include "How to" when it is used in a cross-reference or another situation.
+
+> Implement Application Logic Using Microflows
+>
+> For details, see How to Implement Application Logic Using Microflows.
+
+### Verb Form in Reference Guide Topics
+
+Use gerunds/noun phrases for the names of reference guide topic.
+
+> Using Eclipse
+
+When cross-referencing a reference guide topic, use the gerund/noun phrase + "in the Mendix Reference Guide."
+
+> For details, see Using Eclipse in the Mendix Reference Guide.
+
+## Italics
+
+Use italics when the user needs to enter text.
+
+> In the **Name** field, enter *Customer\_NewEdit\_Commit*.
+
+Also use italics when referencing one of the docs site page/guide titles (especially important when linking to only a section of a page).
+
+> For more information, see Repository in *Version Control Concepts*.
+>
+> The *Mendix Reference Guide* covers important topics on the Desktop Modeler, Web Modeler, Mendix Runtime, and other components of the Mendix Platform.
+
+Use italics for file names, directories, and extensions.
+
+Do not use italics for emphasis. For details, see Emphasis.
+
+Do not use italics on text that is hyperlinked for a cross-reference. The formatting for hyperlinking overrides the need to italicize or bold.
+
+## Keyboard Shortcuts
+
+To indicate a computer key, use the `kbd` element. For guidance on key names and capitalization, refer to <https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/keys-keyboard-shortcuts#key-names>.
+
+> Press the <kbd>Space</kbd> key.
+
+For key combinations, use the `kbd` element around each key and connect the keys with  `+` .
+
+> Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd>.
+
+For unversioned content and for Studio Pro 10 and above, include Mac instructions in parentheses on first mention.
+
+> Press <kbd>Ctrl</kbd> + <kbd>G</kbd> (or <kbd>Command</kbd> + <kbd>G</kbd> on a Mac).
+
+## Languages
+
+Capitalize languages. This should make languages consistent with <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#File-Formats> (while covering both options if necessary).
+
+> HTML, XML, XSC, WSDL
+
+## Latin Abbreviations
+
+Do not use "e.g." Use "For example,…" instead.
+
+> The pages (for example, the start and home pages) are…
+
+Do not use "i.e." Use "That is,…", "Meaning,…", or "As in,…" instead.
+
+> These panes are dockable (that is, you can move a pane to a different position on the screen and place it there).
+
+## Lists
+
+For technical guidance on lists, see Shortcodes, Markdown, and HTML.
+
+### Introducing Lists
+
+Use complete sentences to introduce bulleted and numbered lists. Do not assume the reader has read the heading and knows what will be in that section.
+
+> These are the components of the domain model:
+>
+> • Entities
+>
+> • Associations
+>
+> • Annotations
+
+This complete sentence introducing the list can reflect the heading (even if it is repetitive).
+
+> **Opening a Hybrid Example App**
+>
+> To open a hybrid example app, follow these steps:
+>
+> 1. Go to…
+
+### Number of List Items
+
+Do not use a list with only one bullet point or one step. Rewrite the single list item as a sentence or paragraph.
+
+### Numbering
+
+If you write a sentence that falls outside the numbered list (as in, it is not numbered and not indented to be parallel), do not continue numbering (for example, from "4."). Indent the sentence so it is parallel, integrate it into the previous or subsequent numbered item, or start a new numbered list (from "1.").
+
+### Grammar and Punctuation with Bulleted Lists
+
+Do not use commas at the end of bullet points.
+
+In general, do not use periods at the end of bullet points, as bullet points should list small entities or pieces of language, not complete sentences. However, in certain cases where a list of items needs to be presented and explained (for example, longer definitions, error messages, product features), using complete sentences and periods throughout a bullet point is fine. In this case, use sentence case capitalization. This is done often in the Platform Evaluation Guide, for example.
+
+You can use a colon at the end of a list item to introduce an image directly following the next step, helping to maintain the connection.
+
+If your list items contain introductory text, you can set the introductory text off with an en dash, with a space on either side (as shown in the <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#En-Dash> section).
+
+Make all the items in a list consistent in structure. If one item in the list uses introductory text, all items in the list should have introductory text. If one item uses full sentences with periods, all of them should.
+
+See this example:
+
+### Size of List Items
+
+Do not make paragraph-long bullet points or numbered steps. If you have several long bullet points, turn those into paragraphs and use sub-headings. If you have several long, numbered steps, use sub-steps.
+
+## Literal Text
+
+If you need to write text that includes Markdown symbols for bold or italics, without the styling of bold or italics applied, wrap the text in a code snippet (``).
+
+> `\_propertyName\_`
+
+To render a URL without it being automatically turned into a clickable link, you can also use code formatting. For more details, see <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#URLs>.
+
+> `www.my-example-address.com`
+
+## Menu Items
+
+Menu items should be capitalized.
+
+Menu items should be **bolded** in the documentation.
+
+## Numbers
+
+Write out numbers 1–10 (for example, "five") unless you are providing an example of data that is being entered into the system (in which case you would also italicize the number).
+
+> Five customers
+>
+> In the **Order** field, enter *5*.
+
+You can use ordinal numbers for positions in ranges of numbers and other technical purposes.
+
+Write out ordinal numbers for 1–10 (for example, "fifth"), just like for numbers above.
+
+> This is the fifth example
+
+Do not write out ordinal numbers for 11 and above, just use the number + the suffix.
+
+> 101st
+
+Do not use ordinal numbers for dates (for example, on release notes).
+
+> September 25, 2023
+
+## Person
+
+Address the reader of your documents using the second person instead of the first person: use "you" or "your" instead of "we", "our", or "us".
+
+Assume that the reader is the person who's doing the tasks that you're documenting. Use "you" instead of "user", or use "end-user" when referring to the user of a Mendix app built on the Mendix Platform.
+
+Always use "Mendix" instead of "we" in the regular documentation. Use "we" only in the Studio Pro release notes, which are written from the perspective of PMs or developers.
+
+## Personal or Sensitive Information
+
+In text, screenshots, and code samples, do not show any personal or sensitive information, which includes, but is not limited to, real names, real email addresses, profile pictures of real users, API keys, and OpenIDs. Remove or blur out this information, or replace it with fake information. You can replace an OpenID with a random UUID that you generate using a [UUID generator](https://www.uuidtools.com/v4).
+
+## Placeholders
+
+### Placeholders In Sample Code
+
+Placeholders in sample code represent values that the user must replace when they use the sample code. To indicate a placeholder in inline code, use code formatting, italics, and all caps. To indicate a placeholder in a code block, use all caps and introduce the code block with text instructions that further clarify what the user needs to replace. For details on how to apply italics and code formatting together, see Shortcodes, Markdown, and HTML.
+
+Follow [Google's placeholder guidance](https://developers.google.com/style/placeholders): Use a short but descriptive name for the placeholder; don't use generic text such as or "input" or "placeholder". Use uppercase characters with underscore delimiters, unless that doesn't make sense in context.
+
+> When using the following command, replace `*NAMESPACE\_NAME`* with the name of your namespace.
+
+wide760kubectl create namespace NAMESPACE\_NAME
+
+Do not add any ornaments around placeholders that are in sample code, unless they are part of the code.
+
+### Placeholders in Non-Code Elements
+
+In other cases, for instance, where placeholders are for Studio Pro UI elements, ornaments can be added if they would add clarity. Ornaments can be things like single quotation marks or braces, depending on how the product looks.
+
+> The selected page '*PAGE\_NAME*' expects an object of type '*OBJECT\_TYPE*', which is not available here.
+>
+> Go to the system texts editor: **App Explore** > **App '*****APP\_NAME*****'** > **System texts** > **Text**.
+
+## Plurals in Parentheses
+
+Do not put optional plurals in parentheses, for example "app(s)". Instead, use either the singular form or the plural form. If it is absolutely necessary to indicate both, write the singular form first, followed by "or" and the plural form, together in parentheses.
+
+> Register the app environment (or environments).
+
+## Quotation Marks and Apostrophes
+
+Use double quotation marks (") instead of single quotation marks (') in the text when necessary to bring attention to certain terms or differentiate terms.
+
+Single quotation marks (')—otherwise known as apostrophes in Unicode—should only be used in code snippets where necessary (meaning, where they are *actually* in the code, and not used to just *identify* code). In that case, apply code formatting (using "`" or "```"). They can be used as ornaments around placeholders only if they appear in the product UI. For more information, see [Placeholders](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Placeholders).
+
+## Serial Comma
+
+We use the serial comma. (And we defend its usage when necessary!)
+
+## Space After Period
+
+Use a single space between a period and the first word of the next sentence.
+
+## URLs
+
+Format an example URL (as in, one that does not need to be hyperlinked because it does not go to a Mendix or third-party site) with the Markdown code format. This is to avoid having the link appear as a broken third-party link during a link check.
+
+## Verb Tense
+
+Use present tense. The present tense is often easier to read and understand than the past or future tense. It is the best choice for most content. For more information, see the [Verb Tense](https://docs.microsoft.com/en-us/style-guide/grammar/verbs#verb-tense) section in *Microsoft Style Guide*.
+
+> Save the file. Gulp rebuilds the code in the console as soon as you save the file.

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/grammar-formatting.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/grammar-formatting.md
@@ -5,8 +5,6 @@ weight: 20
 description: "Guidelines on grammar, formatting, capitalization, punctuation, lists, headings, and other writing conventions for Mendix documentation."
 ---
 
-## Introduction
-
 ## Acronyms and Initialisms
 
 Define technical or obscure acronyms and initialisms, and write them out fully the first time before using them throughout the rest of the document.
@@ -132,9 +130,9 @@ Use these phrases consistently when cross-referencing:
 
 > For details on microflow expressions, see Triggering Logic Using Microflows.
 
-> For more information, see the [Troubleshooting](https://docs.mendix.com/refguide/install/#troubleshooting) section of *Installing Mendix Studio Pro*.
+> For more information, see the [Troubleshooting](/refguide/install/#troubleshooting) section of *Installing Mendix Studio Pro*.
 >
-> For more information, see the [Installing Studio Pro Offline](https://docs.mendix.com/refguide/install/#offline) section below.
+> For more information, see the [Installing Studio Pro Offline](/refguide/install/#offline) section below.
 
 Do not use bold or italics on text that is hyperlinked for a cross-reference. The formatting for hyperlinking overrides the need to bold or italicize.
 
@@ -144,7 +142,7 @@ Only link to URLs that use HTTPS. If you're working with a URL that uses HTTP, c
 
 #### APIs
 
-When cross-referencing an API (like Client or Mendix Runtime) that is hosted on <http://apidocs.rnd.mendix.com> but you are only cross-referencing the index (meaning, the general API or the API in its entirety), use a relative link to our docs page for that API: <https://docs.mendix.com/apidocs-mxsdk/apidocs/> .
+When cross-referencing an API (like Client or Mendix Runtime) that is hosted on <http://apidocs.rnd.mendix.com> but you are only cross-referencing the index (meaning, the general API or the API in its entirety), use a relative link to our docs page for that API: <https://docs.mendix.com/apidocs-mxsdk/apidocs/>.
 
 When cross-referencing an API method or a specific element of the API that the user needs to be directed to, use a link to <http://apidocs.rnd.mendix.com> . These links need to be updated/maintained per Studio Pro major version (and thus API version).
 
@@ -176,7 +174,7 @@ You can download it for free at [Tortoise SVN](http://tortoisesvn.tigris.org/) (
 
 ## Dashes
 
-### En Dash
+### En Dash {#en-dash}
 
 Use an en dash (–) in definitions (do not capitalize the word after the en dash) and [number ranges](https://learn.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/enes).
 
@@ -186,7 +184,7 @@ Use the keyboard shortcut`ALT` + `0150` (or `Option` + `Minus sign` on a Mac)
 
 > 2015–2017
 
-Use an en dash to set off introductory text in list items. If you use introductory text in a list item, make sure all other items in that list have introductory text too. Bold the introductory text if it appears in the UI. For more guidance about list formatting, see <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Lists>.
+Use an en dash to set off introductory text in list items. If you use introductory text in a list item, make sure all other items in that list have introductory text too. Bold the introductory text if it appears in the UI. For more guidance about list formatting, see [Lists](#lists).
 
 > * **Decline** – Click this button to reject the request. You can also add a reason. After you decline the request, the submitter will receive a notification.
 > * **Download** – Click this button to download the MPK file of the component.
@@ -206,7 +204,7 @@ Use the keyboard shortcut `ALT` + `0151` (or `Option` + `Shift` + `Minus sign` o
 Dates should be written in the format **month day, year** where:
 
 * month is either the full month in English, or a three-letter abbreviation
-* [day is just the cardinal number](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Numbers) (16) not the ordinal number (16th)
+* [day is just the cardinal number](#numbers) (16) not the ordinal number (16th)
 * year is four digits
 
 > September 25, 2023
@@ -272,9 +270,9 @@ Using *italics* for emphasis was permissible in the past, but because italics is
 
 Do not use single or double quotation marks. You may use italics if a user needs to type the entity name or bold if the name is on the screenshot and you are referring to it.
 
-## File Formats
+## File Formats {#file-formats}
 
-Capitalize file formats for consistency. This should make file formats consistent with <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Languages> (while covering both options if necessary).
+Capitalize file formats for consistency. This should make file formats consistent with [Languages](#languages) (while covering both options if necessary).
 
 Note that file formats can differ from extensions, and file names and extensions are formatted differently (see below).
 
@@ -372,9 +370,9 @@ For unversioned content and for Studio Pro 10 and above, include Mac instruction
 
 > Press <kbd>Ctrl</kbd> + <kbd>G</kbd> (or <kbd>Command</kbd> + <kbd>G</kbd> on a Mac).
 
-## Languages
+## Languages {#languages}
 
-Capitalize languages. This should make languages consistent with <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#File-Formats> (while covering both options if necessary).
+Capitalize languages. This should make languages consistent with [File Formats](#file-formats) (while covering both options if necessary).
 
 > HTML, XML, XSC, WSDL
 
@@ -388,7 +386,7 @@ Do not use "i.e." Use "That is,…", "Meaning,…", or "As in,…" instead.
 
 > These panes are dockable (that is, you can move a pane to a different position on the screen and place it there).
 
-## Lists
+## Lists {#lists}
 
 For technical guidance on lists, see Shortcodes, Markdown, and HTML.
 
@@ -428,7 +426,7 @@ In general, do not use periods at the end of bullet points, as bullet points sho
 
 You can use a colon at the end of a list item to introduce an image directly following the next step, helping to maintain the connection.
 
-If your list items contain introductory text, you can set the introductory text off with an en dash, with a space on either side (as shown in the <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#En-Dash> section).
+If your list items contain introductory text, you can set the introductory text off with an en dash, with a space on either side (as shown in the [En Dash](#en-dash) section).
 
 Make all the items in a list consistent in structure. If one item in the list uses introductory text, all items in the list should have introductory text. If one item uses full sentences with periods, all of them should.
 
@@ -444,7 +442,7 @@ If you need to write text that includes Markdown symbols for bold or italics, wi
 
 > `\_propertyName\_`
 
-To render a URL without it being automatically turned into a clickable link, you can also use code formatting. For more details, see <https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#URLs>.
+To render a URL without it being automatically turned into a clickable link, you can also use code formatting. For more details, see [URLs](#urls).
 
 > `www.my-example-address.com`
 
@@ -454,7 +452,7 @@ Menu items should be capitalized.
 
 Menu items should be **bolded** in the documentation.
 
-## Numbers
+## Numbers {#numbers}
 
 Write out numbers 1–10 (for example, "five") unless you are providing an example of data that is being entered into the system (in which case you would also italicize the number).
 
@@ -484,11 +482,25 @@ Assume that the reader is the person who's doing the tasks that you're documenti
 
 Always use "Mendix" instead of "we" in the regular documentation. Use "we" only in the Studio Pro release notes, which are written from the perspective of PMs or developers.
 
+## Procedures and Examples
+
+Use imperative mood for direct user instructions in procedural steps.
+
+> Click **Save**.
+>
+> Enter the command `ollama pull model-id`.
+
+Use descriptive language when referring to examples that illustrate the instructions. Do not write examples as if they are instructions to the user.
+
+> This example uses DeepSeek-R1.
+
+Do not convert descriptive example statements into imperative instructions, and do not convert instructions into passive descriptions.
+
 ## Personal or Sensitive Information
 
 In text, screenshots, and code samples, do not show any personal or sensitive information, which includes, but is not limited to, real names, real email addresses, profile pictures of real users, API keys, and OpenIDs. Remove or blur out this information, or replace it with fake information. You can replace an OpenID with a random UUID that you generate using a [UUID generator](https://www.uuidtools.com/v4).
 
-## Placeholders
+## Placeholders {#placeholders}
 
 ### Placeholders In Sample Code
 
@@ -520,7 +532,7 @@ Do not put optional plurals in parentheses, for example "app(s)". Instead, use e
 
 Use double quotation marks (") instead of single quotation marks (') in the text when necessary to bring attention to certain terms or differentiate terms.
 
-Single quotation marks (')—otherwise known as apostrophes in Unicode—should only be used in code snippets where necessary (meaning, where they are *actually* in the code, and not used to just *identify* code). In that case, apply code formatting (using "`" or "```"). They can be used as ornaments around placeholders only if they appear in the product UI. For more information, see [Placeholders](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2520678744/Grammar+Formatting#Placeholders).
+Single quotation marks (')—otherwise known as apostrophes in Unicode—should only be used in code snippets where necessary (meaning, where they are *actually* in the code, and not used to just *identify* code). In that case, apply code formatting (using "`" or "```"). They can be used as ornaments around placeholders only if they appear in the product UI. For more information, see [Placeholders](#placeholders).
 
 ## Serial Comma
 
@@ -530,7 +542,7 @@ We use the serial comma. (And we defend its usage when necessary!)
 
 Use a single space between a period and the first word of the next sentence.
 
-## URLs
+## URLs {#urls}
 
 Format an example URL (as in, one that does not need to be hyperlinked because it does not go to a Mendix or third-party site) with the Markdown code format. This is to avoid having the link appear as a broken third-party link during a link check.
 

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
@@ -34,7 +34,7 @@ These are branded Mendix product names. However, they do not always need "Mendix
 
 ### Apps
 
-Capitalize in all instances.
+Refers to a section of the Mendix Portal. Capitalize in all instances (when used in this context rather than as the plural of "app").
 
 This term replaces "Developer Portal", "Sprintr", "Platform Portal," and "Mendix App Platform." These terms are not to be used in the product UI or documentation.
 

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
@@ -1,0 +1,510 @@
+---
+title: "Mendix Product Naming Guide"
+url: /community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide/
+weight: 100
+description: "Guidelines on usage, capitalization, and spelling for Mendix product names and terms, including main products and other Mendix-specific terminology."
+---
+
+## Purpose of This Guide
+
+This guide presents the main Mendix product names, other Mendix terms, and partner terms currently being used in the Mendix Platform UI, the [Mendix Documentation](https://docs.mendix.com/), and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/welcome).
+
+The purpose of this guide is to provide guidelines on usage, capitalization, and spelling as well as notes on important details and terminology history where necessary. The goal of providing and applying these guidelines is to reach company-wide consensus on usage.
+
+The purpose of this guide is not to provide a definition for each term. Terminology details are only given here for clarification where necessary. Product definitions are found throughout the Mendix Documentation and Mendix Platform Evaluation Guide, and for the sake of maintenance, they are not duplicated or summarized here.
+
+For a term to be included in this guide, it should already appear in the Mendix Platform UI, Mendix Documentation, and/or Mendix Platform Evaluation Guide.
+
+A term may not already be included in this guide for the following reasons:
+
+* There are no specific usage guidelines or decisions on the term (at least not yet)
+* It is a generic term, not branded by Mendix (for example, "domain model," "page," "template," or "layout")
+* It is an internal-only term (for example, names of apps or technical terms only used on R&D teams)
+* The term does not feature uniquely enough in the UI to require usage guidelines (for example, on capitalization in documentation)
+* The term is outdated (meaning, usage of it has been decided against; for examples, see Terminology History)
+* The term should not be used in customer-facing resources
+
+This is a useful guide to reference when communicating about the Mendix Platform and especially when you want to [contribute to the Mendix documentation](https://docs.mendix.com/developerportal/community-tools/contribute-to-the-mendix-documentation).
+
+This guide does not give insights into the product roadmap or internal company operations.
+
+## Main Product Names
+
+These are branded Mendix product names. However, they do not always need "Mendix" in front of them in the documentation.
+
+### Apps
+
+Capitalize in all instances.
+
+This term replaces "Developer Portal", "Sprintr", "Platform Portal," and "Mendix App Platform." These terms are not to be used in the product UI or documentation. For more information, see Terminology History.
+
+### Mendix on Kubernetes
+
+Capitalize in all instances.
+
+Always use with "Mendix," so always use "Mendix on Kubernetes."
+
+This term replaces "Mendix for Private Cloud", which is not to be used in the product UI or documentation. For more information, see Terminology History.
+
+### Mendix Cloud
+
+Capitalize in all instances.
+
+Always use with "Mendix," so always use "Mendix Cloud."
+
+Do not use "the Mendix Cloud."
+
+There is now only one version of Mendix Cloud, so it is not necessary to mention a version number when referring to Mendix Cloud.
+
+### Mendix Cloud Dedicated
+
+Capitalize in all instances.
+
+Always use with "Mendix," so always use "Mendix Cloud Dedicated."
+
+There is no separate documentation for this as it works as Mendix Cloud, but is dedicated to a single company.
+
+### Mendix Catalog
+
+Refer to only as "the Catalog", or "your organization's Catalog".
+
+### Mendix Connect
+
+This is not one product, but a grouping of functionalities within Studio Pro, the Catalog, and Marketplace Connectors and Modules that allow for integration with external data. For history, see Data Hub.
+
+### Mendix Control Center
+
+Always capitalize.
+
+It is fine to use "Control Center."
+
+### Mendix Marketplace
+
+Capitalize in all instances, even when just writing "Marketplace."
+
+It is fine to use "the Mendix Marketplace" or "the Marketplace."
+
+### Mendix Platform
+
+Describes Mendix as a product and encompasses all the products released by Mendix (as in, Studio Pro, Apps, etc.).
+
+Capitalize "Platform" when used in "Mendix Platform."
+
+It is fine to use "the Mendix Platform," but do not use "the Platform" (or "the platform").
+
+> This is the power of the Mendix Platform.
+>
+> The platform includes Mendix Studio and our cloud hosting.
+
+### Mendix Portal
+
+The Mendix Portal includes Apps (which replaces "Developer Portal"), Control Center, the Mendix Community, Mendix Marketplace, Catalog, and Mendix Support.
+
+### Mendix Studio Pro
+
+The rebranded name for the Desktop Modeler as of Mendix 8.
+
+"Studio Pro" can be used where regular repetition is necessary in a doc. However, where possible, "Mendix" should be added to the product name.
+
+Capitalize in all instances.
+
+Do not use "the Mendix Studio Pro" or "the Studio Pro."
+
+When you need to also refer to the version of Mendix Runtime that is for a Studio Pro version, you can use the inclusive "Mendix {version number}." However, note that "Studio Pro {version number}" remains the preference for clearly expressing the Studio Pro version (as opposed to "Mendix," which refers to the whole platform and also a group of products released/updated around the same time as the GA release of a new Studio Pro major version, for example, "Mendix 9"). There are circumstances where "Mendix {version number}" can be used to avoid convoluted or confusing constructions, but be sure to maintain clarity.
+
+### Private Mendix Platform
+
+A solution for an air-gapped secure Mendix deployment.
+
+* Product name: **Private Mendix Platform** (capitalized). Example: *"We are proud to introduce our innovative new offering: Private Mendix Platform."*
+* Short form: **the Private Platform** (capitalized). Example: *"The Private Platform features key capabilities to support the full software development cycle for low-code applications."*
+* Generic form: **the platform** (used in possessive cases). Example: *"For ease of deployment, the platform also features a dependency-free build and deploy pipeline over Kubernetes."* This should not be used out-of-context and must be preceded with use of the full product name, in order to establish the correct shorthand reference.
+* Counted as: **an instance of Private Mendix Platform, several instances of Private Mendix Platform**
+* Contracted as: **a single subscription or license to Private Mendix Platform**
+* Delivered as: **a deployment of Private Mendix Platform**
+
+## Other Mendix Terms
+
+This section contains various Mendix terms that are used in the product UI and documentation.
+
+### application & app
+
+An "application" or "app" can be one of the following:
+
+* A local application
+* A Free App
+* A licensed application hosted on the Mendix Cloud; another cloud such as AWS, SAP Cloud, or IBM Cloud Portal; or on the user's own server
+
+Do not capitalize (meaning, do not write "Mendix App").
+
+Do not replace with "app project" (or "project") generically, even when referring to project management-like tasks. **Project** is still used in some UI text, but that usage is being phased out. Using "app" in all instances is prioritized.
+
+The full word "application" has a more well-rounded meaning to it (as in, web and mobile apps), whereas "app" may suggest just mobile apps to the reader. Accordingly, it can be better to use "application" at the beginning of documents and then switch to "app" later on. We want to make it clear that Mendix is not just for building mobile apps, but all kinds of applications.
+
+### App ID
+
+Always capitalize.
+
+### app team
+
+Does not need to be capitalized, and "team" should be used without the qualifier "app" where possible.
+
+### app template
+
+This is the term to use to reflect the create-new-app flow UI in the Developer Portal.
+
+Do not use "starter app."
+
+### App User
+
+For a definition of this term, see the [Access Management](/developerportal/collaborate/general-settings/#managing-app-users) section of the *Developer Portal Guide*.
+
+Capitalize in all instances.
+
+### Atlas UI
+
+Capitalize in all instances.
+
+Do not use just "Atlas."
+
+### Basic Package
+
+Capitalize "Basic" but not package. Use "Basic package" rather than "Basic license".
+
+### Build Server
+
+Capitalize in all instances (to parallel "Team Server" and "Model Server").
+
+### Builder
+
+This is a new way of creating XPath Expressions (or XPath Constraints) and was introduced in Mendix version 10.5.0 in beta.
+
+UX term is "Builder" but in the documentation it is called "visual Builder for XPath constraints".
+
+You can shorten this to "visual Builder", but do not capitalize "Visual Builder" except when beginning a sentence.
+
+### Business Engineer
+
+This is a team role. As such, it differs from the term "business developer," which is used in the Mendix Platform Evaluation Guide as a generic role and persona term.
+
+Capitalize in all instances.
+
+### Buzz
+
+Use "Buzz" on its own, unless you need to specify "Company Buzz" or "App Buzz" for context.
+
+Do not use "the Buzz" (unless the context demands it).
+
+### Company Contact
+
+Capitalize in all instances.
+
+### Custom Developer App
+
+For a definition of this term, see [Creating a Custom Developer App](/refguide/mobile/distributing-mobile-apps/building-native-apps/how-to-devapps/).
+
+Do not capitalize.
+
+### Deployment Package Repository
+
+Capitalize in all instances.
+
+### Fallback
+
+The name of the Mendix *high-availability* option which allows databases to be replicated via streaming between availability zones.
+
+Capitalize in all instances.
+
+### fast deploy & fast deployment
+
+Do not use "insta-deploy" or "instant redeploy."
+
+### Free App
+
+A Free App is an app that can be deployed to the Mendix Cloud without purchasing a specific license and is therefore free. There are restrictions on the resources available to a Free App. A Free App environment is a cloud environment, but it does not support complex or large applications. Free Apps are part of the Free Edition.
+
+This is different from an *Unlicensed App* which is an app deployed to an unlicensed environment on another cloud platform, such as SAP or Private Cloud.
+
+Capitalize in all instances.
+
+Do not use "Sandbox." For more information, see Terminology History.
+
+### Free Edition
+
+This is the package of offerings that users can employ without requiring a paid license.
+
+"Free Edition" replaced "Community Edition" in 2015, and was made a focus of the announcements at Mendix World 2019.
+
+Use to refer to the whole package of Mendix free offerings (Studio Pro, Studio, and Free Apps), not individual parts of the offering.
+
+Capitalize in all instances.
+
+### guided product introduction tour
+
+This describes the user guidance that is built into Mendix Studio. This is a generic term, so it can be applied as more user guidance is built.
+
+It should be qualified by the context/location. In the case of Studio, the generic term is qualified by the context/location in the Studio Release Notes like this: "A guided product introduction tour is now shown when you select **Start Your First App** from the **Introduction Tour** category when creating an app in the Mendix Developer Portal."
+
+Do not capitalize.
+
+### IdP
+
+IdP refers to the Identity Provider and is mostly used in Identity and Access Management (IAM) documentation.
+
+Do not use IDP.
+
+### LTS (Long-Term Support)
+
+As with any acronym the user may not recognize at first, write out the term "long-term support" in full for first usage and use the acronym "LTS" after that. If possible, link to [LTS, MTS & Monthly Releases](/releasenotes/studio-pro/lts-mts/) for more information.
+
+### MTS (Medium-Term Support)
+
+As with any acronym the user may not recognize at first, write out the term "medium-term support" in full for first usage and use the acronym "MTS" after that. If possible, link to [LTS, MTS & Monthly Releases](/releasenotes/studio-pro/lts-mts/) for more information.
+
+### Maia (Mendix AI Assistance)
+
+The rebranded name for "Mendix Assist (MxAssist)" as of Mendix version 10.12.0. For more information on Mendix Assist and MxAssist, see Terminology History.
+
+Use "Mendix AI Assistance (Maia)" for the whole product line when it is introduced for the first time. Use "Maia" subsequently for the whole product line. "Maia" is also the term that appears in the product UI.
+
+For specific Maia features, use the feature name directly: Logic Recommender, Workflow Recommender, Translation Generator, for instance.
+
+It is okay to include "Maia" as part of the feature name if it is introduced for the first time or if no near context about Maia is given: Maia Logic Recommender, Maia Workflow Recommender, Maia Translation Generator, for instance.
+
+Maia Chat is an exception: use "Maia Chat" instead of "Chat". Only use "Chat" in very rare cases: as a page title in the left navigation menu under the [Mendix AI Assistance (Maia)](/refguide/mendix-ai-assistance/) category.
+
+Capitalize in all instances.
+
+### Make It Native app
+
+Capitalize the name of the app ("Make It Native"), but do not capitalize "app."
+
+### Marketplace component
+
+This is the generic name of the individual add-on, widget, module, connector, app template, etc. available in the Mendix Marketplace.
+
+Do not use "Marketplace item."
+
+### Mendix Admin
+
+Capitalize in all instances.
+
+Do not use "Mendix Administrator."
+
+### Mendix mobile app
+
+"Mendix Developer App" is the name for the mobile app available for developers to test hybrid mobile apps.
+
+This term replaces "Mendix" and "Mendix Mobile app" (which are not to be used in the product UI or documentation – for more information, see Terminology History).
+
+Always use "the Mendix Developer App" and cross-reference [Getting the Mendix Developer App](/refguide8/getting-the-mendix-app/) where possible.
+
+### Mendix Client
+
+Capitalize in all instances.
+
+### Mendix Deployment Archive
+
+Capitalize in all instances.
+
+### Mendix Community
+
+Capitalize in all instances.
+
+This term replaces "Mendix Forum" (which is not to be used in the product UI or documentation – for more information, see Terminology History).
+
+### Mendix level
+
+Do not capitalize "level."
+
+### Mendix Metamodel
+
+Capitalize in all instances.
+
+### Mendix points
+
+Do not capitalize "points."
+
+### Mendix Platform Evaluation Guide
+
+Published at [mendix.com/evaluation-guide](https://www.mendix.com/evaluation-guide/welcome).
+
+Use the full name when referencing, not just "Evaluation Guide."
+
+### Mendix Profile
+
+This term replaces "Developer Profile" (which is not to be used in the product UI or documentation – for more information, see Terminology History).
+
+Capitalize in all instances.
+
+### Mendix Runtime
+
+This term replaces "Mendix Business Server" and "Business Engine" (which are not to be used in the product UI or documentation – for more information, see Terminology History).
+
+Capitalize in instances when referring to Runtime as part of the Mendix Platform. The best practice is to use a definite article for additional clarity: "the Mendix Runtime."
+
+Do not capitalize when referring to the generic "runtime" concept.
+
+> The Mendix Runtime executes the application model that is created in Studio Pro.
+>
+> This widget enables filtering a list view at runtime with various constraints.
+
+### Mendix Server
+
+This term is still in use, even though "Mendix Business Server" is no longer used. It can be useful when contrasting with the Mendix Client. In addition, it can be used to cover more than Mendix Runtime.
+
+Capitalize in all instances.
+
+### Mendix Service Console
+
+Capitalize in all instances.
+
+### Mendix Support
+
+Do not use "Customer Support," "Mendix Customer Support," or simply "Support."
+
+Capitalize in all instances.
+
+### Mendix Support Portal
+
+Do not use "Customer Portal" or "Customer Support Portal."
+
+Capitalize in all instances.
+
+### Mendix UI Framework
+
+Capitalize in all instances.
+
+### microflow
+
+Do not capitalize.
+
+### Model Server
+
+Capitalize in all instances (to parallel "Team Server" and "Build Server").
+
+### MSV
+
+This term refers to Mendix Solution Vendor (MSV), which is Independent Software Vendor (ISV) using Mendix low-code.
+
+### MxAssure
+
+Spell with "Mx" abbreviation as one word.
+
+### Native Builder
+
+Do not use "Native Oven".
+
+Capitalize in all instances.
+
+### on-premises
+
+When we talk about the physical location of hardware that contains Mendix software, we are referring to a location, or premises. "Premises" means the land and buildings owned by someone, especially by a company or organization.
+
+"Premise" means an idea or theory on which a statement or action is based. For example, "Your claim that you cannot build apps six times faster with Mendix than with traditional development is based on a false premise."
+
+Do not use "on-premise," "on premise," "on-prem," or "on prem."
+
+> On-premises deployment needs specific security considerations.
+
+### one-to-one & one-to-many associations
+
+For details on association properties, see [Association Properties](/refguide/association-properties/).
+
+Write as "one-to-one" and "one-to-many," not as "1-1" or "1-to-many."
+
+### Partner Profile
+
+Capitalize in all instances.
+
+### persistable & non-persistable
+
+For details on the persistability of entities, see [Persistability](/refguide/persistability/).
+
+Do not use "persistent" or "non-persistent."
+
+Do not use "transient" as a synonym for "persistable."
+
+### Platform APIs
+
+Capitalize to refer to the collection of [Mendix APIs](/apidocs-mxsdk/apidocs/).
+
+### Platform SDK
+
+Capitalize in all instances.
+
+### private/public Mendix Marketplace
+
+Do not capitalize "private" and "public" as qualifiers.
+
+### private cloud
+
+This is a generic term, so do not capitalize.
+
+This is different than Mendix for Private Cloud.
+
+### Product Owner
+
+Capitalize in all instances of the [team role](/developerportal/collaborate/app-roles/#team-roles).
+
+### production, acceptance & test environments
+
+Do not capitalize.
+
+### requirements management
+
+The [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/app-lifecycle/requirements-intro) specifies "requirements management" (or "Agile requirements management") as embedded in the Mendix Platform and not "project management."
+
+### Scrum
+
+This implementation of the Agile framework is explained at [Scrum.org](https://www.scrum.org/resources/what-is-scrum).
+
+Capitalize in all instances.
+
+### Scrum Master
+
+This is the correct capitalization for this team role.
+
+### Software Bill of Materials
+
+When abbreviating, use SBOM.
+
+Do not use SBoM.
+
+### Sprint
+
+Capitalize in all instances.
+
+### Studio Pro landing page
+
+The Studio Pro landing page refers to the page that contains **My Apps**, **Marketplace**, and **Developer Portal** tabs.
+
+Capitalize "Studio Pro".
+
+### sub-microflow
+
+Spell with a hyphen.
+
+### Team Server
+
+Capitalize in all instances. Use "the Team Server" or "Mendix Team Server".
+
+### Technical Contact
+
+Capitalize in all instances of this [role](/developerportal/general/app-roles/#technical-contact).
+
+### Theme Customizer
+
+Capitalize in all instances.
+
+### UI resources package
+
+Do not capitalize, as this is a generic term. **Atlas UI Resources** is an example of such a package, and the proper name of this package is capitalized in the Studio Pro UI.
+
+### Visual Builder
+
+See [Builder](#builder).
+
+### Workflow Engine
+
+Capitalize.

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/product-naming-guide.md
@@ -7,7 +7,7 @@ description: "Guidelines on usage, capitalization, and spelling for Mendix produ
 
 ## Purpose of This Guide
 
-This guide presents the main Mendix product names, other Mendix terms, and partner terms currently being used in the Mendix Platform UI, the [Mendix Documentation](https://docs.mendix.com/), and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/welcome).
+This guide presents the main Mendix product names, other Mendix terms, and partner terms currently being used in the Mendix Platform UI, the [Mendix Documentation](/), and the [Mendix Platform Evaluation Guide](https://www.mendix.com/evaluation-guide/welcome).
 
 The purpose of this guide is to provide guidelines on usage, capitalization, and spelling as well as notes on important details and terminology history where necessary. The goal of providing and applying these guidelines is to reach company-wide consensus on usage.
 
@@ -21,10 +21,10 @@ A term may not already be included in this guide for the following reasons:
 * It is a generic term, not branded by Mendix (for example, "domain model," "page," "template," or "layout")
 * It is an internal-only term (for example, names of apps or technical terms only used on R&D teams)
 * The term does not feature uniquely enough in the UI to require usage guidelines (for example, on capitalization in documentation)
-* The term is outdated (meaning, usage of it has been decided against; for examples, see Terminology History)
+* The term is outdated (meaning, usage of it has been decided against)
 * The term should not be used in customer-facing resources
 
-This is a useful guide to reference when communicating about the Mendix Platform and especially when you want to [contribute to the Mendix documentation](https://docs.mendix.com/developerportal/community-tools/contribute-to-the-mendix-documentation).
+This is a useful guide to reference when communicating about the Mendix Platform and especially when you want to [contribute to the Mendix documentation](/developerportal/community-tools/contribute-to-the-mendix-documentation).
 
 This guide does not give insights into the product roadmap or internal company operations.
 
@@ -36,7 +36,7 @@ These are branded Mendix product names. However, they do not always need "Mendix
 
 Capitalize in all instances.
 
-This term replaces "Developer Portal", "Sprintr", "Platform Portal," and "Mendix App Platform." These terms are not to be used in the product UI or documentation. For more information, see Terminology History.
+This term replaces "Developer Portal", "Sprintr", "Platform Portal," and "Mendix App Platform." These terms are not to be used in the product UI or documentation.
 
 ### Mendix on Kubernetes
 
@@ -44,7 +44,7 @@ Capitalize in all instances.
 
 Always use with "Mendix," so always use "Mendix on Kubernetes."
 
-This term replaces "Mendix for Private Cloud", which is not to be used in the product UI or documentation. For more information, see Terminology History.
+This term replaces "Mendix for Private Cloud", which is not to be used in the product UI or documentation.
 
 ### Mendix Cloud
 
@@ -52,9 +52,7 @@ Capitalize in all instances.
 
 Always use with "Mendix," so always use "Mendix Cloud."
 
-Do not use "the Mendix Cloud."
-
-There is now only one version of Mendix Cloud, so it is not necessary to mention a version number when referring to Mendix Cloud.
+Do not use "the Mendix Cloud", and do not mention a version number when referring to Mendix Cloud.
 
 ### Mendix Cloud Dedicated
 
@@ -62,7 +60,7 @@ Capitalize in all instances.
 
 Always use with "Mendix," so always use "Mendix Cloud Dedicated."
 
-There is no separate documentation for this as it works as Mendix Cloud, but is dedicated to a single company.
+There is no separate documentation for this because it works as Mendix Cloud, but is dedicated to a single company.
 
 ### Mendix Catalog
 
@@ -102,8 +100,6 @@ The Mendix Portal includes Apps (which replaces "Developer Portal"), Control Cen
 
 ### Mendix Studio Pro
 
-The rebranded name for the Desktop Modeler as of Mendix 8.
-
 "Studio Pro" can be used where regular repetition is necessary in a doc. However, where possible, "Mendix" should be added to the product name.
 
 Capitalize in all instances.
@@ -133,7 +129,7 @@ An "application" or "app" can be one of the following:
 
 * A local application
 * A Free App
-* A licensed application hosted on the Mendix Cloud; another cloud such as AWS, SAP Cloud, or IBM Cloud Portal; or on the user's own server
+* A licensed application hosted on Mendix Cloud; another cloud such as AWS, SAP Cloud, or IBM Cloud Portal; or on the user's own server
 
 Do not capitalize (meaning, do not write "Mendix App").
 
@@ -167,7 +163,7 @@ Capitalize in all instances.
 
 Do not use just "Atlas."
 
-### Basic Package
+### Basic package
 
 Capitalize "Basic" but not package. Use "Basic package" rather than "Basic license".
 
@@ -177,11 +173,7 @@ Capitalize in all instances (to parallel "Team Server" and "Model Server").
 
 ### Builder
 
-This is a new way of creating XPath Expressions (or XPath Constraints) and was introduced in Mendix version 10.5.0 in beta.
-
-UX term is "Builder" but in the documentation it is called "visual Builder for XPath constraints".
-
-You can shorten this to "visual Builder", but do not capitalize "Visual Builder" except when beginning a sentence.
+See [visual builder for XPath constraints](#visual-builder).
 
 ### Business Engineer
 
@@ -199,7 +191,7 @@ Do not use "the Buzz" (unless the context demands it).
 
 Capitalize in all instances.
 
-### Custom Developer App
+### custom developer app
 
 For a definition of this term, see [Creating a Custom Developer App](/refguide/mobile/distributing-mobile-apps/building-native-apps/how-to-devapps/).
 
@@ -223,17 +215,15 @@ Do not use "insta-deploy" or "instant redeploy."
 
 A Free App is an app that can be deployed to the Mendix Cloud without purchasing a specific license and is therefore free. There are restrictions on the resources available to a Free App. A Free App environment is a cloud environment, but it does not support complex or large applications. Free Apps are part of the Free Edition.
 
-This is different from an *Unlicensed App* which is an app deployed to an unlicensed environment on another cloud platform, such as SAP or Private Cloud.
+This is different from an *Unlicensed App*, which is an app deployed to an unlicensed environment on another cloud platform, such as SAP or Private Cloud.
 
 Capitalize in all instances.
 
-Do not use "Sandbox." For more information, see Terminology History.
+Do not use "Sandbox."
 
 ### Free Edition
 
 This is the package of offerings that users can employ without requiring a paid license.
-
-"Free Edition" replaced "Community Edition" in 2015, and was made a focus of the announcements at Mendix World 2019.
 
 Use to refer to the whole package of Mendix free offerings (Studio Pro, Studio, and Free Apps), not individual parts of the offering.
 
@@ -263,7 +253,7 @@ As with any acronym the user may not recognize at first, write out the term "med
 
 ### Maia (Mendix AI Assistance)
 
-The rebranded name for "Mendix Assist (MxAssist)" as of Mendix version 10.12.0. For more information on Mendix Assist and MxAssist, see Terminology History.
+The rebranded name for "Mendix Assist (MxAssist)" as of Mendix version 10.12.0.
 
 Use "Mendix AI Assistance (Maia)" for the whole product line when it is introduced for the first time. Use "Maia" subsequently for the whole product line. "Maia" is also the term that appears in the product UI.
 
@@ -295,7 +285,7 @@ Do not use "Mendix Administrator."
 
 "Mendix Developer App" is the name for the mobile app available for developers to test hybrid mobile apps.
 
-This term replaces "Mendix" and "Mendix Mobile app" (which are not to be used in the product UI or documentation – for more information, see Terminology History).
+This term replaces "Mendix" and "Mendix Mobile app" (which are not to be used in the product UI or documentation).
 
 Always use "the Mendix Developer App" and cross-reference [Getting the Mendix Developer App](/refguide8/getting-the-mendix-app/) where possible.
 
@@ -311,7 +301,7 @@ Capitalize in all instances.
 
 Capitalize in all instances.
 
-This term replaces "Mendix Forum" (which is not to be used in the product UI or documentation – for more information, see Terminology History).
+This term replaces "Mendix Forum" (which is not to be used in the product UI or documentation).
 
 ### Mendix level
 
@@ -333,13 +323,13 @@ Use the full name when referencing, not just "Evaluation Guide."
 
 ### Mendix Profile
 
-This term replaces "Developer Profile" (which is not to be used in the product UI or documentation – for more information, see Terminology History).
+This term replaces "Developer Profile" (which is not to be used in the product UI or documentation).
 
 Capitalize in all instances.
 
 ### Mendix Runtime
 
-This term replaces "Mendix Business Server" and "Business Engine" (which are not to be used in the product UI or documentation – for more information, see Terminology History).
+This term replaces "Mendix Business Server" and "Business Engine" (which are not to be used in the product UI or documentation).
 
 Capitalize in instances when referring to Runtime as part of the Mendix Platform. The best practice is to use a definite article for additional clarity: "the Mendix Runtime."
 
@@ -351,9 +341,7 @@ Do not capitalize when referring to the generic "runtime" concept.
 
 ### Mendix Server
 
-This term is still in use, even though "Mendix Business Server" is no longer used. It can be useful when contrasting with the Mendix Client. In addition, it can be used to cover more than Mendix Runtime.
-
-Capitalize in all instances.
+Capitalize in all instances. Don't use "Mendix Business Server".
 
 ### Mendix Service Console
 
@@ -441,13 +429,11 @@ Do not capitalize "private" and "public" as qualifiers.
 
 This is a generic term, so do not capitalize.
 
-This is different than Mendix for Private Cloud.
-
 ### Product Owner
 
 Capitalize in all instances of the [team role](/developerportal/collaborate/app-roles/#team-roles).
 
-### production, acceptance & test environments
+### production, acceptance, and test environments
 
 Do not capitalize.
 
@@ -501,9 +487,13 @@ Capitalize in all instances.
 
 Do not capitalize, as this is a generic term. **Atlas UI Resources** is an example of such a package, and the proper name of this package is capitalized in the Studio Pro UI.
 
-### Visual Builder
+### visual builder for XPath constraints {#visual-builder}
 
-See [Builder](#builder).
+This is a new way of creating XPath expressions (or XPath constraints) and was introduced in Mendix version 10.5.0 in beta.
+
+The UX term is "Builder" but in the documentation it is called "visual Builder for XPath constraints".
+
+You can shorten this to "visual builder", but do not capitalize "visual builder" except when beginning a sentence.
 
 ### Workflow Engine
 

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/terminology.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/terminology.md
@@ -1,0 +1,553 @@
+---
+title: "Terminology"
+url: /community-tools/contribute-to-mendix-docs/style-guide/terminology/
+weight: 30
+description: "Usage guidelines for general terminology in Mendix documentation, covering technical terms, formatting conventions, word choice, and inclusive language."
+---
+
+## How to Use This Section
+
+This section contains decisions and usage guidelines for general (non-Mendix specific) terminology, including inclusive language guidelines. For guidelines on Mendix-specific terminology, see the Mendix Product Naming Guide.
+
+Under each term are the following:
+
+Guidelines.
+
+> Example
+
+## 1-1 & one-to-one
+
+When referring to relationships and associations, it is better to write this out as "one-to-one" rather than "1-1." However, where space is limited (for example, in a long title), it may be preferable to use "1-1."
+
+## activities
+
+The best way to write an activity name is to capitalize the first word of the activity name and then to either add a cross-reference to the activity doc or to bold the activity name (in order to offset it from regular text somehow).
+
+> the [Create variable](/refguide/create-variable/) activity
+>
+> the **Create variable** activity
+
+## add-on
+
+When using as a category title or heading, only capitalize "Add" and add an "s" without an apostrophe.
+
+> Add-ons
+
+Note: this should not be used to describe APD, ATS, or QSM, as these are now referred to as [Partner Solutions](https://docs.mendix.com/appstore/partner-solutions/).
+
+## Agile
+
+Capitalize when referring to the methodology. We also capitalize "Scrum" and "Sprint."
+
+> Work in Agile.
+
+## AM / PM
+
+Use "AM" and "PM" for times, via the MSG.
+
+## angle brackets (not "pointy brackets")
+
+Use to refer to "< >".
+
+## app/application
+
+Use "app" or "application" when referring to apps in general. Do not capitalize (meaning, do not write "Mendix App").
+
+The full word "application" has a more well-rounded meaning to it (i.e., web and mobile apps), whereas "app" may connote just mobile app to the reader. Accordingly, it can be better to use "application" at the beginning of documents and then switch to "app" later on. We want to make it clear that Mendix is not just for building mobile apps, but all kinds of applications.
+
+In the context of development and project management, sometimes using "project" can significantly enhance the clarity of the concept, as demonstrated [here](https://docs.mendix.com/control-center/roles-and-permissions/#centralized-project-roles). In such cases, we can use "project" instead of "app" or "application". Note that such usage of "project" should be agreed upon between the Project Manager and the Technical Writer. For further guidelines, see [project](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2510356519/Terminology#project).
+
+## app owner
+
+This is not a formalized/Mendix term (in comparison to [App Contact](https://docs.mendix.com/developerportal/company-app-roles/#app-contact)), so we cannot assume the user knows what this is. This should be defined in general terms and made clearer via context (for example, via the "Copyright" example in the [MindSphere module documentation](https://docs.mendix.com/partners/siemens/mindsphere-module-details#3-1-configuring-the-os-bar)) that it is the user's responsibility to define/interpret what an app owner is for their app.
+
+## article, document, page
+
+When referring to a document, do not use "article." Use "document," "page," or the title of the document.
+
+## back end/front end & back-end/front-end
+
+Do not use if you can use a more specific term (such as SCSS folder or database).
+
+Two words as a noun. Hyphenate as an adjective.
+
+## beta, preview, general availability
+
+Do not capitalize when used generically. Most instances of using "beta" and "general availability" are generic.
+
+Capitalizing "Beta" can be done when the release is numbered in relation to the fact that it is beta: "Studio Pro 10 Beta 1," "Studio Pro 10 Beta 2," etc.
+
+References: [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/p/preview), [Software release cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle).
+
+## blocklist & safelist
+
+Use "block list" (noun) / "blocklist" (verb) instead of "blacklist."
+
+Use "safe list" (noun) / "safelist" (verb) instead of "whitelist."
+
+## Boolean & data types
+
+"Boolean" should be capitalized, as it is named after a person.
+
+Other data types should not be capitalized.
+
+## braces (not "curly brackets")
+
+Use to refer to "{ }".
+
+## brackets
+
+There are four types of brackets which should be referred to in the following ways:
+
+* "<>" – angle brackets
+* "{}" – braces
+* "()" – parentheses
+* "[]" – square brackets
+
+## buildpack
+
+Write as one word.
+
+## burndown chart
+
+Write as one word.
+
+## camelCase
+
+To be very specific on capitalization (and avoid using lesser-known terms like "PascalCase" and "dromedaryCase"), use "lowerCamelCase" and "UpperCamelCase" when specifying naming conventions.
+
+## certificate authority
+
+Do not capitalize.
+
+Can also be used as the "CA" acronym when referring to the actual certificates: "CA certificates."
+
+## checkbox
+
+Write as one word (following the *Microsoft Style Guide*).
+
+Use the verbs "select" and "clear."
+
+## check mark
+
+Write as two words (following the *Microsoft Style Guide*).
+
+## click
+
+Use "click" and not "click on."
+
+> Click **Name**.
+
+## data
+
+Always use with a singular verb.
+
+> All the data changed in a transaction is only available within that specific transaction.
+
+## data container
+
+This term is used for widgets that provide contained widgets with data (for example, a data view or list view).
+
+Previously, the more technical description "inside the context of an entity" was used.
+
+## dataset
+
+Write as one word.
+
+## deploy
+
+The act of putting a Mendix app into an environment where it has access to all the resources it needs to run. This is triggered in the Developer Portal, or in the modeler by clicking **Run** or **Run Locally**.
+
+Use *deploy to* when referring to a cloud environment.
+
+> Click **Run** to deploy the app to SAP BTP
+
+## dialog box
+
+A dialog box enables making configuration choices. It has menus and buttons for the user to interact with. In that way, it differs from a pop-up window.
+
+Do not use just "dialog" when describing a UI element.
+
+## dock
+
+Use "pane" instead.
+
+## double-click
+
+Hyphenate for the verb.
+
+For the noun, use "double-clicking".
+
+## drop-zone
+
+Hyphenate.
+
+## drop-down menu or list
+
+Use only if necessary to describe how an item such as a menu or list works or what it looks like.
+
+"Drop-down menu" is mostly used for where you select an option at the top-bar of an app. The selection will often take the user to a different page.
+
+"Drop-down list" is mostly used for selecting an option when there are a variety of options of available. A list is used where also a radio button or something like a list box could be used.
+
+Do not use "drop down" or "dropdown" as a noun to mean a menu or a list or as a verb to describe clicking a menu or downloading a file (unless referring to Mendix core widget).
+
+## email
+
+Do not hyphenate.
+
+## endpoint
+
+Write as one word.
+
+## end-user
+
+The user of a Mendix app (as in, an app team builds an app, and the end-users use that app).
+
+Hyphenate.
+
+## execute
+
+Use "run" instead of "execute," except where "execute" occurs in the code and thus for reasons of accuracy it must be used in the documentation.
+
+This is also advised by the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/e/execute).
+
+## exotic
+
+Use "unusual" instead of "exotic."
+
+> unusual DateTime formats
+
+## experimental
+
+Do not use the term experimental in the documentation. This can lead to issues with analysts and customers not believing that features can be used, particularly if they are not removed in a timely manner.
+
+If a stakeholder wants to use the term "experimental", strongly advise them not to. If necessary, use "beta" instead.
+
+## functionality
+
+Use in the singular as a mass noun. Do not use "functionalities."
+
+You are going to add more advanced functionality to the app.
+
+## Git
+
+Capitalize when referring to the system or using conceptually.
+
+Reference: [Git](https://git-scm.com/).
+
+## home page
+
+Write as two words.
+
+## hover over
+
+Use consistently.
+
+Do not use "mouse over."
+
+## how-to
+
+Do not capitalize as a document type unless it is in a category name or a heading, in which case use "How-to" or "How-tos."
+
+Do not add an apostrophe before the "s" to make plural, just use "how-tos."
+
+> The **Create and Deploy Your First App** how-to
+
+## inline
+
+Write as one word.
+
+## internet
+
+Do not capitalize.
+
+## internet of things
+
+Do not capitalize, even when introducing the acronym "IoT."
+
+## Java
+
+Java, and nearly all computer languages, should be capitalized. If in doubt, reference this list of [programming languages](https://en.wikipedia.org/wiki/List_of_programming_languages).
+
+## left/right
+
+Can use "left-side" and "right-side" as adjectives.
+
+> The left-side section of the window pane has been updated.
+
+However, it is even more clear to use "on the left side" and "on the right side."
+
+> The section on the right side of the window pane has been updated.
+
+To be even more specific, use "upper-left," "bottom-right," etc.
+
+> The bottom-left section of this window pane presents the properties.
+
+Do not use "left-hand" or "right-hand."
+
+## lifecycle
+
+Write as one word.
+
+## low-code, low code
+
+When used as an adjective, include a hyphen between the words. Otherwise, don't use a hyphen.
+
+Do not capitalize as a noun or as an adjective.
+
+> Mendix's low-code development platform.
+>
+> Low code is a new and emerging market.
+
+## lower-left/lower-right
+
+When used as an adjective, include a hyphen between the words.
+
+> The lower-right corner of the original image is mapped to the fourth corner of the parallelogram.
+
+Do not use "bottom left" and "bottom right".
+
+## master & slave
+
+Use "primary" or "leader" instead of "master," except where "master" occurs in the code and thus for reasons of accuracy it must be used in the documentation (until it is changed in the code). Other organizations (like Facebook) have replaced "master" with "main," and such cross-references also appear in the docs.
+
+Use "follower" instead of "slave," except where "slave" occurs in the code and thus for reasons of accuracy it must be used in the documentation (until it is changed in the code).
+
+## metamodel
+
+Write as one word. Do not capitalize.
+
+## Microsoft SQL Server
+
+Capitalize in all instances, as this is a Microsoft product.
+
+## mouse pointer
+
+Use this instead of "mouse cursor" or "cursor."
+
+## native mobile
+
+Use lower-case unless it is part of a term like "Mendix Native Mobile Builder".
+
+## navigation pane
+
+Use to refer to the navigation interface on the left side of the screen in the Developer Portal.
+
+Do not capitalize.
+
+> Select your app in the Developer Portal, then click **Backups** in the navigation pane.
+
+## no-code, no code
+
+When used as an adjective, include a hyphen between the words. Otherwise, don't use a hyphen.
+
+Do not capitalize as a noun or as an adjective.
+
+> It is a no-code development platform.
+>
+> No code is a new and emerging market.
+
+## N/A
+
+Use this (all-caps) acronym for "not available."
+
+## on-premises
+
+When we talk about the physical location of hardware that contains Mendix software, we're referring to a location, or premises. "Premises" means the land and buildings owned by someone, especially by a company or organization.
+
+"Premise" means something completely different: an idea or theory on which a statement or action is based. For example, "Your claim that Mendix can't build apps six times faster than traditional development are based on a false premise."
+
+Do not use "on-premise," "on premise," "on-prem," "on prem," or any other variation of "on-premises."
+
+> On-premises deployment is the process of…
+
+## pane (not "dock")
+
+Use "pane" to refer to the various movable and dockable window panes in the Modeler.
+
+Do not use "dock" as a synonym for pane. "Dockable window pane" is acceptable.
+
+## parentheses
+
+Refer to parentheses – "()" – rather than "round brackets" or just "brackets."
+
+## persistable vs. persistent
+
+"Persistable" is a property that is used in the UI of the Modeler, where you can choose to make an entity "persistable" or "non-persistable."
+
+"Persistable" can be used in this context to describe both the property and the entity. "Persistent" does not need to be used in this context, in order to avoid confusion.
+
+> The persistable property of an entity in the domain model defines…
+>
+> When an entity is declared persistable, a database table is created.
+
+## please
+
+Avoid using "please" in instructions unless the user is asked to do something very inconvenient or the product is to blame for a difficult situation (for example, via a known issue).
+
+## pop-up window
+
+A pop-up window displays information (for example, an error message). There is nothing the user can do with a pop-up window except read the information and close the window. Avoid confusion of UI elements between pop-up windows and dialog boxes (where the user can input something, select something, etc.).
+
+Never use just "pop-up" on its own to describe a UI entity.
+
+> A pop-up window will appear telling you the error code.
+
+## Postgres
+
+Capitalize, as this is the name of a product.
+
+## pronouns & gender identity
+
+Use "they" instead of "he," "she," "he/she," or "he or she." You can also use "the user."
+
+Use "their" instead of "his" or "her."
+
+> For the user and their application needs…
+
+Do not use "male" and "female" as data examples (in enumerations, for example) unless you are also adding "non-binary" and "unlisted." Due to changing terminology and discourse, it is best to avoid "male" and "female" as data examples altogether.
+
+## project
+
+Do not use generically. Use "app" instead.
+
+Only use when it appears in the UI.
+
+One exception where "project" can be used in explanatory or descriptive text is when it significantly enhances the clarity of the concept (in the context of development and project management), as demonstrated [here](https://docs.mendix.com/control-center/roles-and-permissions/#centralized-project-roles). Any such usage of "project" should be agreed upon between the Project Manager and the Technical Writer.
+
+## quick start
+
+Spell as two words without a hyphen.
+
+Spelling of this doc type varies in the industry, but the decision to go with two words is based on usage from [Siemens](https://cache.industry.siemens.com/dl/files/923/109739923/att_890063/v1/A5E31805656-06_SIPROCESS_GA700_KBA_en_en-US.pdf), [AWS](https://aws.amazon.com/quickstart/?solutions-all.sort-by=item.additionalFields.sortDate&solutions-all.sort-order=desc&awsf.filter-content-type=content-type%23quick-start&awsf.filter-tech-category=*all&awsf.filter-industry=*all), and [Microsoft](https://support.microsoft.com/en-au/office/microsoft-365-quick-starts-25f909da-3e76-443d-94f4-6cdf7dedc51e).
+
+## recommend
+
+Use "Mendix recommends" rather than "we recommend".
+
+## rethrow
+
+Write as one word.
+
+## revert vs. roll back
+
+"Revert" describes making an error look like it never happened. Use when a mistake happened that wasn't modeled (meaning, behavior outside of what was modeled).
+
+"Roll back" describes wanting to see what happened that caused the rollback. Use when a user makes a mistake and the app has been modeled to deal with that mistake (for example, canceling an order halfway through a process causes a rollback).
+
+The result of both situations is the same.
+
+## right-click
+
+Hyphenate for the verb.
+
+## role
+
+Do not capitalize job roles (for example, "business developer") unless they are Mendix user roles (for example, "Business Engineer," "SCRUM Master") or Mendix-internal titles (for example, "Product Manager" and "Customer Success Manager" for referring to communication between the Mendix community and Mendix).
+
+## SQL
+
+Stands for Structured Query Language.
+
+Does not have to be defined for the acronym.
+
+> An SQL statement
+
+## standalone
+
+Write as one word, not with a hyphen.
+
+## Scrum
+
+Capitalize in all instances. We also capitalize "Agile" and "Sprint."
+
+## sign in/sign out
+
+When referring to an action which is taking place, use "sign in" and "sign out" instead of "log in," "login," "log out," "log off," etc.
+
+When referring to a button or other element of the UI, refer to the UI text.
+
+> Sign out of the Developer Portal by clicking **Log out** in the menu under your avatar.
+
+## single sign-on
+
+Write "sign-on" with a hyphen for this compound noun.
+
+## Sprint
+
+Capitalize in all instances. We also capitalize "Agile" and "Scrum."
+
+## Subversion
+
+Capitalize in all instances (because this is a product name).
+
+## sync
+
+Can use, along with "synchronize". We can also use as a phrasal verb, such as "sync up" or "in sync with".
+
+## third-party
+
+Hyphenate.
+
+Do not use "3rd party."
+
+Do not use as a noun. Only use as an adjective.
+
+> Mendix integrates with third-party systems such as SAP.
+
+## time zone
+
+Spell as two words unless referencing code where it is one word (like in "`timezone`").
+
+## toggle
+
+Can use as a noun.
+
+You may notice an **Enable dev mode** toggle on the app home page.
+
+Can use as a verb.
+
+> Click this to toggle the protection level for the content.
+
+## upper left/upper right
+
+When used as an adjective, include a hyphen between the words.
+
+> The upper-left corner of the original image is mapped to the first corner of the parallelogram.
+
+Do not use "top left" and "top right".
+
+## user vs. end-user
+
+A "user" is a user of the Mendix Platform (apps in development, app projects, project management, Developer Portal, etc.).
+
+An "end-user" is a user of a Mendix app built on the platform. This term will be used less in the documentation, as we document for Mendix Platform users and not general Mendix app users in most cases.
+
+## v for version
+
+Use lower-case "v" and not "V" for abbreviating "version."
+
+You can use "v" for Mendix Cloud versions, API versions, and third-party products/references.
+
+> Mendix Cloud v4, Deploy API v3, OData v4
+
+Do not use a lower-case "v" to describe a version for Mendix, Studio Pro, Mendix Runtime, Native Builder, Native Mobile Builder, Native Template, or Make It Native app. Generally, Mendix products released in numbered versions (with release notes organized by numbered versions) do not need "v" (or "version") to describe the version. Just use {Mendix product name} + {version number}.
+
+> Studio Pro 10.1
+
+## version and above or below
+
+Use "above" (or "below") to describe the starting point for a range of applicable versions. Do not use "higher" or "later" (although these are not strictly incorrect; we just need to stay consistent).
+
+> For Studio Pro 10.1 and above . . .
+
+## web
+
+Do not capitalize.
+
+> Restart the web services.
+
+## X-axis & Y-axis
+
+Capitalize "X" and "Y".

--- a/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/terminology.md
+++ b/content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/terminology.md
@@ -33,7 +33,7 @@ When using as a category title or heading, only capitalize "Add" and add an "s" 
 
 > Add-ons
 
-Note: this should not be used to describe APD, ATS, or QSM, as these are now referred to as [Partner Solutions](https://docs.mendix.com/appstore/partner-solutions/).
+Note: this should not be used to describe APD, ATS, or QSM, as these are now referred to as [Partner Solutions](/appstore/partner-solutions/).
 
 ## Agile
 
@@ -55,11 +55,11 @@ Use "app" or "application" when referring to apps in general. Do not capitalize 
 
 The full word "application" has a more well-rounded meaning to it (i.e., web and mobile apps), whereas "app" may connote just mobile app to the reader. Accordingly, it can be better to use "application" at the beginning of documents and then switch to "app" later on. We want to make it clear that Mendix is not just for building mobile apps, but all kinds of applications.
 
-In the context of development and project management, sometimes using "project" can significantly enhance the clarity of the concept, as demonstrated [here](https://docs.mendix.com/control-center/roles-and-permissions/#centralized-project-roles). In such cases, we can use "project" instead of "app" or "application". Note that such usage of "project" should be agreed upon between the Project Manager and the Technical Writer. For further guidelines, see [project](https://mendix.atlassian.net/wiki/spaces/RNDHB/pages/2510356519/Terminology#project).
+In the context of development and project management, sometimes using "project" can significantly enhance the clarity of the concept, as demonstrated in [Centralized Project Roles](/control-center/roles-and-permissions/#centralized-project-roles). In such cases, we can use "project" instead of "app" or "application". Note that such usage of "project" should be agreed upon between the Project Manager and the Technical Writer. For further guidelines, see [project](#project).
 
 ## app owner
 
-This is not a formalized/Mendix term (in comparison to [App Contact](https://docs.mendix.com/developerportal/company-app-roles/#app-contact)), so we cannot assume the user knows what this is. This should be defined in general terms and made clearer via context (for example, via the "Copyright" example in the [MindSphere module documentation](https://docs.mendix.com/partners/siemens/mindsphere-module-details#3-1-configuring-the-os-bar)) that it is the user's responsibility to define/interpret what an app owner is for their app.
+This is not a formalized/Mendix term (in comparison to [App Contact](/developerportal/company-app-roles/#app-contact)), so we cannot assume the user knows what this is. This should be defined in general terms and made clearer via context (for example, via the "Copyright" example in the [MindSphere module documentation](/partners/siemens/mindsphere-module-details#3-1-configuring-the-os-bar)) that it is the user's responsibility to define/interpret what an app owner is for their app.
 
 ## article, document, page
 
@@ -408,13 +408,13 @@ Use "their" instead of "his" or "her."
 
 Do not use "male" and "female" as data examples (in enumerations, for example) unless you are also adding "non-binary" and "unlisted." Due to changing terminology and discourse, it is best to avoid "male" and "female" as data examples altogether.
 
-## project
+## project {#project}
 
 Do not use generically. Use "app" instead.
 
 Only use when it appears in the UI.
 
-One exception where "project" can be used in explanatory or descriptive text is when it significantly enhances the clarity of the concept (in the context of development and project management), as demonstrated [here](https://docs.mendix.com/control-center/roles-and-permissions/#centralized-project-roles). Any such usage of "project" should be agreed upon between the Project Manager and the Technical Writer.
+One exception where "project" can be used in explanatory or descriptive text is when it significantly enhances the clarity of the concept (in the context of development and project management), as demonstrated in [Centralized Project Roles](/control-center/roles-and-permissions/#centralized-project-roles). Any such usage of "project" should be agreed upon between the Project Manager and the Technical Writer.
 
 ## quick start
 


### PR DESCRIPTION
Adds Mendix style guide documentation and updates Claude Code configuration to use it.

- Adds style guide pages under content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/:
    - grammar-formatting.md — Grammar and formatting rules
    - terminology.md — General terminology guidance with capitalization and hyphenation rules
    - product-naming-guide.md — Mendix product names and terms reference
- Updates CLAUDE.md to reference the style guides
- Refines polish and proofread skills
    - Simplifies the proofread skill to better differentiate it from polish, which applies the style guide
    - Speeds up the polish skill and gets it to apply the in-repo style guidance

These changes create a single source of truth for documentation style decisions and enable more consistent automated editing.