### PR TITLE
Add research skills for docs and Evaluation Guide

### DIFF
--- a/.claude/skills/docs-research/SKILL.md
+++ b/.claude/skills/docs-research/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: docs-research
+description: "Locates and summarizes content across the Mendix documentation repository. Use when the user needs to find where a topic is documented or needs information from the docs."
+---
+
+# Docs Research
+
+Locate, read, and summarize content across 4,500+ Markdown files in the Mendix documentation repository.
+
+## Workflow
+
+1. Identify relevant topic(s) from the topic map below or by searching.
+2. Locate source files using the methods in Finding Content. When a question spans multiple topics, read files in parallel.
+3. Read the file(s) and extract passages relevant to the user's question.
+4. Respond using the output format below.
+
+## Finding Content
+
+| Goal | Method |
+|------|--------|
+| URL → source file | `bash .claude/scripts/resolve-doc-url.sh "/refguide/security/"` |
+| Find by filename | `glob "content/en/docs/**/*offline*.md"` |
+| Search body text | `grep "offline-first" --include="*.md" --path="content/en/docs/"` |
+| Find images | `glob "static/attachments/refguide/**/*.png"` |
+| Resolve a link target | Check `url:` in the target file's front matter |
+
+## Output Format
+
+1. **Direct answer** — Begin with a concise answer to the user's question.
+2. **Supporting details** — Provide relevant details, quoting key passages where helpful.
+3. **Citations** — End with a list of source links.
+
+If no relevant content is found, state that clearly and do not speculate.
+
+### Citation Format
+
+Cite each source as a markdown link using the page's `title` and `url` front matter fields:
+
+```
+[Page Title](https://docs.mendix.com{url})
+```
+
+For example, a page with `title: "Security"` and `url: /refguide/security/` is cited as:
+
+```
+[Security](https://docs.mendix.com/refguide/security/)
+```
+
+## Topic Map
+
+### Studio Pro Reference (`refguide/`)
+
+| Topic | Path | URL |
+|-------|------|-----|
+| App Modeling | `refguide/modeling/` | `/refguide/modeling/` |
+| Pages & UI | `refguide/modeling/pages/` | `/refguide/pages/` |
+| Domain Model | `refguide/modeling/domain-model/` | `/refguide/domain-model/` |
+| Application Logic | `refguide/modeling/application-logic/` | `/refguide/application-logic/` |
+| Security | `refguide/modeling/security/` | `/refguide/security/` |
+| Integration (REST, OData) | `refguide/modeling/integration/` | `/refguide/integration/` |
+| XPath | `refguide/modeling/xpath/` | `/refguide/xpath/` |
+| Resources | `refguide/modeling/resources/` | `/refguide/resources/` |
+| Consistency Errors | `refguide/modeling/consistency-errors/` | `/refguide/consistency-errors/` |
+| Menus & Studio Pro UI | `refguide/modeling/menus/` | `/refguide/menus/` |
+| AI Assistance (Maia) | `refguide/modeling/mendix-ai-assistance/` | `/refguide/mendix-ai-assistance/` |
+| App Explorer | `refguide/modeling/app-explorer/` | `/refguide/app-explorer/` |
+| Import/Export | `refguide/modeling/import-and-export/` | `/refguide/import-and-export/` |
+| Best Practices | `refguide/modeling/best-practices/` | `/refguide/modeling-best-practices/` |
+| Runtime | `refguide/runtime/` | `/refguide/runtime/` |
+| Java Programming | `refguide/java-programming/` | `/refguide/java-programming/` |
+| Version Control | `refguide/version-control/` | `/refguide/version-control/` |
+| Installation | `refguide/installation/` | `/refguide/installation/` |
+| Testing | `refguide/testing/` | `/refguide/testing/` |
+
+### Mobile Development (`refguide/mobile/`)
+
+| Topic | URL |
+|-------|-----|
+| Getting Started | `/refguide/mobile/getting-started-with-mobile/` |
+| Intro to Technologies | `/refguide/mobile/introduction-to-mobile-technologies/` |
+| Building Efficient Apps | `/refguide/mobile/building-efficient-mobile-apps/` |
+| Mobile UI Design | `/refguide/mobile/designing-mobile-user-interfaces/` |
+| Mobile Capabilities | `/refguide/mobile/using-mobile-capabilities/` |
+| Build, Test, Distribute | `/refguide/mobile/distributing-mobile-apps/` |
+| PWA Wrapper | `/refguide/mobile/pwa-wrapper/` |
+| Mobile Best Practices | `/refguide/mobile/best-practices/` |
+
+### How-Tos (`howto/`)
+
+| Topic | URL |
+|-------|-----|
+| Data Models | `/howto/data-models/` |
+| Front End (UI/UX) | `/howto/front-end/` |
+| Securing Your Data | `/howto/security/` |
+| Extensibility | `/howto/extensibility/` |
+
+### Deployment (`deployment/`)
+
+| Topic | URL |
+|-------|-----|
+| General | `/developerportal/deploy/general/` |
+| Mendix Cloud | `/developerportal/deploy/mendix-cloud-deploy/` |
+| Docker | `/developerportal/deploy/docker/` |
+| Azure | `/developerportal/deploy/mendix-on-azure/` |
+| Kubernetes / Private Cloud | `/developerportal/deploy/private-cloud/` |
+| SAP BTP | `/developerportal/deploy/sap-cloud-platform/` |
+| On-Premises | `/developerportal/deploy/on-premises-design/` |
+
+### Developer Portal (`developerportal/`)
+
+| Topic | URL |
+|-------|-----|
+| General | `/developerportal/general/` |
+| App Insights | `/developerportal/app-insights/` |
+| Project Management | `/developerportal/project-management/` |
+| Repository / Team Server | `/developerportal/repository/` |
+| Settings | `/developerportal/general-settings/` |
+
+### Control Center (`control-center/`)
+
+| Topic | URL |
+|-------|-----|
+| Apps | `/control-center/apps/` |
+| Company | `/control-center/company/` |
+| Content Curation | `/control-center/content-curation/` |
+| Entitlements | `/control-center/entitlements/` |
+| Marketplace | `/control-center/marketplace/` |
+| People | `/control-center/people/` |
+| Security | `/control-center/security/` |
+
+### Marketplace (`marketplace/`)
+
+| Topic | URL |
+|-------|-----|
+| Overview | `/appstore/overview/` |
+| Using Content | `/appstore/use-content/` |
+| Creating Content | `/appstore/creating-content/` |
+| Uploading Content | `/appstore/submit-content/` |
+| GenAI Capabilities | `/appstore/modules/genai/` |
+| Platform-Supported Content | `/appstore/platform-supported-content/` |
+| Partner Solutions | `/appstore/partner-solutions/` |
+
+### Other Sections
+
+| Section | URL |
+|---------|-----|
+| Catalog | `/catalog/` |
+| APIs & SDK | `/apidocs-mxsdk/` |
+| Release Notes | `/releasenotes/` |
+| Quickstarts | `/quickstarts/` |
+| Support | `/support/` |
+| Private Platform | `/private-mendix-platform/` |
+| Mendix Portal | `/portal/` |
+| Community Tools / Style Guide | `/community-tools/` |
+| Partners (AWS, SAP, Siemens, Snowflake) | `/partners/<name>/` |
+| Workstation | `/workstation/` |
+
+### Older Versions
+
+`refguide10/`, `refguide9/`, `refguide8/`, `howto10/`, `howto9/`, `howto8/` — same structure as current, for Studio Pro 10, 9, and 8.
+
+## Style Guide Location
+
+`content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/`:
+
+- `grammar-formatting.md` — Grammar and formatting rules
+- `terminology.md` — Term conventions
+- `product-naming-guide.md` — Product names
+
+## Conventions
+
+- `_index.md` = section landing page
+- `url` field: starts/ends with `/`, lowercase, hyphens only
+- Images: `{{< figure src="/attachments/..." alt="..." >}}`
+- Links: use `url` value (e.g., `[Security](/refguide/security/)`)
+- All paths relative to `content/en/docs/`

