### PR TITLE
Update backups API documentation for optional comment

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/deployment/backups-api-v2.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deployment/backups-api-v2.md
@@ -171,9 +171,11 @@ A JSON object with the following attributes:
 
 * `comment` (String): Optional comment for this snapshot.
 
-Please note that the comment attribute is optional, but the API expects an empty JSON Object for a successful response. 
+{{% alert color="info" %}}
+The `comment` attribute is optional, but the API requires an empty JSON object (`{}`) to return a successful response.
+{{% /alert %}}
 
-**Example Requests**
+**Example Request 1**
 
 ```bash
 POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
@@ -182,13 +184,11 @@ Host: deploy.mendix.com
 Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
-
-Request-Body:
-{
-     "comment" :  "My snapshot"
-}
+{"comment": "My snapshot"}
 ```
-Or,
+
+**Example Request 2**
+
 ```bash
 POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
 Host: deploy.mendix.com
@@ -196,8 +196,6 @@ Host: deploy.mendix.com
 Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
-
-Request-Body: 
 {}
 ```
 

--- a/content/en/docs/apidocs-mxsdk/apidocs/deployment/backups-api-v2.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deployment/backups-api-v2.md
@@ -171,7 +171,9 @@ A JSON object with the following attributes:
 
 * `comment` (String): Optional comment for this snapshot.
 
-**Example Request**
+Please note that the comment attribute is optional, but the API expects an empty JSON Object for a successful response. 
+
+**Example Requests**
 
 ```bash
 POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
@@ -181,9 +183,22 @@ Content-Type: application/json
 Mendix-Username: richard.ford51@example.com
 Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
 
+Request-Body:
 {
      "comment" :  "My snapshot"
 }
+```
+Or,
+```bash
+POST /api/v2/apps/543857rfds-dfsfsd12c5e24-3224d32eg/environments/cd5fc610-edb0-43c5-a374-0439a6411ace/snapshots
+Host: deploy.mendix.com
+
+Content-Type: application/json
+Mendix-Username: richard.ford51@example.com
+Mendix-ApiKey:  26587896-1cef-4483-accf-ad304e2673d6
+
+Request-Body: 
+{}
 ```
 
 #### Output


### PR DESCRIPTION
Clarified that the comment attribute is optional and specified that an empty JSON object is needed for a successful response.