### PR TITLE
Prevent build-and-deploy workflow from running in forks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    if: github.event.repository.fork == false
     outputs:
       target: ${{ steps.env.outputs.target }}
     concurrency:


### PR DESCRIPTION
## Issue

The `build-and-deploy.yml` workflow uses `push` and `pull_request` triggers scoped to the `development` and `production` branches. This caused the workflow to run in two unintended scenarios:

- **In forks**: any fork that has a `development` or `production` branch triggers the workflow on pushes to those branches, consuming the fork's Actions minutes and failing when deployment secrets are absent.
- **On fork sync**: when a fork is synced to the main repo and opens a PR, the `pull_request` trigger fires the workflow in the main repo against the fork's code.

## Resolution

Added `if: github.event.repository.fork == false` to the `build` job. Because the `deploy` job depends on `build` via `needs: build`, it is automatically skipped whenever `build` is skipped. The workflow now only runs in the main repository, for both push and pull request events.