--- a/.claude/skills/docs-research/SKILL.md
+++ b/.claude/skills/docs-research/SKILL.md
@@ -13,6 +13,7 @@ Locate, read, and summarize content across 4,500+ Markdown files in the Mendix d
 2. Locate source files using the methods in Finding Content. When a question spans multiple topics, read files in parallel.
 3. Read the file(s) and extract passages relevant to the user's question.
 4. Respond using the output format below.
+5. Cite sources — End your response with a **Citations** section listing every source you consulted. This step is mandatory — never omit it.
 
 ## Finding Content
 
@@ -28,7 +29,7 @@ Locate, read, and summarize content across 4,500+ Markdown files in the Mendix d
 
 1. **Direct answer** — Begin with a concise answer to the user's question.
 2. **Supporting details** — Provide relevant details, quoting key passages where helpful.
-3. **Citations** — End with a list of source links.
+3. **Citations** (required) — You MUST end your response with a list of source links. Never omit this section.
 
 If no relevant content is found, state that clearly and do not speculate.
 

--- a/.claude/skills/evalguide-research/SKILL.md
+++ b/.claude/skills/evalguide-research/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: evalguide-research
+description: "Fetches and summarizes content from the Mendix Evaluation Guide to answer questions about platform capabilities, architecture, security, deployment, and governance."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Mendix Evaluation Guide Research
+
+Fetch and summarize content from the Mendix Evaluation Guide at `https://www.mendix.com/evaluation-guide/`.
+
+## Workflow
+
+1. Identify relevant topic(s) from the topic map below.
+2. Use WebFetch to fetch the full page(s). When a question spans multiple topics, fetch pages in parallel.
+3. Read the entire fetched content to find passages relevant to the user's question.
+4. Respond using the output format below.
+
+If the topic map does not cover the user's question, report that no relevant content was found in the Evaluation Guide.
+
+## Output Format
+
+1. **Direct answer** — Begin with a concise answer to the user's question.
+2. **Supporting details** — Provide relevant details, quoting key passages where helpful.
+3. **Citations** — End with a list of source links.
+
+If no relevant content is found, state that clearly and do not speculate.
+
+### Citation Format
+
+Cite each source as a markdown link using the page title and its full URL:
+
+```
+[Page Title](https://www.mendix.com/evaluation-guide/...)
+```
+
+For example:
+
+```
+[Runtime Security](https://www.mendix.com/evaluation-guide/security/runtime-security/)
+```
+
+## Topic Map
+
+All URLs are relative to `https://www.mendix.com`. Prepend the base URL when fetching.
+
+### Overview
+
+| Topic | URL |
+|-------|-----|
+| Welcome to Mendix | /evaluation-guide/what-is-mendix/ |
+| What You Can Build | /evaluation-guide/what-can-i-build/ |
+| Why Choose Mendix | /evaluation-guide/mendix-difference/ |
+| Industry Analysts | /evaluation-guide/gartner-forrester-mendix/ |
+| Digital Execution Practice | /evaluation-guide/digital-execution-practice/ |
+
+### Software Development Life Cycle
+
+| Topic | URL |
+|-------|-----|
+| SDLC Overview | /evaluation-guide/app-lifecycle/ |
+| Ideate | /evaluation-guide/app-lifecycle/ideate/ |
+| Prioritize | /evaluation-guide/app-lifecycle/prioritize/ |
+| Plan | /evaluation-guide/app-lifecycle/plan/ |
+| Develop | /evaluation-guide/app-lifecycle/develop/ |
+| Deploy | /evaluation-guide/app-lifecycle/deploy/ |
+| Operate | /evaluation-guide/app-lifecycle/operate/ |
+| Evaluate | /evaluation-guide/app-lifecycle/evaluate/ |
+
+### Deployment
+
+| Topic | URL |
+|-------|-----|
+| Deployment Overview | /evaluation-guide/deployment/ |
+| Deployment Flexibility | /evaluation-guide/deployment/flexibility/ |
+| Mendix Cloud Deployments | /evaluation-guide/deployment/mendix-cloud/ |
+| Private Cloud Deployments | /evaluation-guide/deployment/private-cloud/ |
+| Partner Cloud Deployments | /evaluation-guide/deployment/partner-cloud/ |
+
+### Architecture
+
+| Topic | URL |
+|-------|-----|
+| Architecture Overview | /evaluation-guide/architecture/ |
+| Architecture Principles | /evaluation-guide/architecture/architecture-principles/ |
+| Platform Architecture | /evaluation-guide/architecture/platform-architecture/ |
+| Cloud Architecture | /evaluation-guide/architecture/cloud-architecture/ |
+| Runtime Architecture | /evaluation-guide/architecture/runtime-architecture/ |
+| Twelve-Factor Architecture | /evaluation-guide/architecture/twelve-factor-architecture/ |
+| Openness & Extensibility | /evaluation-guide/architecture/openness-extensibility/ |
+
+### Security
+
+| Topic | URL |
+|-------|-----|
+| Security Overview | /evaluation-guide/security/ |
+| Introduction to Mendix Security | /evaluation-guide/security/introduction-to-mendix-security/ |
+| Organization & Compliance | /evaluation-guide/security/organization-compliance/ |
+| Platform Security | /evaluation-guide/security/platform-security/ |
+| Security Model | /evaluation-guide/security/security-model/ |
+| Runtime Security | /evaluation-guide/security/runtime-security/ |
+| Cloud Security | /evaluation-guide/security/cloud-security/ |
+| Secure Development Lifecycle | /evaluation-guide/security/secure-development-lifecycle/ |
+| Integrated Monitoring and Logging | /evaluation-guide/security/integrated-monitoring-and-logging/ |
+| Data Security | /evaluation-guide/security/data-security/ |
+| Governance, Risk, and Compliance | /evaluation-guide/security/governance-risk-and-compliance/ |
+
+### Governance
+
+| Topic | URL |
+|-------|-----|
+| Governance Overview | /evaluation-guide/governance/ |
+| Investment Control | /evaluation-guide/governance/investment-control/ |
+| Risk Control | /evaluation-guide/governance/risk-control/ |
+
+### Strategic Partnerships
+
+| Topic | URL |
+|-------|-----|
+| Strategic Partners Overview | /evaluation-guide/strategic-partners/ |
+| AWS | /evaluation-guide/strategic-partners/aws/ |
+| SAP | /evaluation-guide/strategic-partners/sap/ |
+| Snowflake | /evaluation-guide/strategic-partners/snowflake/ |
+
+### Getting Started
+
+| Topic | URL |
+|-------|-----|
+| Getting Started Overview | /evaluation-guide/evaluation-learning/ |
+| Try Mendix for Free | /evaluation-guide/evaluation-learning/try-mendix-for-free/ |
+| Learning | /evaluation-guide/evaluation-learning/certification-talent/ |
+| Company Onboarding | /evaluation-guide/evaluation-learning/company-onboarding/ |
+| Community | /evaluation-guide/evaluation-learning/community/ |
+| Support | /evaluation-guide/evaluation-learning/support/ |

