### PR TITLE
Include example manifest for Cloud Foundry deployment

### DIFF
--- a/content/en/docs/deployment/on-premises-design/cloud-foundry/cloud-foundry-deploy-pad.md
+++ b/content/en/docs/deployment/on-premises-design/cloud-foundry/cloud-foundry-deploy-pad.md
@@ -46,6 +46,27 @@ To deploy your app to Cloud Foundry, perform the following steps:
       services:
       env:
     ```
-  
+
+ It should be a manifest like the following example
+
+``` yaml
+applications:
+- name: mx-java-app
+  path: <path-to-zip>
+  memory: 1G
+  buildpacks:
+  - java_buildpack
+  services:
+  - <service instance_id to be bind>
+  - <service instance_id to be bind>
+  env:
+    JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+}}'
+    JBP_LOG_LEVEL: INFO 
+    JAVA_OPTS: >
+      -Xmx512m
+      -Xms512m
+      -XX:MaxDirectMemorySize=20M
+      -XX:MaxMetaspaceSize=128M
+ ``` 
 5. Run the `cf push` command.
 6. Verify that the Mendix app has started successfully.

--- a/content/en/docs/deployment/on-premises-design/cloud-foundry/cloud-foundry-deploy-pad.md
+++ b/content/en/docs/deployment/on-premises-design/cloud-foundry/cloud-foundry-deploy-pad.md
@@ -47,26 +47,27 @@ To deploy your app to Cloud Foundry, perform the following steps:
       env:
     ```
 
- It should be a manifest like the following example
+    An example manifest file can look like the following:
 
-``` yaml
-applications:
-- name: mx-java-app
-  path: <path-to-zip>
-  memory: 1G
-  buildpacks:
-  - java_buildpack
-  services:
-  - <service instance_id to be bind>
-  - <service instance_id to be bind>
-  env:
-    JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+}}'
-    JBP_LOG_LEVEL: INFO 
-    JAVA_OPTS: >
-      -Xmx512m
-      -Xms512m
-      -XX:MaxDirectMemorySize=20M
-      -XX:MaxMetaspaceSize=128M
- ``` 
+    ``` yaml
+    applications:
+    - name: mx-java-app
+      path: <path-to-zip>
+        memory: 1G
+        buildpacks:
+        - java_buildpack
+        services:
+        - <service instance_id to be bind>
+        - <service instance_id to be bind>
+        env:
+          JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+}}'
+          JBP_LOG_LEVEL: INFO 
+          JAVA_OPTS: >
+            -Xmx512m
+            -Xms512m
+            -XX:MaxDirectMemorySize=20M
+            -XX:MaxMetaspaceSize=128M
+       ``` 
+
 5. Run the `cf push` command.
 6. Verify that the Mendix app has started successfully.


### PR DESCRIPTION
Added an example manifest for deploying a Java app on Cloud Foundry.