### PR TITLE
Remove dependencies sections from js action doc

### DIFF
--- a/content/en/docs/howto/extensibility/build-javascript-actions/create-native-javascript-action.md
+++ b/content/en/docs/howto/extensibility/build-javascript-actions/create-native-javascript-action.md
@@ -132,37 +132,6 @@ Now make a JavaScript action to read the NFC tag information:
 
 1. Optionally, click the **Expose as nanoflow action** tab, select **Expose as nanoflow action**, and **Select** an icon for your JavaScript action.
 
-### Installing a Dependency in Your App {#install-dependency-project}
-
-The dependency is split into two parts: the native device part, and the client JavaScript part. In this section we will add the dependency JavaScript for the client bundle. For the bundling we need to add the dependency builder, so that we can add the `react-native-nfc-manager` JavaScript code.
-
-1. In your CLI, open the module folder which contains your JavaScript action:
-
-    ```powershell
-    cd C:\MendixApps\NativeNFC\javascriptsource\nativenfc\actions
-    ```
-
-1. Make sure *HasNFCSupport.js* is in this folder so you know you are in the right place.
-1. Install the dependency with the command `npm install react-native-nfc-manager@1.2.2`.
-
-{{% alert type="info" %}}
-This will create a **node_module** folder inside your **actions** folder. There is a known issue that when you try to commit the *node_modules* folder using Apache Subversion, there could be problems if your commit contains a large number of files. To solve this, try removing unnecessary files before committing.
-{{% /alert %}}
-
-#### Declaring Native Dependencies
-
-To make Mendix install and link native dependencies automatically while creating production-like builds of a native app, create JSON files next to your JavaScript actions: *HasNFCSupport.json* and *ReadNFCTag.json*. Define the same native dependencies in each of them:
-
-```json
-{
-    "nativeDependencies": {
-        "react-native-nfc-manager": "1.2.2"
-    }
-}
-```
-
-For more information see [Declaring Native Dependencies](/apidocs-mxsdk/apidocs/pluggable-widgets-native-dependencies/).
-
 ### Using NFC JavaScript Actions {#use-nfc-action}
 
 Make a nanoflow to use your new actions:

--- a/content/en/docs/howto10/extensibility/build-javascript-actions/create-native-javascript-action.md
+++ b/content/en/docs/howto10/extensibility/build-javascript-actions/create-native-javascript-action.md
@@ -132,37 +132,6 @@ Now make a JavaScript action to read the NFC tag information:
 
 1. Optionally, click the **Expose as nanoflow action** tab, select **Expose as nanoflow action**, and **Select** an icon for your JavaScript action.
 
-### Installing a Dependency in Your App {#install-dependency-project}
-
-The dependency is split into two parts: the native device part, and the client JavaScript part. In this section we will add the dependency JavaScript for the client bundle. For the bundling we need to add the dependency builder, so that we can add the `react-native-nfc-manager` JavaScript code.
-
-1. In your CLI, open the module folder which contains your JavaScript action:
-
-    ```powershell
-    cd C:\MendixApps\NativeNFC\javascriptsource\nativenfc\actions
-    ```
-
-1. Make sure *HasNFCSupport.js* is in this folder so you know you are in the right place.
-1. Install the dependency with the command `npm install react-native-nfc-manager@1.2.2`.
-
-{{% alert type="info" %}}
-This will create a **node_module** folder inside your **actions** folder. There is a known issue that when you try to commit the *node_modules* folder using Apache Subversion, there could be problems if your commit contains a large number of files. To solve this, try removing unnecessary files before committing.
-{{% /alert %}}
-
-#### Declaring Native Dependencies
-
-To make Mendix install and link native dependencies automatically while creating production-like builds of a native app, create JSON files next to your JavaScript actions: *HasNFCSupport.json* and *ReadNFCTag.json*. Define the same native dependencies in each of them:
-
-```json
-{
-    "nativeDependencies": {
-        "react-native-nfc-manager": "1.2.2"
-    }
-}
-```
-
-For more information see [Declaring Native Dependencies](/apidocs-mxsdk/apidocs/pluggable-widgets-native-dependencies/).
-
 ### Using NFC JavaScript Actions {#use-nfc-action}
 
 Make a nanoflow to use your new actions:

