### PR TITLE
Update prerequisites and add project ID section for release 2512

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/modules/siemens/capital-connector.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/siemens/capital-connector.md
@@ -17,7 +17,7 @@ The Capital connector is licensed under the [Apache V2.0 License](https://www.ap
 
 ### Prerequisites
  
-* Studio Pro version 10.24.3 or above
+* Studio Pro version 10.24.8 or above
 * A Capital instance, with licensed Capital Integration Server (CIS) enabled and running
 
 ### Dependencies {#dependencies}
@@ -70,6 +70,10 @@ For details on defining a filter, refer to the REST API documentation of your Ca
 ### Capital object IDs
 
 Some operations take an object ID as parameter. Many Capital objects have a `BaseID` attribute. For those that do not have this attribute, please use the ID getter microflow available in the toolbox. This takes the link attribute available on the associated metadata object, and returns the ID of the parent object.
+
+### Capital project IDs
+
+Sometimes you need the project ID as input for a REST operation. In case you don't have the project ID to your disposition, but you do have a metadata link attribute from a Capital object, you can use the exposed `Get project id for Capital object` microflow.
 
 ## Resources
 

--- a/content/en/docs/marketplace/platform-supported-content/modules/siemens/capital-connector.md
+++ b/content/en/docs/marketplace/platform-supported-content/modules/siemens/capital-connector.md
@@ -67,13 +67,13 @@ In the **Filtering** category of the toolbox, you can find microflows that allow
 
 For details on defining a filter, refer to the REST API documentation of your Capital instance. This is available by accessing `{protocol}://{host}:{port}/restapidocs/`.
 
-### Capital object IDs
+### Capital Object IDs
 
-Some operations take an object ID as parameter. Many Capital objects have a `BaseID` attribute. For those that do not have this attribute, please use the ID getter microflow available in the toolbox. This takes the link attribute available on the associated metadata object, and returns the ID of the parent object.
+Some operations take an object ID as parameter. Many Capital objects have a `BaseID` attribute. For those that do not have this attribute, use the ID getter microflow available in the toolbox. This takes the link attribute available on the associated metadata object, and returns the ID of the parent object.
 
-### Capital project IDs
+### Capital Project IDs
 
-Sometimes you need the project ID as input for a REST operation. In case you don't have the project ID to your disposition, but you do have a metadata link attribute from a Capital object, you can use the exposed `Get project id for Capital object` microflow.
+The project ID is sometimes required as input for a REST operation. If you do not have the project ID, but you do have a metadata link attribute from a Capital object, you can use the exposed `Get project id for Capital object` microflow.
 
 ## Resources
 


### PR DESCRIPTION
Updated the prerequisites for Studio Pro version and added information about Capital project IDs.

This update is for the new Capital Connector 2512 release. Please note that the release is managed by my colleagues Michiel Bijlsma and Sharath Nambala Shyamsundar since I will be on PTO until and including May 19. Release will probably take place early next week. For questions, please contact them.