--- a/.claude/skills/evalguide-research/SKILL.md
+++ b/.claude/skills/evalguide-research/SKILL.md
@@ -15,6 +15,7 @@ Fetch and summarize content from the Mendix Evaluation Guide at `https://www.men
 2. Use WebFetch to fetch the full page(s). When a question spans multiple topics, fetch pages in parallel.
 3. Read the entire fetched content to find passages relevant to the user's question.
 4. Respond using the output format below.
+5. Cite sources — End your response with a **Citations** section listing every source you consulted. This step is mandatory — never omit it.
 
 If the topic map does not cover the user's question, report that no relevant content was found in the Evaluation Guide.
 
@@ -22,7 +23,7 @@ If the topic map does not cover the user's question, report that no relevant con
 
 1. **Direct answer** — Begin with a concise answer to the user's question.
 2. **Supporting details** — Provide relevant details, quoting key passages where helpful.
-3. **Citations** — End with a list of source links.
+3. **Citations** (required) — You MUST end your response with a list of source links. Never omit this section.
 
 If no relevant content is found, state that clearly and do not speculate.
 

--- a/.claude/skills/release-research/SKILL.md
+++ b/.claude/skills/release-research/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: release-research
+description: "Researches Mendix release notes to find changes, new features, improvements, and bug fixes across Studio Pro and other product releases."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Mendix Release Research
+
+Research Mendix release notes to answer questions about new features, changes, improvements, and bug fixes introduced in specific versions or time periods.
+
+## Workflow
+
+### Step 1: Identify Scope
+
+Determine the version(s) or date range relevant to the user's question.
+
+### Step 2: Locate and Read Release Notes
+
+Use the methods below to find the appropriate files under `content/en/docs/releasenotes/`. Read the relevant file(s). When multiple files are needed, read them in parallel.
+
+| Goal | Method |
+|------|--------|
+| URL → source file | `bash .claude/scripts/resolve-doc-url.sh "/releasenotes/studio-pro/11.1/"` |
+| Find by filename | `glob "content/en/docs/releasenotes/studio-pro/11/*.md"` |
+| Search body text | `grep "React client" --include="*.md" --path="content/en/docs/releasenotes/"` |
+| Search by date | `grep "Release date:" --include="*.md" --path="content/en/docs/releasenotes/studio-pro/11/"` |
+
+### Step 3: Collect All Release Blog URLs
+
+After reading the release notes, search the content you just read for any markdown links matching `https://www.mendix.com/blog/...`. These look like:
+
+```
+[11.1 Mendix release blog](https://www.mendix.com/blog/mendix-11-1-more-power-less-effort/)
+```
+
+or:
+
+```
+[11.0 Mendix release blog](https://www.mendix.com/blog/mendix-release-11-0-start-with-ai-build-anything-the-next-era-of-enterprise-development-is-here/)
+```
+
+Collect ALL such URLs from ALL release notes files you read.
+
+### Step 4: Fetch Every Release Blog
+
+Fetch EVERY blog URL you collected in Step 3 using WebFetch. Fetch multiple blogs in parallel. Do NOT proceed to the response without fetching these blogs first.
+
+### Step 5: Parse Release Blogs
+
+Read the entire blog content and extract information relevant to the user's query. The blog structure varies between releases. Map the content to the original question, pulling out feature names, descriptions, and context regardless of heading structure. Ignore site navigation, footer, menus, and promotional boilerplate.
+
+### Step 6: Synthesize and Respond
+
+Combine information from BOTH the release notes AND the blog post(s). Always include insights from the blog when one was fetched. If a blog did not contain relevant information, state this. If no blog link was found for a version, state this.
+
+### Step 7: Cite Sources
+
+End your response with a **Citations** section listing every source you consulted. This step is mandatory — never omit it. Include:
+
+- Release notes pages (using their `url` front matter)
+- Blog posts (full URL)
+- Any other documentation files you read to answer the question
+
+## Identifying Versions by Date
+
+- Each patch/minor release has a date line: `**Release date: <month> <day>, <year>**`
+- For date-range queries (e.g., "H2 2025", "Q1 2025"), use Grep to search for `Release date:` across the relevant major version folder, then read matching files.
+- Date mappings: Q1=Jan–Mar, Q2=Apr–Jun, Q3=Jul–Sep, Q4=Oct–Dec; H1=Jan–Jun, H2=Jul–Dec
+
+## Scope
+
+Primary focus is **Studio Pro**, but also covers:
+
+| Product Area | Path |
+|---|---|
+| Studio Pro | `content/en/docs/releasenotes/studio-pro/` |
+| Deployment | `content/en/docs/releasenotes/deployment/` |
+| Developer Portal | `content/en/docs/releasenotes/developer-portal/` |
+| Mobile | `content/en/docs/releasenotes/mobile/` |
+| Marketplace | `content/en/docs/releasenotes/marketplace/` |
+| Control Center | `content/en/docs/releasenotes/control-center/` |
+| Private Platform | `content/en/docs/releasenotes/private-platform/` |
+| Catalog | `content/en/docs/releasenotes/catalog/` |
+
+## File Conventions
+
+- Studio Pro: `content/en/docs/releasenotes/studio-pro/{major}/{major}.{minor}.md`
+- Major versions available: 8, 9, 10, 11
+- Each file contains all patch releases for that minor version
+- Sections per release: New Features, Improvements, Fixes, Known Issues, Deprecations, Breaking Changes
+
+## Output Format
+
+1. **Direct answer** — Begin with a concise answer to the user's question.
+2. **Supporting details** — List relevant features, changes, or fixes with brief descriptions. Group by product area when covering multiple topics. Quote key passages where helpful.
+3. **Citations** (see Step 7) — Always included. Never omit.
+
+If no relevant content is found, state that clearly and do not speculate. If specific versions or date ranges yield no results, report which versions were checked and that no matching content was found.
+
+### Citation Format
+
+Always cite both the release notes and any blog posts you fetched. Use the page's `title` and `url` front matter fields for release notes:
+
+```
+[Studio Pro 10.21](https://docs.mendix.com/releasenotes/studio-pro/10.21/)
+```
+
+For blog posts, use the full URL:
+
+```
+[Mendix 11.1 Release Blog](https://www.mendix.com/blog/mendix-11-1-more-power-less-effort/)
+```
+
+## Example Queries
+
+- "What are the major features introduced in Mendix 11?"
+- "What is the most exciting feature in H2 2025?"
+- "When was the React client made default?"
+- "What changed in Studio Pro 10.21?"
+- "What workflow improvements were made in 2025?"
+- "What GenAI features were added recently?"

