### PR TITLE
Date Picker improve reference date documentation

### DIFF
--- a/content/en/docs/refguide/modeling/pages/input-widgets/date-picker.md
+++ b/content/en/docs/refguide/modeling/pages/input-widgets/date-picker.md
@@ -64,10 +64,28 @@ The possible values for date format are shown below:
 If you choose **Custom** as the date format (see above), this property determines how the value is formatted. The custom date format is a string that allows for any combination of symbols found in the table below. Any punctuation will be rendered literally.
 
 {{% alert color="info" %}}
-When using `yyyy` custom format and typing `yy` in the date picker widget, the century guessing by proximity follows the rule of **50/50**. Specifically, it adjusts dates to be within 50 years before and 50 years after the time the date format instance is created:
+When the custom date format uses `yyyy`, the date picker also accepts a two-digit year (`yy`).
+{{% /alert %}}
+
+{{% alert color="info" %}}
+The date picker uses a reference date for parsing partial date inputs (e.g. `mm/dd` or `yy/mm/dd`) into complete date inputs `yyyy/mm/dd`. The reference date is the date from the value already in the field. If the field is empty, the current date is the reference date.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+Starting with Mendix 12, the date picker will always use the current date as the reference date, even if the field already contains a value.
+{{% /alert %}}
+
+{{% alert color="info" %}}
+For two-digit year input, the date picker chooses the century that places the entered year closest to the reference year. If two years are equally close, it chooses the earlier year.
+
+For example, with `2026` as the reference year:
 
 * `24` {{< icon name="arrow-narrow-right" >}} `2024`
-* `75` {{< icon name="arrow-narrow-right" >}} `1975`
+* `75` {{< icon name="arrow-narrow-right" >}} `2075`
+* `76` {{< icon name="arrow-narrow-right" >}} `1976`
+* `97` {{< icon name="arrow-narrow-right" >}} `1997`
+
+If the field previously contained a date in `1970`, entering `24` results in `1924`.
 {{% /alert %}}
 
 {{% snippet file="/static/_includes/refguide/custom-date-format-tokens.md" %}}


### PR DESCRIPTION
Hey team,

This PR aims to clarify the behavior of the Date Picker when filling in partial dates. I tried to keep it compact but clear, but as dates get confusing very fast I am very open about suggestions (I also realize that there are a lot of alerts now).

As stated in the warning, we plan to change this behavior for Mendix 12, we cannot do it for previous versions as that would be a breaking change.

If there are any questions about the behavior, feel free to ask!