### PR TITLE
Include prompt engineering guide link in Maia Make section

### DIFF
--- a/content/en/docs/refguide/mendix-ai-assistance/maia-make/_index.md
+++ b/content/en/docs/refguide/mendix-ai-assistance/maia-make/_index.md
@@ -19,6 +19,8 @@ Maia Make is a set of AI-assisted development capabilities in Studio Pro that ar
 
 You can also ask Maia to provide explanations of your existing documents, such as microflows, workflows, and pages. Moreover, this interface allows you to integrate with external tools, such as Playwright and Figma, via MCP Servers, and it supports story-based development by generating app artifacts based on existing user stories.
 
+For guidance on how to best prompt Maia, have a look at our [prompt engineering guide](https://docs.mendix.com/agents/prompt-engineering/).
+
 ## Maia Make Capabilities Overview
 
 ### Supported Document Types

--- a/content/en/docs/refguide/mendix-ai-assistance/maia-make/_index.md
+++ b/content/en/docs/refguide/mendix-ai-assistance/maia-make/_index.md
@@ -19,7 +19,7 @@ Maia Make is a set of AI-assisted development capabilities in Studio Pro that ar
 
 You can also ask Maia to provide explanations of your existing documents, such as microflows, workflows, and pages. Moreover, this interface allows you to integrate with external tools, such as Playwright and Figma, via MCP Servers, and it supports story-based development by generating app artifacts based on existing user stories.
 
-For guidance on how to best prompt Maia, have a look at our [prompt engineering guide](https://docs.mendix.com/agents/prompt-engineering/).
+For guidance on how to best prompt Maia, refer to [Prompt Engineering](/agents/prompt-engineering/).
 
 ## Maia Make Capabilities Overview
 


### PR DESCRIPTION
Added a link to the prompt engineering guide for Maia.