### PR TITLE
Update Cloud Foundry deployment documentation

### DIFF
--- a/content/en/docs/deployment/on-premises-design/buildpacks/cloud-foundry-deploy.md
+++ b/content/en/docs/deployment/on-premises-design/buildpacks/cloud-foundry-deploy.md
@@ -24,7 +24,9 @@ aliases:
 {{% alert color="warning" %}} 
 Cloud Foundry buildpack deployment from Studio Pro is deprecated in version 10 and removed in version 11. Consider using the [Mendix Portable Runtime for Cloud Foundry](/developerportal/deploy/cloud-foundry-pad/) option instead. 
 
-With the release of Mendix Portable Runtime, we are transitioning away from the Cloud Foundry buildpack toward a modern, container-native approach that packages Mendix applications. As part of this shift, the Cloud Foundry Buildpack will begin deprecating support for Mendix 12 and future Runtime versions. For more information, see the [blog release](https://www.mendix.com/blog/mendix-portable-runtime/) 
+With the release of Mendix Portable Runtime, we are transitioning away from the Cloud Foundry buildpack toward a modern, container-native approach that packages Mendix applications. As part of this shift, the Cloud Foundry Buildpack will begin deprecating support for Mendix 12 and future Runtime versions.
+
+For more information, see [Mendix Portable Runtime: Deployment, Simplified](https://www.mendix.com/blog/mendix-portable-runtime/).
 
 The following documentation is provided for reference purposes only.
 {{% /alert %}}

--- a/content/en/docs/deployment/on-premises-design/buildpacks/cloud-foundry-deploy.md
+++ b/content/en/docs/deployment/on-premises-design/buildpacks/cloud-foundry-deploy.md
@@ -24,6 +24,8 @@ aliases:
 {{% alert color="warning" %}} 
 Cloud Foundry buildpack deployment from Studio Pro is deprecated in version 10 and removed in version 11. Consider using the [Mendix Portable Runtime for Cloud Foundry](/developerportal/deploy/cloud-foundry-pad/) option instead. 
 
+With the release of Mendix Portable Runtime, we are transitioning away from the Cloud Foundry buildpack toward a modern, container-native approach that packages Mendix applications. As part of this shift, the Cloud Foundry Buildpack will begin deprecating support for Mendix 12 and future Runtime versions. For more information, see the [blog release](https://www.mendix.com/blog/mendix-portable-runtime/) 
+
 The following documentation is provided for reference purposes only.
 {{% /alert %}}
 


### PR DESCRIPTION
Added information about the transition from Cloud Foundry buildpack to Mendix Portable Runtime and its implications for future versions.