### PR TITLE
Document Activity Log limitation for Mendix on Kubernetes Deploy API

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
@@ -31,7 +31,7 @@ The Standard Operator conversion to Global Operator managed namespace is not yet
 {{% /alert %}}
 
 {{% alert color="info" %}}
-Actions performed through this API are not always recorded in the environment's [Activity Log](/developerportal/deploy/private-cloud-deploy/#activity-log-api).
+Actions performed through this API are not always recorded in the environment's [Activity Log](/developerportal/deploy/private-cloud-deploy/#activity-log-api). For more information, see [Known Limitations: Logging API-Initiated Actions](#activity-log-api).
 {{% /alert %}}
 
 ## Using the API

--- a/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
@@ -30,6 +30,10 @@ The Mendix on Kubernetes Deploy API is for connected clusters only.
 The Standard Operator conversion to Global Operator managed namespace is not yet available in Deploy API.
 {{% /alert %}}
 
+{{% alert color="info" %}}
+Actions performed through this API are not always recorded in the environment's [Activity Log](/developerportal/deploy/private-cloud-deploy/#activity-log-api).
+{{% /alert %}}
+
 ## Using the API
 
 To help you work with the Mendix on Kubernetes Build API, the following sections of this document describe how to authenticate for the API, how to manage asynchronous API calls, and what to keep in mind when assigning unique IDs for the resources.

--- a/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/deployment/private-cloud-deploy-api.md
@@ -31,7 +31,7 @@ The Standard Operator conversion to Global Operator managed namespace is not yet
 {{% /alert %}}
 
 {{% alert color="info" %}}
-Actions performed through this API are not always recorded in the environment's [Activity Log](/developerportal/deploy/private-cloud-deploy/#activity-log-api). For more information, see [Known Limitations: Logging API-Initiated Actions](#activity-log-api).
+Actions performed through this API are not always recorded in the environment's activity log. For more information, see [Known Limitations: Logging API-Initiated Actions](/developerportal/deploy/private-cloud-deploy/#activity-log-api).
 {{% /alert %}}
 
 ## Using the API

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
@@ -409,7 +409,7 @@ This section shows all the activities which have taken place in this environment
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-deploy/image20.png" class="no-border" >}}
 
 {{% alert color="info" %}}
-Actions performed through the Mendix on Kubernetes Deploy API are not always recorded here. See [Current Limitations](#activity-log-api) for details.
+Actions performed through the Mendix on Kubernetes Deploy API are not always recorded here. For more information, see [Known Limitations: Logging API-Initiated Actions](#activity-log-api).
 {{% /alert %}}
 
 ### Application Settings

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
@@ -805,7 +805,7 @@ Delete all environments before you delete an app. If you delete an app which has
 
 Mendix on Kubernetes has a limit of 1024 MB on the size of a deployment package.
 
-### API-Initiated Actions Not Always Recorded in the Activity Log {#activity-log-api}
+### Logging API-Initiated Actions {#activity-log-api}
 
 Actions performed using the [Mendix on Kubernetes Deploy API](/apidocs-mxsdk/apidocs/private-cloud-deploy-api/), such as deploying a package or creating an environment, are not always recorded in the environment's [Activity Log](#activity-log). Only actions performed through the Mendix Portal are guaranteed to appear.
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-deploy/_index.md
@@ -408,6 +408,10 @@ This section shows all the activities which have taken place in this environment
 
 {{< figure src="/attachments/deployment/private-cloud/private-cloud-deploy/image20.png" class="no-border" >}}
 
+{{% alert color="info" %}}
+Actions performed through the Mendix on Kubernetes Deploy API are not always recorded here. See [Current Limitations](#activity-log-api) for details.
+{{% /alert %}}
+
 ### Application Settings
 
 #### Technical Contact
@@ -800,6 +804,10 @@ Delete all environments before you delete an app. If you delete an app which has
 ### Deployment Package Size
 
 Mendix on Kubernetes has a limit of 1024 MB on the size of a deployment package.
+
+### API-Initiated Actions Not Always Recorded in the Activity Log {#activity-log-api}
+
+Actions performed using the [Mendix on Kubernetes Deploy API](/apidocs-mxsdk/apidocs/private-cloud-deploy-api/), such as deploying a package or creating an environment, are not always recorded in the environment's [Activity Log](#activity-log). Only actions performed through the Mendix Portal are guaranteed to appear.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Documents a known limitation: actions performed through the Mendix on Kubernetes Deploy API are not always recorded in the environment's Activity Log.
- Adds a new subsection under **Current Limitations** on the Environments page, plus a short cross-referencing note on the Activity Log section and on the Deploy API reference page.

## Background
Surfaced via a support ticket (MOK-86 in JPD, internally tracking the underlying feature request) where API-initiated deploys weren't showing up in the Activity Log. This PR documents the current behavior as a known limitation; no product change is implied.

## Test plan
- [x] Content-only change, no shortcode/frontmatter errors
- [x] Anchor `#activity-log-api` referenced correctly from both cross-linking pages
- [ ] Docs team review for tone/placement

@Nidhi251289 you'd asked about getting the docs aligned on this - here's the change.
@katarzyna-koltun-mx small, self-contained doc change, can be merged immediately if it looks good.