--- a/content/en/docs/howto9/extensibility/build-javascript-actions/create-native-javascript-action.md
+++ b/content/en/docs/howto9/extensibility/build-javascript-actions/create-native-javascript-action.md
@@ -132,37 +132,6 @@ Now make a JavaScript action to read the NFC tag information:
 
 1. Optionally, click the **Expose as nanoflow action** tab, select **Expose as nanoflow action**, and **Select** an icon for your JavaScript action.
 
-### Installing a Dependency in Your App {#install-dependency-project}
-
-The dependency is split into two parts: the native device part, and the client JavaScript part. In this section we will add the dependency JavaScript for the client bundle. For the bundling we need to add the dependency builder, so that we can add the `react-native-nfc-manager` JavaScript code.
-
-1. In your CLI, open the module folder which contains your JavaScript action:
-
-    ```powershell
-    cd C:\MendixApps\NativeNFC\javascriptsource\nativenfc\actions
-    ```
-
-1. Make sure *HasNFCSupport.js* is in this folder so you know you are in the right place.
-1. Install the dependency with the command `npm install react-native-nfc-manager@1.2.2`.
-
-{{% alert type="info" %}}
-This will create a **node_module** folder inside your **actions** folder. There is a known issue that when you try to commit the *node_modules* folder using Apache Subversion, there could be problems if your commit contains a large number of files. To solve this, try removing unnecessary files before committing.
-{{% /alert %}}
-
-#### Declaring Native Dependencies
-
-To make Mendix install and link native dependencies automatically while creating production-like builds of a native app, create JSON files next to your JavaScript actions: *HasNFCSupport.json* and *ReadNFCTag.json*. Define the same native dependencies in each of them:
-
-```json
-{
-    "nativeDependencies": {
-        "react-native-nfc-manager": "1.2.2"
-    }
-}
-```
-
-For more information see [Declaring Native Dependencies](/apidocs-mxsdk/apidocs/pluggable-widgets-native-dependencies/).
-
 ### Using NFC JavaScript Actions {#use-nfc-action}
 
 Make a nanoflow to use your new actions:

--- a/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/bitrise.md
+++ b/content/en/docs/refguide/mobile/distributing-mobile-apps/building-native-apps/bitrise.md
@@ -182,7 +182,7 @@ Now, every time some runs **Build Native App** to update the application bundle,
 ## Additional Considerations
 
 {{% alert color="info" %}}
-When using pipelines, avoid manual commits to the repository that holds your native template. These can interfere with the build pipeline and cause errors in builds. Instead, use the configuration options provided by Build Native App and add dependencies by [declaring them in JavaScript Actions](/howto/extensibility/create-native-javascript-action/#declaring-native-dependencies) or pluggable widgets.
+When using pipelines, avoid manual commits to the repository that holds your native template. These can interfere with the build pipeline and cause errors in builds. Instead, use the configuration options provided by Build Native App, and declare dependencies by [adding them in JavaScript actions and pluggable widgets](/apidocs-mxsdk/apidocs/pluggable-widgets-native-dependencies/).
 {{% /alert %}}
 
 Our MVP Marcel Groeneweg has written a [Medium post](https://marcel-groeneweg.medium.com/mendix-native-builds-with-bitrise-6ce56f0bb8fc) about optimizing Mendix native mobile builds with Bitrise. Mendix cannot take responsibility for third-party recommendations.


### PR DESCRIPTION
This PR solves issue https://github.com/mendix/docs/issues/10749

Dependency instructions better documented in this other document: https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-native-dependencies/