### PR TITLE
Mendix on Kubernetes 2.28.0 release notes (planned for release on Friday, August 14)

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -213,7 +213,7 @@ If an app's MDA was built using a newer Java version, Mendix Operator 2.15.0 (an
 {{% /alert %}}
 
 {{% alert color="info" %}}
-Red Hat Hardened Images don't provide images for Java 8, 11, or 17; only Java 21 is supported at the moment.
+Red Hat Hardened Images do not provide images for Java 8, 11, or 17. Only Java 21 is supported at the moment.
 
 To use Hardened Images, upgrade to Mendix 11, or any supported LTS version of Mendix.
 {{% /alert %}}
@@ -241,9 +241,9 @@ For information on using advanced network configuration settings, see [Network I
 When switching between Ingress and OpenShift Routes, you need to [restart the Mendix Operator](#restart-after-changing-network-cr) for the changes to be fully applied.
 {{% /alert %}}
 
-### Mendix App Deployment settings {#advanced-deployment-settings}
+### Mendix App Deployment Settings {#advanced-deployment-settings}
 
-The OperatorConfiguration contains the following user-editable options for configuring Mendix app Deployments (Pods):
+Users can edit the following `OperatorConfiguration` options for configuring Mendix app deployments (pods):
 
 ```yaml
 apiVersion: privatecloud.mendix.com/v1alpha1
@@ -263,8 +263,8 @@ spec:
 
 You can change the following options:
 
-* **runtimeAutomountServiceAccountToken**: – specify if Mendix app Pods should get a Kubernetes Service Account token; defaults to `false`; should be set to `true` when using Linkerd [Automatic Proxy Injection](https://linkerd.io/2.10/features/proxy-injection/)
-* **runtimeDeploymentPodAnnotations**: – specify default annotations for Mendix app Pods
+* **runtimeAutomountServiceAccountToken** – specify if Mendix app Pods should get a Kubernetes Service Account token; defaults to `false`; should be set to `true` when using Linkerd [Automatic Proxy Injection](https://linkerd.io/2.10/features/proxy-injection/)
+* **runtimeDeploymentPodAnnotations** – specify default annotations for Mendix app Pods
 
 ### Mendix App Resource Customization {#advanced-resource-customization}
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -215,7 +215,7 @@ If an app's MDA was built using a newer Java version, Mendix Operator 2.15.0 (an
 {{% alert color="info" %}}
 Red Hat Hardened Images don't provide images for Java 8, 11, or 17; only Java 21 is supported at the moment.
 
-To use Hardened Images, upgrade to any supported LTS version of Mendix.
+To use Hardened Images, upgrade to Mendix 11, or any supported LTS version of Mendix.
 {{% /alert %}}
 
 {{% alert color="info" %}}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -206,13 +206,32 @@ At the moment, the `baseOSImageTagTemplate` can be set to one of the following v
 
 * `ubi8-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 8 Micro images; this option can be used for some cases where backward compatibility is needed.
 * `ubi9-1-jre{{.JavaVersion}}-entrypoint` - to use Red Hat UBI 9 Micro images; this is the default option.
+* `hi-1-jre{{.JavaVersion}}-entrypoint` - to use [Red Hat Hardened Images](https://www.redhat.com/en/products/hardened-images)
 
 {{% alert color="info" %}}
-
-Future Studio Pro releases will have an option to use alternative (newer) LTS versions of Java, such as Java 17 or Java 21.
-
 If an app's MDA was built using a newer Java version, Mendix Operator 2.15.0 (and newer versions) will detect this and use a base image with the same major Java version that was used to build the MDA. Because of that, Java 17 or Java 21-based applications should use the Operator in version 2.15.0 or above.
+{{% /alert %}}
 
+{{% alert color="info" %}}
+Red Hat Hardened Images don't provide images for Java 8, 11, or 17; only Java 21 is supported at the moment.
+
+To use Hardened Images, upgrade to any supported LTS version of Mendix.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+At this time, to improve security and remove unnecessary components, Hardened Images for Mendix apps are shipped without Bash or other standard UNIX tools.
+
+The recommended way to run diagnostics is using [ephemeral debug containers](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container).
+
+Any non-root container can be attached to a Mendix app pod and can have access to the Mendix app's filesystem and processes.
+For example, this command can be used to attach a curl container to a pod (replace `$POD_NAME` with the name of the target pod):
+
+```shell
+POD_NAME=<name-of-mendix-app-pod>
+kubectl debug $POD_NAME --target mendix --image registry.access.redhat.com/hi/curl:latest-builder --profile restricted -it -- /bin/bash
+```
+
+This debug container will share the process space with the Mendix app, and the Mendix app container's filesystem will be mounted into `/proc/1/root`.
 {{% /alert %}}
 
 ### Endpoint (network) Configuration {#advanced-network-settings}

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/_index.md
@@ -227,7 +227,6 @@ Any non-root container can be attached to a Mendix app pod and can have access t
 For example, this command can be used to attach a curl container to a pod (replace `$POD_NAME` with the name of the target pod):
 
 ```shell
-POD_NAME=<name-of-mendix-app-pod>
 kubectl debug $POD_NAME --target mendix --image registry.access.redhat.com/hi/curl:latest-builder --profile restricted -it -- /bin/bash
 ```
 

--- a/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
+++ b/content/en/docs/deployment/private-cloud/reduced-downtime-deployment.md
@@ -29,6 +29,13 @@ Previous versions of the Operator did not manage `PodDisruptionBudgets`. Instead
 If you have manually created a `PodDisruptionBudget` for an app, delete it and instead specify the `PodDisruptionBudget` parameters [in the MendixApp CR](#pod-disruption-budget-in-standalone).
 {{% /alert %}}
 
+
+{{% alert color="info" %}}
+Mendix Operator 2.28.0 specifies `unhealthyPodEvictionPolicy: AlwaysAllow` in the `PodDisruptionBudget`, allowing Kubernetes to evict crashlooping or unavailable pods without applying rules from the `PodDisruptionBudget`.
+
+This prevents situations where a crashlooping pod could block node maintenance.
+{{% /alert %}}
+
 ## Prerequisites
 
 ## Prerequisites for Operator version 2.25.0 and Higher{#prerequisites-2.25.0}

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -12,6 +12,25 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ## 2026
 
+### August 14, 2026
+
+#### Mendix Operator v2.28.0 {#2.28.0}
+
+* We have updated Operator images from ubi9 to [Red Hat Hardened Images](https://www.redhat.com/en/products/hardened-images), achieving near-zero vulnerabilities. Mendix apps built with this version of the Operator will keep using ubi9 as the base image by default - it is possible to switch Mendix apps to Hardened Images in the Operator Configuration.
+* We have updated the Helm chart UI to include advanced Operator Configuration options.
+* We have updated some default options in the Helm chart to increase security.
+* The Helm chart will now use proxy and custom TLS configuration when registering Storage Plans in the Portal.
+* We have fixed an issue with enabling the Kubernetes Gateway API in existing clusters after an upgrade.
+* We have fixed an issue with configuring the Kubernetes Gateway API in non-interactive mode.
+* We have fixed an issue with enabling TLS in the the Kubernetes Gateway API. (Ticket 281256)
+* We have fixed an issue with applying nodeSelector configuration. (Ticket 283820)
+* We have fixed an issue where passwordless IAM or Managed Identity authentication wouldn't update tokens while an app is starting, and caused database connection errors in apps that took 15+ minutes to start. (Ticket 282784)
+* We have fixed issue with uploading air-gapped images from the mxpc-cli Configuration Tool. (Ticket 283942)
+* We have improved error handling where an Azure and Blob Storage provisioners would fail with a 409 error when creating a Managed Identity. (Ticket 283808)
+* We have updated the PodDisruptionBudget to allow eviction of unhealthy pods by default. This will prevent crashlooping pods from blocking node maintenance.
+* We have updated the components to use the latest dependency versions in order to improve security score ratings for container images.
+* We have updated components to use Go 1.26 and the latest dependency versions in order to improve security score ratings for container images.
+
 ### July 23, 2026
 
 #### Portal Improvements

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -19,15 +19,15 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 * We have updated Operator images from ubi9 to [Red Hat Hardened Images](https://www.redhat.com/en/products/hardened-images), achieving near-zero vulnerabilities. Mendix apps built with this version of the Operator will keep using ubi9 as the base image by default - it is possible to switch Mendix apps to Hardened Images in the Operator Configuration.
 * We have updated the Helm chart UI to include advanced Operator Configuration options.
 * We have updated some default options in the Helm chart to increase security.
-* The Helm chart will now use proxy and custom TLS configuration when registering Storage Plans in the Portal.
+* The Helm chart now uses proxy and custom TLS configuration when registering Storage Plans in the Portal.
 * We have fixed an issue with enabling the Kubernetes Gateway API in existing clusters after an upgrade.
 * We have fixed an issue with configuring the Kubernetes Gateway API in non-interactive mode.
 * We have fixed an issue with enabling TLS in the the Kubernetes Gateway API. (Ticket 281256)
 * We have fixed an issue with applying nodeSelector configuration. (Ticket 283820)
-* We have fixed an issue where passwordless IAM or Managed Identity authentication wouldn't update tokens while an app is starting, and caused database connection errors in apps that took 15+ minutes to start. (Ticket 282784)
+* We have fixed an issue where passwordless IAM or Managed Identity authentication would not update tokens while an app is starting, and caused database connection errors in apps that took 15+ minutes to start. (Ticket 282784)
 * We have fixed issue with uploading air-gapped images from the mxpc-cli Configuration Tool. (Ticket 283942)
 * We have improved error handling where an Azure and Blob Storage provisioners would fail with a 409 error when creating a Managed Identity. (Ticket 283808)
-* We have updated the PodDisruptionBudget to allow eviction of unhealthy pods by default. This will prevent crashlooping pods from blocking node maintenance.
+* We have updated the PodDisruptionBudget to allow eviction of unhealthy pods by default. This will prevent crash-looping pods from blocking node maintenance.
 * We have updated the components to use the latest dependency versions in order to improve security score ratings for container images.
 * We have updated components to use Go 1.26 and the latest dependency versions in order to improve security score ratings for container images.
 


### PR DESCRIPTION
We're planning to release a new version of the MxOK Operator this Friday .

This release mostly contains bugfixes and an option to switch to Red Hat Hardened Images for Mendix apps.
Red Hat HI images only support Java 21, so the documentation recommends upgrading to a supported Mendix LTS version (all Mendix LTS versions have switched to Java 21).