### PR TITLE
Clarify custom error page placement for Atlas 2 (Mendix 9) apps

### DIFF
--- a/content/en/docs/howto/front-end/custom-error-page.md
+++ b/content/en/docs/howto/front-end/custom-error-page.md
@@ -42,7 +42,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 ## Creating a Custom Error Page {#create-custom-error}
 
 {{% alert color="info" %}}
-These steps apply to Atlas 3, which is used from Mendix 9 onwards. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
+These steps apply to Atlas 3, which is used from Mendix 9 and above. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
 {{% /alert %}}
 
 If you are using Atlas 3, do the following:

--- a/content/en/docs/howto/front-end/custom-error-page.md
+++ b/content/en/docs/howto/front-end/custom-error-page.md
@@ -41,6 +41,10 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## Creating a Custom Error Page {#create-custom-error}
 
+{{% alert color="info" %}}
+If you are using Atlas 2, consider [upgrading](/refguide9/moving-from-atlas-2-to-3/). If you cannot, follow the instructions below but create the **error_page** folder in your **theme** folder directly.
+{{% /alert %}}
+
 If you are using Atlas 3, do the following:
 
 1. Open the local folder of your app.

--- a/content/en/docs/howto/front-end/custom-error-page.md
+++ b/content/en/docs/howto/front-end/custom-error-page.md
@@ -42,7 +42,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 ## Creating a Custom Error Page {#create-custom-error}
 
 {{% alert color="info" %}}
-If you are using Atlas 2, consider [upgrading](/refguide9/moving-from-atlas-2-to-3/). If you cannot, follow the instructions below but create the **error_page** folder in your **theme** folder directly.
+These steps apply to Atlas 3, which is used from Mendix 9 onwards. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
 {{% /alert %}}
 
 If you are using Atlas 3, do the following:

--- a/content/en/docs/howto10/front-end/custom-error-page.md
+++ b/content/en/docs/howto10/front-end/custom-error-page.md
@@ -42,7 +42,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 ## Creating a Custom Error Page {#create-custom-error}
 
 {{% alert color="info" %}}
-These steps apply to Atlas 3, which is used from Mendix 9 onwards. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
+These steps apply to Atlas 3, which is used from Mendix 9 and above. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
 {{% /alert %}}
 
 If you are using Atlas 3, do the following:

--- a/content/en/docs/howto10/front-end/custom-error-page.md
+++ b/content/en/docs/howto10/front-end/custom-error-page.md
@@ -41,6 +41,10 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## Creating a Custom Error Page {#create-custom-error}
 
+{{% alert color="info" %}}
+If you are using Atlas 2, consider [upgrading](/refguide9/moving-from-atlas-2-to-3/). If you cannot, follow the instructions below but create the **error_page** folder in your **theme** folder directly.
+{{% /alert %}}
+
 If you are using Atlas 3, do the following:
 
 1. Open the local folder of your app.

--- a/content/en/docs/howto10/front-end/custom-error-page.md
+++ b/content/en/docs/howto10/front-end/custom-error-page.md
@@ -42,7 +42,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 ## Creating a Custom Error Page {#create-custom-error}
 
 {{% alert color="info" %}}
-If you are using Atlas 2, consider [upgrading](/refguide9/moving-from-atlas-2-to-3/). If you cannot, follow the instructions below but create the **error_page** folder in your **theme** folder directly.
+These steps apply to Atlas 3, which is used from Mendix 9 onwards. If you are on Mendix 9 and your app still uses **Atlas 2**, the folder structure is different: the entire **theme** folder acts as the web root. In that case, create the **error_page** folder directly inside **theme** (not inside **theme/web**), otherwise it is nested one level too deep in the deployment package and the custom error pages are not served. Alternatively, [upgrade the app to Atlas 3](/refguide9/moving-from-atlas-2-to-3/).
 {{% /alert %}}
 
 If you are using Atlas 3, do the following:


### PR DESCRIPTION
## What

Adds a clarifying note to the **Create Custom Error Pages** how-to about folder placement for apps still on **Atlas 2**.

## Why

The how-to documents only the Atlas 3 location for the error page (`theme/web/error_page`). In Atlas 2 the entire `theme` folder is the web root, so following the Atlas 3 path nests the `error_page` folder one level too deep in the deployment package — the custom error pages are never served and users keep seeing the default Mendix error page.

Because the unversioned how-to is where search typically lands readers regardless of their Mendix version, the note helps a supported Mendix 9 / Atlas 2 reader who arrives here. Atlas 2 applies only to Mendix 9 apps still on Atlas 2 (Mendix 10 and 11 use Atlas 3+), and the note states this explicitly.

## Change

Adds the note to:

- `content/en/docs/howto/front-end/custom-error-page.md` (current / Mendix 11)
- `content/en/docs/howto10/front-end/custom-error-page.md` (Mendix 10)

The Studio Pro 9 version (`howto9`) already documents the Atlas 2 case, and the Mendix 8 version (`howto8`) already instructs placing `error_page` directly in `theme`, so neither needs a change. The migration link reuses the existing `/refguide9/moving-from-atlas-2-to-3/` reference.