### PR TITLE
Remove link to general beta release page

### DIFF
--- a/content/en/docs/releasenotes/studio-pro/lts-mts.md
+++ b/content/en/docs/releasenotes/studio-pro/lts-mts.md
@@ -16,7 +16,7 @@ In the 11.6.1 example, the first number (**11**) indicates the major version.
 
 Mendix supports three major versions at a time. As defined in our SLA, while the current major version is Mendix 11, Mendix supports major versions 9, 10, and 11. 
 
-To make version support duration clearer for our users, Mendix plans a new major release in a regular cadence. Mendix announce each new major version at least a year in advance. This helps you to prepare and plan to adopt new releases and upgrade from older Mendix versions. Each major version release may start with public [beta releases](/releasenotes/release-status/) to obtain feedback from users.
+To make version support duration clearer for our users, Mendix plans a new major release in a regular cadence. Mendix announce each new major version at least a year in advance. This helps you to prepare and plan to adopt new releases and upgrade from older Mendix versions. Each major version release may start with public beta releases to obtain feedback from users.
 
 ### Minor Version
 


### PR DESCRIPTION
The beta release page does not contain any additional information on the process of Major Mendix releases, is mostly to describe beta release of new products and features, and leads to confusion of end-users on this process. We also don't want to explain the release process of Studio Pro in this separate page, the explanation on the LTS/MTS page should be sufficient. Due to that, we are removing the link.