### PR TITLE
Document self-managed Private DNS zone option for internal service resolution

### DIFF
--- a/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
+++ b/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
@@ -75,17 +75,17 @@ Virtual network peering enables IP traffic flow but DNS resolution must also be 
 
 Users in linked networks can now access Mendix apps using the usual URLs.
 
-#### DNS Name Resolution towards Resources in Other Networks {#name-resolution-dns-override}
+#### DNS Name Resolution toward Resources in Other Networks {#name-resolution-dns-override}
 
 To allow Mendix apps to resolve internal services in your network, configure DNS resolution using one of the following options.
 
-##### Option 1: Link a Self-managed Private DNS Zone to the Mendix Virtual Network {#dns-zone-outside-mrg}
+##### Option 1: Link a Private DNS Zone{#dns-zone-outside-mrg}
 
 The Mendix on Azure virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg), which is protected by [Azure deny assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments). This prevents you from creating or modifying most resources, including Private DNS zones and their record sets, directly inside that resource group.
 
-To manage your own DNS records for internal services without running into these restrictions:
+To manage your own DNS records for internal services without running into these restrictions, you can link a self-managed private DNS zone to the Mendix virtual network by performing the following steps:
 
-1. Create a new [Azure Private DNS zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone) for the FQDN(s) you need Mendix apps to resolve (for example, *internal.yourcompany.com*), in a resource group you fully control, outside the Managed Resource Group.
+1. Create a new [Azure Private DNS zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone) for the FQDNs which you need Mendix apps to resolve (for example, *internal.yourcompany.com*), in a resource group you fully control, outside the Managed Resource Group.
 2. Add [DNS records](https://learn.microsoft.com/en-us/azure/dns/dns-operations-recordsets-portal) in this zone pointing to the IP addresses of your internal services.
 3. Create a [virtual network link](https://learn.microsoft.com/en-us/azure/dns/private-dns-virtual-network-links) from this Private DNS zone to the Mendix on Azure virtual network in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg).
 

--- a/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
+++ b/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
@@ -77,10 +77,27 @@ Users in linked networks can now access Mendix apps using the usual URLs.
 
 #### DNS Name Resolution towards Resources in Other Networks {#name-resolution-dns-override}
 
-To allow Mendix apps to resolve internal services in your network, configure DNS resolution selecting one of the following options:
+To allow Mendix apps to resolve internal services in your network, configure DNS resolution using one of the following options.
 
-* Create or use an existing Private DNS Zone for the internal service's FQDN and link it to the Mendix virtual network by using a [virtual network link](https://learn.microsoft.com/en-us/azure/dns/private-dns-virtual-network-links).
-* Configure the Mendix virtual network to use your own DNS server that resolves internal service names, as described in [Microsoft's DNS configuration instructions](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances). The Mendix virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg).
+##### Option 1: Link a Self-managed Private DNS Zone to the Mendix Virtual Network {#dns-zone-outside-mrg}
+
+The Mendix on Azure virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg), which is protected by [Azure deny assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments). This prevents you from creating or modifying most resources, including Private DNS zones and their record sets, directly inside that resource group.
+
+To manage your own DNS records for internal services without running into these restrictions:
+
+1. Create a new [Azure Private DNS zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone) for the FQDN(s) you need Mendix apps to resolve (for example, *internal.yourcompany.com*), in a resource group you fully control, outside the Managed Resource Group.
+2. Add [DNS records](https://learn.microsoft.com/en-us/azure/dns/dns-operations-recordsets-portal) in this zone pointing to the IP addresses of your internal services.
+3. Create a [virtual network link](https://learn.microsoft.com/en-us/azure/dns/private-dns-virtual-network-links) from this Private DNS zone to the Mendix on Azure virtual network in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg).
+
+Because the zone lives in a resource group you own, you can add, change, or remove records yourself at any time, without needing to modify anything inside the Managed Resource Group.
+
+{{% alert color="info" %}}
+This is standard Azure Private DNS configuration, not something specific to Mendix on Azure. Refer to the Microsoft documentation linked above for full details on managing Private DNS zones and virtual network links.
+{{% /alert %}}
+
+##### Option 2: Override DNS Resolution on the Mendix Virtual Network
+
+Configure the Mendix virtual network to use your own DNS server that resolves internal service names, as described in [Microsoft's DNS configuration instructions](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances). The Mendix virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg).
 
 ### Solution 2: PrivateLink with Private Endpoints
 

--- a/content/en/docs/deployment/mx-azure/mx-azure-support.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-support.md
@@ -95,7 +95,7 @@ The following customizations are related to establishing connectivity to and fro
 * Override DNS configuration on the subnet hosting AKS nodes.
 * Configure Private Link Service to expose Mendix apps in other Azure virtual networks.
 * Configure Private Endpoints to establish connectivity between Mendix apps and other services.
-* Link a self-managed Private DNS zone to the vNet hosting AKS nodes to resolve internal service names. See [DNS Name Resolution towards Resources in Other Networks](/developerportal/deploy/mendix-on-azure/configuration/interconnecting-networks/#name-resolution-dns-override).
+* Link a self-managed Private DNS zone to the vNet hosting AKS nodes to resolve internal service names. See [DNS Name Resolution toward Resources in Other Networks](/developerportal/deploy/mendix-on-azure/configuration/interconnecting-networks/#name-resolution-dns-override).
 * Tune the server parameters of the shared Azure Database for PostgreSQL Flexible Server. Only a small set of parameters is safe to change, and some parameters can cause server crashes or permanent data loss. Before changing any parameters, see [Tuning PostgreSQL Server Parameters](/developerportal/deploy/mendix-on-azure/configuration/postgresql-parameter-tuning/).
 
 Mendix limits customization to what is described above to ensure a consistent, predictable, and scalable customer experience.

--- a/content/en/docs/deployment/mx-azure/mx-azure-support.md
+++ b/content/en/docs/deployment/mx-azure/mx-azure-support.md
@@ -95,6 +95,7 @@ The following customizations are related to establishing connectivity to and fro
 * Override DNS configuration on the subnet hosting AKS nodes.
 * Configure Private Link Service to expose Mendix apps in other Azure virtual networks.
 * Configure Private Endpoints to establish connectivity between Mendix apps and other services.
+* Link a self-managed Private DNS zone to the vNet hosting AKS nodes to resolve internal service names. See [DNS Name Resolution towards Resources in Other Networks](/developerportal/deploy/mendix-on-azure/configuration/interconnecting-networks/#name-resolution-dns-override).
 * Tune the server parameters of the shared Azure Database for PostgreSQL Flexible Server. Only a small set of parameters is safe to change, and some parameters can cause server crashes or permanent data loss. Before changing any parameters, see [Tuning PostgreSQL Server Parameters](/developerportal/deploy/mendix-on-azure/configuration/postgresql-parameter-tuning/).
 
 Mendix limits customization to what is described above to ensure a consistent, predictable, and scalable customer experience.


### PR DESCRIPTION
## Summary

Customers configuring outbound DNS resolution from Mendix apps to internal on-prem services were hitting Azure deny-assignment errors when trying to create a Private DNS zone (and its record sets) directly inside the Mendix on Azure Managed Resource Group. The existing docs mentioned creating/using a Private DNS zone as an option, but did not explain this restriction or where the zone should actually live.

This PR expands that section to clarify: create the Private DNS zone in a resource group you control, outside the Managed Resource Group, then link it to the Mendix vNet via a virtual network link. A cross-link is also added from the support/customization page.

## Changes

* `content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md`: expanded the "DNS Name Resolution towards Resources in Other Networks" section into two clearly labeled options, with step-by-step instructions and the deny-assignment rationale for Option 1.
* `content/en/docs/deployment/mx-azure/mx-azure-support.md`: added a cross-link bullet to the connectivity customization list.

## Test plan

- [ ] Review rendered content for accuracy and tone
- [ ] Confirm anchor links (`#name-resolution-dns-override`, `#dns-zone-outside-mrg`) resolve correctly

@katarzyna-koltun-mx this can be merged immediately once approved.
