### PR TITLE
Add Technical Contact role and permissions documentation

### DIFF
--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -37,6 +37,8 @@ To deploy your app, you have two options:
 
 When you deploy through the Mendix Portal, this can be done by any Mendix user who has been given the appropriate rights to the cluster which has been registered.
 
+When an application is created, its creator automatically becomes the application's **Technical Contact**, a role that grants Administrator permissions on all namespaces where the application is deployed. For more information on this role and how to manage it, see [Technical Contact Role and Permissions](/developerportal/deploy/private-cloud/private-cloud-technical-contact/).
+
 ## Connected and Standalone Clusters{#connected-standalone}
 
 To allow you to manage the deployment of your apps to Red Hat OpenShift and Kubernetes, you first need to register a cluster in the Mendix Portal. This will provide you with the information you need to deploy the **Mendix Operator** in your cluster.

--- a/content/en/docs/deployment/private-cloud/_index.md
+++ b/content/en/docs/deployment/private-cloud/_index.md
@@ -37,7 +37,7 @@ To deploy your app, you have two options:
 
 When you deploy through the Mendix Portal, this can be done by any Mendix user who has been given the appropriate rights to the cluster which has been registered.
 
-When an application is created, its creator automatically becomes the application's **Technical Contact**, a role that grants Administrator permissions on all namespaces where the application is deployed. For more information on this role and how to manage it, see [Technical Contact Role and Permissions](/developerportal/deploy/private-cloud/private-cloud-technical-contact/).
+When an application is created, its creator automatically becomes the application's *Technical Contact*, a role that grants Administrator permissions on all namespaces where the application is deployed. For more information on this role and how to manage it, see [Technical Contact Role and Permissions](/developerportal/deploy/private-cloud/private-cloud-technical-contact/).
 
 ## Connected and Standalone Clusters{#connected-standalone}
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
@@ -412,23 +412,25 @@ This section shows all the activities which have taken place in this environment
 
 #### Technical Contact
 
-This section allows you to designate the Technical Contact for the application. The Technical Contact serves as the point of contact for any app-related inquiries and should have the capability to manage all environments within the app.
+The Technical Contact is the operational owner of the app and serves as the point of contact for any app-related inquiries.
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-deploy/technicalContact.png" class="no-border" >}}
 
-For applications created before December 12, the Technical Contact field is empty by default. It can be set by a user with cloud access permissions for the application.
+Every application has a Technical Contact. When an application is created, its creator is automatically assigned as the Technical Contact.
 
 {{% alert color="warning" %}}  
-Once a Technical Contact is assigned, they automatically receive administrative permissions for all namespaces associated with environments in the application. This means that the Technical Contact can perform all actions on all environments in the application. The Administrative permissions will be intact even when the Technical Contact is changed. Hence, the cluster manager must either manually assign a new role to the developer if they do not want all the permissions assigned to the developer, or remove the role assigned to the developer if they want all the permissions to be revoked for the developer.
+Once a Technical Contact is assigned, they automatically receive namespace Administrator permissions on all namespaces where the application's environments are deployed. This means the Technical Contact can perform all actions on all of the application's environments. Whenever a new environment is added, the Technical Contact receives Administrator permissions on the namespace associated with that environment.
 {{% /alert %}}
 
-For applications created on or after December 12, the Technical Contact is automatically set to the application's creator. In such cases, whenever a new environment is added, the Technical Contact receives administrative permissions for the namespaces associated with that environment.
+Changing the Technical Contact does not automatically revoke the previous Technical Contact's Administrator permissions. If the previous Technical Contact should no longer have administrative access, you must revoke their permissions separately through namespace user and permission management.
 
