### PR TITLE
Fix compatibility matrix Mendix version compabilitity for 2506

### DIFF
--- a/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/compatibility-matrix.md
+++ b/content/en/docs/marketplace/industry/xcelerator/platform-supported/teamcenter-connector/compatibility-matrix.md
@@ -13,7 +13,7 @@ This table showcases the compatibility between the Teamcenter Connector and vari
 | :--- | :--- | :--- | :--- | :--- |
 | 2606.0.0 | 11.12.1 or above | 2606, 2512, 2506, 2412 | 2606, 2512, 2506 | N/A |
 | 2512.1.1 | 10.24.8 or above* | 2512, 2506, 2412, 2406 | 2512, 2506 | N/A |
-| 2506.0.1 | 10.24.8 or above** | 2506 | 2506 | N/A |
+| 2506.0.1 | 10.24.8 or above* | 2506 | 2506 | N/A |
 | 2412.3.0 | 10.24.8 or above** | 2412 | N/A | N/A |
 | 3.7.0 | 9.24.41 or above*** | 14.x, 13.3 | N/A | TC SSO does not work for self-hosted TC 2506 and above |
 


### PR DESCRIPTION
Fixing a mistake I made yesterday: 2506.0.1 is Mendix 10 but also compatible with Mendix 11, so change it back to one asteriks.