### PR TITLE
Revise compatibility matrix for Teamcenter Connector

### DIFF
--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/compatibility-matrix.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/compatibility-matrix.md
@@ -11,11 +11,10 @@ This table showcases the compatibility between the Teamcenter Connector and vari
 
 |Teamcenter Connector | Studio Pro version | Supported Teamcenter Self-hosted version | Supported Teamcenter X versions | Known Teamcenter incompatibility
 | :--- | :--- | :--- | :--- | :--- |
-| 2606.0.0 | 11.12.1 or above* | 2606, 2512, 2506, 2412 | 2606, 2512, 2506 | N/A |
+| 2606.0.0 | 11.12.1 or above | 2606, 2512, 2506, 2412 | 2606, 2512, 2506 | N/A |
 | 2512.1.1 | 10.24.8 or above* | 2512, 2506, 2412, 2406 | 2512, 2506 | N/A |
-| 2506.0.1 | 10.20.0 or above* | 2506 | 2506 | N/A |
-| 2412.3.0 | 10.4.0 or above** | 2412 | N/A | N/A |
-| 2406.3.1 | 10.0.0 or above** | 2406 |N/A | N/A |
+| 2506.0.1 | 10.24.8 or above** | 2506 | 2506 | N/A |
+| 2412.3.0 | 10.24.8 or above** | 2412 | N/A | N/A |
 | 3.7.0 | 9.24.41 or above*** | 14.x, 13.3 | N/A | TC SSO does not work for self-hosted TC 2506 and above |
 
 <sub>* Latest Mendix 10 LTS version recommended. Also compatible with Mendix 11.</sub>


### PR DESCRIPTION
Updated compatibility matrix for Teamcenter Connector:
- Dropped support for 2406
- Removed astrix for 2606 (version recommendation)

I'll ask @wanchoorohan to review this before we finish the pull request.