--- a/.github/prompts/evalguide-research.prompt.md
+++ b/.github/prompts/evalguide-research.prompt.md
@@ -1,0 +1,24 @@
+---
+description: Query the Mendix Evaluation Guide to find information about platform capabilities, architecture, security, deployment, and governance.
+---
+
+Query the Mendix Evaluation Guide at `https://www.mendix.com/evaluation-guide/` to answer questions about Mendix platform capabilities. Fetch the relevant page(s) using the topic overview below, summarize the key information, and cite the source URL(s).
+
+## Topic Overview
+
+| Section | Topics | Base URL |
+|---------|--------|----------|
+| **Overview** | Welcome, What You Can Build, Why Choose Mendix, Industry Analysts, Digital Execution Practice | `/evaluation-guide/` |
+| **SDLC** | Ideate, Prioritize, Plan, Develop, Deploy, Operate, Evaluate | `/evaluation-guide/app-lifecycle/` |
+| **Deployment** | Flexibility, Mendix Cloud, Private Cloud, Partner Cloud | `/evaluation-guide/deployment/` |
+| **Architecture** | Principles, Platform, Cloud, Runtime, Twelve-Factor, Openness & Extensibility | `/evaluation-guide/architecture/` |
+| **Security** | Intro, Organization & Compliance, Platform, Security Model, Runtime, Cloud, Secure Dev Lifecycle, Monitoring & Logging, Data Security, GRC | `/evaluation-guide/security/` |
+| **Governance** | Investment Control, Risk Control | `/evaluation-guide/governance/` |
+| **Strategic Partners** | AWS, SAP, Snowflake | `/evaluation-guide/strategic-partners/` |
+| **Getting Started** | Try Free, Learning, Company Onboarding, Community, Support | `/evaluation-guide/evaluation-learning/` |
+
+## Instructions
+
+1. Identify which topic(s) are relevant to the question.
+2. Fetch the page(s) from `https://www.mendix.com` + the topic URL (add subtopic slug as needed, e.g. `/evaluation-guide/security/cloud-security/`).
+3. Summarize concisely and cite source URLs.

