### PR TITLE
Update macOS requirements

### DIFF
--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -19,7 +19,7 @@ Mendix Studio Pro has the requirements listed in the following sections.
 [Mendix Studio Pro](/refguide/modeling/) 11 is supported on 64-bit versions of Windows 10 release 1809 and above; this also includes Windows 11. 
 We support running on Windows locally, or locally virtualized.
 
-Mendix Studio Pro 11 can run in beta mode on an ARM Mac and Intel Mac running macOS Sonoma 14.0 and above. For information on known limitation, see the [Known Limitations for Mac](#mac-limitations) section below. 
+Mendix Studio Pro 11 can run in beta mode on Apple Silicon (arm64) Macs running macOS Sonoma 14.0 and above. Starting with Studio Pro 11.12, the native macOS version of Studio Pro supports only Apple Silicon. Intel-based (x64) Macs are no longer supported. This enables Mendix to focus the macOS experience on a single native architecture, which improves performance, efficiency, and compatibility. For information on known limitations, see the [Known Limitations for Mac](#mac-limitations) section below.
 
 {{% alert color="info" %}}
 While Studio Pro on Mac is in [public beta](/releasenotes/release-status/), Mendix can only verify support for the latest macOS version available. Support for earlier versions is not guaranteed and it is best to update macOS to the newest version when using Studio Pro. 
@@ -91,7 +91,7 @@ Mendix Studio Pro will run on any machine which can run the [minimum requirement
 * **RAM** – recommended 16GB or more depending on the size of your app and how many instances of Studio Pro you want to have open at the same time
 * **Display Resolution** – 1080p (1920x1080)
 
-Mendix Studio Pro on Mac (Beta) runs on any machine compatible with [macOS Sonoma](https://support.apple.com/en-us/105113).
+Mendix Studio Pro on Mac (Beta) runs on any Apple Silicon Mac compatible with [macOS Sonoma](https://support.apple.com/en-us/105113).
 
 These requirements also need to be taken into account when using a virtual machine.
 

--- a/content/en/docs/refguide/installation/system-requirements.md
+++ b/content/en/docs/refguide/installation/system-requirements.md
@@ -19,7 +19,7 @@ Mendix Studio Pro has the requirements listed in the following sections.
 [Mendix Studio Pro](/refguide/modeling/) 11 is supported on 64-bit versions of Windows 10 release 1809 and above; this also includes Windows 11. 
 We support running on Windows locally, or locally virtualized.
 
-Mendix Studio Pro 11 can run in beta mode on Apple Silicon (arm64) Macs running macOS Sonoma 14.0 and above. Starting with Studio Pro 11.12, the native macOS version of Studio Pro supports only Apple Silicon. Intel-based (x64) Macs are no longer supported. This enables Mendix to focus the macOS experience on a single native architecture, which improves performance, efficiency, and compatibility. For information on known limitations, see the [Known Limitations for Mac](#mac-limitations) section below.
+Mendix Studio Pro 11 can run in beta mode on Apple Silicon (ARM64) Macs running macOS Sonoma 14.0 and above. Starting with Studio Pro 11.12, the native macOS version of Studio Pro supports only Apple Silicon. Intel-based (x64) Macs are no longer supported. This shift allows Mendix to focus on a single native architecture for macOS, improving performance, efficiency, and overall compatibility. For information on known limitations, see the [Known Limitations for Mac](#mac-limitations) section below.
 
 {{% alert color="info" %}}
 While Studio Pro on Mac is in [public beta](/releasenotes/release-status/), Mendix can only verify support for the latest macOS version available. Support for earlier versions is not guaranteed and it is best to update macOS to the newest version when using Studio Pro. 


### PR DESCRIPTION
Specify that Studio Pro for macOS is now only arm64