### PR TITLE
Clarify read replica Entra admin permissions banner

### DIFF
--- a/content/en/docs/deployment/mx-azure/configuration/mx-azure-direct-database-access.md
+++ b/content/en/docs/deployment/mx-azure/configuration/mx-azure-direct-database-access.md
@@ -55,7 +55,7 @@ By default, the read replica for Postgres database is disabled. To enable it, pe
 
 {{% alert color="info" %}}Never delete the existing ServicePrincipal user.{{% /alert %}}
 
-{{% alert color="info" %}}Users added here only have full Read access to the database, as network access is restricted to the read replica only using [Network Security Group](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) rules.{{% /alert %}}
+{{% alert color="info" %}}Users added here only have full Read access to the database, as network access is restricted using [Network Security Group](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) rules. This means that access to the primary database is blocked and only the read replica can be accessed.{{% /alert %}}
 
 ## Enabling Virtual Network Peering and DNS Name Resolution
 


### PR DESCRIPTION
## Summary
Improves documentation banner clarity for the Direct Database Access (read replica) feature to prevent confusion about Entra admin permissions.

## Problem
Partners and customers were confused about why Service Principals need to be added as Entra Admin on the **primary database** just to get read-only access to the **read replica**. It appeared as though everyone needed full admin rights on production.

## Solution
Adds an explicit clarifying sentence to the existing banner stating that network access to the primary database is blocked by NSG rules, ensuring only the read replica can be accessed despite having admin rights in the database.

## Changes
**File:** `content/en/docs/deployment/mx-azure/configuration/mx-azure-direct-database-access.md`

**Before:**
> Users added here only have full Read access to the database, as network access is restricted to the read replica only using Network Security Group rules.

**After:**
> Users added here only have full Read access to the database, as network access is restricted using Network Security Group rules. **This means that access to the primary database is blocked and only the read replica can be accessed.**

## Context
- **Use case:** Setting up read replica access during POC

## Testing
Documentation change only - no code changes.
