### PR TITLE
Add Firebase CocoaPods deprecation notice to FCM setup guide

### DIFF
--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -9,7 +9,9 @@ aliases:
 ---
 
 {{% alert color="info" %}}
-Google will stop publishing new Firebase versions to CocoaPods in October 2026, but existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix Native today will continue to build and run without interruption. Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, expected around September 2026. No action is required now.
+Google will stop publishing new Firebase versions to CocoaPods in October 2026. Existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix native today will continue to build and run without interruption. 
+
+Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, which we expect around September 2026. No action is required now.
 {{% /alert %}}
 
 ## Introduction

--- a/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -8,6 +8,10 @@ aliases:
     - /howto/mobile/setting-up-google-firebase-cloud-messaging-server/
 ---
 
+{{% alert color="info" %}}
+Google will stop publishing new Firebase versions to CocoaPods in October 2026, but existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix Native today will continue to build and run without interruption. Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, expected around September 2026. No action is required now.
+{{% /alert %}}
+
 ## Introduction
 
 This guide teaches you how to register native or progressive web apps (PWAs) for FCM and configure the service in your app.

--- a/content/en/docs/refguide10/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide10/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -8,6 +8,10 @@ aliases:
     - /howto10/mobile/setting-up-google-firebase-cloud-messaging-server/
 ---
 
+{{% alert color="info" %}}
+Google will stop publishing new Firebase versions to CocoaPods in October 2026, but existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix Native today will continue to build and run without interruption. Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, expected around September 2026. No action is required now.
+{{% /alert %}}
+
 ## Introduction
 
 You can use Google's Firebase Cloud Messaging (FCM) service to send push notifications to both Android and iOS devices. To send push notifications using FCM from the Push Notifications Connector module, you must set up a Firebase account with FCM enabled. This section teaches you how to register for FCM and configure the service in your app.

--- a/content/en/docs/refguide10/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
+++ b/content/en/docs/refguide10/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server.md
@@ -9,7 +9,9 @@ aliases:
 ---
 
 {{% alert color="info" %}}
-Google will stop publishing new Firebase versions to CocoaPods in October 2026, but existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix Native today will continue to build and run without interruption. Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, expected around September 2026. No action is required now.
+Google will stop publishing new Firebase versions to CocoaPods in October 2026. Existing published versions will remain available indefinitely — they will not be removed. This means apps using Firebase through Mendix native today will continue to build and run without interruption. 
+
+Mendix will update the Native Template to use Swift Package Manager once React Native ships official support, which we expect around September 2026. No action is required now.
 {{% /alert %}}
 
 ## Introduction


### PR DESCRIPTION
## Summary

Adds an info alert to the [Part 3: Set Up the Google Firebase Cloud Messaging Server](https://docs.mendix.com/refguide/mobile/using-mobile-capabilities/push-notifications/setting-up-google-firebase-cloud-messaging-server/) page informing customers of Google's plan to stop publishing Firebase to CocoaPods in October 2026.

## Details

- Google will stop publishing new Firebase versions to CocoaPods in October 2026
- Existing published versions remain available indefinitely — no immediate action required
- Mendix will update the Native Template to use Swift Package Manager once React Native ships official support (expected ~September 2026)
- Message has been validated with the Native Mobile tech lead