### PR TITLE
Clarify Mendix on Kubernetes subscription requirement after Operator license removal

### DIFF
--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -105,10 +105,10 @@ This percentage can be adjusted by providing a custom value in Custom JVM Option
 ### Operator License
 
 {{% alert color="info" %}}
-Mendix Operator versions older than 2.23.0 require a separate Operator license key. Starting from Operator version 2.23.0, this separate license key is no longer needed. This was a technical change only — a valid Mendix on Kubernetes subscription and support contract is still required to use the Mendix Operator, regardless of Operator version.
+Mendix Operator versions older than 2.23.0 require a separate Operator license key. Starting from Operator version 2.23.0, this separate license key is no longer needed. This was a technical change only. A valid Mendix on Kubernetes subscription and support contract is still required to use the Mendix Operator, regardless of Operator version.
 {{% /alert %}}
 
-Mendix on Kubernetes is a premium offering from Mendix, and requires a valid subscription to use it for your applications. If you are running Mendix Operator versions older than 2.23.0, you also need a separate **Operator license**. This license allows you to manage Mendix apps in your cluster through the Mendix Operator and, optionally, the Mendix Gateway Agent.
+Mendix on Kubernetes is a premium offering from Mendix, and requires a valid subscription to use it for your applications. If you are running Mendix Operator versions older than 2.23.0, you also need a separate Operator license. This license allows you to manage Mendix apps in your cluster through the Mendix Operator and, optionally, the Mendix Gateway Agent.
 
 You need one license for each namespace you want to manage.
 
@@ -135,7 +135,7 @@ You can run the Mendix Operator in trial mode for evaluation purposes. When the 
 
 ### Runtime License
 
-A runtime license per environment is required. In addition to that, the Mendix Runtime license is independent of the Operator license. The Mendix Runtime license removes [trial restrictions](/developerportal/deploy/licensing-apps-outside-mxcloud/) from a Mendix App itself. You need both types of licenses to manage and run an application through Mendix on Kubernetes.
+A runtime license per environment is required. In addition to that, the Mendix Runtime license is independent of the Operator license. The Mendix Runtime license removes [trial restrictions](/developerportal/deploy/licensing-apps-outside-mxcloud/) from a Mendix app. You need both types of licenses to manage and run an application through Mendix on Kubernetes.
 
 You can request a Runtime license by doing the following:
 

--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -105,12 +105,10 @@ This percentage can be adjusted by providing a custom value in Custom JVM Option
 ### Operator License
 
 {{% alert color="info" %}}
-Mendix Operator versions older than 2.23.0 require an Operator licence. Starting from Operator version 2.23.0, Operator licenses are no longer needed.
-
-A valid subscription and support contract is still necessary to be receive technical support.
+Mendix Operator versions older than 2.23.0 require a separate Operator license key. Starting from Operator version 2.23.0, this separate license key is no longer needed. This was a technical change only — a valid Mendix on Kubernetes subscription and support contract is still required to use the Mendix Operator, regardless of Operator version.
 {{% /alert %}}
 
-Mendix on Kubernetes is a premium offering from Mendix, and you will need an additional license to use it for your applications. This **Operator license** allows you to manage Mendix apps in your cluster through the Mendix Operator and, optionally, the Mendix Gateway Agent.
+Mendix on Kubernetes is a premium offering from Mendix, and requires a valid subscription to use it for your applications. If you are running Mendix Operator versions older than 2.23.0, you also need a separate **Operator license**. This license allows you to manage Mendix apps in your cluster through the Mendix Operator and, optionally, the Mendix Gateway Agent.
 
 You need one license for each namespace you want to manage.
 
@@ -137,7 +135,7 @@ You can run the Mendix Operator in trial mode for evaluation purposes. When the 
 
 ### Runtime License
 
-A runtime license per environment is required. In addition to that, the Operator license is independent of a Mendix Runtime license. The Mendix Runtime license removes [trial restrictions](/developerportal/deploy/licensing-apps-outside-mxcloud/) from a Mendix App itself. You need both types of licenses to manage and run an application through Mendix on Kubernetes.
+A runtime license per environment is required. In addition to that, the Mendix Runtime license is independent of the Operator license. The Mendix Runtime license removes [trial restrictions](/developerportal/deploy/licensing-apps-outside-mxcloud/) from a Mendix App itself. You need both types of licenses to manage and run an application through Mendix on Kubernetes.
 
 You can request a Runtime license by doing the following:
 

--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -14,7 +14,7 @@ Your organization may have a requirement to use a private cloud, perhaps as part
 
 You can use Mendix on Kubernetes with the *connected* option to keep the simplicity of one-click deployments from the Mendix Portal, or utilize the *standalone* Mendix Operator to deploy Mendix apps through your own DevOps process, which is particularly useful for private clouds with an *air-gap* isolating them from the internet. See [Connected and Standalone Clusters](#connected-standalone), below, for more information.
 
-Please see [Supported Providers](/developerportal/deploy/private-cloud-supported-environments/) for a list of platforms supported by Mendix on Kubernetes.
+For a list of platforms supported by Mendix on Kubernetes, see [Supported Providers](/developerportal/deploy/private-cloud-supported-environments/).
 
 There are two steps required to achieve this, listed below.
 


### PR DESCRIPTION
## Summary
- The Operator License alert on the Mendix on Kubernetes page implied a subscription was only needed for technical support, which caused real customer confusion after the standalone Operator license key was removed in Operator 2.23.0 (a customer asked support whether Mendix on Kubernetes still needed to be purchased at all).
- Rewords the alert and the following paragraph to make clear that removing the license key was a technical change only, and a valid Mendix on Kubernetes subscription is still required to use the Operator, regardless of Operator version.
- Also fixes a confusingly-ordered sentence in the Runtime License section that described the Runtime/Operator license relationship starting from the wrong subject.

## Test plan
- [x] Rendered the page locally to confirm formatting/alert shortcodes are unaffected
- [x] Verified no other page content references the old wording
