### PR TITLE
Mendix Public Cloud Aug 12 release note: access logs fix

### DIFF
--- a/content/en/docs/releasenotes/deployment/_index.md
+++ b/content/en/docs/releasenotes/deployment/_index.md
@@ -15,7 +15,7 @@ Follow the links in the table below to see the release notes you want:
 
 | Type of Deployment | Last Updated |
 | --- | --- |
-| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | August 9, 2026 |
+| [Mendix Cloud](/releasenotes/developer-portal/mendix-cloud/) | August 12, 2026 |
 | [Mendix on Kubernetes](/releasenotes/developer-portal/mendix-for-private-cloud/) | June 11, 2026 |
 | [Mendix on Azure](/releasenotes/developer-portal/mendix-on-azure/) | July 2, 2026 |
 | [SAP Business Technology Platform (SAP BTP)](/releasenotes/developer-portal/sap-cloud-platform/) | September 28, 2025 |

--- a/content/en/docs/releasenotes/deployment/mendix-cloud/_index.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud/_index.md
@@ -16,6 +16,12 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 ## August 2026
 
+### August 12, 2026
+
+#### Fixes
+
+* We fixed an issue that, in rare cases, caused application access logs to stop appearing on the [Logs](/developerportal/operate/logs/) page. You will have to restart or redeploy your app to apply this fix.
+
 ### August 9, 2026
 
 #### Fixes

--- a/content/en/docs/releasenotes/deployment/mendix-cloud/_index.md
+++ b/content/en/docs/releasenotes/deployment/mendix-cloud/_index.md
@@ -20,7 +20,7 @@ For information on the current status of deployment to Mendix Cloud and any plan
 
 #### Fixes
 
-* We fixed an issue that, in rare cases, caused application access logs to stop appearing on the [Logs](/developerportal/operate/logs/) page. You will have to restart or redeploy your app to apply this fix.
+* We fixed an issue that, in rare cases, caused application access logs to stop appearing on the [Logs](/developerportal/operate/logs/) page. You must restart or redeploy your app for the fix to take effect.
 
 ### August 9, 2026
 

--- a/layouts/partials/landingpage/latest-releases.html
+++ b/layouts/partials/landingpage/latest-releases.html
@@ -14,7 +14,7 @@
     </li>
     <li class="lp-panel-list">
         <a href="/releasenotes/developer-portal/deployment/">Deployment</a>
-        <p class="rn-date">August 9, 2026</p>
+        <p class="rn-date">August 12, 2026</p>
     </li>
     <li class="lp-panel-list">
         <a href="/releasenotes/catalog/">Catalog Release 2.150.0</a>


### PR DESCRIPTION
Adds an August 12, 2026 release note entry for [LM-2866](https://mendix.atlassian.net/browse/LM-2866), which fixed a rare bug in the logs-sidecar multiline filter that could cause application access logs to stop being ingested. The fix is already live in Mendix Cloud.

## Changes

- `content/en/docs/releasenotes/deployment/mendix-cloud/_index.md` — new **August 12, 2026** Fixes entry
- `content/en/docs/releasenotes/deployment/_index.md` — bump *Last Updated* for Mendix Cloud
- `layouts/partials/landingpage/latest-releases.html` — bump landing page Deployment date