### PR TITLE
Release note for End-Users dash

### DIFF
--- a/content/en/docs/releasenotes/control-center/2026.md
+++ b/content/en/docs/releasenotes/control-center/2026.md
@@ -9,6 +9,13 @@ numberless_headings: true
 
 ## June 2026
 
+### June 30, 2026
+
+#### New Features
+
+* We have introduced end-user metering in Control Center. The new **End-Users** page allows you to keep track of end-user subscriptions and usage across all apps in your company. User consumption is tracked automatically from the moment an app is deployed to production, and monthly usage reports are generated and made available in Control Center. You can view named user counts per app, monitor entitlements by subscription type, and assign single-app internal user subscriptions to specific environments.      
+    For details, refer to [End-Users](/control-center/end-users/).
+
 ### June 24, 2026
 
 #### New Features

--- a/content/en/docs/releasenotes/control-center/2026.md
+++ b/content/en/docs/releasenotes/control-center/2026.md
@@ -13,7 +13,7 @@ numberless_headings: true
 
 #### New Features
 
-* We have introduced end-user metering in Control Center. The new **End-Users** page allows you to keep track of end-user subscriptions and usage across all apps in your company. User consumption is tracked automatically from the moment an app is deployed to production, and monthly usage reports are generated and made available in Control Center. You can view named user counts per app, monitor entitlements by subscription type, and assign single-app internal user subscriptions to specific environments.      
+* We have introduced end-user metering in Control Center. The new **End-Users** page gives you centralized visibility into user subscription consumption across all production apps. User metering runs continuously in the background, automatically deduplicating cross-app users and hashing user identities for privacy. You can view named user counts per app, monitor entitlements by subscription type, and access monthly reports and daily usage snapshots. Apps continue running without disruption if usage exceeds seat limits.
     For details, refer to [End-Users](/control-center/end-users/).
 
 ### June 24, 2026


### PR DESCRIPTION
The End-Users dashboard was released as private beta, so no release note was needed at the time. Adding one now for visibility (Mx11.12) per discussions with the team.