### PR TITLE
Remove PIM blocker from Mendix on Azure prerequisites

### DIFF
--- a/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-deploy.md
@@ -16,7 +16,7 @@ To deploy Mendix on Azure, make sure you have the following available:
 * A Mendix platform account
 * An Azure account with the following permissions:
     * Permission to grant admin consent on the Mendix on Azure portal app registration (e.g. Global Administrator in Entra ID)
-    * Owner role assigned on the target subscription (temporary elevated Privileged Identity Management - PIM - access does not suffice)
+    * Owner role assigned on the target subscription
 * In case you want to integrate the Mendix on Azure environment into your existing corporate network, be sure to consider the [network configuration options](/developerportal/deploy/mendix-on-azure/configuration/#networking-settings) that cannot be changed after initial environment deployment
 
 ## Deploying the Mendix on Azure offering from Azure Marketplace


### PR DESCRIPTION
## Summary
Removes outdated restriction stating that temporary elevated PIM (Privileged Identity Management) access does not suffice for Owner role on target Azure subscription.

## Changes
- Updated `/content/en/docs/deployment/mx-azure/mx-azure-deploy.md` line 19
- Removed parenthetical: "(temporary elevated Privileged Identity Management - PIM - access does not suffice)"
- Now simply states: "Owner role assigned on the target subscription"

## Rationale
Testing has confirmed that PIM-elevated accounts work correctly with Mendix on Azure deployments. The previous caveat is no longer accurate and was blocking customers who use PIM for just-in-time privilege elevation.

## Related
- MXFORAZURE-577