### PR TITLE
Release notes for make-it-native 11.12.0

### DIFF
--- a/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
+++ b/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
@@ -10,11 +10,12 @@ Depending on the Mendix version your app is developed in and the device you want
 
 ## Android 11.12.0 / iOS 11.12.0
 
-**Release date: July 2, 2026**
+**Release date: July X, 2026**
 
 ### Improvements 
 
 * We improved the build time on iOS for Make it Native by using prebuilt react-native binaries.
+* On Android, READ_MEDIA_IMAGES and READ_MEDIA_VIDEO are explicitly removed following [Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
 
 ## Android 11.11.0 / iOS 11.11.0
 

--- a/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
+++ b/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
@@ -14,8 +14,8 @@ Depending on the Mendix version your app is developed in and the device you want
 
 ### Improvements 
 
-* We improved the build time on iOS for Make it Native by using prebuilt react-native binaries.
-* On Android, READ_MEDIA_IMAGES and READ_MEDIA_VIDEO are explicitly removed following [Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
+* We improved the build time on iOS for Make it Native by using prebuilt `react-native` binaries.
+* On Android, `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` were explicitly removed following [Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
 
 ## Android 11.11.0 / iOS 11.11.0
 

--- a/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
+++ b/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
@@ -8,6 +8,14 @@ description: "These release notes showcase each release of the iOS and Android M
 
 Depending on the Mendix version your app is developed in and the device you want to run on, you need a different Make It Native app. For more information on how to get the correct version, see the [Getting the Make It Native App](/refguide/mobile/getting-started-with-mobile/prerequisites/#get-min-app) section in *Native App Prerequisites and Troubleshooting*.
 
+## Android 11.12.0 / iOS 11.12.0
+
+**Release date: July 2, 2026**
+
+### Improvements 
+
+* We improved the build time on iOS for Make it Native by using prebuilt react-native binaries.
+
 ## Android 11.11.0 / iOS 11.11.0
 
 **Release date: June 3, 2026**

--- a/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
+++ b/content/en/docs/releasenotes/mobile/make-it-native-parent/make-it-native.md
@@ -10,7 +10,7 @@ Depending on the Mendix version your app is developed in and the device you want
 
 ## Android 11.12.0 / iOS 11.12.0
 
-**Release date: July X, 2026**
+**Release date: July 6, 2026**
 
 ### Improvements 
 


### PR DESCRIPTION
NOTE: WAIT before approving until both iOS and Android are published in the respective stores.
Currently in review...

Added release notes for MiN Android 11.12.0 and iOS 11.12.0.