### PR TITLE
Update docs for including assets directories of widgets in the app bundle

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
@@ -68,7 +68,7 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view (the ideal image size is 256x192 pixels, but other sizes will be resized to fit)
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-    * All CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
+    * All CSS files you add (except the ones located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
     * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 * Optionally, a *locales* folder.
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
@@ -69,7 +69,7 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
     * All CSS files you add (except the ones located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
-    * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
+    * When the React client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 * Optionally, a *locales* folder.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-10/pluggable-widgets/_index.md
@@ -68,7 +68,8 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view (the ideal image size is 256x192 pixels, but other sizes will be resized to fit)
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-    * Note that all CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget
+    * All CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
+    * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 * Optionally, a *locales* folder.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
@@ -69,7 +69,7 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view (the ideal image size is 256x192 pixels, but other sizes will be resized to fit)
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-    * All CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
+    * All CSS files you add (except the ones located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
     * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
@@ -70,7 +70,7 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
     * All CSS files you add (except the ones located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
-    * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
+    * When the React client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/studio-pro-11/pluggable-widgets/_index.md
@@ -69,7 +69,8 @@ A widget package file is just a ZIP archive containing the following things:
     * *{widgetName}.tile.png* sets the tile image inside the Studio Pro toolbox in tile view (the ideal image size is 256x192 pixels, but other sizes will be resized to fit)
     * *{widgetName}.tile.dark.png* sets the dark-mode equivalent to *{widgetName}.tile.png*
 * Optionally, some widget-related resources, preferably located next to the file which contains the client component
-    * Note that all CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget
+    * All CSS files you add (except the one located in the **lib** sub-directory) will automatically be loaded in an app via the widget.
+    * When the React Client is enabled for an app, any `assets` directories in a widget package are automatically copied to the widget's directory under `dist` during bundling. This ensures that all asset files from a pluggable widget are included in the final build and available at runtime.
 
 Naming your widget package file after the `widgetName` is best practice. Also, a widget package can include multiple widgets by putting several of the above items in the same widget package. However, creating such packages is *not recommended*. 
 


### PR DESCRIPTION
- It requires tech review
- It is fixed for 11.6.7, 11.12.0, 10.24.22