### PR TITLE
revise the Teamcenter Connector Upgrade path to 2606

### DIFF
--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -7,30 +7,32 @@ description: "Describes how to migrate an existing app from Teamcenter Connector
 
 ## Introduction
 
-With the 2606.0.0 release of the Teamcenter Connector, we introduced major changes and improvements, some of them breaking. This document provides an overview of these breaking changes and guides you through the upgrade path. 
+Teamcenter Connector 2606.0.0 introduces major changes and improvements, some of them breaking. This document provides an overview of these breaking changes and guides you through the upgrade path. 
 
-One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension (which was available through a separate marketplace module). 
+One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension, which was previousl available through a separate Marketplace module. 
 
 The changes fall into three categories:
-*	Changes to the `TcConnector` module (improved security and error handling, deprecations)
-*	Merging of the `TeamcenterToolkit` domain model, microflows and Java actions (previously part of the Teamcenter Extension) into the `TcConnector`
-*	Introduction of the Teamcenter service document, a new Mendix Studio Pro document to create, manage and organize your Teamcenter integrations.
 
-As mentioned, this migration involves some breaking changes, but they are outweighed by the benefits:
-*	Unified module
-*	Modern Extension framework
-*	Improved security
-*	Better error handling
+* Changes to the `TcConnector` module. These include improved security, error handling, and deprecations.
+* Merging of the `TeamcenterToolkit` domain model, microflows, and Java actions, which were previously part of the Teamcenter Extension, into the `TcConnector`.
+* Introduction of the Teamcenter service document, a new Mendix Studio Pro document which allows you to create, manage, and organize your Teamcenter integrations.
+
+The migration to 2606 involves some breaking changes, but they are outweighed by the benefits:
+
+* Unified module
+* Modern extension framework
+* Improved security
+* Better error handling
 
 ## Migration Scenarios
 
 There are three migration scenarios:
-1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in section [4](#teamcenter-connector-migration-process).
-2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [5](#teamcenter-toolkit-migration-process).
-3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-to-teamcenter-service-document).
 
+* Upgrade the Teamcenter Connector from 2512 to 2606 – read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in the [Teamcenter Connector Migration Process](#teamcenter-connector-migration-process) section.
+* Upgrade the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension) – read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in the [Teamcenter Connector Migration Process](#teamcenter-connector-migration-process) and [Teamcenter Toolkit Migration Process](#teamcenter-toolkit-migration-process) sections.
+* Upgrade the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter service document – read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in the [Teamcenter Connector Migration Process](#teamcenter-connector-migration-process) and [Migrating to a Teamcenter Service Document](#migrate-to-teamcenter-service-document) sections.
 
-## Pre-Migration Checklist
+### Pre-Migration Checklist {#pre-migration-checklist}
 
 Follow these steps carefully to avoid issues:
 
@@ -39,7 +41,7 @@ Follow these steps carefully to avoid issues:
 3. Migrate from Teamcenter Connector 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
 4. Make a backup. Before starting, either create a full backup of your app or commit all current changes to version control. This gives you a safety net in case you need to roll back.
 
-## Teamcenter Connector Migration Process
+### Teamcenter Connector Migration Process {#teamcenter-connector-migration-process}
 
 Follow these steps in this exact order to ensure a proper migration:
 
@@ -48,27 +50,25 @@ Follow these steps in this exact order to ensure a proper migration:
     1. Open your app in Studio Pro 11.12.1 or above.
     1. Make sure all changes are committed, if using version control, or backed up.
 
-2. Remove the resource files.
-
-    1. In your *Resources* folder, remove the *OperationMapping*, *TeamcenterCommon*, *TeamcenterConnector* folders. The contents of these folders are now in the *TcConnector* folder
+2. Remove the resource files.    
+    In your *Resources* folder, remove the *OperationMapping*, *TeamcenterCommon*, *TeamcenterConnector* folders. The contents of these folders are now in the *TcConnector* folder
    
-3. Import the new Teamcenter Connector 2606.
-
-    1. Download the Teamcenter Connector 2606 from Mendix Marketplace. This now also contains the new version of the extension.
-    {{% alert color="info" %}} The Teamcenter Extension is no longer found under the Extensions menu at the top. Instead, it is available as a new Service Document; similar to a microflow. You can find it by right-clicking a module in your project, selecting **Add other**, then selecting **Teamcenter service**. {{% /alert %}}
+3. Import Teamcenter Connector 2606.    
+    Download the Teamcenter Connector 2606 from Mendix Marketplace. This now also contains the new version of the extension.
+    {{% alert color="info" %}} The Teamcenter Extension is no longer found under the **Extensions** menu at the top. Instead, it is available as a new service document, similar to a microflow. You can find it by right-clicking a module in your project, selecting **Add other**, then selecting **Teamcenter service**. {{% /alert %}}
 
 4. Resolve breaking changes.
 
-    1. For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows-and-their-replacements) and [Deprecated Java Actions and Their Replacements](#deprecated-java-actions-and-their-replacements).
-    1. Deprecated microflows and Java actions can be found in the *internal &rarr; deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
-    1. References to `FileType` should be changed to `NamedReference`.
-    1. The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead, whenever it was unsuccessful.
-    1. We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
-    1. For more information, refer to the [Breaking Changes](#breaking-changes) section.
+    * For a list of deprecated microflows and Java actions, refer to [Deprecated Microflows and Their Replacements](#deprecated-microflows-and-their-replacements) and [Deprecated Java Actions and Their Replacements](#deprecated-java-actions-and-their-replacements).
+    * Deprecated microflows and Java actions are available in the *internal &rarr; deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
+    * Change all `FileType` references to `NamedReference`.
+    * The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead, whenever it was unsuccessful.
+    * We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
+    * For more information, refer to the [Breaking Changes](#breaking-changes) section.
 
 5. Update security.
 
-    1. Click **Update Security** in the domain model of the implementing module, to synchronize the changes coming from the `TcConnector`. 
+    1. Click **Update Security** in the domain model of the implementing module. This synchronizes the changes coming from `TcConnector`. 
     1. Make sure that all attributes on persistent entities have read rights. The **Administrator** role now only has access to Teamcenter Configuration, so assign the **User** role to module roles that need entity access.
 
 6. Enable the React client.
@@ -76,16 +76,25 @@ Follow these steps in this exact order to ensure a proper migration:
     1. In your App Settings, go to the **Runtime** tab.
     1. Select **Yes** next to **Use React client**.
   
-## Teamcenter Toolkit Migration Process
+### Teamcenter Toolkit Migration Process {#teamcenter-toolkit-migration-process}
 
-This step descibes how to keep the original integrations using both the `TeamcenterToolkit` module and the Teamcenter Connector 2606 module. Since we have merged the `TeamcenterToolkit` module and the `TcConnector` module, there are some minor errors we have to solve in the model. This mainly involves the `BOMLine` entity.
+You can keep the original integrations using both the `TeamcenterToolkit` module and the Teamcenter Connector 2606 module. Since the `TeamcenterToolkit` module and the `TcConnector` module are merged, there are some minor errors that need to be solved in the model. These mainly involve the `BOMLine` entity. Follow these steps:
 
-1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the `TcConnector` module.
-    * An easy way to migrate a lot of references in a simple way is to rename the `TeamcenterToolkit` `BOMLine` to `BOMLine2`, then move `BOMLine2` to the `TcConnector` module, remove `BOMLine2`, and rename the `BOMLine` in the `TcConnector` module to `BOMLine2` and back to `BOMLine`. Do the same for the associations.
-2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`, use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`, to see if there are any BO mappings left that reference the `TeamcenterToolkit`, replace these with `TcConnector.BOMLine'.
+1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the `TcConnector` module.    
+    An easy way to migrate a large number of references is to follow this proces:
+    
+    1. Rename the `BOMLine` item in `TeamcenterToolkit` to `BOMLine2`.
+    2. Move `BOMLine2` to the `TcConnector` module.
+    3. Remove `BOMLine2`.
+    4. Rename the `BOMLine` item in the `TcConnector` module to `BOMLine2`, then back to `BOMLine`. 
+    5. Repeat the process for associations.
+2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`. Follow these steps to do that:
+
+    1. Use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`. This allows you to see if there are any BO mappings left that reference the `TeamcenterToolkit`.
+    2. Replace any remaining references with `TcConnector.BOMLine`.
 3. Validate if everything still works correctly. 
 
-## Migrate to Teamcenter service document
+### Migrating to a Teamcenter Service Document {#migrate-to-teamcenter-service-document}
 
 1. Create a Teamcenter service document.
 
@@ -108,16 +117,15 @@ This step descibes how to keep the original integrations using both the `Teamcen
     4. Replace the old microflows with the newly generated microflows.
     5. You can use the **Duplicate** feature on the **Integrations** tab to create variations of an integration without reconfiguring them from scratch.
 
-
-4. Remove the TeamcenterToolkit module from your project.
+4. Remove the `TeamcenterToolkit` module from your project.
 
     1. Before removing the `TeamcenterToolkit` module, commit your work.
     1. Make sure that the `TeamcenterToolkit` is not used anymore by right-clicking on the `TeamcenterToolkit` module and selecting **Find usages of this module**.
     1. Remove the `TeamcenterToolkit` module.
-    {{% alert color="info" %}} If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. {{% /alert %}}
-    2. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the `TeamcenterToolkit`. If there are, replace them with `TcConnector`.
-    3. Once all the journeys are migrated you can remove the *TeamcenterExtension* folder from your project's resources folder on disk.
-    4. Remove the `TeamcenterExtension` module under Add-ons. This is the older Teamcenter Extension which is no longer needed now that you are using the Teamcenter service document.
+        {{% alert color="info" %}} If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. {{% /alert %}}
+    1. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, and identify any remaining BO mappings that reference the `TeamcenterToolkit`. If there are any, replace them with `TcConnector`.
+    1. Once all the journeys are migrated, you can remove the *TeamcenterExtension* folder from your project's resources folder on the disk.
+    1. Remove the `TeamcenterExtension` module under **Add-ons**. This is the older Teamcenter Extension which is no longer needed since you are using the Teamcenter service document.
 
 5. Test thoroughly.
 
@@ -126,7 +134,7 @@ This step descibes how to keep the original integrations using both the `Teamcen
     3. Test error handling by triggering error conditions (for example, invalid search criteria).
     4. If you have automated tests, run them to ensure integration behavior is correct.
 
-## Breaking Changes
+## Breaking Changes {#breaking-changes}
 
 This is a comprehensive table of breaking changes and actions to take for each one:
 
@@ -142,7 +150,7 @@ This is a comprehensive table of breaking changes and actions to take for each o
 | `Logout` Java action | Now returns Boolean. | Update callers if return value was previously ignored. |
 | Error messages | Connector no longer shows in-app messages. It throws exceptions instead. | Ensure calling microflows have error handlers. |
 
-## Deprecated Microflows and Their Replacements
+## Deprecated Microflows and Their Replacements {#deprecated-microflows-and-their-replacements}
 
 These microflows still exist in the deprecated folder, but should no longer be used. Replace them with the recommended alternatives:
 
@@ -163,7 +171,7 @@ These microflows still exist in the deprecated folder, but should no longer be u
 | `ShowPartialErrors` | No replacement |
 | `UpdateSession` | No replacement |
 
-## Deprecated Java Actions and Their Replacements
+## Deprecated Java Actions and Their Replacements {#deprecated-java-actions-and-their-replacements}
 
 These Java actions still exist in the deprecated folder, but should no longer be used. Replace them with the recommended alternatives:
 

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -27,10 +27,10 @@ As mentioned, this migration involves some breaking changes, but they are outwei
 There are three migration scenarios:
 1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in section [4](#teamcenter-connector-migration-process).
 2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [5](#teamcenter-toolkit-migration-process).
-3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-teamcenter-service-document).
+3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-to-teamcenter-service-document).
 
 
-## Pre-Migration Checklist (#pre-migration-checklist)
+## Pre-Migration Checklist
 
 Follow these steps carefully to avoid issues:
 
@@ -39,7 +39,7 @@ Follow these steps carefully to avoid issues:
 3. Migrate from Teamcenter 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
 4. Make a backup. Before starting, either create a full backup of your app or commit all current changes to version control. This gives you a safety net in case you need to roll back.
 
-## Teamcenter Connector Migration Process (#teamcenter-connector-migration-process)
+## Teamcenter Connector Migration Process
 
 Follow these steps in this exact order to ensure a proper migration:
 
@@ -59,7 +59,7 @@ Follow these steps in this exact order to ensure a proper migration:
 
 4. Resolve breaking changes.
 
-    1. For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows) and [Deprecated Java Actions and Their Replacements](#deprecated-java).
+    1. For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows-and-their-replacements) and [Deprecated Java Actions and Their Replacements](#deprecated-java-actions-and-their-replacements).
     1. Deprecated microflows and Java actions can be found in the *internal>deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
     1. References to `FileType` should be changed to `NamedReference`.
     1. The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead.
@@ -76,7 +76,7 @@ Follow these steps in this exact order to ensure a proper migration:
     1. In your App Settings, go to the **Runtime** tab.
     1. Select **Yes** next to **Use React client**.
   
-## Teamcenter Toolkit Migration Process (#teamcenter-toolkit-migration-process)
+## Teamcenter Toolkit Migration Process
 
 This step descibes how to keep the original integrations using both the `TeamcenterToolkit` module and the Teamcenter Connector 2606 module. Since we have merged the `TeamcenterToolkit` module and the `TcConnector` module, there are some minor errors we have to solve in the model. This mainly involves the `BOMLine` entity.
 
@@ -85,7 +85,7 @@ This step descibes how to keep the original integrations using both the `Teamcen
 2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`, use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`, to see if there are any BO mappings left that reference the `TeamcenterToolkit`, replace these with `TcConnector.BOMLine'.
 3. Validate if everything still works correctly. 
 
-## Migrate to Teamcenter Service Document (#migrate-teamcenter-service-document)
+## Migrate to Teamcenter Service Document
 
 1. Create a Teamcenter Service Document.
 
@@ -126,7 +126,7 @@ This step descibes how to keep the original integrations using both the `Teamcen
     1. Test error handling by triggering error conditions (for example, invalid search criteria).
     1. If you have automated tests, run them to ensure integration behavior is correct.
 
-## Breaking Changes {#breaking-changes}
+## Breaking Changes
 
 This is a comprehensive table of breaking changes and actions to take for each one:
 
@@ -142,7 +142,7 @@ This is a comprehensive table of breaking changes and actions to take for each o
 | `Logout` Java action | Now returns Boolean. | Update callers if return value was previously ignored. |
 | Error messages | Connector no longer shows in-app messages. It throws exceptions instead. | Ensure calling microflows have error handlers. |
 
-## Deprecated Microflows and Their Replacements {#deprecated-microflows}
+## Deprecated Microflows and Their Replacements
 
 These microflows still exist in the deprecated folder, but should no longer be used. Replace them with the recommended alternatives:
 
@@ -163,7 +163,7 @@ These microflows still exist in the deprecated folder, but should no longer be u
 | `ShowPartialErrors` | No replacement |
 | `UpdateSession` | No replacement |
 
-## Deprecated Java Actions and Their Replacements {#deprecated-java}
+## Deprecated Java Actions and Their Replacements
 
 These Java actions still exist in the deprecated folder, but should no longer be used. Replace them with the recommended alternatives:
 
@@ -179,7 +179,7 @@ These Java actions still exist in the deprecated folder, but should no longer be
 | `GetItemFromId` | `GetItemAndRelatedObjects` |
 | `RetrieveCookie` | No replacement |
 
-## Deprecated Entities {#deprecated-entities}
+## Deprecated Entities
 
 The following entities have been deprecated. To indicate this, the entities have been renamed with an underscore prefix:
 

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -14,7 +14,7 @@ One of the main changes is that the Teamcenter Connector 2606 combines the Teamc
 The changes fall into three categories:
 *	Changes to the `TcConnector` module (improved security and error handling, deprecations)
 *	Merging of the `TeamcenterToolkit` domain model, microflows and Java actions (previously part of the Teamcenter Extension) into the `TcConnector`
-*	Introduction of the Teamcenter Service document, a new Mendix Studio Pro document to create, manage and organize your Teamcenter integrations.
+*	Introduction of the Teamcenter service document, a new Mendix Studio Pro document to create, manage and organize your Teamcenter integrations.
 
 As mentioned, this migration involves some breaking changes, but they are outweighed by the benefits:
 *	Unified module
@@ -27,7 +27,7 @@ As mentioned, this migration involves some breaking changes, but they are outwei
 There are three migration scenarios:
 1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in section [4](#teamcenter-connector-migration-process).
 2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [5](#teamcenter-toolkit-migration-process).
-3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-to-teamcenter-service-document).
+3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-to-teamcenter-service-document).
 
 
 ## Pre-Migration Checklist
@@ -36,7 +36,7 @@ Follow these steps carefully to avoid issues:
 
 1. Upgrade to Studio Pro 11.12.1 or above. If you are using Studio Pro 10, you must upgrade before importing Teamcenter 2606.
 2. Have only one developer perform the migration. If multiple developers migrate simultaneously, there will be duplicate artifacts. Coordinate with your team and designate one person to handle the migration, then have others pull the updated code from version control.
-3. Migrate from Teamcenter 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
+3. Migrate from Teamcenter Connector 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
 4. Make a backup. Before starting, either create a full backup of your app or commit all current changes to version control. This gives you a safety net in case you need to roll back.
 
 ## Teamcenter Connector Migration Process
@@ -55,20 +55,20 @@ Follow these steps in this exact order to ensure a proper migration:
 3. Import the new Teamcenter Connector 2606.
 
     1. Download the Teamcenter Connector 2606 from Mendix Marketplace. This now also contains the new version of the extension.
-    {{% alert color="info" %}} The Teamcenter Extension is no longer included in Extensions. It is available as a new Service Document, similar to a microflow. You can find it by right-clicking the module, selecting **Add other**, then selecting **Teamcenter service**. {{% /alert %}}
+    {{% alert color="info" %}} The Teamcenter Extension is no longer found under the Extensions menu at the top. Instead, it is available as a new Service Document; similar to a microflow. You can find it by right-clicking a module in your project, selecting **Add other**, then selecting **Teamcenter service**. {{% /alert %}}
 
 4. Resolve breaking changes.
 
     1. For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows-and-their-replacements) and [Deprecated Java Actions and Their Replacements](#deprecated-java-actions-and-their-replacements).
-    1. Deprecated microflows and Java actions can be found in the *internal>deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
+    1. Deprecated microflows and Java actions can be found in the *internal &rarr; deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
     1. References to `FileType` should be changed to `NamedReference`.
-    1. The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead.
+    1. The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead, whenever it was unsuccessful.
     1. We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
     1. For more information, refer to the [Breaking Changes](#breaking-changes) section.
 
 5. Update security.
 
-    1. Click **Update Security** in Studio Pro. 
+    1. Click **Update Security** in the TcConnector domain model in Studio Pro. 
     1. Make sure that all attributes on persistent entities have read rights. The **Administrator** role now only has access to Teamcenter Configuration, so assign the **User** role to module roles that need entity access.
 
 6. Enable the React client.
@@ -85,28 +85,28 @@ This step descibes how to keep the original integrations using both the `Teamcen
 2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`, use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`, to see if there are any BO mappings left that reference the `TeamcenterToolkit`, replace these with `TcConnector.BOMLine'.
 3. Validate if everything still works correctly. 
 
-## Migrate to Teamcenter Service Document
+## Migrate to Teamcenter service document
 
-1. Create a Teamcenter Service Document.
+1. Create a Teamcenter service document.
 
-    1. In the module where your Teamcenter integrations live, right-click and select **Add others**, then click **Teamcenter Service**.
+    1. In the module where your Teamcenter integrations are stored, right-click and select **Add others**, then select **Teamcenter service**.
     1. Give it a name.
 
 2. Reconfigure your connection.
 
-    1. Open the Teamcenter Service Document and go to the **Settings** tab.
+    1. Open the Teamcenter service document and go to the **Settings** tab.
     1. Enter your Teamcenter URL and authentication settings.
     1. Click **Sign In** and log in to Teamcenter.
 
 3. Recreate your integrations.
 
-    Your existing domain model entities and microflows are still in your app. However, you need to regenerate them using the new Extension to take advantage of improvements and ensure compatibility with the new connector. To do that, follow these steps:
+    Your existing domain model entities and microflows are still in your app. However, you need to regenerate them using the new Teamcenter service document to take advantage of the improvements and ensure compatibility with the new connector. To do that, follow these steps:
                 
-    1. In the Service Document, click **+Add integration** and start a journey that matches each of your existing integrations.
-    1. Configure the integration the same way as before. The journey types and options are the same.
-    1. Click **Generate** to save and generate the integration. 
-    1. Replace the old microflows with the newly generated microflows.
-    1. You can use the **Duplicate** feature on the **History** tab to create variations of an integration without reconfiguring from scratch.
+    1. In the Teamcenter service, click **+Add integration** and select a journey that matches each of your existing integrations.
+    2. Configure the integration the same way as before. The journey types and options are the same.
+    3. Click **Generate** to save and generate the integration. 
+    4. Replace the old microflows with the newly generated microflows.
+    5. You can use the **Duplicate** feature on the **Integrations** tab to create variations of an integration without reconfiguring them from scratch.
 
 
 4. Remove the TeamcenterToolkit module from your project.
@@ -114,17 +114,17 @@ This step descibes how to keep the original integrations using both the `Teamcen
     1. Before removing the `TeamcenterToolkit` module, commit your work.
     1. Make sure that the `TeamcenterToolkit` is not used anymore by right-clicking on the `TeamcenterToolkit` module and selecting **Find usages of this module**.
     1. Remove the `TeamcenterToolkit` module.
-    ...* If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. 
-    1. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the `TeamcenterToolkit`. If there are, replace them with `TcConnector`.
-    1. Once all the journeys are migrated you can remove the *TeamcenterExtension* folder.
-    1. Remove the `TeamcenterExtension` module under add-ons, this contains the old Teamcenter Extension and is not needed anymore for using the Teamcenter Service Document.
+    {{% alert color="info" %}} If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. {{% /alert %}}
+    2. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the `TeamcenterToolkit`. If there are, replace them with `TcConnector`.
+    3. Once all the journeys are migrated you can remove the *TeamcenterExtension* folder from your project's resources folder on disk.
+    4. Remove the `TeamcenterExtension` module under Add-ons. This is the older Teamcenter Extension which is no longer needed now that you are using the Teamcenter service document.
 
 5. Test thoroughly.
 
     1. Run each generated microflow against your Teamcenter instance.
-    1. Verify that search, create, update, and retrieval operations work as expected.
-    1. Test error handling by triggering error conditions (for example, invalid search criteria).
-    1. If you have automated tests, run them to ensure integration behavior is correct.
+    2. Verify that search, create, update, and retrieval operations work as expected.
+    3. Test error handling by triggering error conditions (for example, invalid search criteria).
+    4. If you have automated tests, run them to ensure integration behavior is correct.
 
 ## Breaking Changes
 

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -9,7 +9,7 @@ description: "Describes how to migrate an existing app from Teamcenter Connector
 
 Teamcenter Connector 2606.0.0 introduces major changes and improvements, some of them breaking. This document provides an overview of these breaking changes and guides you through the upgrade path. 
 
-One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension, which was previousl available through a separate Marketplace module. 
+One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension, which was previously available through a separate Marketplace module. 
 
 The changes fall into three categories:
 
@@ -51,7 +51,7 @@ Follow these steps in this exact order to ensure a proper migration:
     1. Make sure all changes are committed, if using version control, or backed up.
 
 2. Remove the resource files.    
-    In your *Resources* folder, remove the *OperationMapping*, *TeamcenterCommon*, *TeamcenterConnector* folders. The contents of these folders are now in the *TcConnector* folder
+    In your *Resources* folder, remove the *OperationMapping*, *TeamcenterCommon*, *TeamcenterConnector* folders. The contents of these folders are now in the *TcConnector* folder.
    
 3. Import Teamcenter Connector 2606.    
     Download the Teamcenter Connector 2606 from Mendix Marketplace. This now also contains the new version of the extension.
@@ -60,10 +60,10 @@ Follow these steps in this exact order to ensure a proper migration:
 4. Resolve breaking changes.
 
     * For a list of deprecated microflows and Java actions, refer to [Deprecated Microflows and Their Replacements](#deprecated-microflows-and-their-replacements) and [Deprecated Java Actions and Their Replacements](#deprecated-java-actions-and-their-replacements).
-    * Deprecated microflows and Java actions are available in the *internal &rarr; deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
+    * Deprecated microflows and Java actions are available in the **internal > deprecated** folder in the **TcConnector** module. These microflows are no longer used by the connector, but you can include them and move them to your own module if required.
     * Change all `FileType` references to `NamedReference`.
-    * The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead, whenever it was unsuccessful.
-    * We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
+    * The **Login** microflow no longer returns a Boolean value. **Login** now throws an exception whenever it is unsuccessful.
+    * Microflows that use the `TcSession` entity are deprecated. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
     * For more information, refer to the [Breaking Changes](#breaking-changes) section.
 
 5. Update security.
@@ -81,7 +81,7 @@ Follow these steps in this exact order to ensure a proper migration:
 You can keep the original integrations using both the `TeamcenterToolkit` module and the Teamcenter Connector 2606 module. Since the `TeamcenterToolkit` module and the `TcConnector` module are merged, there are some minor errors that need to be solved in the model. These mainly involve the `BOMLine` entity. Follow these steps:
 
 1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the `TcConnector` module.    
-    An easy way to migrate a large number of references is to follow this proces:
+    An easy way to migrate a large number of references is to follow this process:
     
     1. Rename the `BOMLine` item in `TeamcenterToolkit` to `BOMLine2`.
     2. Move `BOMLine2` to the `TcConnector` module.
@@ -92,7 +92,7 @@ You can keep the original integrations using both the `TeamcenterToolkit` module
 
     1. Use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`. This allows you to see if there are any BO mappings left that reference the `TeamcenterToolkit`.
     2. Replace any remaining references with `TcConnector.BOMLine`.
-3. Validate if everything still works correctly. 
+3. Verify that everything still works correctly. 
 
 ### Migrating to a Teamcenter Service Document {#migrate-to-teamcenter-service-document}
 
@@ -105,7 +105,7 @@ You can keep the original integrations using both the `TeamcenterToolkit` module
 
     1. Open the Teamcenter service document and go to the **Settings** tab.
     1. Enter your Teamcenter URL and authentication settings.
-    1. Click **Sign In** and log in to Teamcenter.
+    1. Click **Sign In** and sign in to Teamcenter.
 
 3. Recreate your integrations.
 
@@ -122,7 +122,7 @@ You can keep the original integrations using both the `TeamcenterToolkit` module
     1. Before removing the `TeamcenterToolkit` module, commit your work.
     1. Make sure that the `TeamcenterToolkit` is not used anymore by right-clicking on the `TeamcenterToolkit` module and selecting **Find usages of this module**.
     1. Remove the `TeamcenterToolkit` module.
-        {{% alert color="info" %}} If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. {{% /alert %}}
+        {{% alert color="info" %}} If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resources in the `TeamcenterToolkit` to the new ones in the `TcConnector`. {{% /alert %}}
     1. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, and identify any remaining BO mappings that reference the `TeamcenterToolkit`. If there are any, replace them with `TcConnector`.
     1. Once all the journeys are migrated, you can remove the *TeamcenterExtension* folder from your project's resources folder on the disk.
     1. Remove the `TeamcenterExtension` module under **Add-ons**. This is the older Teamcenter Extension which is no longer needed since you are using the Teamcenter service document.
@@ -136,7 +136,7 @@ You can keep the original integrations using both the `TeamcenterToolkit` module
 
 ## Breaking Changes {#breaking-changes}
 
-This is a comprehensive table of breaking changes and actions to take for each one:
+The following table lists the breaking changes and the action required for each one:
 
 | Area | Change | Action required |
 | --- | --- | --- | 
@@ -207,7 +207,7 @@ The following entities have been deprecated. To indicate this, the entities have
 
 ## Automatically Migrated Items
 
-Not everything needs to be rebuilt from scratch. These items are automatically migrated as they are:
+The following items are automatically migrated and do not need to be rebuilt:
 
 * Domain model – Entities and associations generated by the previous Extension remain in your module. They are part of your app, so they do not disappear during the migration.
 * Microflows – Generated microflows remain in your app. Only those affected by specific breaking changes, such as input entity naming or Toolkit module references, need to be regenerated or updated.

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -7,14 +7,28 @@ description: "Describes how to migrate an existing app from Teamcenter Connector
 
 ## Introduction
 
-Teamcenter Connector 2606 contains both the Teamcenter Connector and the Teamcenter Extension. From this version onwards, the Teamcenter Extension does not need to be downloaded separately. If you have an existing app using Teamcenter Connector 2512 and the Teamcenter Extension v4.x, you can migrate to version 2606.
+With the 2606.0.0 release of the Teamcenter Connector, we introduced major changes and improvements, some of them breaking. This document provides an overview of these breaking changes and guides you through the upgrade path. 
 
-This migration involves some breaking changes, but they are outweighed by the benefits:
+One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension (which was available through a separate marketplace module). 
 
-* Unified module
-* Modern Extension framework
-* Improved security
-* Better error handling
+The changes fall into three categories:
+*	Changes to the TcConnector (improved security and error handling, deprecations)
+*	Merging of the Teamcenter Toolkit domain model, microflows and Java actions (previously part of the Teamcenter Extension) into the TcConnector
+*	Introduction of the Teamcenter Service document, a new Mendix Studio Pro document to create, manage and organize your Teamcenter integrations.
+
+As mentioned, this migration involves some breaking changes, but they are outweighed by the benefits:
+*	Unified module
+*	Modern Extension framework
+*	Improved security
+*	Better error handling
+
+## Migration Scenarios
+
+There are three migration scenarios:
+1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the pre-migration checklist and follow the steps in section 4.
+2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the pre-migration checklist and follow the steps in sections 4 and 5.
+3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the pre-migration checklist and follow the steps in sections 4 and 6.
+
 
 ## Pre-Migration Checklist
 
@@ -22,10 +36,10 @@ Follow these steps carefully to avoid issues:
 
 1. Upgrade to Studio Pro 11.12.1 or above. If you are using Studio Pro 10, you must upgrade before importing Teamcenter 2606.
 2. Have only one developer perform the migration. If multiple developers migrate simultaneously, there will be duplicate artifacts. Coordinate with your team and designate one person to handle the migration, then have others pull the updated code from version control.
-3. Migrate from Teamcenter 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.0.0 to 2512.0.0](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
+3. Migrate from Teamcenter 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
 4. Make a backup. Before starting, either create a full backup of your app or commit all current changes to version control. This gives you a safety net in case you need to roll back.
 
-## Migration Process
+## Teamcenter Connector Migration Process
 
 Follow these steps in this exact order to ensure a proper migration:
 
@@ -37,28 +51,20 @@ Follow these steps in this exact order to ensure a proper migration:
 2. Remove the resource files.
 
     1. In your *Resources* folder, remove the *OperationMapping*, *TeamcenterCommon*, *TeamcenterConnector* folders. The contents of these folders are now in the *TcConnector* folder
-    1. Keep the *TeamcenterExtension* folder for now. You can remove it after all the journeys are migrated to the new service document.
+   
+3. Import the new Teamcenter Connector 2606.
 
-3. Import the new connector.
-
-    1. Remove the TeamcenterExtension module under add-ons, as the old extension is not compatible with version 2606 of the Teamcenter Connector.
     1. Download the Teamcenter Connector 2606 from Mendix Marketplace. This now also contains the new version of the extension.
     {{% alert color="info" %}} The Teamcenter Extension is no longer included in Extensions. It is available as a new Service Document, similar to a microflow. You can find it by right-clicking the module, selecting **Add other**, then selecting **Teamcenter service**. {{% /alert %}}
 
 4. Resolve breaking changes.
 
-    1. Studio Pro displays errors where your microflows or domain model reference things that have changed. Work through these systematically.
-
-        The most common issues you will encounter are:
-
-        * Errors in microflows that were generated by the Teamcenter Extension can best be recreated by the new version of the extension. Refer to step 9 for details.
-        * For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows) and [Deprecated Java Actions and Their Replacements](#deprecated-java).
-        * Deprecated microflows and Java actions can be found in the *internal>deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required. 
-        * References to `TeamcenterToolkit.*` in BO mappings should be changed to `TcConnector.*` The Toolkit module is merged into TcConnector.
-        * References to `FileType` should be changed to `NamedReference`.
-        * The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead.
-        * We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.    
-        * For more information, refer to the [Breaking Changes](#breaking-changes) section.
+    1. For a list of deprecated microflows and Java actions, see [Deprecated Microflows and Their Replacements](#deprecated-microflows) and [Deprecated Java Actions and Their Replacements](#deprecated-java).
+    1. Deprecated microflows and Java actions can be found in the *internal>deprecated* folder in the **TcConnector** module. These microflows are not used by the connector anymore, but you can include them and move them to your own module if required.
+    1. References to `FileType` should be changed to `NamedReference`.
+    1. The **Login** microflow does not return a Boolean value anymore. **Login** now throws an exception instead.
+    1. We have deprecated microflows that use the `TcSession` entity. Do not use the `TcSession` entity in your code. If you want to know if someone is logged in, use `RULE_TeamcenterConfiguration_IsLoggedIn` instead.
+    1. For more information, refer to the [Breaking Changes](#breaking-changes) section.
 
 5. Update security.
 
@@ -69,38 +75,51 @@ Follow these steps in this exact order to ensure a proper migration:
 
     1. In your App Settings, go to the **Runtime** tab.
     1. Select **Yes** next to **Use React client**.
+  
+## Teamcenter Toolkit Migration Process
 
-7. Create a Teamcenter Service Document.
+This step descibes how to keep the original integrations using both the TeamcenterToolkit module and the Teamcenter Connector 2606 module. Since we have merged the TeamcenterToolkit module and the TcConnector module, there are some minor errors we have to solve in the model. This mainly involves the BOMLine.
+
+1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the TcConnector module.
+    * An easy way to migrate a lot of references in a simple way is to rename the `TeamcenterToolkit` `BOMLine` to `BOMLine2`, then move `BOMLine2` to the `TcConnector` module, remove `BOMLine2`, and rename the `BOMLine` in the `TcConnector` module to `BOMLine2` and back to `BOMLine`. Do the same for the associations.
+2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`, use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`, to see if there are any BO mappings left that reference the `TeamcenterToolkit`, replace these with `TcConnector.BOMLine'.
+3. Validate if everything still works correctly. 
+
+## Migrate to Teamcenter Service Document
+
+1. Create a Teamcenter Service Document.
 
     1. In the module where your Teamcenter integrations live, right-click and select **Add others**, then click **Teamcenter Service**.
     1. Give it a name.
 
-8. Reconfigure your connection.
+2. Reconfigure your connection.
 
     1. Open the Teamcenter Service Document and go to the **Settings** tab.
     1. Enter your Teamcenter URL and authentication settings.
     1. Click **Sign In** and log in to Teamcenter.
 
-9. Recreate your integrations.
+3. Recreate your integrations.
 
     Your existing domain model entities and microflows are still in your app. However, you need to regenerate them using the new Extension to take advantage of improvements and ensure compatibility with the new connector. To do that, follow these steps:
-
+                
     1. In the Service Document, click **+Add integration** and start a journey that matches each of your existing integrations.
     1. Configure the integration the same way as before. The journey types and options are the same.
     1. Click **Generate** to save and generate the integration. 
     1. Replace the old microflows with the newly generated microflows.
     1. You can use the **Duplicate** feature on the **History** tab to create variations of an integration without reconfiguring from scratch.
 
-10. Remove the Toolkit module from your project.
 
-    1. Before removing the Toolkit module, commit your work by right-clicking on the Toolkit module and selecting **Find usages of this module**.
-    1. Since the Toolkit module is merged with the TcConnector module, all references to the Toolkit should point to the TcConnector.
+4. Remove the Toolkit module from your project.
 
-       If there are still many resources pointing to the Toolkit, you can rename the Toolkit to TcConnector2, remove the TcConnector2, rename the TcConnector to TcConnector2 and back to TcConnector. This trick connects the old resouces in the Toolkit to the new ones in the TcConnector.
-       
-    1. Use **Ctrl+F** to search for *"Toolkit"*, to see if there are any BO mappings left that reference the Toolkit. If there are, replace them with TcConnector. 
+    1. Before removing the Toolkit module, commit your work.
+    1. Make sure that the TeamcenterToolkit is not used anymore by right-clicking on the Toolkit module and selecting **Find usages of this module**.
+    1. Remove the `TeamcenterToolkit` module.
+    ...* If there are still many resources pointing to the Toolkit, you can rename the Toolkit to TcConnector2, remove the TcConnector2, rename the TcConnector to TcConnector2 and back to TcConnector. This trick connects the old resouces in the Toolkit to the new ones in the TcConnector. 
+    1. Since the TeamcenterToolkit module is merged with the TcConnector module, all references to the Toolkit should point to the TcConnector. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the TeamcenterToolkit. If there are, replace them with `TcConnector`.
+    1. Once all the journeys are migrated you can remove the *TeamcenterExtension* folder.
+    1. Remove the TeamcenterExtension module under add-ons, this contains the old Teamcenter Extension and is not needed anymore for using the Teamcenter Service Document.
 
-11. Test thoroughly.
+5. Test thoroughly.
 
     1. Run each generated microflow against your Teamcenter instance.
     1. Verify that search, create, update, and retrieval operations work as expected.

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -12,8 +12,8 @@ With the 2606.0.0 release of the Teamcenter Connector, we introduced major chang
 One of the main changes is that the Teamcenter Connector 2606 combines the Teamcenter Connector and the Teamcenter Extension (which was available through a separate marketplace module). 
 
 The changes fall into three categories:
-*	Changes to the TcConnector (improved security and error handling, deprecations)
-*	Merging of the Teamcenter Toolkit domain model, microflows and Java actions (previously part of the Teamcenter Extension) into the TcConnector
+*	Changes to the `TcConnector` module (improved security and error handling, deprecations)
+*	Merging of the `TeamcenterToolkit` domain model, microflows and Java actions (previously part of the Teamcenter Extension) into the `TcConnector`
 *	Introduction of the Teamcenter Service document, a new Mendix Studio Pro document to create, manage and organize your Teamcenter integrations.
 
 As mentioned, this migration involves some breaking changes, but they are outweighed by the benefits:
@@ -25,12 +25,12 @@ As mentioned, this migration involves some breaking changes, but they are outwei
 ## Migration Scenarios
 
 There are three migration scenarios:
-1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the pre-migration checklist and follow the steps in section 4.
-2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the pre-migration checklist and follow the steps in sections 4 and 5.
-3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the pre-migration checklist and follow the steps in sections 4 and 6.
+1.	Upgrade of the Teamcenter Connector from 2512 to 2606: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in section [4](#teamcenter-connector-migration-process).
+2.	Upgrade of the Teamcenter Connector from 2512 to 2606 and keep the original integrations (Teamcenter Extension): read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [5](#teamcenter-toolkit-migration-process).
+3.	Upgrade of the Teamcenter Connector from 2512 to 2606 and migrate the original integrations to the new Teamcenter Service document: read the [pre-migration checklist](#pre-migration-checklist) and follow the steps in sections [4](#teamcenter-connector-migration-process) and [6](#migrate-teamcenter-service-document).
 
 
-## Pre-Migration Checklist
+## Pre-Migration Checklist (#pre-migration-checklist)
 
 Follow these steps carefully to avoid issues:
 
@@ -39,7 +39,7 @@ Follow these steps carefully to avoid issues:
 3. Migrate from Teamcenter 2512. If the project still contains an older version of the Teamcenter Connector, such as 2506 or older, first follow the steps for [Upgrading Teamcenter Connector 2506.x to 2512.x](/appstore/industry/teamcenter-connector/upgrade-teamcenter-connector-2506-to-2512/).
 4. Make a backup. Before starting, either create a full backup of your app or commit all current changes to version control. This gives you a safety net in case you need to roll back.
 
-## Teamcenter Connector Migration Process
+## Teamcenter Connector Migration Process (#teamcenter-connector-migration-process)
 
 Follow these steps in this exact order to ensure a proper migration:
 
@@ -76,16 +76,16 @@ Follow these steps in this exact order to ensure a proper migration:
     1. In your App Settings, go to the **Runtime** tab.
     1. Select **Yes** next to **Use React client**.
   
-## Teamcenter Toolkit Migration Process
+## Teamcenter Toolkit Migration Process (#teamcenter-toolkit-migration-process)
 
-This step descibes how to keep the original integrations using both the TeamcenterToolkit module and the Teamcenter Connector 2606 module. Since we have merged the TeamcenterToolkit module and the TcConnector module, there are some minor errors we have to solve in the model. This mainly involves the BOMLine.
+This step descibes how to keep the original integrations using both the `TeamcenterToolkit` module and the Teamcenter Connector 2606 module. Since we have merged the `TeamcenterToolkit` module and the `TcConnector` module, there are some minor errors we have to solve in the model. This mainly involves the `BOMLine` entity.
 
-1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the TcConnector module.
+1. In the `TeamcenterToolkit` module, remove the `BOMLine` entity and start using the `BOMLine` entity in the `TcConnector` module.
     * An easy way to migrate a lot of references in a simple way is to rename the `TeamcenterToolkit` `BOMLine` to `BOMLine2`, then move `BOMLine2` to the `TcConnector` module, remove `BOMLine2`, and rename the `BOMLine` in the `TcConnector` module to `BOMLine2` and back to `BOMLine`. Do the same for the associations.
 2. Map the old `TeamcenterToolkit.BOMLine` BO mappings to `TcConnector.BOMLine`, use **Ctrl+F** to search for `TeamcenterToolkit.BOMLine`, to see if there are any BO mappings left that reference the `TeamcenterToolkit`, replace these with `TcConnector.BOMLine'.
 3. Validate if everything still works correctly. 
 
-## Migrate to Teamcenter Service Document
+## Migrate to Teamcenter Service Document (#migrate-teamcenter-service-document)
 
 1. Create a Teamcenter Service Document.
 
@@ -109,15 +109,15 @@ This step descibes how to keep the original integrations using both the Teamcent
     1. You can use the **Duplicate** feature on the **History** tab to create variations of an integration without reconfiguring from scratch.
 
 
-4. Remove the Toolkit module from your project.
+4. Remove the TeamcenterToolkit module from your project.
 
-    1. Before removing the Toolkit module, commit your work.
-    1. Make sure that the TeamcenterToolkit is not used anymore by right-clicking on the Toolkit module and selecting **Find usages of this module**.
+    1. Before removing the `TeamcenterToolkit` module, commit your work.
+    1. Make sure that the `TeamcenterToolkit` is not used anymore by right-clicking on the `TeamcenterToolkit` module and selecting **Find usages of this module**.
     1. Remove the `TeamcenterToolkit` module.
-    ...* If there are still many resources pointing to the Toolkit, you can rename the Toolkit to TcConnector2, remove the TcConnector2, rename the TcConnector to TcConnector2 and back to TcConnector. This trick connects the old resouces in the Toolkit to the new ones in the TcConnector. 
-    1. Since the TeamcenterToolkit module is merged with the TcConnector module, all references to the Toolkit should point to the TcConnector. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the TeamcenterToolkit. If there are, replace them with `TcConnector`.
+    ...* If there are still many resources pointing to the `TeamcenterToolkit`, you can rename the `TeamcenterToolkit` to `TcConnector2`, remove the `TcConnector2`, rename the `TcConnector` to `TcConnector2` and back to `TcConnector`. This trick connects the old resouces in the `TeamcenterToolkit` to the new ones in the `TcConnector`. 
+    1. Since the `TeamcenterToolkit` module is merged with the `TcConnector` module, all references to the `TeamcenterToolkit` should point to the `TcConnector`. Use **Ctrl+F** to search for *"TeamcenterToolkit."*, to see if there are any BO mappings left that reference the `TeamcenterToolkit`. If there are, replace them with `TcConnector`.
     1. Once all the journeys are migrated you can remove the *TeamcenterExtension* folder.
-    1. Remove the TeamcenterExtension module under add-ons, this contains the old Teamcenter Extension and is not needed anymore for using the Teamcenter Service Document.
+    1. Remove the `TeamcenterExtension` module under add-ons, this contains the old Teamcenter Extension and is not needed anymore for using the Teamcenter Service Document.
 
 5. Test thoroughly.
 
@@ -132,12 +132,12 @@ This is a comprehensive table of breaking changes and actions to take for each o
 
 | Area | Change | Action required |
 | --- | --- | --- | 
-| Teamcenter Toolkit Module | The module was merged into TcConnector. The module no longer exists. | Update all references from `TeamcenterToolkit.*` to `TcConnector.*`. |
+| `TeamcenterToolkit` Module | The module was merged into `TcConnector`. The module no longer exists. | Update all references from `TeamcenterToolkit.*` to `TcConnector.*`. |
 | Entity security | The `Create` and `Delete` rights were removed from all entities. | Remove any UI or microflow logic that relied on client-side `Create`/`Delete`. Use microflows instead. |
 | Input parameter `ConfigName` renamed to `ConfigurationName` | In generated microflows, the input parameter is now called `ConfigurationName` and is optional. | Set the `ConfigurationName` or leave it empty. |
 | Admin role | The **Administrator** no longer has entity access. | Assign the **User** role where needed. |
 | `FileType` / `File Type` | This was renamed to `NamedReference` / `Named Reference`. | Update all references in microflows and mappings. |
-| `CreateBOMWindow_Generic` | This was moved to TcConnector, and was updated to use `CreateOrReconfigureBOMWindows`. Pre-configured variants were removed. | Regenerate BOM microflows via the Extension or update manually to use `TcConnector.CreateBOMWindow_Generic`. |
+| `CreateBOMWindow_Generic` | This was moved to `TcConnector`, and was updated to use `CreateOrReconfigureBOMWindows`. Pre-configured variants were removed. | Regenerate BOM microflows via the Extension or update manually to use `TcConnector.CreateBOMWindow_Generic`. |
 | `Login` Java action | No longer returns Boolean. Throws exception on failure. | Remove Boolean result handling and wrap in error handler. |
 | `Logout` Java action | Now returns Boolean. | Update callers if return value was previously ignored. |
 | Error messages | Connector no longer shows in-app messages. It throws exceptions instead. | Ensure calling microflows have error handlers. |
@@ -157,9 +157,9 @@ These microflows still exist in the deprecated folder, but should no longer be u
 | `HandleServiceErrors` | No replacement |
 | `RetrieveConfigNameFromSingleActiveConfiguration` | Use `empty` for the `configurationName` parameter in Java actions. Java actions now handle active configuration in the Java code. |
 | `RetrieveHttpHeaderList` | No replacement |
-| `RetrieveTcSessionBasedOnConfigName` | No replacement. `TcSession` should not be manually consumed. It is automatically handled by the TcConnector module. |
+| `RetrieveTcSessionBasedOnConfigName` | No replacement. `TcSession` should not be manually consumed. It is automatically handled by the `TcConnector` module. |
 | `RetrieveTeamcenterConifgurationByName` | Use `empty` for the `configurationName` parameter in Java actions. Java actions now handle active configuration in the Java code. |
-| `RetrieveTeamcenterConifgurationFromTcSession` | No replacement. `TcSession` should not be manually consumed. It is automatically handled by the TcConnector module. |
+| `RetrieveTeamcenterConifgurationFromTcSession` | No replacement. `TcSession` should not be manually consumed. It is automatically handled by the `TcConnector` module. |
 | `ShowPartialErrors` | No replacement |
 | `UpdateSession` | No replacement |
 

--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/2606-configuration/migrate-to-2606.md
@@ -68,7 +68,7 @@ Follow these steps in this exact order to ensure a proper migration:
 
 5. Update security.
 
-    1. Click **Update Security** in the TcConnector domain model in Studio Pro. 
+    1. Click **Update Security** in the domain model of the implementing module, to synchronize the changes coming from the `TcConnector`. 
     1. Make sure that all attributes on persistent entities have read rights. The **Administrator** role now only has access to Teamcenter Configuration, so assign the **User** role to module roles that need entity access.
 
 6. Enable the React client.


### PR DESCRIPTION
We decided to add different migration steps to the guide. 

Docs team could you have a look at the changes and double ckeck the markdown? 

I'll ask either @wanchoorohan or @khode-mx to review these changes as well, then we can merge them back and publish the changes. 