--- a/.github/prompts/release-research.prompt.md
+++ b/.github/prompts/release-research.prompt.md
@@ -1,0 +1,42 @@
+---
+description: Research Mendix release notes and release blogs to find changes, new features, improvements, and bug fixes across Studio Pro and other products.
+---
+
+Research Mendix release notes to answer questions about new features, changes, improvements, and bug fixes introduced in specific versions or time periods.
+
+## CRITICAL RULE: Always Fetch Release Blogs
+
+When a release notes file contains a markdown link to `https://www.mendix.com/blog/...`, you MUST fetch that URL. Never skip this. The blog contains detailed feature descriptions not available in the release notes alone. Your response will be incomplete without it.
+
+## Instructions
+
+1. **Identify scope** — Determine the version(s) or date range from the user's question.
+2. **Locate and read release notes** — Find files under `content/en/docs/releasenotes/`. Studio Pro notes are at `studio-pro/{major}/{major}.{minor}.md` (major versions: 8, 9, 10, 11).
+3. **Collect all release blog URLs** — After reading, find every markdown link matching `https://www.mendix.com/blog/...` in the files you read.
+4. **Fetch EVERY release blog** — Use WebFetch on every blog URL collected. Fetch in parallel when multiple. Do NOT skip this step.
+5. **Parse release blogs** — Read the entire fetched content. Extract information relevant to the query regardless of blog structure. Ignore navigation/footer boilerplate.
+6. **Respond** — Combine information from BOTH release notes AND blog post(s). If no blog link exists for a version, report that. If information is not found, report that clearly. Cite all sources.
+
+## Date Ranges
+
+- Release dates appear as `**Release date: <month> <day>, <year>**`
+- For date queries, grep for `Release date:` across the relevant major version folder to find matching files.
+- Q1=Jan–Mar, Q2=Apr–Jun, Q3=Jul–Sep, Q4=Oct–Dec; H1=Jan–Jun, H2=Jul–Dec
+
+## Scope
+
+| Product Area | Path |
+|---|---|
+| Studio Pro (primary) | `content/en/docs/releasenotes/studio-pro/` |
+| Deployment | `content/en/docs/releasenotes/deployment/` |
+| Developer Portal | `content/en/docs/releasenotes/developer-portal/` |
+| Mobile | `content/en/docs/releasenotes/mobile/` |
+| Marketplace | `content/en/docs/releasenotes/marketplace/` |
+| Control Center | `content/en/docs/releasenotes/control-center/` |
+| Private Platform | `content/en/docs/releasenotes/private-platform/` |
+| Catalog | `content/en/docs/releasenotes/catalog/` |
+
+## Citation Format
+
+- Release notes: `[Studio Pro 10.21 Release Notes](/releasenotes/studio-pro/10.21/)`
+- Blog posts: `[Mendix 11.1 Release Blog](https://www.mendix.com/blog/mendix-11-1-more-power-less-effort/)`

