### PR TITLE
[WC-3209]: mark Any Chart pages as deprecated and refresh Charts configuration docs

### DIFF
--- a/content/en/docs/marketplace/platform-supported-content/widgets/charts/_index.md
+++ b/content/en/docs/marketplace/platform-supported-content/widgets/charts/_index.md
@@ -19,7 +19,7 @@ For more examples of what Charts widgets can do, see the following documents:
 * [Use Custom Chart](/appstore/widgets/charts-custom-usage/)
 * [Fine-Tune a Chart with Chart Playground](/appstore/widgets/chart-advanced-tuning/)
 * [Use the Charts Theme](/appstore/widgets/charts-theme/)
-* [Create a Dynamic Series Chart](/appstore/widgets/charts-dynamic-series/)
+* [Create a Multiple Series Chart](/appstore/widgets/charts-dynamic-series/)
 * [Use a Chart with a REST Data Source](/appstore/widgets/charts-basic-rest/)
 
 {{% alert color="info" %}}
@@ -389,16 +389,15 @@ These are the available charts:
 
 A **Line chart** (scatter chart) should have one or more series, each displaying commonly grouped data points.
 
-A series' data can be retrieved from the database, by a microflow, or from a REST endpoint:
+A series' data can be retrieved from the database or by a microflow:
 
-1. Place the widget in a page within the context of an entity.
-2. Select the either **Static** or **Dynamic** for the **Series**.
-3. Select a **Data entity** for the chart values.
-4. Select the **Data source**:
-    * If the **Data source** selected is **Database**, optionally change the **XPath constraint**
-    * If the **Data source** selected is **Microflow,** select a **Microflow** that returns the series values
-    * If the **Data source** selected is **REST endpoint**, enter the **REST URL**
-5. If you set a **Dynamic** series, this will retrieve all the chart series in one configuration. Add configurations for them on the **Dynamic series** tab.
+1. Place the widget in a page.
+2. On the **General** tab, in the **Data source** section, add a **Series** item.
+3. Select either **Single series** or **Multiple series** for **Data set**.
+4. Select the **Data source** for the chart values:
+    * If the **Data source** selected is **Database**, select the entity and optionally change the **XPath constraint**
+    * If the **Data source** selected is **Microflow**, select a **Microflow** that returns the series values
+5. If you set **Multiple series**, one data source provides the data points for every series. Select the attribute to split them on in **Group by**: data points that share a value form one series.
 
 {{% alert color="info" %}}
 The line chart's X-axis provides support for dates, and thus the line chart can be configured as a [time series chart](#time-series).
