### PR TITLE
Update strict mode limitation on platform supported widget

### DIFF
--- a/content/en/docs/refguide/modeling/security/app-security/strict-mode.md
+++ b/content/en/docs/refguide/modeling/security/app-security/strict-mode.md
@@ -35,6 +35,13 @@ When strict mode is enabled, the following [client APIs](/apidocs-mxsdk/apidocs/
 
 The APIs will be disabled on the Runtime, which means that these APIs cannot be invoked in online apps via JavaScript actions or the browser's console. If any of these APIs are used in a JavaScript action, consider using a nanoflow instead.
 
+### Restricted Client APIs in Platform supported widgets
+
+In strict mode, some actions in platform-supported widgets are restricted because they rely on blocked client APIs.
+
+* [File Uploader](/appstore/modules/file-uploader/) - The delete action does not work in strict mode because it uses `data.remove`. To work around this restriction, create a custom button and use a nanoflow to delete the file object. For guidance, see [Enable custom buttons](/appstore/modules/file-uploader/#enable-custom-buttons).
+* [Web Actions](/appstore/modules/web-actions/) - The **Take Picture** action does not work in strict mode because it uses `data.commit` to create the object.
+
 ## Save And Cancel Changes Action {#save-and-cancel}
 
 In strict mode, your model is analyzed by Studio Pro to ensure that only entities within editable widgets can be saved or rolled back during save or cancel actions. 

--- a/content/en/docs/refguide/modeling/security/app-security/strict-mode.md
+++ b/content/en/docs/refguide/modeling/security/app-security/strict-mode.md
@@ -35,12 +35,12 @@ When strict mode is enabled, the following [client APIs](/apidocs-mxsdk/apidocs/
 
 The APIs will be disabled on the Runtime, which means that these APIs cannot be invoked in online apps via JavaScript actions or the browser's console. If any of these APIs are used in a JavaScript action, consider using a nanoflow instead.
 
-### Restricted Client APIs in Platform supported widgets
+### Restricted Client APIs in Platform Supported Widgets
 
 In strict mode, some actions in platform-supported widgets are restricted because they rely on blocked client APIs.
 
-* [File Uploader](/appstore/modules/file-uploader/) - The delete action does not work in strict mode because it uses `data.remove`. To work around this restriction, create a custom button and use a nanoflow to delete the file object. For guidance, see [Enable custom buttons](/appstore/modules/file-uploader/#enable-custom-buttons).
-* [Web Actions](/appstore/modules/web-actions/) - The **Take Picture** action does not work in strict mode because it uses `data.commit` to create the object.
+* [File Uploader](/appstore/modules/file-uploader/) – The delete action does not work in strict mode because it uses `data.remove`. To work around this restriction, create a custom button and use a nanoflow to delete the file object. For guidance, see the [Enable Custom Buttons](/appstore/modules/file-uploader/#enable-custom-buttons) section in *File Uploader*.
+* [Web Actions](/appstore/modules/web-actions/) – The **Take picture** action does not work in strict mode because it uses `data.commit` to create the object.
 
 ## Save And Cancel Changes Action {#save-and-cancel}
 


### PR DESCRIPTION
**Summary**
This PR updates the Strict Mode documentation to clarify limitations in platform-supported widgets when restricted client APIs are enabled.

**Changes**
Added a File Uploader limitation: the delete action does not work in Strict Mode because it uses data.remove.
Added a File Uploader workaround: users can create a custom button and use a nanoflow to delete the file object.
Added a guidance link for that workaround: /appstore/modules/file-uploader/#enable-custom-buttons
Added a Web Actions limitation: Take Picture does not work in Strict Mode because it uses data.commit to create the object.

**Updated Documentation**
[strict-mode.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Why**
These changes make Strict Mode behavior clearer, document known limitations, and provide a supported workaround path.

**Validation**
Documentation-only change.
Verified formatting and placement under Restricted Client APIs in Platform supported widgets.