--- a/.github/prompts/research.prompt.md
+++ b/.github/prompts/research.prompt.md
@@ -1,0 +1,134 @@
+---
+description: Locate content, resolve URLs to source files, and navigate the topic map to find relevant pages before editing or reviewing.
+---
+
+Locate content in the Mendix documentation repository using the topic map and search tools below. Return the source file path(s) and a brief summary of what each file contains.
+
+## Finding Content
+
+| Goal | Method |
+|------|--------|
+| URL → source file | Run `bash .claude/scripts/resolve-doc-url.sh "/refguide/security/"` |
+| Find by filename | Glob `content/en/docs/**/*<keyword>*.md` |
+| Search body text | Grep for the keyword in `content/en/docs/` |
+| Resolve a link target | Check the `url:` field in the target file's front matter |
+
+## Topic Map
+
+### Studio Pro Reference (`refguide/`)
+
+| Topic | Path | URL |
+|-------|------|-----|
+| App Modeling | `refguide/modeling/` | `/refguide/modeling/` |
+| Pages & UI | `refguide/modeling/pages/` | `/refguide/pages/` |
+| Domain Model | `refguide/modeling/domain-model/` | `/refguide/domain-model/` |
+| Application Logic | `refguide/modeling/application-logic/` | `/refguide/application-logic/` |
+| Security | `refguide/modeling/security/` | `/refguide/security/` |
+| Integration (REST, OData) | `refguide/modeling/integration/` | `/refguide/integration/` |
+| XPath | `refguide/modeling/xpath/` | `/refguide/xpath/` |
+| Resources | `refguide/modeling/resources/` | `/refguide/resources/` |
+| Consistency Errors | `refguide/modeling/consistency-errors/` | `/refguide/consistency-errors/` |
+| Menus & Studio Pro UI | `refguide/modeling/menus/` | `/refguide/menus/` |
+| AI Assistance (Maia) | `refguide/modeling/mendix-ai-assistance/` | `/refguide/mendix-ai-assistance/` |
+| App Explorer | `refguide/modeling/app-explorer/` | `/refguide/app-explorer/` |
+| Import/Export | `refguide/modeling/import-and-export/` | `/refguide/import-and-export/` |
+| Best Practices | `refguide/modeling/best-practices/` | `/refguide/modeling-best-practices/` |
+| Runtime | `refguide/runtime/` | `/refguide/runtime/` |
+| Java Programming | `refguide/java-programming/` | `/refguide/java-programming/` |
+| Version Control | `refguide/version-control/` | `/refguide/version-control/` |
+| Installation | `refguide/installation/` | `/refguide/installation/` |
+| Testing | `refguide/testing/` | `/refguide/testing/` |
+
+### Mobile Development (`refguide/mobile/`)
+
+| Topic | URL |
+|-------|-----|
+| Getting Started | `/refguide/mobile/getting-started-with-mobile/` |
+| Intro to Technologies | `/refguide/mobile/introduction-to-mobile-technologies/` |
+| Building Efficient Apps | `/refguide/mobile/building-efficient-mobile-apps/` |
+| Mobile UI Design | `/refguide/mobile/designing-mobile-user-interfaces/` |
+| Mobile Capabilities | `/refguide/mobile/using-mobile-capabilities/` |
+| Build, Test, Distribute | `/refguide/mobile/distributing-mobile-apps/` |
+| PWA Wrapper | `/refguide/mobile/pwa-wrapper/` |
+| Mobile Best Practices | `/refguide/mobile/best-practices/` |
+
+### How-Tos (`howto/`)
+
+| Topic | URL |
+|-------|-----|
+| Data Models | `/howto/data-models/` |
+| Front End (UI/UX) | `/howto/front-end/` |
+| Securing Your Data | `/howto/security/` |
+| Extensibility | `/howto/extensibility/` |
+
+### Deployment (`deployment/`)
+
+| Topic | URL |
+|-------|-----|
+| General | `/developerportal/deploy/general/` |
+| Mendix Cloud | `/developerportal/deploy/mendix-cloud-deploy/` |
+| Docker | `/developerportal/deploy/docker/` |
+| Azure | `/developerportal/deploy/mendix-on-azure/` |
+| Kubernetes / Private Cloud | `/developerportal/deploy/private-cloud/` |
+| SAP BTP | `/developerportal/deploy/sap-cloud-platform/` |
+| On-Premises | `/developerportal/deploy/on-premises-design/` |
+
+### Developer Portal (`developerportal/`)
+
+| Topic | URL |
+|-------|-----|
+| General | `/developerportal/general/` |
+| App Insights | `/developerportal/app-insights/` |
+| Project Management | `/developerportal/project-management/` |
+| Repository / Team Server | `/developerportal/repository/` |
+| Settings | `/developerportal/general-settings/` |
+
+### Control Center (`control-center/`)
+
+| Topic | URL |
+|-------|-----|
+| Apps | `/control-center/apps/` |
+| Company | `/control-center/company/` |
+| Content Curation | `/control-center/content-curation/` |
+| Entitlements | `/control-center/entitlements/` |
+| Marketplace | `/control-center/marketplace/` |
+| People | `/control-center/people/` |
+| Security | `/control-center/security/` |
+
+### Marketplace (`marketplace/`)
+
+| Topic | URL |
+|-------|-----|
+| Overview | `/appstore/overview/` |
+| Using Content | `/appstore/use-content/` |
+| Creating Content | `/appstore/creating-content/` |
+| Uploading Content | `/appstore/submit-content/` |
+| GenAI Capabilities | `/appstore/modules/genai/` |
+| Platform-Supported Content | `/appstore/platform-supported-content/` |
+| Partner Solutions | `/appstore/partner-solutions/` |
+
+### Other Sections
+
+| Section | URL |
+|---------|-----|
+| Catalog | `/catalog/` |
+| APIs & SDK | `/apidocs-mxsdk/` |
+| Release Notes | `/releasenotes/` |
+| Quickstarts | `/quickstarts/` |
+| Support | `/support/` |
+| Private Platform | `/private-mendix-platform/` |
+| Mendix Portal | `/portal/` |
+| Community Tools / Style Guide | `/community-tools/` |
+| Partners (AWS, SAP, Siemens, Snowflake) | `/partners/<name>/` |
+| Workstation | `/workstation/` |
+
+### Older Versions
+
+`refguide10/`, `refguide9/`, `refguide8/`, `howto10/`, `howto9/`, `howto8/` — same structure as current, for Studio Pro 10, 9, and 8.
+
+## Conventions
+
+- All paths are relative to `content/en/docs/`
+- `_index.md` = section landing page
+- `url` field in front matter: starts/ends with `/`, lowercase, hyphens only
+- Links use the `url` value, not the file path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ When instructions conflict, follow this order of precedence:
    - **`docs-add`** — Add new content to an existing page.
    - **`docs-alt-text`** — Generate W3C-compliant alt text for images.
    - **`evalguide-research`** — Query the Mendix Evaluation Guide to find information about platform capabilities, architecture, security, deployment, and governance.