@@ -418,17 +417,15 @@ The **Bar chart** has data properties identical to those of the [Column chart](#
 
 #### Pie Chart {#pie-chart}
 
-Unlike the chart types above, the **Pie chart** requires no series. 
+Unlike the chart types above, the **Pie chart** takes a single data source instead of a list of series.
 
-These are the properties for configuring Pie chart data:
+These are the properties for configuring Pie chart data, in the **Data source** section of the **General** tab:
 
-* **Data source** tab
-    * **Entity** (required) – the entity from which the data values will be retrieved
-* **Data points** tab
-    * **Name attribute** (required) – the attribute that contains the data point captions
-    * **Value attribute** (required) – the attribute that contains the data point values
-    * **Color attribute** (required) – the attribute that contains the data point colors
-    * **Sort attribute** – the attribute to use for sorting the X-axis data
+* **Series** (required) – the data source from which the slices are retrieved
+* **Series name** (required) – the text template that renders the slice captions
+* **Value attribute** (required) – the attribute that contains the slice values
+* **Sort attribute** – the attribute to use for sorting the slices, combined with **Sort order**
+* **Slice color** – an expression that returns the color of the slice
 
 #### Time Series Chart {#time-series}
 
@@ -450,7 +447,7 @@ The **Bubble chart** has data properties identical to those of the [Line chart](
 
 The charts in this widget are based on the [mendixlabs/charts](https://github.com/mendixlabs/charts/issues) library. As such, the widget provides support for advanced users to extend or overwrite the basic settings by adding the chart properties as JSON.
 
-To enable this feature, go to the **Mode** option in the **Advanced** properties tab. For the [Line chart](#line-chart) and [Column chart](#column-chart), each series has its own **Advanced** tab for specialized configurations.
+To enable this feature, select **Enable advanced options** on the **General** tab. You can then enter JSON in **Custom layout** and **Custom configurations** on the **Advanced** tab. Each series also has a **Custom series options** property in its own **Advanced** section for specialized configurations.
 
 The available advanced options and their usage are described below.
 

--- a/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-create.md
+++ b/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-create.md
@@ -75,18 +75,10 @@ To configure a Charts widget, follow these steps:
 
 1. Open the page with the Charts widget.
 2. Right-click the **Area chart** and select **Properties**.
-3. In the tab **Chart properties**, add a new **Series** property.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-create/charts-series.png" alt="Chart Series" class="no-border" >}}
-
-4. In the tab **Data source**, select *Value* as the **Entity**.
-5. Set the **Data source** as **Database**.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-create/chart-add-entity.png" alt="select Entity" class="no-border" >}}
-
-6. In the tab **Data points**, select *xValue* as the **X-axis data attribute** and *yValue* as the **Y-axis data attribute**.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-create/charts-data-points.png" alt="select Data Points" class="no-border" >}}
+3. On the **General** tab, in the **Data source** section, add a new **Series** item.
+4. In the **General** section of the series, leave **Data set** set to **Single series**.
+5. Set **Data source** to **Database** and select the *Value* entity.
+6. Select *xValue* as the **X axis attribute** and *yValue* as the **Y axis attribute**.
 
 ### Viewing the Chart
 
@@ -105,6 +97,7 @@ To view the chart, follow these steps:
 
 ## Read More
 
-* [Use a Chart With a REST Data Source](/howto/front-end/charts-basic-rest/)
+* [Create a Multiple Series Chart](/appstore/widgets/charts-dynamic-series/)
+* [Use a Chart With a REST Data Source](/appstore/widgets/charts-basic-rest/)
 * [Use Any Chart](/appstore/widgets/charts-any-usage/)
-* [Use Charts Themes](/howto/front-end/charts-theme/)
+* [Use Charts Themes](/appstore/widgets/charts-theme/)

--- a/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-rest.md
+++ b/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-rest.md
@@ -11,7 +11,7 @@ aliases:
 
 With the Charts widget, you can plot data that comes from a REST service.
 
-The widget does not call a REST service itself. Its data source accepts a database query, a microflow, a nanoflow, or an association, so you retrieve the REST data in a microflow and point the chart at that microflow.
+The widget does not call a REST service itself. Its data source accepts a database query (a microflow, a nanoflow, or an association) so you retrieve the REST data in a microflow and point the chart at that microflow.
 
 This how-to teaches you how to do the following:
 

--- a/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-rest.md
+++ b/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-basic-rest.md
@@ -2,18 +2,22 @@
 title: "Use a Chart with a REST Data Source"
 url: /appstore/widgets/charts-basic-rest/
 weight: 60
+description: "Describes how to plot data from a REST service in a chart by retrieving the data in a microflow and using that microflow as the chart's data source."
 aliases:
     - /howto/front-end/charts-basic-rest/
 ---
 
 ## Introduction
 
-With the Charts widgets, you can use data from a REST Service to plot graphs.
+With the Charts widget, you can plot data that comes from a REST service.
+
+The widget does not call a REST service itself. Its data source accepts a database query, a microflow, a nanoflow, or an association, so you retrieve the REST data in a microflow and point the chart at that microflow.
 
 This how-to teaches you how to do the following:
 
 * Publish a REST API
-* Use a REST endpoint as a data source for the Charts widget
+* Retrieve the data from a REST service in a microflow
+* Use that microflow as the data source for the Charts widget
 
 ## Prerequisites
 
@@ -24,7 +28,7 @@ Before starting this how-to, make sure you have completed the following prerequi
 
 ## Setting up Data to be Exposed by a REST Endpoint
 
-Mendix allows you to publish REST Web services natively from Studio Pro. Using these capabilities you can publish a REST service and use it in our Charts widget to plot graphs.
+Mendix allows you to publish REST web services natively from Studio Pro. This how-to publishes a service first, so that there is an endpoint to consume in the next sections.
 
 To create an Area Chart with data from a REST service, follow these steps:
 
@@ -68,40 +72,38 @@ To configure the REST service, follow these steps:
 1. Add **Export mapping**.
     {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-export-mapping.png" alt="Charts Rest Export Mapping" class="no-border" >}}
 
-## Using REST as a Data Source
+## Retrieving the REST Data in a Microflow
 
-To use the REST Data source endpoint in your chart, follow these steps:
+To make the published data available to the chart, consume the service and return its results from a microflow:
+
+1. Add a [consumed REST service](/refguide/consumed-rest-service/) for the endpoint you published.
+1. Add an [import mapping](/refguide/import-mappings/) that maps the JSON response to the **Value** entity.
+1. Create a microflow named *DS_ValuesFromREST*.
+1. In the microflow, add a [Call REST service](/refguide/call-rest-action/) activity that calls the endpoint and applies the import mapping.
+1. Set the list of **Value** objects produced by the mapping as the return value of the microflow.
+
+{{% alert color="info" %}}
+The mapping can return non-persistable objects. The chart only reads the attributes you select for the axes, so the objects do not have to be committed to the database.
+{{% /alert %}}
+
+## Using the Microflow as a Chart Data Source
+
+To plot the retrieved data, follow these steps:
 
 1. Create a page in your app containing an **Area chart** widget.
-
-1. Double-click the **Area chart** widget.
-
-1. In the tab **Chart properties**, add a new chart **Series** property.
-
-1. Add **Series name** and **Entity**.
-
-1. Select **Data source** REST endpoint.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-series.png" alt="Chart Rest Series" class="no-border" >}}
-
-1. Add the **REST URL**.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-url.png" alt="Chart Rest URL" class="no-border" >}}
-
-1. In the tab **Data points**, select the **X-axis data attribute** and the **Y-axis data attribute**.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-create/charts-data-points.png" alt="select Data Points" class="no-border" >}}  
-
-1. Add Parameters to the REST Request. The **contextId**, **series name** are provided by default.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-parameters.png" alt="select Data Points" class="no-border" >}} 
-
+1. Double-click the **Area chart** widget to open its properties.
+1. On the **General** tab, in the **Data source** section, add a new **Series** item.
+1. In the **General** section of the series, leave **Data set** set to **Single series**.
+1. Set **Data source** to **Microflow** and select *DS_ValuesFromREST*.
+1. Set **Series name** to the text that should appear in the legend.
+1. Select the **X axis attribute** and the **Y axis attribute**.
 1. Run your app and view the chart.
 
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-area-chart.png" alt="Show Chart" class="no-border" >}}
+    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-rest/charts-rest-area-chart.png" alt="Area chart plotting data retrieved from a REST service" class="no-border" >}}
 
 ## Read More
 
-* [Use Chart Data Source REST](/howto/front-end/charts-basic-create/)
+* [Create a Basic Chart](/appstore/widgets/charts-basic-create/)
+* [Create a Multiple Series Chart](/appstore/widgets/charts-dynamic-series/)
 * [Use Any Chart](/appstore/widgets/charts-any-usage/)
-* [Use Theme Charts](/howto/front-end/charts-theme/)
+* [Use Charts Themes](/appstore/widgets/charts-theme/)

--- a/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-dynamic-series.md
+++ b/content/en/docs/marketplace/platform-supported-content/widgets/charts/charts-dynamic-series.md
@@ -1,51 +1,49 @@
 ---
-title: "Create a Dynamic Series Chart"
+title: "Create a Multiple Series Chart"
 url: /appstore/widgets/charts-dynamic-series/
 weight: 50
+description: "Describes how to configure a chart that derives its series from your data at runtime by grouping a single data source."
 aliases:
     - /howto/front-end/charts-dynamic-series/
 ---
 
 ## Introduction
 
-The charts widget provides a basic implementation of dynamic series. This allows you to vary the number of data series (for example lines on a line chart) in your chart at runtime, based on the data in your app.
+The Charts widget can derive its series from your data at runtime. Instead of configuring one series for every line you want to show, you configure a single series, point it at one data source, and choose an attribute to group by. Every distinct value of that attribute becomes its own series, so the number of lines in the chart follows the data in your app.
 
 This how-to teaches you how to do the following:
 
-* Create a chart with dynamic series
+* Create a chart whose series are determined by your data at runtime
 
 ## Prerequisites
 
 Before starting this how-to, make sure you have completed the following prerequisites:
 
-* Download the latest [Charts Widget](/appstore/widgets/charts/) from the Mendix Marketplace
+* Download the latest [Charts](/appstore/widgets/charts/) widget from the Mendix Marketplace
 
 ## Setting up Chart Data
 
 ### Setting up the Domain Model
 
-In order to create the Charts widget with dynamic series, a specific data structure is set up.
+The chart reads all data points from one data source and splits them into series. This means the attribute that identifies the series must be stored on the same entity as the data points.
 
-1. Configure your domain model to contain an entity **Value** with attributes **xValue** and **yValue**.
-1. Add another entity, **Series**, with attributes **name**, **color**, and **fillColor**.
-1. Add an association **Value_Series** between the two entities.
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-model.png" alt="Values entity" class="no-border" >}}
+1. Configure your domain model to contain an entity **Value**.
+1. Give **Value** an attribute for each axis: **xValue** and **yValue**.
+1. Give **Value** a third attribute to group by, for example a string attribute named **seriesName**.
+
+{{% alert color="info" %}}
+The **Group by** property can only use an attribute of the entity the data source returns. It cannot follow an association, so storing the series name on a separate entity does not work.
+{{% /alert %}}
 
 ### Entering Data for the Chart
 
 Now you need to enter data for the chart.
 
-1. Right-click the **Series** entity.
-2. Choose **Generate overview pages...**.
-3. Select both **Series** and **Value** as the entities for which to generate pages.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-generate-pages.png" alt="Generate Series and Value overview and data entry pages" class="no-border" >}}
-
-4. Connect the **Series_Overview** page to the navigation.
-5. Click **Run Locally** ({{% icon name="controls-play" %}}) to run the app locally.
-6. Enter some sample data.
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-data-entry.png" alt="Enter data for chart" class="no-border" >}}
+1. Right-click the **Value** entity.
+1. Choose **Generate overview pages...**.
+1. Connect the **Value_Overview** page to the navigation.
+1. Click **Run Locally** ({{% icon name="controls-play" %}}) to run the app locally.
+1. Enter some sample data. Give every data point that belongs to the same line the same **seriesName** value.
 
 ## Configuring the Charts Widget
 
@@ -54,50 +52,32 @@ Now you need to enter data for the chart.
 Now you need to create a page containing the chart.
 
 1. Create a new page.
-2. Add a data view which uses a microflow to make a context which is the first object of the **Value**.
-3. Add an **Area chart** widget inside the data view.
+1. Add an **Area chart** widget to the page.
+1. Add the page to the user navigation.
 
-### Configuring the Area Chart with Dynamic Series
+### Configuring the Area Chart with Multiple Series
 
-To configure a Charts widget with a dynamic series, follow these steps:
+To configure a chart that builds its series from the data, follow these steps:
 
-1. Right-click the area chart widget and select **Properties**.
-1. In the tab **Chart properties**, add a new **Series** property.
+1. Double-click the **Area chart** widget to open its properties.
+1. On the **General** tab, in the **Data source** section, add a new **Series** item.
+1. In the **General** section of the series, set **Data set** to **Multiple series**.
+1. Set **Data source** to **Database** and select the **Value** entity. This is the entity from which all data points are retrieved.
+1. Set **Group by** to **seriesName**. Data points that share a value form one series.
+1. Set **Series name** to a text template that renders the label shown in the legend, for example the **seriesName** attribute. The name is taken from the first data point in each group.
+1. Set **X axis attribute** to **xValue** and **Y axis attribute** to **yValue**.
+1. Optionally, set **Aggregation function** to combine data points when several Y values share the same X value.
 
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-basic-create/charts-series.png" alt="Chart Series" class="no-border" >}}
-
-1. In the tab **Data source**, select **Dynamic**.
-1. Set the **Data entity** to *Value*. This is the entity from which the data values will be retrieved.
-1. Set the **Data source** as **Database** (note that REST endpoints are not supported for dynamic series).
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-select.png" alt="select Dynamic" class="no-border" >}}
-
-1. In the tab **Data Points**, set:
-
-    * **X-axis data attribute** to *Value/xValue*
-    * **Y-axis data attribute** to *Value/yValue*
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-data-points.png" alt="select Data Points" class="no-border" >}}
-
-1. In the tab **Dynamic series**, set: 
-
-    * **Series entity** to *Series*
-    * **Series name attribute** to *Series/name*
-    * **Line color attribute** to *Series/color*
-    * **Area color attribute** to *Series/fillcolor*
-
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-attributes.png" alt="select Data Points" class="no-border" >}}
-
-1. Add the charts page to user navigation.
+To give the series distinct colors, use the **Appearance** section of the series. **Line color**, **Marker color**, and **Area fill color** are expressions that return a color string, and each is evaluated against the first data point of the group, so the value applies to the whole series. For example, store a color on the **Value** entity and enter `$currentObject/color` as the expression.
 
 ## Viewing the Chart
 
 To view the chart, follow these steps:
 
 1. Run the app (locally).
-1. Open the page containing the dynamic series chart.
+1. Open the page containing the chart.
 
-    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-chart.png" alt="Dynamic Series Chart" class="no-border" >}}
+    {{< figure src="/attachments/appstore/platform-supported-content/widgets/charts/charts-tutorials/charts-dynamic-series/charts-dynamic-series-chart.png" alt="Area chart showing one line for each series name found in the data" class="no-border" >}}
 
 ## Read More
 

--- a/content/en/docs/refguide10/modeling/pages/chart-widgets/_index.md
+++ b/content/en/docs/refguide10/modeling/pages/chart-widgets/_index.md
@@ -39,6 +39,10 @@ From version 1.4 of the basic charts you can create charts with a variable numbe
 
 ## Any Chart {#any-chart}
 
+{{% alert color="warning" %}}
+The Any Chart widget is not compatible with the [Mendix React Client](/refguide10/mendix-client/react/). We have published a version of Any Chart that supports the React client called Custom Chart. Update your [Charts](/appstore/widgets/charts/) widget (to version 6.0 or above) to use the Custom Chart feature.
+{{% /alert %}}
+
 With *Any Chart* you can build all the chart types that are possible with Plotly.js up to the version supported by the widget (see the widget description in the Marketplace for more details). If you want to build a chart which is not available in the Basic charts, *Any Chart* is your friend.
 
 {{< figure src="/attachments/refguide10/modeling/pages/chart-widgets/contour.png" alt="Sample Contour Chart made with Any Chart"   width="400"  class="no-border" >}}

--- a/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-building-blocks.md
+++ b/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-building-blocks.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Building Blocks"
+deprecated: true
 url: /refguide10/charts-any-building-blocks/
 description: "A reference for the Any Chart building blocks which are provided as part of the Any Chart widget"
 weight: 40
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is not compatible with the [Mendix React Client](/refguide10/mendix-client/react/). We have published a version of Any Chart that supports the React client called Custom Chart. Update your [Charts](/appstore/widgets/charts/) widget (to version 6.0 or above) to use the Custom Chart feature.
+{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-cheat-sheet.md
+++ b/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-cheat-sheet.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Cheat Sheet"
+deprecated: true
 url: /refguide10/charts-any-cheat-sheet/
 description: "Shows, with examples, how the most common types of chart can be configured using the Any Chart Widget"
 weight: 50
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is not compatible with the [Mendix React Client](/refguide10/mendix-client/react/). We have published a version of Any Chart that supports the React client called Custom Chart. Update your [Charts](/appstore/widgets/charts/) widget (to version 6.0 or above) to use the Custom Chart feature.
+{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-configuration.md
+++ b/content/en/docs/refguide10/modeling/pages/chart-widgets/charts-any-configuration.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Widgets"
+deprecated: true
 url: /refguide10/charts-any-configuration/
 description: "A reference for the configuration of the Any Chart widget to pass the correct values to plotly. This enables you to draw a wide variety of charts"
 weight: 30
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is not compatible with the [Mendix React Client](/refguide10/mendix-client/react/). We have published a version of Any Chart that supports the React client called Custom Chart. Update your [Charts](/appstore/widgets/charts/) widget (to version 6.0 or above) to use the Custom Chart feature.
+{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide9/modeling/pages/chart-widgets/_index.md
+++ b/content/en/docs/refguide9/modeling/pages/chart-widgets/_index.md
@@ -39,6 +39,10 @@ From version 1.4 of the basic charts you can create charts with a variable numbe
 
 ## Any Chart {#any-chart}
 
+{{% alert color="warning" %}}
+The Any Chart widget is deprecated. Its successor, Custom Chart, is not available for Studio Pro 9: it requires [Charts](/appstore/widgets/charts/) widget version 6.0 or above, which is supported in Studio Pro 10 and above.
+{{% /alert %}}
+
 With *Any Chart* you can build all the chart types that are possible with Plotly.js up to the version supported by the widget (see the widget description in the Marketplace for more details). If you want to build a chart which is not available in the Basic charts, *Any Chart* is your friend.
 
 {{< figure src="/attachments/refguide9/modeling/pages/chart-widgets/contour.png" alt="Sample Contour Chart made with Any Chart"   width="400"  class="no-border" >}}

--- a/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-building-blocks.md
+++ b/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-building-blocks.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Building Blocks"
+deprecated: true
 url: /refguide9/charts-any-building-blocks/
 description: "A reference for the Any Chart building blocks which are provided as part of the Any Chart widget"
 weight: 40
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is deprecated. Its successor, Custom Chart, is not available for Studio Pro 9: it requires [Charts](/appstore/widgets/charts/) widget version 6.0 or above, which is supported in Studio Pro 10 and above.
+{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-cheat-sheet.md
+++ b/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-cheat-sheet.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Cheat Sheet"
+deprecated: true
 url: /refguide9/charts-any-cheat-sheet/
 description: "Shows, with examples, how the most common types of chart can be configured using the Any Chart Widget"
 weight: 50
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is deprecated. Its successor, Custom Chart, is not available for Studio Pro 9: it requires [Charts](/appstore/widgets/charts/) widget version 6.0 or above, which is supported in Studio Pro 10 and above.
+{{% /alert %}}
 
 ## Introduction
 

--- a/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-configuration.md
+++ b/content/en/docs/refguide9/modeling/pages/chart-widgets/charts-any-configuration.md
@@ -1,9 +1,14 @@
 ---
 title: "Any Chart Widgets"
+deprecated: true
 url: /refguide9/charts-any-configuration/
 description: "A reference for the configuration of the Any Chart widget to pass the correct values to plotly. This enables you to draw a wide variety of charts"
 weight: 30
 ---
+
+{{% alert color="warning" %}}
+The Any Chart widget is deprecated. Its successor, Custom Chart, is not available for Studio Pro 9: it requires [Charts](/appstore/widgets/charts/) widget version 6.0 or above, which is supported in Studio Pro 10 and above.
+{{% /alert %}}
 
 ## Introduction
 


### PR DESCRIPTION
Closes #10764

## What

**Any Chart deprecation visibility (WC-3209)**

- Adds `deprecated: true` front matter to the three Any Chart pages in the Mendix 9 and 10 guides, so they show the DEPRECATED badge in the sidebar like their Mendix 11 counterparts.
- Adds a deprecation alert to those pages and to the **Any Chart** section of the Charts landing page in both guides.

**Charts configuration refresh (#10764)**

- `charts-dynamic-series.md`: retitled to **Create a Multiple Series Chart** and rewritten against the current widget. The old page described a **Dynamic series** tab, a separate `Series` entity, and a `Value_Series` association; the widget now takes one data source and splits it with a **Group by** attribute. The page URL is unchanged, so no inbound links break.
- `charts-basic-create.md`: corrected the property navigation for the current widget.
- `charts-basic-rest.md`: rewritten around a microflow. The old page told readers to select a **REST endpoint** data source and enter a **REST URL**; the widget has no such option, so the page now consumes the service and returns its results from a microflow, which the chart uses as its data source.
- `_index.md`: corrected the Line chart configuration steps, the Pie chart property list, and the advanced configuration instructions.
- Removed screenshots of property dialogs that no longer exist. The steps now describe the current UI in text.

## Why

Any Chart is already marked deprecated in the Mendix 11 guide, but the 9 and 10 guides gave no signal at all — a reader landing on those pages could not tell the widget was deprecated or that Custom Chart superseded it.

The Mendix 10 alert reuses the Mendix 11 wording. The Mendix 9 alert is worded differently on purpose: there is no React Client page in the Mendix 9 guide to link to, and Custom Chart requires Charts 6.0+, which needs Studio Pro 10 or above — so pointing Mendix 9 readers at the React client migration would be a dead link and unactionable advice.

Scope for the deprecation change is deliberately limited to visibility. Removing Any Chart references throughout the docs is a much larger change and should wait until Any Chart support is actually dropped.

The Charts pages had drifted far from the widget. Property names in the docs (**Chart properties** tab, **Data points** tab, **Dynamic series** tab, **Data entity**, **X-axis data attribute**) do not exist in the widget any more, and the multiple-series mechanism changed shape entirely. Every replacement label in this PR was taken from the widget XML in `mendix/web-widgets` (Charts 6.3.2).

## Notes for reviewers

- **`Group by` cannot follow an association.** The chart attribute properties do not set `isPath`, which defaults to `no` in `custom_widget.xsd`, so the grouping attribute must live on the entity the data source returns. This is why the rewritten how-to uses a single entity with a grouping attribute rather than the old `Series` entity plus association.
- **Series names and colors are resolved per group, not per data point.** `groupDataSourceItems` takes the series name from the first data point in the group, and `getExpressionValue` evaluates the color expressions against the first data point too, applying the result to the whole series.
- **Screenshots are not replaced.** The removed figures showed property dialogs from an older widget version. New screenshots need Studio Pro and are not included here.
- **No REST data source exists any more.** A `datasource` property offers Database, Microflow, Nanoflow, and Association, per [Pluggable Widget Property Types](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#datasource). That is why `charts-basic-rest.md` now routes the REST call through a microflow, and why the Line chart steps in `_index.md` no longer list a REST option.
- **Inbound link text is not updated.** Six references in the `refguide`, `refguide9`, and `refguide10` chart-widgets pages still call the page "How to Create a Dynamic Series Chart". Those pages document the legacy Charts widget and are left alone here.
