### PR TITLE
Update the GitHub URL in embedded client doc

### DIFF
--- a/content/en/docs/refguide/runtime/mendix-client/embedding-the-client.md
+++ b/content/en/docs/refguide/runtime/mendix-client/embedding-the-client.md
@@ -46,7 +46,7 @@ The same integration pattern works in React, Vue, plain JavaScript, and other fr
 
 ## Example Host Apps
 
-See the [embedded-mendix-demo-apps](https://github.com/mendix/embedded-mendix-demo-apps) GitHub repository for an example Mendix application that has been configured to be embedded, together with example host applications using Vue, React, and vanilla JavaScript.
+See the [embedded-mendix-demo-apps](https://github.com/mendixlabs/embedded-mendix-demo-apps) GitHub repository for an example Mendix application that has been configured to be embedded, together with example host applications using Vue, React, and vanilla JavaScript.
 
 ## Configuring the Embedded App
 


### PR DESCRIPTION
The example repro has been moved from the `mendix` org to the `mendixlab` on GitHub due to the demos being Beta and not part of the supported product.

This PR can be merged imminently.