+   - **`release-research`** — Research release notes and blogs to find new features, changes, and fixes across Mendix product releases.
 3. Overlay instruction files (for example, `.github/release-notes-instructions.md`) when path-scoped.
 4. This file (`CLAUDE.md`).
 5. Mendix Style Guide files in `content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/` for detailed grammar, terminology, and formatting rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,22 @@
 
 <!-- markdownlint-disable-file -->
 
-**Your role**: Edit and review Markdown documentation files under `content/en/docs/` following the style guidance and project-specific conventions below.
+**Your role**: Edit and review Markdown documentation files under `content/en/docs/` following the style guidance and project-specific conventions below. Alternatively, research and locate content across the documentation by navigating the topic map, resolving URLs to source files, and searching the repository — use the `docs-research` skill for this.
 
 ## Instruction Precedence
 
 When instructions conflict, follow this order of precedence:
 
 1. The user's current request.
-2. Task-specific prompt files in `.github/prompts/*.prompt.md` (for Copilot) or skills in `.claude/skills/*/SKILL.md` (for Claude) when explicitly referenced or invoked.
+2. Task-specific prompt files in `.github/prompts/*.prompt.md` (for Copilot) or skills in `.claude/skills/*/SKILL.md` (for Claude) when explicitly referenced or invoked. Available skills include:
+   - **`docs-research`** — Locate content, resolve URLs to source files, and navigate the topic map. Use before editing or reviewing when you need to find relevant pages.
+   - **`docs-review`** — Analyze a page and suggest improvements without editing.
+   - **`docs-pr-review`** — Analyze all changes in a pull request and suggest improvements.
+   - **`docs-enhance`** — Comprehensively rewrite and restructure a page.
+   - **`docs-polish`** — Apply style guide standards without restructuring.
+   - **`docs-proofread`** — Fix spelling, grammar, and punctuation only.
+   - **`docs-add`** — Add new content to an existing page.
+   - **`docs-alt-text`** — Generate W3C-compliant alt text for images.
 3. Overlay instruction files (for example, `.github/release-notes-instructions.md`) when path-scoped.
 4. This file (`CLAUDE.md`).
 5. Mendix Style Guide files in `content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/` for detailed grammar, terminology, and formatting rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ When instructions conflict, follow this order of precedence:
    - **`docs-proofread`** — Fix spelling, grammar, and punctuation only.
    - **`docs-add`** — Add new content to an existing page.
    - **`docs-alt-text`** — Generate W3C-compliant alt text for images.
