### PR TITLE
RP-INTRODUCE_SONNET-5: Introduce Claude Sonnet 5

### DIFF
--- a/content/en/docs/genai/_index.md
+++ b/content/en/docs/genai/_index.md
@@ -49,7 +49,7 @@ Mendix [connectors](/agents/agents-kit-2/#connectors) offer direct support for t
 
 | Models | Category | Input | Output | Additional Capabilities |
 | --- | --- | --- | --- | --- |
-| [Anthropic Claude Sonnet Models](/agents/mx-cloud-genai/resource-packs/#supported-models) | Chat completions | text, image, document | text | Function calling |
+| [Anthropic Claude Models](/agents/mx-cloud-genai/resource-packs/#supported-models) | Chat completions | text, image, document | text | Function calling |
 | [Cohere Embed Models](/agents/mx-cloud-genai/resource-packs/#supported-models) | Embeddings | text | embeddings | |
 
 ### Microsoft Foundry (OpenAI) / OpenAI

--- a/content/en/docs/genai/mendix-cloud-genai/mendix-cloud-grp.md
+++ b/content/en/docs/genai/mendix-cloud-genai/mendix-cloud-grp.md
@@ -47,6 +47,7 @@ The Mendix Cloud GenAI Resource Packs provide access to the following models:
 | Anthropic Claude Haiku 4.5 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
 | Anthropic Claude Sonnet 4.5 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
 | Anthropic Claude Sonnet 4.6 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
+| Anthropic Claude Sonnet 5 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
 | Anthropic Claude Sonnet 3 | Text | Mendix Cloud Canada (Montreal) | NO | ca-central-1 |
 | Anthropic Claude Opus 4.6 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
 | Anthropic Claude Opus 4.7 | Text | Mendix Cloud EU (Frankfurt, Germany) | YES | eu-north-1,<br> Europe (Paris),<br> eu-south-1,<br> eu-south-2,<br> Europe (Ireland),<br> Europe (Frankfurt) |
@@ -74,6 +75,7 @@ For example, if you allocate 50 Cloud Tokens per month, your resource receives 5
 | Claude Haiku 4.5 | 35.81 | 179.07 |
 | Claude Sonnet 4.5 | 107.44 | 537.21 |
 | Claude Sonnet 4.6 | 107.44 | 537.21 |
+| Claude Sonnet 5 | 107.44 | 537.21 |
 | Claude Opus 4.6 | 179.07 | 895.35 |
 | Claude Opus 4.7 | 179.07 | 895.35 |
 | Claude Opus 4.8 | 179.07 | 895.35 |


### PR DESCRIPTION
## Changes

  `content/en/docs/genai/mendix-cloud-genai/mendix-cloud-grp.md`
  * Added Sonnet 5 to the Supported Models table — available in Mendix Cloud EU
    (Frankfurt, Germany) via cross-region inference. Not available in Mendix Cloud
    Canada (Montreal).
  * Added Sonnet 5 to the GenAI Units exchange rate table at 107.44 units per 1M
    input tokens and 537.21 per 1M output tokens, consistent with the other
    Sonnet-family models.

  `content/en/docs/genai/_index.md`
  * Changed "Anthropic Claude Sonnet Models" to "Anthropic Claude Models" in the
    Mendix Cloud GenAI table. The resource packs support Haiku, Sonnet, and Opus,
    so naming only Sonnet was inaccurate.