### PR TITLE
Removed Free App Deployment

### DIFF
--- a/content/en/docs/control-center/security/security.md
+++ b/content/en/docs/control-center/security/security.md
@@ -17,10 +17,6 @@ The **Settings** page in the **Security** category in Control Center allows you 
 
 ## Security Settings Tab
 
-### Free App Deployment
-
-With [Free Apps](/developerportal/deploy/mendix-cloud-deploy/deploying-an-app/#deploy-free-app), you can deploy your app to Mendix Cloud from Studio Pro. The ability to deploy Free Apps can be blocked at the company level by disabling **Free App Deployment**.
-
 ### Email Signing {#disable-enable-digital-signing-emails}
 
 The Mendix Platform digitally signs the content of emails from senders [no-reply@notifications.mendix.com](mailto:no-reply@notifications.mendix.com) and [no-reply@platform-mail.mendix.com](mailto:no-reply@platform-mail.mendix.com). By digitally signing the content of an email, Mendix provides assurance to the recipient of the email that the content of an email has not been altered in transit. For reasons of security, this feature is enabled by default. However, if digitally signing the content of an email interferes with the delivery of that email to the recipient, a Mendix Admin can disable this feature for emails sent to receivers in the company domains. For more information, see the [Why Would You Want to Disable the Digital Signing of Email Content?](#why-disable-email-signing) section below.

--- a/content/en/docs/deployment/mendix-cloud-deploy/deploying-to-mendix-cloud.md
+++ b/content/en/docs/deployment/mendix-cloud-deploy/deploying-to-mendix-cloud.md
@@ -101,10 +101,6 @@ The app is now deployed. You can configure the administrative account.
 
 Deploying a Free App is a single-stage process that is completed from Studio Pro. This process is described in detail below.
 
-{{% alert color="info" %}}
-Free App deployment can be disabled at the [organization level](/control-center/security-settings/#free-app-deployment). If you cannot deploy a Free App, contact your Mendix Admin.
-{{% /alert %}}
-
 ### Prerequisites
 
 Before starting the process of deploying a Free App, make sure to complete these prerequisites:


### PR DESCRIPTION
This reverts https://github.com/mendix/docs/pull/11381. The feature is in fact hidden, and only enabled on demand. The initial request (https://github.com/mendix/docs/issues/11367) came from an internal user, who was part of a demo account which had the feature enabled.