+   - **`evalguide-research`** — Query the Mendix Evaluation Guide to find information about platform capabilities, architecture, security, deployment, and governance.
 3. Overlay instruction files (for example, `.github/release-notes-instructions.md`) when path-scoped.
 4. This file (`CLAUDE.md`).
 5. Mendix Style Guide files in `content/en/docs/community-tools/contribute-to-mendix-docs/style-guide/` for detailed grammar, terminology, and formatting rules.


### PR DESCRIPTION
Adds two new AI assistant skills to support research workflows across the documentation repository and the Mendix Evaluation Guide.
### Changes
docs-research skill (.claude/skills/docs-research/SKILL.md, .github/prompts/research.prompt.md)
- New skill for locating and summarizing content across the 4,500+ Markdown files in the docs repository
- Includes a topic map covering all major documentation sections (Studio Pro, mobile, deployment, Marketplace, etc.)
- Defines a consistent workflow: identify topics → find source files → extract relevant passages → respond with citations
- Companion Copilot prompt for the same research workflow

evalguide-research skill (.claude/skills/evalguide-research/SKILL.md, .github/prompts/evalguide-research.prompt.md)
- New skill for fetching and summarizing content from the Mendix Evaluation Guide at mendix.com/evaluation-guide/
- Covers platform capabilities, architecture, security, deployment, governance, and strategic partnerships
- Uses WebFetch to retrieve live content and returns direct answers with source citations
- Companion Copilot prompt for the same workflow

CLAUDE.md
- Updated the role description to mention research as a supported use case
- Added a full skill directory under the instruction precedence section so the agent knows which skill to invoke for each task type