-The Technical Contact can be changed later, but only by the current Technical Contact.
+Only the current Technical Contact can change the assignment, by transferring the role to another member of the application team. If the current Technical Contact is unavailable or unreachable, contact [Mendix Support](https://support.mendix.com/) to update the assignment.
+
+For more information about the Technical Contact role and its permissions, see [Technical Contact Role and Permissions](/developerportal/deploy/private-cloud/private-cloud-technical-contact/).
 
 #### Environment Purpose {#environment-purpose}
 
-This section allows you to edit the Environment Purpose for the environments within the application. Setting the purpose of your environment does not affect its operational state. However, it helps ensure the environment is used as intended, providing clarity for both you and us. We strongly recommend setting this field, as future features may be tailored to specific environment purposes. For applications where the Technical Contact is not set, this section is not visible.
+This section allows you to edit the Environment Purpose for the environments within the application. Setting the purpose of your environment does not affect its operational state. However, it helps ensure the environment is used as intended, providing clarity for both you and us. We strongly recommend setting this field, as future features may be tailored to specific environment purposes.
 
 When creating a new environment, the Technical Contact can set the environment purpose. The field is not visible when some one else other than the Technical Contact is creating the environment. It is also possible to change the purpose in **Application Settings** after environment creation. However, the purpose can only be edited by the Technical Contact.
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-technical-contact.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-technical-contact.md
@@ -1,0 +1,153 @@
+---
+title: "Technical Contact Role and Permissions"
+linktitle: "Technical Contact"
+url: /developerportal/deploy/private-cloud/private-cloud-technical-contact/
+description: "Describes the Technical Contact role for Mendix on Kubernetes and Mendix on Azure applications, the permissions it grants, and how to assign and review it."
+weight: 55
+---
+
+## Introduction
+
+The **Technical Contact** is the designated operational owner of a Mendix application deployed on a Mendix on Kubernetes or Mendix on Azure cluster. This role is assigned at the application level and automatically grants namespace Administrator permissions across all namespaces where the application is deployed.
+
+Key characteristics:
+
+* One Technical Contact per application
+* Automatically assigned Administrator role on all deployment namespaces
+* Receives operational notifications about the application
+* Primary point of contact for application-level issues
+
+## Permissions Granted
+
+When you assign a Technical Contact, that user receives full Administrator permissions on every namespace where the application deploys. Administrator permissions include:
+
+**Application Control**
+
+* Start, stop, restart, and roll back application versions
+* Deploy new packages and manage deployment settings
+* Delete environments
+
+**Data and Backups**
+
+* Create, restore, and delete backups (Mendix on Azure clusters)
+* Access application constant values (which may include credentials)
+
+**Configuration**
+
+* Modify environment variables and constants
+* Manage scheduled events
+* Configure custom settings
+
+**Access and Monitoring**
+
+* View application logs and metrics (Mendix on Azure clusters)
+* Manage SSL certificates and custom domains
+* Invite and remove users within the namespace
+* Change permissions for other users in the namespace
+
+{{% alert color="info" %}}
+While assigning Technical Contact grants Administrator permissions at the namespace level, users also need appropriate permissions at the application (project) level to effectively access and manage application environments. Namespace permissions and application permissions work together – having one without the other may limit what operations a user can perform.
+{{% /alert %}}
+
+## How is Technical Contact Assigned?
+
+### Automatic Assignment
+
+When you create a new application, the application creator is automatically assigned as the Technical Contact.
+
+### Manual Assignment
+
+On Mendix on Kubernetes and Mendix on Azure, only the current Technical Contact can transfer the role to another application team member. Cluster managers, namespace administrators, and other users cannot reassign the Technical Contact on these platforms – the transfer can only be completed by the person who currently holds the role, through the Mendix Platform Portal.
+
+If you are the current Technical Contact, here is how you transfer the role:
+
+Starting point: navigate to your application's project page on the Mendix Platform Portal.
+
+Steps:
+
+1. Navigate to the **Environments** page for your application.
+2. Go to the **Application Settings** tab.
+3. Click the **Edit** button next to the Technical Contact field.
+4. A modal dialog opens with a warning message about Administrator permissions.
+5. Search for and select a new user from the application members list.
+6. Confirm your selection.
+7. A success message confirms the Technical Contact has been updated.
+
+{{% alert color="warning" %}}
+If the current Technical Contact is unavailable or unreachable, contact Mendix Support to have the role reassigned. On Mendix on Kubernetes and Mendix on Azure there is no cluster-manager, namespace-administrator, or Deploy API route to change the Technical Contact – Mendix Support is the only path in this situation.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+Changing the Technical Contact immediately grants Administrator permissions to the new user and does not remove permissions from the previous Technical Contact unless explicitly revoked.
+{{% /alert %}}
+
+## Who Should Be Technical Contact?
+
+The Technical Contact should be:
+
+* Actively involved in the application's operation
+* Familiar with deployment and troubleshooting procedures
+* Available to respond to operational issues
+* Authorized by your organization to have full administrative access
+
+Not recommended:
+
+* Users who have left the team or organization
+* Users who only need view-only access
+* External contractors without proper authorization
+
+## How to Review Your Technical Contact Assignments
+
+Recommended frequency: quarterly, or whenever team membership changes.
+
+Steps:
+
+1. Navigate to the Mendix Platform Portal and sign in.
+2. For each application you manage, navigate to the application's project page.
+3. Go to the **Environments** page.
+4. Click the **Application Settings** tab.
+5. Review the current Technical Contact assignment.
+6. Verify that the assigned user is:
+    * Still an active member of your team
+    * Involved in the application's operation
+    * Authorized for full Administrator access
+7. If the assignment is incorrect and you are the current Technical Contact, click **Edit** and follow the transfer process described above. If you are not the current Technical Contact, only that person can transfer the role – if they are unavailable or unreachable, contact Mendix Support.
+8. If the previous Technical Contact should no longer have Administrator access, manually revoke their permissions through namespace user management.
+
+## FAQ
+
+**What is a Technical Contact?**
+
+The designated operational owner of your application. This user automatically receives Administrator permissions on all deployment namespaces.
+
+**What permissions does the Technical Contact have?**
+
+Full Administrator permissions including: deploy/start/stop applications, manage backups, access credentials stored as constants, modify configurations, manage users, and delete environments.
+
+**Who should I assign as Technical Contact?**
+
+Choose an active team member who is familiar with the application's operation and authorized for full administrative access. Avoid assigning users who have left the team or only need view-only access.
+
+**How do I change the Technical Contact?**
+
+On Mendix on Kubernetes and Mendix on Azure, only the current Technical Contact can transfer the role. If you are the current Technical Contact, navigate to Environments → Application Settings → click Edit next to Technical Contact → select new user → confirm. The new user immediately receives Administrator permissions on all deployment namespaces. If the current Technical Contact is unavailable or unreachable, contact Mendix Support – no cluster manager or namespace administrator can make this change on these platforms.
+
+**Can I have multiple Technical Contacts?**
+
+No. Only one Technical Contact per application. For additional administrators, use the namespace user management interface to grant permissions separately.
+
+**What happens to the previous Technical Contact's permissions?**
+
+Permissions are NOT automatically removed when you change the Technical Contact. If the previous user should no longer have Administrator access, you must manually revoke their permissions in each namespace.
+
+**How often should I review Technical Contact assignments?**
+
+Best practice: review quarterly and whenever team membership changes (new hires, departures, role changes).
+
+**Does the Technical Contact need to accept an invitation?**
+
+No. The permissions are automatically granted when the Technical Contact is assigned. No invitation or acceptance step is required.
+
+**Can I assign a Technical Contact who isn't already a member of the application?**
+
+No. The Technical Contact must be selected from existing application members. Add the user to the application first, then assign them as Technical Contact.

--- a/content/en/docs/deployment/private-cloud/private-cloud-technical-contact.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-technical-contact.md
@@ -8,7 +8,7 @@ weight: 55
 
 ## Introduction
 
-The **Technical Contact** is the designated operational owner of a Mendix application deployed on a Mendix on Kubernetes or Mendix on Azure cluster. This role is assigned at the application level and automatically grants namespace Administrator permissions across all namespaces where the application is deployed.
+The *Technical Contact* is the designated operational owner of a Mendix application deployed on a Mendix on Kubernetes or Mendix on Azure cluster. This role is assigned at the application level and automatically grants namespace Administrator permissions across all namespaces where the application is deployed.
 
 Key characteristics:
 
@@ -21,24 +21,24 @@ Key characteristics:
 
 When you assign a Technical Contact, that user receives full Administrator permissions on every namespace where the application deploys. Administrator permissions include:
 
-**Application Control**
+### Application Control
 
 * Start, stop, restart, and roll back application versions
 * Deploy new packages and manage deployment settings
 * Delete environments
 
-**Data and Backups**
+### Data and Backups
 
 * Create, restore, and delete backups (Mendix on Azure clusters)
 * Access application constant values (which may include credentials)
 
-**Configuration**
+### Configuration
 
 * Modify environment variables and constants
 * Manage scheduled events
 * Configure custom settings
 
-**Access and Monitoring**
+### Access and Monitoring
 
 * View application logs and metrics (Mendix on Azure clusters)
 * Manage SSL certificates and custom domains
@@ -59,13 +59,10 @@ When you create a new application, the application creator is automatically assi
 
 On Mendix on Kubernetes and Mendix on Azure, only the current Technical Contact can transfer the role to another application team member. Cluster managers, namespace administrators, and other users cannot reassign the Technical Contact on these platforms – the transfer can only be completed by the person who currently holds the role, through the Mendix Platform Portal.
 
-If you are the current Technical Contact, here is how you transfer the role:
+If you are the current Technical Contact, you can transfer the role by performing the following steps:
 
-Starting point: navigate to your application's project page on the Mendix Platform Portal.
-
-Steps:
-
-1. Navigate to the **Environments** page for your application.
+1. Navigate to your application's project page on the Mendix Platform Portal.
+2. Navigate to the **Environments** page for your application.
 2. Go to the **Application Settings** tab.
 3. Click the **Edit** button next to the Technical Contact field.
 4. A modal dialog opens with a warning message about Administrator permissions.
@@ -74,14 +71,14 @@ Steps:
 7. A success message confirms the Technical Contact has been updated.
 
 {{% alert color="warning" %}}
-If the current Technical Contact is unavailable or unreachable, contact Mendix Support to have the role reassigned. On Mendix on Kubernetes and Mendix on Azure there is no cluster-manager, namespace-administrator, or Deploy API route to change the Technical Contact – Mendix Support is the only path in this situation.
+If the current Technical Contact is unavailable or unreachable, contact Mendix Support to have the role reassigned. On Mendix on Kubernetes and Mendix on Azure there is no cluster-manager, namespace-administrator, or Deploy API route to change the Technical Contact. Mendix Support is the only path in this situation.
 {{% /alert %}}
 
 {{% alert color="info" %}}
 Changing the Technical Contact immediately grants Administrator permissions to the new user and does not remove permissions from the previous Technical Contact unless explicitly revoked.
 {{% /alert %}}
 
-## Who Should Be Technical Contact?
+## Who Should Be the Technical Contact?
 
 The Technical Contact should be:
 
@@ -90,7 +87,7 @@ The Technical Contact should be:
 * Available to respond to operational issues
 * Authorized by your organization to have full administrative access
 
-Not recommended:
+We do not recommend assigning the role to:
 
 * Users who have left the team or organization
 * Users who only need view-only access
@@ -98,9 +95,7 @@ Not recommended:
 
 ## How to Review Your Technical Contact Assignments
 
-Recommended frequency: quarterly, or whenever team membership changes.
-
-Steps:
+We recommend revieweing your technical contact assignments at a quarterly frequency, or whenever team membership changes.
 
 1. Navigate to the Mendix Platform Portal and sign in.
 2. For each application you manage, navigate to the application's project page.
@@ -114,40 +109,48 @@ Steps:
 7. If the assignment is incorrect and you are the current Technical Contact, click **Edit** and follow the transfer process described above. If you are not the current Technical Contact, only that person can transfer the role – if they are unavailable or unreachable, contact Mendix Support.
 8. If the previous Technical Contact should no longer have Administrator access, manually revoke their permissions through namespace user management.
 
-## FAQ
+## Frequently Asked Questions
 
-**What is a Technical Contact?**
+This section answers common questions about Technical Contact assignments.
+
+### What is a Technical Contact?
 
 The designated operational owner of your application. This user automatically receives Administrator permissions on all deployment namespaces.
 
-**What permissions does the Technical Contact have?**
+### What permissions does the Technical Contact have?
 
 Full Administrator permissions including: deploy/start/stop applications, manage backups, access credentials stored as constants, modify configurations, manage users, and delete environments.
 
-**Who should I assign as Technical Contact?**
+### Who should I assign as Technical Contact?
 
 Choose an active team member who is familiar with the application's operation and authorized for full administrative access. Avoid assigning users who have left the team or only need view-only access.
 
-**How do I change the Technical Contact?**
+### How do I change the Technical Contact?
 
-On Mendix on Kubernetes and Mendix on Azure, only the current Technical Contact can transfer the role. If you are the current Technical Contact, navigate to Environments → Application Settings → click Edit next to Technical Contact → select new user → confirm. The new user immediately receives Administrator permissions on all deployment namespaces. If the current Technical Contact is unavailable or unreachable, contact Mendix Support – no cluster manager or namespace administrator can make this change on these platforms.
+On Mendix on Kubernetes and Mendix on Azure, only the current Technical Contact can transfer the role. If you are the current Technical Contact, to transfer the role, perform the following steps:
 
-**Can I have multiple Technical Contacts?**
+1. Navigate to **Environments > Application Settings**. 
+2. Click **Edit** next to **Technical Contact**.
+3. Select the new user and click **Confirm**.
 
-No. Only one Technical Contact per application. For additional administrators, use the namespace user management interface to grant permissions separately.
+The new user immediately receives Administrator permissions on all deployment namespaces. If the current Technical Contact is unavailable or unreachable, contact Mendix Support. No cluster manager or namespace administrator can make this change on these platforms.
 
-**What happens to the previous Technical Contact's permissions?**
+### Can I have multiple Technical Contacts?
 
-Permissions are NOT automatically removed when you change the Technical Contact. If the previous user should no longer have Administrator access, you must manually revoke their permissions in each namespace.
+No. You can have only one Technical Contact per application. For additional administrators, use the namespace user management interface to grant permissions separately.
 
-**How often should I review Technical Contact assignments?**
+### What happens to the previous Technical Contact's permissions?
 
-Best practice: review quarterly and whenever team membership changes (new hires, departures, role changes).
+Permissions are not automatically removed when you change the Technical Contact. If the previous user should no longer have Administrator access, you must manually revoke their permissions in each namespace.
 
-**Does the Technical Contact need to accept an invitation?**
+### How often should I review Technical Contact assignments?
+
+As a best practice, review the assignments quarterly and whenever the team membership changes (for example due to new hires, departures, or role changes).
+
+### Does the Technical Contact need to accept an invitation?
 
 No. The permissions are automatically granted when the Technical Contact is assigned. No invitation or acceptance step is required.
 
-**Can I assign a Technical Contact who isn't already a member of the application?**
+### Can I assign a Technical Contact who i snot already a member of the application?
 
-No. The Technical Contact must be selected from existing application members. Add the user to the application first, then assign them as Technical Contact.
+No. The Technical Contact must be selected from existing application members. Add the user to the application first, and then assign them as Technical Contact.


### PR DESCRIPTION
## Summary
- New page documenting the Technical Contact role for Mendix on Kubernetes and Mendix on Azure applications: what permissions it grants, how it's assigned, who should hold it, and how to review/transfer it
- Adds a cross-reference from the Mendix on Kubernetes overview page (`_index.md`)
- Corrects an outdated Technical Contact section on the existing "Deploying a Mendix App to a Mendix on Kubernetes Cluster" page — removes a superseded "before/after December 12" distinction (every application now gets a Technical Contact from creation) and clarifies that only the current Technical Contact can transfer the role
- Removes a now-inaccurate note on the same page stating the Environment Purpose section is hidden when no Technical Contact is set — no longer possible, since every application has one from creation

## Context
This documentation page is a dependency for a related Portunus UI change that will link to it from the Change Technical Contact modal.

## Test plan
- [ ] Verify front matter renders correctly (title, description, weight, URL) on the new page
- [ ] Verify the new page appears under Mendix on Kubernetes deployment docs at the expected URL
- [ ] Verify the FAQ section renders as expected (bold Q, plain A, per existing doc conventions)
- [ ] Verify the new cross-reference links (from `_index.md` and from the corrected deploy page) resolve correctly
- [ ] Verify the corrected deploy-page sections read coherently in context
- [ ] Docs team review for tone/style consistency with neighboring pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)