### PR TITLE
Clarify DNS override on Mendix on Azure vNet requires a support ticket

### DIFF
--- a/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
+++ b/content/en/docs/deployment/mx-azure/configuration/mx-azure-network-interconnecting-networks.md
@@ -97,7 +97,9 @@ This is standard Azure Private DNS configuration, not something specific to Mend
 
 ##### Option 2: Override DNS Resolution on the Mendix Virtual Network
 
-Configure the Mendix virtual network to use your own DNS server that resolves internal service names, as described in [Microsoft's DNS configuration instructions](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances). The Mendix virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg).
+Configuring the Mendix virtual network to use your own DNS server, as described in [Microsoft's DNS configuration instructions](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances), requires modifying the virtual network itself. Because the Mendix virtual network is located in the [Managed Resource Group](/developerportal/deploy/mendix-on-azure/configuration/#mrg), which is protected by [Azure deny assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments), you cannot make this change yourself.
+
+To apply this change, [raise a support ticket](/developerportal/deploy/mendix-on-azure/support/) with Mendix Support, specifying your desired DNS server IP addresses and the names of the Mendix on Azure environments the change should be applied to.
 
 ### Solution 2: PrivateLink with Private Endpoints
 


### PR DESCRIPTION
## Summary
- Option 2 under "DNS Name Resolution toward Resources in Other Networks" told customers to configure a custom DNS server on the Mendix on Azure virtual network themselves, following Microsoft's standard instructions.
- That vNet lives in the Managed Resource Group, and `Microsoft.Network/virtualNetworks/write` is not excepted from the deny assignment - customers cannot make this change themselves, unlike what the doc implied.
- Updated the doc to direct customers to raise a support ticket with Mendix Support instead, specifying their desired DNS server IPs and the Mendix on Azure environment names to apply the change to.

Jira: MXFORAZURE-831

@katarzyna-koltun-mx this is a small, low-risk wording fix - good to merge immediately once you've had a look.

## Test plan
- [ ] Doc renders correctly (Option 1/Option 2 formatting unchanged aside from the added paragraph)