### PR TITLE
Update Marketplace React status: Audittrail/DatabaseReplication now ready, AnyChart deprecated note

### DIFF
--- a/content/en/docs/refguide/runtime/mendix-client/content-readiness.md
+++ b/content/en/docs/refguide/runtime/mendix-client/content-readiness.md
@@ -18,16 +18,16 @@ The following table shows which of the more popular platform-supported Marketpla
 | Marketplace Component | React Client Ready | Alternative |
 | --- | --- | --- |
 | [Administration Module](https://marketplace.mendix.com/link/component/23513) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [AnyChart](https://marketplace.mendix.com/link/component/106517) | {{< icon name="remove-circle-filled" color="red" >}} |  CustomChart from [Charts](https://marketplace.mendix.com/link/component/105695) |
+| [AnyChart](https://marketplace.mendix.com/link/component/106517) | {{< icon name="remove-circle-filled" color="red" >}} | AnyChart is deprecated and will not be made React compatible. Use CustomChart from [Charts](https://marketplace.mendix.com/link/component/105695) instead. |
 | [Atlas Core](https://marketplace.mendix.com/link/component/117187) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Atlas Native Content](https://marketplace.mendix.com/link/component/117175) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Atlas Web Content](https://marketplace.mendix.com/link/component/117183) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [Audittrail](https://marketplace.mendix.com/link/component/138) | {{< icon name="remove-circle-filled" color="red" >}} | |
+| [Audittrail](https://marketplace.mendix.com/link/component/138) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [AWS Authentication Connector](https://marketplace.mendix.com/link/component/120333) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Community Commons](https://marketplace.mendix.com/link/component/170) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Data Widgets](https://marketplace.mendix.com/link/component/116540) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Database Connector](https://marketplace.mendix.com/link/component/2888) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [DatabaseReplication](https://marketplace.mendix.com/link/component/160) | {{< icon name="remove-circle-filled" color="red" >}} | |
+| [DatabaseReplication](https://marketplace.mendix.com/link/component/160) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Deep Link Module](https://marketplace.mendix.com/link/component/43) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Email Connector](https://marketplace.mendix.com/link/component/120739) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Encryption](https://marketplace.mendix.com/link/component/1011) | {{< icon name="checkmark-circle-filled" color="green" >}} | |

--- a/content/en/docs/refguide/runtime/mendix-client/content-readiness.md
+++ b/content/en/docs/refguide/runtime/mendix-client/content-readiness.md
@@ -47,7 +47,7 @@ The following table shows which of the more popular platform-supported Marketpla
 | [OIDC SSO](https://marketplace.mendix.com/link/component/120371) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Push Notifications Connector](https://marketplace.mendix.com/link/component/3003) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [SAML](https://marketplace.mendix.com/link/component/1174) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [SCIM](https://marketplace.mendix.com/link/component/229630) | {{< icon name="remove-circle-filled" color="red" >}} | |
+| [SCIM](https://marketplace.mendix.com/link/component/229630) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [UnitTesting](https://marketplace.mendix.com/link/component/390) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [UserCommons](https://marketplace.mendix.com/link/component/223053) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Web Actions](https://marketplace.mendix.com/link/component/114337) | {{< icon name="checkmark-circle-filled" color="green" >}} | |

--- a/content/en/docs/refguide10/runtime/mendix-client/content-readiness.md
+++ b/content/en/docs/refguide10/runtime/mendix-client/content-readiness.md
@@ -18,16 +18,16 @@ The following table shows which of the more popular platform-supported Marketpla
 | Marketplace Component | React Client Ready | Alternative |
 | --- | --- | --- |
 | [Administration Module](https://marketplace.mendix.com/link/component/23513) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [AnyChart](https://marketplace.mendix.com/link/component/106517) | {{< icon name="remove-circle-filled" color="red" >}} |  CustomChart from [Charts](https://marketplace.mendix.com/link/component/105695) |
+| [AnyChart](https://marketplace.mendix.com/link/component/106517) | {{< icon name="remove-circle-filled" color="red" >}} | AnyChart is deprecated and will not be made React compatible. Use CustomChart from [Charts](https://marketplace.mendix.com/link/component/105695) instead. |
 | [Atlas Core](https://marketplace.mendix.com/link/component/117187) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Atlas Native Content](https://marketplace.mendix.com/link/component/117175) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Atlas Web Content](https://marketplace.mendix.com/link/component/117183) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [Audittrail](https://marketplace.mendix.com/link/component/138) | {{< icon name="remove-circle-filled" color="red" >}} | |
+| [Audittrail](https://marketplace.mendix.com/link/component/138) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [AWS Authentication Connector](https://marketplace.mendix.com/link/component/120333) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Community Commons](https://marketplace.mendix.com/link/component/170) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Data Widgets](https://marketplace.mendix.com/link/component/116540) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Database Connector](https://marketplace.mendix.com/link/component/2888) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
-| [DatabaseReplication](https://marketplace.mendix.com/link/component/160) | {{< icon name="remove-circle-filled" color="red" >}} | |
+| [DatabaseReplication](https://marketplace.mendix.com/link/component/160) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Deep Link Module](https://marketplace.mendix.com/link/component/43) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Email Connector](https://marketplace.mendix.com/link/component/120739) | {{< icon name="checkmark-circle-filled" color="green" >}} | |
 | [Encryption](https://marketplace.mendix.com/link/component/1011) | {{< icon name="checkmark-circle-filled" color="green" >}} | |


### PR DESCRIPTION
## Summary

Updates the Marketplace Component React Status page based on team feedback:

- **AnyChart**: Added a note that AnyChart is deprecated and will not be made React compatible. The Charts alternative (CustomChart) was already listed.
- **Audittrail**: Marked as React-ready. A release updated all widgets to React widgets (confirmed with DataStorage).
- **DatabaseReplication**: Marked as React-ready. Same release update as Audittrail (confirmed with DataStorage).

Changes applied to both `refguide/` (SP11) and `refguide10/` (SP10).

**Not changed** (pending further confirmation):
- Image Crop — needs confirmation from Web Content team
- APM — owned by Clevr, status unknown
- SCIM — owned by Identity Service Extensions (Cloud), status unknown
- XSUAA Connector for SAP Cloud Platform — owned by Cloud team, status unknown