### PR TITLE
Add security warning for anonymous users setting

### DIFF
--- a/content/en/docs/refguide/modeling/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide/modeling/security/app-security/anonymous-users.md
@@ -21,6 +21,10 @@ The properties of anonymous users are described in the table below:
 | Allow anonymous users | When **Yes** is selected, anonymous users are allowed. End-users do not have to sign in to access the application. <br />When **No** is selected, anonymous users are not allowed. End-users have to sign in to access the application. |
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
+{{% alert color="warning" %}}
+Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+{{% /alert %}}
+
 ## Read More
 
 * [App Security](/refguide/app-security/)

--- a/content/en/docs/refguide/modeling/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide/modeling/security/app-security/anonymous-users.md
@@ -22,7 +22,7 @@ The properties of anonymous users are described in the table below:
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
 {{% alert color="warning" %}}
-Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+Enabling anonymous users allows anyone to use your app without signing in. To prevent unintended data exposure, ensure that the anonymous user role has limited access across your app by configuring appropriate entity and microflow access rules.
 {{% /alert %}}
 
 ## Read More

--- a/content/en/docs/refguide10/modeling/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide10/modeling/security/app-security/anonymous-users.md
@@ -21,6 +21,10 @@ The properties of anonymous users are described in the table below:
 | Allow anonymous users | When **Yes** is selected, anonymous users are allowed. End-users do not have to sign in to access the application. <br />When **No** is selected, anonymous users are not allowed. End-users have to sign in to access the application. |
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
+{{% alert color="warning" %}}
+Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+{{% /alert %}}
+
 ## Read More
 
 * [App Security](/refguide10/app-security/)

--- a/content/en/docs/refguide10/modeling/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide10/modeling/security/app-security/anonymous-users.md
@@ -22,7 +22,7 @@ The properties of anonymous users are described in the table below:
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
 {{% alert color="warning" %}}
-Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+Enabling anonymous users allows anyone to use your app without signing in. To prevent unintended data exposure, ensure that the anonymous user role has limited access across your app by configuring appropriate entity and microflow access rules.
 {{% /alert %}}
 
 ## Read More

--- a/content/en/docs/refguide9/modeling/app-explorer/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/security/app-security/anonymous-users.md
@@ -22,7 +22,7 @@ The properties of anonymous users are described in the table below:
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
 {{% alert color="warning" %}}
-Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+Enabling anonymous users allows anyone to use your app without signing in. To prevent unintended data exposure, ensure that the anonymous user role has limited access across your app by configuring appropriate entity and microflow access rules.
 {{% /alert %}}
 
 ## Read More

--- a/content/en/docs/refguide9/modeling/app-explorer/security/app-security/anonymous-users.md
+++ b/content/en/docs/refguide9/modeling/app-explorer/security/app-security/anonymous-users.md
@@ -21,6 +21,10 @@ The properties of anonymous users are described in the table below:
 | Allow anonymous users | When **Yes** is selected, anonymous users are allowed. End-users do not have to sign in to access the application. <br />When **No** is selected, anonymous users are not allowed. End-users have to sign in to access the application. |
 | Anonymous user role   | The user role that end-users of your application have when they are not signed in. This tells the application which role should be automatically applied to anonymous users who access the app. The **Allow anonymous users** property should be set to **Yes** to select an anonymous user role. |
 
+{{% alert color="warning" %}}
+Enabling anonymous users allows anyone to start using your app without signing in. If you do not secure your data with appropriate entity access rules for the anonymous user role, this can lead to unintended data exposure.
+{{% /alert %}}
+
 ## Read More
 
 * [App Security](/refguide9/app-security/)


### PR DESCRIPTION
Adds a warning alert below the Anonymous Users properties table to inform developers that enabling anonymous users allows anyone to access the app without signing in, and that without appropriate entity access rules on the anonymous user role, this can lead to unintended data exposure.