### PR TITLE
Document Teamcenter role sharing with embedded Mendix app

### DIFF
--- a/content/en/docs/refguide/runtime/mendix-client/mendix-inside-teamcenter.md
+++ b/content/en/docs/refguide/runtime/mendix-client/mendix-inside-teamcenter.md
@@ -221,6 +221,12 @@ Follow these steps to configure authentication.
 
         For instructions, see the [Adding an SSO Login Button to Your Login Page](/appstore/industry/teamcenter-connector/configuring-connection-2512/#add-sso-login-button) section of *Configuring the Connection to Teamcenter with Teamcenter Connector 2512.0.0 and Above*.
 
+## Role Sharing with Teamcenter {#role-sharing}
+
+Teamcenter users can be assigned multiple roles, and the active role affects which objects and data the user can access. Active Workspace lets users switch roles within their session without logging in again.
+
+The active Teamcenter role is shared between Active Workspace and the embedded Mendix app, so a role switch in Active Workspace also applies to the Mendix app without requiring the user to reauthenticate. Switching roles reloads the Active Workspace UI, which also reloads the embedded Mendix app.
+
 ## Passing Context from Teamcenter {#passing-context}
 
 The `MendixEmbedded` Active Workspace component passes Teamcenter object context to the Mendix app as startup parameters. Configure these parameters in the `context` and `declarativeKeyContext` fields of the XRT `htmlPanel` and Product Lifecycle (PL) Home card.

--- a/content/en/docs/refguide/runtime/mendix-client/mendix-inside-teamcenter.md
+++ b/content/en/docs/refguide/runtime/mendix-client/mendix-inside-teamcenter.md
@@ -225,7 +225,7 @@ Follow these steps to configure authentication.
 
 Teamcenter users can be assigned multiple roles, and the active role affects which objects and data the user can access. Active Workspace lets users switch roles within their session without logging in again.
 
-The active Teamcenter role is shared between Active Workspace and the embedded Mendix app, so a role switch in Active Workspace also applies to the Mendix app without requiring the user to reauthenticate. Switching roles reloads the Active Workspace UI, which also reloads the embedded Mendix app.
+The active Teamcenter role is shared between Active Workspace and the embedded Mendix app. This means that a role switch in Active Workspace also applies to the Mendix app without requiring the user to reauthenticate. Switching roles reloads the Active Workspace interface, which also reloads the embedded Mendix app.
 
 ## Passing Context from Teamcenter {#passing-context}
 


### PR DESCRIPTION
Adds a short section to Mendix Inside Teamcenter explaining that the active Teamcenter role is shared between Active Workspace and the embedded Mendix app, and that switching roles reloads both.