### PR TITLE
Add Parallels connection troubleshooting to mobile prerequisites

### DIFF
--- a/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide/mobile/getting-started-with-mobile/prerequisites.md
@@ -163,6 +163,11 @@ The latest version of Make It Native 9 is only compatible with versions of Mendi
 
 To use Studio Pro on a Mac device, you will first need to install and configure Parallels. For more information, see [Configuring Parallels](/refguide/using-mendix-studio-pro-on-a-mac/).
 
+If the Make It Native app cannot connect when you use Parallels, check the following:
+
+* Enter your Mac's IP address in the Make It Native app's **Host** field, not the IP address of the Windows virtual machine that Studio Pro shows. For instructions on finding your Mac's IP address, see the [Viewing Your App on Your Testing Device](/refguide/using-mendix-studio-pro-on-a-mac/#viewing-your-app-on-your-testing-device) section of *Configuring Parallels*.
+* Make sure port forwarding is enabled for ports 8080, 8083, and 8100 in your Parallels network preferences. For setup steps, see the [Configuring Your Windows Virtual Machine for Mendix Studio Pro](/refguide/using-mendix-studio-pro-on-a-mac/#configuring) section of *Configuring Parallels*.
+
 ### Avoid Network or Cloud Folders
 
 Storing a Mendix project on a network drive or in a cloud folder (such as those provided by OneDrive or Dropbox) is **not recommended**. Storing your projects in such folders will significantly slow down Studio Pro and cause errors when trying to run projects containing a native mobile profile. Note also that projects with a native mobile profile can only be started from drive **C:**.

--- a/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide10/mobile/getting-started-with-mobile/prerequisites.md
@@ -144,6 +144,11 @@ The latest version of Make It Native 9 is only compatible with versions of Mendi
 
 To use Studio Pro on a Mac device, you will first need to install and configure Parallels. For more information, see [Configuring Parallels](/refguide10/using-mendix-studio-pro-on-a-mac/).
 
+If the Make It Native app cannot connect when you use Parallels, check the following:
+
+* Enter your Mac's IP address in the Make It Native app's **Host** field, not the IP address of the Windows virtual machine that Studio Pro shows. For instructions on finding your Mac's IP address, see the [Viewing Your App on Your Testing Device](/refguide10/using-mendix-studio-pro-on-a-mac/#viewing-your-app-on-your-testing-device) section of *Configuring Parallels*.
+* Make sure port forwarding is enabled for ports 8080, 8083, and 8100 in your Parallels network preferences. For setup steps, see the [Configuring Your Windows Virtual Machine for Mendix Studio Pro](/refguide10/using-mendix-studio-pro-on-a-mac/#configuring) section of *Configuring Parallels*.
+
 ### Avoid Network or Cloud Folders
 
 Storing a Mendix project on a network drive or in a cloud folder (such as those provided by OneDrive or Dropbox) is **not recommended**. Storing your projects in such folders will significantly slow down Studio Pro and cause errors when trying to run projects containing a native mobile profile. Note also that projects with a native mobile profile can only be started from drive **C:**.

--- a/content/en/docs/refguide9/mobile/getting-started-with-mobile/prerequisites.md
+++ b/content/en/docs/refguide9/mobile/getting-started-with-mobile/prerequisites.md
@@ -130,3 +130,8 @@ The latest version of Make It Native 9 is only compatible with versions of Mendi
 ### Configure Parallels
 
 To use Studio Pro on a Mac device, you will first need to install and configure Parallels. For more information, see [Configuring Parallels](/refguide9/using-mendix-studio-pro-on-a-mac/).
+
+If the Make It Native app cannot connect when you use Parallels, check the following:
+
+* Enter your Mac's IP address in the Make It Native app's **Host** field, not the IP address of the Windows virtual machine that Studio Pro shows. For instructions on finding your Mac's IP address, see the [Viewing Your App on Your Testing Device](/refguide9/using-mendix-studio-pro-on-a-mac/#viewing-your-app-on-your-testing-device) section of *Configuring Parallels*.
+* Make sure port forwarding is enabled for ports 8080, 8083, and 8100 in your Parallels network preferences. For setup steps, see the [Configuring Your Windows Virtual Machine for Mendix Studio Pro](/refguide9/using-mendix-studio-pro-on-a-mac/#configuring-your-windows-virtual-machine-for-mendix-studio-pro) section of *Configuring Parallels*.


### PR DESCRIPTION
Surface the Mac IP vs Windows VM IP gotcha and port forwarding requirement directly in the Make It Native troubleshooting section, instead of only linking out to Configuring Parallels. Applied to Studio Pro 11, 10, and 9 refguides.