### PR TITLE
Add retry and node_modules cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,21 +37,16 @@ branches:
 #     - name: hugo
 #       channel: extended/stable # needs extended to compile SCSS etc. Issue if snap is not updated correctly
 
-# cache:
-######## Skipped
-#
-# Is there anything worth cacheing that isn't currently cached?
-# see https://docs.travis-ci.com/user/caching/#how-does-caching-work
-# Probably NOT /static
-# Docsy theme?
-# Custom layouts?
-# SASS/CSS
-#
+cache:
+# Cache node_modules to avoid re-downloading on every build
+# See https://docs.travis-ci.com/user/caching/
+  directories:
+    - node_modules
 
 before_install:
 ###############
   # Hugo, Docsy and dependencies are installed via npm
-  - npm install # use npm rather than yarn - HUGO doesn't have that many dependencies
+  - travis_retry npm install # use npm rather than yarn - HUGO doesn't have that many dependencies
   #
   # Currently will use custom version of htmltest stored in /htmltest/htmltest
   # This version makes the html.Parse much smaller

--- a/content/en/docs/genai/how-to/creating-agents/create-agent-programmatically.md
+++ b/content/en/docs/genai/how-to/creating-agents/create-agent-programmatically.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Introduction
 
-This approach uses microflows and GenAI Commons building blocks to define agents programmatically. You start with a prompt at runtime but configure tools and knowledge base retrieval directly in microflow logic at design time. This approach provides maximum control and debugging capabilities, making it useful for specific use cases or when the agent logic needs to be part of the code repository.
+This approach uses microflows and GenAI Commons building blocks to define agents programmatically. You start with a prompt at runtime but configure tools and knowledge base retrieval directly in microflow logic at design time. This approach provides maximum control and debugging capabilities, making it useful for specific use cases or when the agent logic needs to be part of the code repository. 
 
 ## Prerequisites
 

--- a/content/en/docs/genai/how-to/creating-agents/create-agent-programmatically.md
+++ b/content/en/docs/genai/how-to/creating-agents/create-agent-programmatically.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Introduction
 
-This approach uses microflows and GenAI Commons building blocks to define agents programmatically. You start with a prompt at runtime but configure tools and knowledge base retrieval directly in microflow logic at design time. This approach provides maximum control and debugging capabilities, making it useful for specific use cases or when the agent logic needs to be part of the code repository. 
+This approach uses microflows and GenAI Commons building blocks to define agents programmatically. You start with a prompt at runtime but configure tools and knowledge base retrieval directly in microflow logic at design time. This approach provides maximum control and debugging capabilities, making it useful for specific use cases or when the agent logic needs to be part of the code repository.
 
 ## Prerequisites
 


### PR DESCRIPTION
Cache node_modules to save ~40 seconds on Travis runs: setting up build cache takes about 6 additional seconds, but npm_install drops from 50 seconds to less than a second because it only has to download or update packages when the dependencies change. Add retry logic to npm install in case of timeouts.